### PR TITLE
Use `console-testing-library` to get consistent snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,6 +2463,16 @@
       "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
       "dev": true
     },
+    "console-testing-library": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/console-testing-library/-/console-testing-library-0.2.2.tgz",
+      "integrity": "sha512-GhVHh/kQHxBhhNNPJCBheg8fECTbVLohgjjoylQhRAxVohaWSLzdyT+Vv6EYRtwuOq9ziQ2XTEC5Mvvd7XxuWA==",
+      "dev": true,
+      "requires": {
+        "jest-snapshot": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/jest": "^24.0.11",
     "@types/node": "^10.14.4",
     "@types/redux-immutable-state-invariant": "^2.1.1",
+    "console-testing-library": "^0.2.2",
     "eslint-config-react-app": "^5.0.1",
     "prettier": "^1.18.2",
     "react": "^16.8.6",

--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -1,6 +1,5 @@
 import { Reducer } from 'redux'
-import { Console } from 'console'
-import { Writable } from 'stream'
+import { getLog } from 'console-testing-library'
 import { configureStore } from './configureStore'
 
 import {
@@ -81,35 +80,6 @@ describe('findNonSerializableValue', () => {
 })
 
 describe('serializableStateInvariantMiddleware', () => {
-  let log = ''
-  const originalConsole = window.console
-
-  beforeEach(() => {
-    log = ''
-
-    const writable = new Writable({
-      write(chunk, encoding, callback) {
-        log += chunk
-        callback()
-      }
-    })
-
-    const mockConsole = new Console({
-      stdout: writable,
-      stderr: writable
-    })
-
-    Object.defineProperty(window, 'console', {
-      value: mockConsole
-    })
-  })
-
-  afterEach(() => {
-    Object.defineProperty(window, 'console', {
-      value: originalConsole
-    })
-  })
-
   it('Should log an error when a non-serializable action is dispatched', () => {
     const reducer: Reducer = (state = 0, _action) => state + 1
 
@@ -125,11 +95,12 @@ describe('serializableStateInvariantMiddleware', () => {
 
     store.dispatch(dispatchedAction)
 
-    expect(log).toMatchInlineSnapshot(`
+    expect(getLog().log).toMatchInlineSnapshot(`
       "A non-serializable value was detected in an action, in the path: \`type\`. Value: Symbol(SOME_CONSTANT) 
-      Take a look at the logic that dispatched this action:  { type: Symbol(SOME_CONSTANT) } 
-      (See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)
-      "
+      Take a look at the logic that dispatched this action:  Object {
+        \\"type\\": Symbol(SOME_CONSTANT),
+      } 
+      (See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)"
     `)
   })
 
@@ -165,11 +136,10 @@ describe('serializableStateInvariantMiddleware', () => {
 
     store.dispatch({ type: ACTION_TYPE })
 
-    expect(log).toMatchInlineSnapshot(`
+    expect(getLog().log).toMatchInlineSnapshot(`
       "A non-serializable value was detected in the state, in the path: \`testSlice.a\`. Value: Map {} 
       Take a look at the reducer(s) handling this action type: TEST_ACTION.
-      (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)
-      "
+      (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)"
     `)
   })
 
@@ -226,9 +196,11 @@ describe('serializableStateInvariantMiddleware', () => {
       store.dispatch({ type: ACTION_TYPE })
 
       // since default options are used, the `entries` function in `serializableObject` will cause the error
-      expect(log).toMatch(
-        /^A non-serializable value was detected in the state, in the path: \`testSlice.a.entries\`. Value:/
-      )
+      expect(getLog().log).toMatchInlineSnapshot(`
+        "A non-serializable value was detected in the state, in the path: \`testSlice.a.entries\`. Value: [Function entries] 
+        Take a look at the reducer(s) handling this action type: TEST_ACTION.
+        (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)"
+      `)
     })
 
     it('Should use consumer supplied isSerializable and getEntries options to tolerate certain structures', () => {
@@ -269,11 +241,10 @@ describe('serializableStateInvariantMiddleware', () => {
       store.dispatch({ type: ACTION_TYPE })
 
       // error reported is from a nested class instance, rather than the `entries` function `serializableObject`
-      expect(log).toMatchInlineSnapshot(`
+      expect(getLog().log).toMatchInlineSnapshot(`
         "A non-serializable value was detected in the state, in the path: \`testSlice.a.third.bad-map-instance\`. Value: Map {} 
         Take a look at the reducer(s) handling this action type: TEST_ACTION.
-        (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)
-        "
+        (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)"
       `)
     })
   })
@@ -316,7 +287,7 @@ describe('serializableStateInvariantMiddleware', () => {
 
     // Supplied 'isSerializable' considers all values serializable, hence
     // no error logging is expected:
-    expect(log).toBe('')
+    expect(getLog().log).toBe('')
   })
 
   it('should not check serializability for ignored action types', () => {


### PR DESCRIPTION
As mentioned in https://github.com/reduxjs/redux-toolkit/pull/271#issuecomment-564184500, `console-testing-library` is a simple package I built to help test console output more align to what users see.

It's new, so it's probably not stable for every cases, but I think it's quite stable for our simple use case.

Under the hood, it uses `new Console()` as in #257 did, and also uses `pretty-format` from jest to generate consistent output across different node versions.