### PR TITLE
Inline values in error messages

### DIFF
--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -20,11 +20,15 @@ export function isPlain(val: any) {
   )
 }
 
-const NON_SERIALIZABLE_STATE_MESSAGE = [
-  'A non-serializable value was detected in the state, in the path: `%s`. Value: %o',
-  'Take a look at the reducer(s) handling this action type: %s.',
-  '(See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)'
-].join('\n')
+function rich(strings: string[], ...keys: unknown[]) {
+  const arr: unknown[] = [strings[0]]
+
+  for (let i = 0; i < keys.length; i += 1) {
+    arr.push(keys[i], strings[i + 1])
+  }
+
+  return arr
+}
 
 const NON_SERIALIZABLE_ACTION_MESSAGE = [
   'A non-serializable value was detected in an action, in the path: `%s`. Value: %o',
@@ -135,7 +139,13 @@ export function createSerializableStateInvariantMiddleware(
     if (foundActionNonSerializableValue) {
       const { keyPath, value } = foundActionNonSerializableValue
 
-      console.error(NON_SERIALIZABLE_ACTION_MESSAGE, keyPath, value, action)
+      console.error(
+        `A non-serializable value was detected in an action, in the path: \`${keyPath}\`. Value:`,
+        value,
+        '\nTake a look at the logic that dispatched this action: ',
+        action,
+        '\n(See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)'
+      )
     }
 
     const result = next(action)
@@ -152,7 +162,13 @@ export function createSerializableStateInvariantMiddleware(
     if (foundStateNonSerializableValue) {
       const { keyPath, value } = foundStateNonSerializableValue
 
-      console.error(NON_SERIALIZABLE_STATE_MESSAGE, keyPath, value, action.type)
+      console.error(
+        `A non-serializable value was detected in the state, in the path: \`${keyPath}\`. Value:`,
+        value,
+        `
+Take a look at the reducer(s) handling this action type: ${action.type}.
+(See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)`
+      )
     }
 
     return result

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -20,22 +20,6 @@ export function isPlain(val: any) {
   )
 }
 
-function rich(strings: string[], ...keys: unknown[]) {
-  const arr: unknown[] = [strings[0]]
-
-  for (let i = 0; i < keys.length; i += 1) {
-    arr.push(keys[i], strings[i + 1])
-  }
-
-  return arr
-}
-
-const NON_SERIALIZABLE_ACTION_MESSAGE = [
-  'A non-serializable value was detected in an action, in the path: `%s`. Value: %o',
-  'Take a look at the logic that dispatched this action:  %o.',
-  '(See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)'
-].join('\n')
-
 interface NonSerializableValue {
   keyPath: string
   value: unknown


### PR DESCRIPTION
Fix #253.

Inline the values in the error messages to fix that some environment won't properly display [string substitutions](https://developer.mozilla.org/en-US/docs/Web/API/console#Using_string_substitutions). By using `,` to separate each value, we can remain native formatter in each environment (node.js or all major browsers devtool). Since the value we want to log here might be non-serializable, converting them to strings often loose context and make the developer confused.

I also rewrite the tests to better represent how it's actually seen in the logs, so that we can guard it when something like this issue ever occurred in the future. A caveat here is that by doing so, our tests might only be able to run in node v10+.