### PR TITLE
Fix module bundling & ESM runtime error

### DIFF
--- a/src/getDefaultMiddleware.ts
+++ b/src/getDefaultMiddleware.ts
@@ -1,6 +1,8 @@
 import { Middleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
-// UMD-DEV-ONLY: import createImmutableStateInvariantMiddleware from 'redux-immutable-state-invariant'
+/* START_REMOVE_UMD */
+import createImmutableStateInvariantMiddleware from 'redux-immutable-state-invariant'
+/* STOP_REMOVE_UMD */
 
 import {
   createSerializableStateInvariantMiddleware,
@@ -55,10 +57,10 @@ export function getDefaultMiddleware<S = any>(
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    /* START_REMOVE_UMD */
     if (immutableCheck) {
-      const createImmutableStateInvariantMiddleware = require('redux-immutable-state-invariant')
-        .default
+      /* PROD_START_REMOVE_UMD */
+
+      // UMD-ONLY: const createImmutableStateInvariantMiddleware = require('redux-immutable-state-invariant').default
 
       let immutableOptions: ImmutableStateInvariantMiddlewareOptions = {}
 
@@ -69,9 +71,9 @@ export function getDefaultMiddleware<S = any>(
       middlewareArray.unshift(
         createImmutableStateInvariantMiddleware(immutableOptions)
       )
-    }
 
-    /* STOP_REMOVE_UMD */
+      /* PROD_STOP_REMOVE_UMD */
+    }
 
     if (serializableCheck) {
       let serializableOptions: SerializableStateInvariantMiddlewareOptions = {}

--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -15,19 +15,26 @@ module.exports = {
       case 'umd':
         delete config.external
         config.output.indent = false
-        config.plugins.push(
+        config.plugins.unshift(
           replace({
-            '// UMD-DEV-ONLY: ': ''
+            '// UMD-ONLY: ': '',
+            delimiters: ['', '']
           })
         )
-        config.plugins.push(
+        config.plugins.unshift(
           stripCode({
-            // Remove the `require()` import of RISI so we use the import statement
+            // Remove the `import` of RISI so we use the dynamic `require()` statement
             start_comment: 'START_REMOVE_UMD',
             end_comment: 'STOP_REMOVE_UMD'
           })
         )
         if (env === 'production') {
+          config.plugins.unshift(
+            stripCode({
+              start_comment: 'PROD_START_REMOVE_UMD',
+              end_comment: 'PROD_STOP_REMOVE_UMD'
+            })
+          )
           config.output.file = join(__dirname, pkg.unpkg)
         } else {
           config.output.file = config.output.file.replace(


### PR DESCRIPTION
Closes #278 

I've tested the ESM build locally and confirmed that I no longer see the original issue.
When building for production, the `if (process.env.NODE_ENV !== 'production') {` is evaluated to `false` by Webpack and the chunk of code is omitted from output.

The contents of the generated UMD file (`redux-toolkit.umd.min.js`), hasn't changed, so there shouldn't be a problem there.
However the development build has changed (screenshot attached below).
I believe this is because `redux-immutable-state-invariant` was not being instantiated before. I might be missing context here, but let me know if the old behaviour was correct and can fix the logic.

![Screen Shot 2019-12-13 at 17 11 10](https://user-images.githubusercontent.com/1646307/70835602-91ce3b80-1dcb-11ea-829c-e961c7f375bf.png)
