### PR TITLE
Mock the console manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2412,9 +2412,9 @@
       "dev": true
     },
     "console-testing-library": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/console-testing-library/-/console-testing-library-0.2.2.tgz",
-      "integrity": "sha512-GhVHh/kQHxBhhNNPJCBheg8fECTbVLohgjjoylQhRAxVohaWSLzdyT+Vv6EYRtwuOq9ziQ2XTEC5Mvvd7XxuWA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/console-testing-library/-/console-testing-library-0.3.1.tgz",
+      "integrity": "sha512-E+OUjJmX8dzAuMLKDbkh+y68cjjJj3iTO3yK4rV5xeOy5/nBuQAc0DHO+krGSd2d3KryJM/yWhWCsVQEpKBDCQ==",
       "dev": true,
       "requires": {
         "jest-snapshot": "^24.9.0",
@@ -3681,7 +3681,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3702,12 +3703,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3722,17 +3725,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3849,7 +3855,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3861,6 +3868,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3875,6 +3883,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3882,12 +3891,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3906,6 +3917,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3986,7 +3998,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3998,6 +4011,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4083,7 +4097,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4119,6 +4134,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4138,6 +4154,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4181,12 +4198,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^24.0.11",
     "@types/node": "^10.14.4",
     "@types/redux-immutable-state-invariant": "^2.1.1",
-    "console-testing-library": "^0.2.2",
+    "console-testing-library": "^0.3.1",
     "eslint-config-react-app": "^5.0.1",
     "prettier": "^1.18.2",
     "react": "^16.8.6",

--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -1,5 +1,9 @@
 import { Reducer } from 'redux'
-import { getLog } from 'console-testing-library'
+import {
+  mockConsole,
+  createConsole,
+  getLog
+} from 'console-testing-library/pure'
 import { configureStore } from './configureStore'
 
 import {
@@ -7,6 +11,13 @@ import {
   findNonSerializableValue,
   isPlain
 } from './serializableStateInvariantMiddleware'
+
+// Mocking console
+let restore = () => {}
+beforeEach(() => {
+  restore = mockConsole(createConsole())
+})
+afterEach(() => restore())
 
 describe('findNonSerializableValue', () => {
   it('Should return false if no matching values are found', () => {


### PR DESCRIPTION
As mentioned in https://github.com/reduxjs/redux-toolkit/pull/277#issuecomment-565787398, I updated the package to include an entry to mock the console manually via `console-testing-library/pure`.

Also fixed an issue in https://github.com/kevin940726/console-testing-library/issues/1 where the `restore ` function never got called.