### PR TITLE
exportable case reducers type, bugfix, documentation

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -196,7 +196,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
      */
-    "untrimmedFilePath": "<projectFolder>/dist/typings.d.ts"
+    "untrimmedFilePath": "",
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "beta" release.
@@ -222,7 +222,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: ""
      */
-    // "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts",
+    "publicTrimmedFilePath": "<projectFolder>/dist/typings.d.ts"
 
     /**
      * When a declaration is trimmed, by default it will be replaced by a code comment such as

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -324,14 +324,9 @@
         "logLevel": "warning"
         // "addToApiReportFile": false
       },
-
-      "ae-missing-release-tag": {
-        "logLevel": "none",
-        "addToApiReportFile": true
-      },
       "ae-forgotten-export": {
         "logLevel": "none",
-        "addToApiReportFile": true
+        "addToApiReportFile": false
       }
       //
       // . . .

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -196,7 +196,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
      */
-    "untrimmedFilePath": "",
+    "untrimmedFilePath": "<projectFolder>/dist/typings.d.ts"
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "beta" release.
@@ -222,7 +222,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: ""
      */
-    "publicTrimmedFilePath": "<projectFolder>/dist/typings.d.ts"
+    // "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts",
 
     /**
      * When a declaration is trimmed, by default it will be replaced by a code comment such as

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -245,7 +245,7 @@ Like in `createReducer`, the `extraReducers` map object is not easy to fully typ
 
 ### Wrapping `createSlice`
 
-If you want to wrap `createSlice` in a "higher-order slice-generator function" to abstract repeating patterns in your code, you have have to use the `SliceCaseReducers` and `ValidateSliceCaseReducers` types in a very specific way.
+If you need to reuse reducer logic, it is common to write ["higher-order reducers"](https://redux.js.org/recipes/structuring-reducers/reusing-reducer-logic#customizing-behavior-with-higher-order-reducers) that wrap a reducer function with additional common behavior.  This can be done with `createSlice` as well, but due to the complexity of the types for `createSlice`, you have to use the `SliceCaseReducers` and `ValidateSliceCaseReducers` types in a very specific way.
 
 Here is an example of such a "generic" wrapped `createSlice` call:
 

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -245,7 +245,7 @@ Like in `createReducer`, the `extraReducers` map object is not easy to fully typ
 
 ### Wrapping `createSlice`
 
-If you need to reuse reducer logic, it is common to write ["higher-order reducers"](https://redux.js.org/recipes/structuring-reducers/reusing-reducer-logic#customizing-behavior-with-higher-order-reducers) that wrap a reducer function with additional common behavior.  This can be done with `createSlice` as well, but due to the complexity of the types for `createSlice`, you have to use the `SliceCaseReducers` and `ValidateSliceCaseReducers` types in a very specific way.
+If you need to reuse reducer logic, it is common to write ["higher-order reducers"](https://redux.js.org/recipes/structuring-reducers/reusing-reducer-logic#customizing-behavior-with-higher-order-reducers) that wrap a reducer function with additional common behavior. This can be done with `createSlice` as well, but due to the complexity of the types for `createSlice`, you have to use the `SliceCaseReducers` and `ValidateSliceCaseReducers` types in a very specific way.
 
 Here is an example of such a "generic" wrapped `createSlice` call:
 

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -243,7 +243,7 @@ If you actually _need_ that type, unfortunately there is no other way than manua
 
 Like in `createReducer`, the `extraReducers` map object is not easy to fully type. So, like with `createReducer`, you may also use the "builder callback" approach for defining the reducer object argument. See [the `createReducer` section above](#createReducer) for an example.
 
-### Wrapping createSlice
+### Wrapping `createSlice`
 
 If you want to wrap `createSlice` in a "higher-order slice-generator function" to abstract repeating patterns in your code, you have have to use the `SliceCaseReducers` and `ValidateSliceCaseReducers` types in a very specific way.
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -117,7 +117,7 @@ export interface CreateSliceOptions<State = any, CR extends SliceCaseReducers<St
     extraReducers?: CaseReducers<NoInfer<State>, any> | ((builder: ActionReducerMapBuilder<NoInfer<State>>) => void);
     initialState: State;
     name: string;
-    reducers: CR & ValidateSliceCaseReducers<State, CR>;
+    reducers: ValidateSliceCaseReducers<State, CR>;
 }
 
 // @public
@@ -190,7 +190,7 @@ export type SliceCaseReducers<State> = {
 };
 
 // @public
-export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = {
+export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = ACR & {
     [P in keyof ACR]: ACR[P] extends {
         reducer(s: S, action?: {
             payload: infer O;

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -18,66 +18,45 @@ import { Store } from 'redux';
 import { StoreEnhancer } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 
-// Warning: (ae-forgotten-export) The symbol "BaseActionCreator" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface ActionCreatorWithNonInferrablePayload<T extends string = string> extends BaseActionCreator<unknown, T> {
-    // (undocumented)
     <PT extends unknown>(payload: PT): PayloadAction<PT, T>;
 }
 
 // @public
 export interface ActionCreatorWithOptionalPayload<P, T extends string = string> extends BaseActionCreator<P, T> {
-    // (undocumented)
     (payload?: undefined): PayloadAction<undefined, T>;
-    // Warning: (ae-forgotten-export) The symbol "Diff" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>;
 }
 
 // @public
 export interface ActionCreatorWithoutPayload<T extends string = string> extends BaseActionCreator<undefined, T> {
-    // (undocumented)
     (): PayloadAction<undefined, T>;
 }
 
 // @public
 export interface ActionCreatorWithPayload<P, T extends string = string> extends BaseActionCreator<P, T> {
-    // (undocumented)
     <PT extends P>(payload: PT): PayloadAction<PT, T>;
-    // (undocumented)
     (payload: P): PayloadAction<P, T>;
 }
 
 // @public
 export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T extends string = string, E = never, M = never> extends BaseActionCreator<P, T, M, E> {
-    // (undocumented)
     (...args: Args): PayloadAction<P, T, M, E>;
 }
 
-// Warning: (ae-missing-release-tag) "ActionReducerMapBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface ActionReducerMapBuilder<State> {
-    // Warning: (ae-forgotten-export) The symbol "TypedActionCreator" needs to be exported by the entry point index.d.ts
     addCase<ActionCreator extends TypedActionCreator<string>>(actionCreator: ActionCreator, reducer: CaseReducer<State, ReturnType<ActionCreator>>): ActionReducerMapBuilder<State>;
     addCase<Type extends string, A extends Action<Type>>(type: Type, reducer: CaseReducer<State, A>): ActionReducerMapBuilder<State>;
 }
 
-// Warning: (ae-missing-release-tag) "Actions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
+// @public @deprecated
 export type Actions<T extends keyof any = string> = Record<T, Action>;
 
-// Warning: (ae-missing-release-tag) "CaseReducer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export type CaseReducer<S = any, A extends Action = AnyAction> = (state: Draft<S>, action: A) => S | void;
 
-// Warning: (ae-forgotten-export) The symbol "ActionCreatorForCaseReducerWithPrepare" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ActionCreatorForCaseReducer" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type CaseReducerActions<CaseReducers extends SliceCaseReducerDefinitions<any, any>> = {
     [Type in keyof CaseReducers]: CaseReducers[Type] extends {
@@ -85,9 +64,7 @@ export type CaseReducerActions<CaseReducers extends SliceCaseReducerDefinitions<
     } ? ActionCreatorForCaseReducerWithPrepare<CaseReducers[Type]> : ActionCreatorForCaseReducer<CaseReducers[Type]>;
 };
 
-// Warning: (ae-missing-release-tag) "CaseReducers" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
+// @public @deprecated
 export type CaseReducers<S, AS extends Actions> = {
     [T in keyof AS]: AS[T] extends Action ? CaseReducer<S, AS[T]> : void;
 };
@@ -98,18 +75,12 @@ export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
     prepare: PrepareAction<Action['payload']>;
 };
 
-// Warning: (ae-missing-release-tag) "ConfigureEnhancersCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type ConfigureEnhancersCallback = (defaultEnhancers: StoreEnhancer[]) => StoreEnhancer[];
 
-// Warning: (ae-missing-release-tag) "configureStore" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function configureStore<S = any, A extends Action = AnyAction>(options: ConfigureStoreOptions<S, A>): EnhancedStore<S, A>;
 
-// Warning: (ae-missing-release-tag) "ConfigureStoreOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface ConfigureStoreOptions<S = any, A extends Action = AnyAction> {
     devTools?: boolean | EnhancerOptions;
@@ -119,20 +90,14 @@ export interface ConfigureStoreOptions<S = any, A extends Action = AnyAction> {
     reducer: Reducer<S, A> | ReducersMapObject<S, A>;
 }
 
-// Warning: (ae-missing-release-tag) "createAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "createAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function createAction<P = void, T extends string = string>(type: T): PayloadActionCreator<P, T>;
 
-// @public (undocumented)
+// @public
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 export { createNextState }
 
-// Warning: (ae-missing-release-tag) "createReducer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "createReducer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function createReducer<S, CR extends CaseReducers<S, any> = CaseReducers<S, any>>(initialState: S, actionsMap: CR): Reducer<S>;
 
@@ -141,52 +106,35 @@ export function createReducer<S>(initialState: S, builderCallback: (builder: Act
 
 export { createSelector }
 
-// Warning: (ae-missing-release-tag) "createSerializableStateInvariantMiddleware" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function createSerializableStateInvariantMiddleware(options?: SerializableStateInvariantMiddlewareOptions): Middleware;
 
-// Warning: (ae-missing-release-tag) "createSlice" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function createSlice<State, CaseReducers extends SliceCaseReducerDefinitions<State, CaseReducers>>(options: CreateSliceOptions<State, CaseReducers>): Slice<State, CaseReducers>;
 
 // @public
 export interface CreateSliceOptions<State = any, CR extends SliceCaseReducerDefinitions<State, any> = SliceCaseReducerDefinitions<State, any>> {
-    // Warning: (ae-forgotten-export) The symbol "NoInfer" needs to be exported by the entry point index.d.ts
     extraReducers?: CaseReducers<NoInfer<State>, any> | ((builder: ActionReducerMapBuilder<NoInfer<State>>) => void);
     initialState: State;
     name: string;
     reducers: CR;
 }
 
-// Warning: (ae-missing-release-tag) "EnhancedStore" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface EnhancedStore<S = any, A extends Action = AnyAction> extends Store<S, A> {
     // (undocumented)
     dispatch: ThunkDispatch<S, any, A>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "NonSerializableValue" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "findNonSerializableValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export function findNonSerializableValue(value: unknown, path?: ReadonlyArray<string>, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][]): NonSerializableValue | false;
 
-// Warning: (ae-forgotten-export) The symbol "GetDefaultMiddlewareOptions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "getDefaultMiddleware" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function getDefaultMiddleware<S = any>(options?: GetDefaultMiddlewareOptions): Middleware<{}, S>[];
 
-// Warning: (ae-missing-release-tag) "getType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function getType<T extends string>(actionCreator: PayloadActionCreator<any, T>): T;
 
-// Warning: (ae-missing-release-tag) "isPlain" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function isPlain(val: any): boolean;
 
@@ -200,13 +148,6 @@ export type PayloadAction<P = void, T extends string = string, M = never, E = ne
     error: E;
 });
 
-// Warning: (ae-forgotten-export) The symbol "IfPrepareActionMethodProvided" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "_ActionCreatorWithPreparedPayload" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "IsUnknownOrNonInferrable" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "IfVoid" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "IfMaybeUndefined" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type PayloadActionCreator<P = void, T extends string = string, PA extends PrepareAction<P> | void = void> = IfPrepareActionMethodProvided<PA, _ActionCreatorWithPreparedPayload<PA, T>, IsAny<P, ActionCreatorWithPayload<any, T>, IsUnknownOrNonInferrable<P, ActionCreatorWithNonInferrablePayload<T>, IfVoid<P, ActionCreatorWithoutPayload<T>, IfMaybeUndefined<P, ActionCreatorWithOptionalPayload<P, T>, ActionCreatorWithPayload<P, T>>>>>>;
 
@@ -225,8 +166,6 @@ export type PrepareAction<P> = ((...args: any[]) => {
     error: any;
 });
 
-// Warning: (ae-missing-release-tag) "SerializableStateInvariantMiddlewareOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface SerializableStateInvariantMiddlewareOptions {
     getEntries?: (value: any) => [string, any][];
@@ -239,19 +178,14 @@ export interface Slice<State = any, CaseReducers extends SliceCaseReducerDefinit
     [key: string]: any;
 }> {
     actions: CaseReducerActions<CaseReducers>;
-    // Warning: (ae-forgotten-export) The symbol "SliceDefinedCaseReducers" needs to be exported by the entry point index.d.ts
     caseReducers: SliceDefinedCaseReducers<CaseReducers>;
     name: string;
     reducer: Reducer<State>;
 }
 
-// Warning: (ae-missing-release-tag) "SliceActionCreator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated
 export type SliceActionCreator<P> = PayloadActionCreator<P>;
 
-// Warning: (ae-forgotten-export) The symbol "SliceCaseReducersCheck" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type SliceCaseReducerDefinitions<State, CR> = {
     [K: string]: CaseReducer<State, PayloadAction<any>> | CaseReducerWithPrepare<State, PayloadAction<any>>;

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -19,17 +19,14 @@ import { StoreEnhancer } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 
 // Warning: (ae-forgotten-export) The symbol "BaseActionCreator" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ActionCreatorWithNonInferrablePayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface ActionCreatorWithNonInferrablePayload<T extends string = string> extends BaseActionCreator<unknown, T> {
     // (undocumented)
     <PT extends unknown>(payload: PT): PayloadAction<PT, T>;
 }
 
-// Warning: (ae-missing-release-tag) "ActionCreatorWithOptionalPayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ActionCreatorWithOptionalPayload<P, T extends string = string> extends BaseActionCreator<P, T> {
     // (undocumented)
     (payload?: undefined): PayloadAction<undefined, T>;
@@ -39,17 +36,13 @@ export interface ActionCreatorWithOptionalPayload<P, T extends string = string> 
     <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>;
 }
 
-// Warning: (ae-missing-release-tag) "ActionCreatorWithoutPayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ActionCreatorWithoutPayload<T extends string = string> extends BaseActionCreator<undefined, T> {
     // (undocumented)
     (): PayloadAction<undefined, T>;
 }
 
-// Warning: (ae-missing-release-tag) "ActionCreatorWithPayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ActionCreatorWithPayload<P, T extends string = string> extends BaseActionCreator<P, T> {
     // (undocumented)
     <PT extends P>(payload: PT): PayloadAction<PT, T>;
@@ -57,17 +50,13 @@ export interface ActionCreatorWithPayload<P, T extends string = string> extends 
     (payload: P): PayloadAction<P, T>;
 }
 
-// Warning: (ae-missing-release-tag) "ActionCreatorWithPreparedPayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T extends string = string, E = never, M = never> extends BaseActionCreator<P, T, M, E> {
     // (undocumented)
     (...args: Args): PayloadAction<P, T, M, E>;
 }
 
-// Warning: (ae-missing-release-tag) "_ActionCreatorWithPreparedPayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @internal
 export type _ActionCreatorWithPreparedPayload<PA extends PrepareAction<any> | void, T extends string = string> = PA extends PrepareAction<infer P> ? ActionCreatorWithPreparedPayload<Parameters<PA>, P, T, ReturnType<PA> extends {
     error: infer E;
 } ? E : never, ReturnType<PA> extends {
@@ -93,11 +82,27 @@ export type Actions<T extends keyof any = string> = Record<T, Action>;
 // @public
 export type CaseReducer<S = any, A extends Action = AnyAction> = (state: Draft<S>, action: A) => S | void;
 
+// Warning: (ae-forgotten-export) The symbol "ActionCreatorForCaseReducerWithPrepare" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ActionCreatorForCaseReducer" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type CaseReducerActions<CaseReducers extends SliceCaseReducerDefinitions<any, any>> = {
+    [Type in keyof CaseReducers]: CaseReducers[Type] extends {
+        prepare: any;
+    } ? ActionCreatorForCaseReducerWithPrepare<CaseReducers[Type]> : ActionCreatorForCaseReducer<CaseReducers[Type]>;
+};
+
 // Warning: (ae-missing-release-tag) "CaseReducers" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type CaseReducers<S, AS extends Actions> = {
     [T in keyof AS]: AS[T] extends Action ? CaseReducer<S, AS[T]> : void;
+};
+
+// @public
+export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
+    reducer: CaseReducer<State, Action>;
+    prepare: PrepareAction<Action['payload']>;
 };
 
 // Warning: (ae-missing-release-tag) "ConfigureEnhancersCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -148,15 +153,11 @@ export { createSelector }
 // @public
 export function createSerializableStateInvariantMiddleware(options?: SerializableStateInvariantMiddlewareOptions): Middleware;
 
-// Warning: (ae-forgotten-export) The symbol "SliceCaseReducerDefinitions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "RestrictCaseReducerDefinitionsToMatchReducerAndPrepare" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "createSlice" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function createSlice<State, CaseReducers extends SliceCaseReducerDefinitions<State, any>>(options: CreateSliceOptions<State, CaseReducers> & RestrictCaseReducerDefinitionsToMatchReducerAndPrepare<State, CaseReducers>): Slice<State, CaseReducers>;
+export function createSlice<State, CaseReducers extends SliceCaseReducerDefinitions<State, CaseReducers>>(options: CreateSliceOptions<State, CaseReducers>): Slice<State, CaseReducers>;
 
-// Warning: (ae-missing-release-tag) "CreateSliceOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface CreateSliceOptions<State = any, CR extends SliceCaseReducerDefinitions<State, any> = SliceCaseReducerDefinitions<State, any>> {
     // Warning: (ae-forgotten-export) The symbol "NoInfer" needs to be exported by the entry point index.d.ts
@@ -196,8 +197,6 @@ export function getType<T extends string>(actionCreator: PayloadActionCreator<an
 // @public
 export function isPlain(val: any): boolean;
 
-// Warning: (ae-missing-release-tag) "PayloadAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export type PayloadAction<P = void, T extends string = string, M = never, E = never> = {
     payload: P;
@@ -209,17 +208,16 @@ export type PayloadAction<P = void, T extends string = string, M = never, E = ne
 });
 
 // Warning: (ae-forgotten-export) The symbol "IfPrepareActionMethodProvided" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IsUnknownOrNonInferrable" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IfVoid" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IfMaybeUndefined" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "PayloadActionCreator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-incompatible-release-tags) The symbol "PayloadActionCreator" is marked as @public, but its signature references "_ActionCreatorWithPreparedPayload" which is marked as @internal
 //
 // @public
-export type PayloadActionCreator<P = void, T extends string = string, PA extends PrepareAction<P> | void = void> = IfPrepareActionMethodProvided<PA, _ActionCreatorWithPreparedPayload<PA, T>, IsUnknownOrNonInferrable<P, ActionCreatorWithNonInferrablePayload<T>, IfVoid<P, ActionCreatorWithoutPayload<T>, IfMaybeUndefined<P, ActionCreatorWithOptionalPayload<P, T>, ActionCreatorWithPayload<P, T>>>>>;
+export type PayloadActionCreator<P = void, T extends string = string, PA extends PrepareAction<P> | void = void> = IfPrepareActionMethodProvided<PA, _ActionCreatorWithPreparedPayload<PA, T>, IsAny<P, ActionCreatorWithPayload<any, T>, IsUnknownOrNonInferrable<P, ActionCreatorWithNonInferrablePayload<T>, IfVoid<P, ActionCreatorWithoutPayload<T>, IfMaybeUndefined<P, ActionCreatorWithOptionalPayload<P, T>, ActionCreatorWithPayload<P, T>>>>>>;
 
-// Warning: (ae-missing-release-tag) "PrepareAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type PrepareAction<P> = ((...args: any[]) => {
     payload: P;
 }) | ((...args: any[]) => {
@@ -243,19 +241,13 @@ export interface SerializableStateInvariantMiddlewareOptions {
     isSerializable?: (value: any) => boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "PayloadActions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "Slice" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface Slice<State = any, CaseReducers extends SliceCaseReducerDefinitions<State, PayloadActions> = {
+// @public
+export interface Slice<State = any, CaseReducers extends SliceCaseReducerDefinitions<State, any> = {
     [key: string]: any;
 }> {
-    // Warning: (ae-forgotten-export) The symbol "CaseReducerActions" needs to be exported by the entry point index.d.ts
     actions: CaseReducerActions<CaseReducers>;
     // Warning: (ae-forgotten-export) The symbol "SliceDefinedCaseReducers" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    caseReducers: SliceDefinedCaseReducers<CaseReducers, State>;
+    caseReducers: SliceDefinedCaseReducers<CaseReducers>;
     name: string;
     reducer: Reducer<State>;
 }
@@ -264,6 +256,13 @@ export interface Slice<State = any, CaseReducers extends SliceCaseReducerDefinit
 //
 // @public @deprecated
 export type SliceActionCreator<P> = PayloadActionCreator<P>;
+
+// Warning: (ae-forgotten-export) The symbol "SliceCaseReducersCheck" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type SliceCaseReducerDefinitions<State, CR> = {
+    [K: string]: CaseReducer<State, PayloadAction<any>> | CaseReducerWithPrepare<State, PayloadAction<any>>;
+} & SliceCaseReducersCheck<State, CR>;
 
 
 export * from "redux";

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -56,13 +56,6 @@ export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T e
     (...args: Args): PayloadAction<P, T, M, E>;
 }
 
-// @internal
-export type _ActionCreatorWithPreparedPayload<PA extends PrepareAction<any> | void, T extends string = string> = PA extends PrepareAction<infer P> ? ActionCreatorWithPreparedPayload<Parameters<PA>, P, T, ReturnType<PA> extends {
-    error: infer E;
-} ? E : never, ReturnType<PA> extends {
-    meta: infer M;
-} ? M : never> : void;
-
 // Warning: (ae-missing-release-tag) "ActionReducerMapBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -208,11 +201,11 @@ export type PayloadAction<P = void, T extends string = string, M = never, E = ne
 });
 
 // Warning: (ae-forgotten-export) The symbol "IfPrepareActionMethodProvided" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "_ActionCreatorWithPreparedPayload" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IsUnknownOrNonInferrable" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IfVoid" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IfMaybeUndefined" needs to be exported by the entry point index.d.ts
-// Warning: (ae-incompatible-release-tags) The symbol "PayloadActionCreator" is marked as @public, but its signature references "_ActionCreatorWithPreparedPayload" which is marked as @internal
 //
 // @public
 export type PayloadActionCreator<P = void, T extends string = string, PA extends PrepareAction<P> | void = void> = IfPrepareActionMethodProvided<PA, _ActionCreatorWithPreparedPayload<PA, T>, IsAny<P, ActionCreatorWithPayload<any, T>, IsUnknownOrNonInferrable<P, ActionCreatorWithNonInferrablePayload<T>, IfVoid<P, ActionCreatorWithoutPayload<T>, IfMaybeUndefined<P, ActionCreatorWithOptionalPayload<P, T>, ActionCreatorWithPayload<P, T>>>>>>;

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -23,12 +23,19 @@ import { getDefaultMiddleware } from './getDefaultMiddleware'
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 
+/**
+ * Callback function type, to be used in `ConfigureStoreOptions.enhancers`
+ *
+ * @public
+ */
 export type ConfigureEnhancersCallback = (
   defaultEnhancers: StoreEnhancer[]
 ) => StoreEnhancer[]
 
 /**
  * Options for `configureStore()`.
+ *
+ * @public
  */
 export interface ConfigureStoreOptions<S = any, A extends Action = AnyAction> {
   /**
@@ -78,9 +85,14 @@ export interface ConfigureStoreOptions<S = any, A extends Action = AnyAction> {
 /**
  * A Redux store returned by `configureStore()`. Supports dispatching
  * side-effectful _thunks_ in addition to plain actions.
+ *
+ * @public
  */
 export interface EnhancedStore<S = any, A extends Action = AnyAction>
   extends Store<S, A> {
+  /**
+   * @inheritdoc
+   */
   dispatch: ThunkDispatch<S, any, A>
 }
 
@@ -89,6 +101,8 @@ export interface EnhancedStore<S = any, A extends Action = AnyAction>
  *
  * @param config The store configuration.
  * @returns A configured Redux store.
+ *
+ * @public
  */
 export function configureStore<S = any, A extends Action = AnyAction>(
   options: ConfigureStoreOptions<S, A>

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -77,6 +77,8 @@ export type _ActionCreatorWithPreparedPayload<
 
 /**
  * Basic type for all action creators.
+ *
+ * @inheritdoc {redux#ActionCreator}
  */
 interface BaseActionCreator<P, T extends string, M = never, E = never> {
   type: T
@@ -84,12 +86,15 @@ interface BaseActionCreator<P, T extends string, M = never, E = never> {
 }
 
 /**
- * An action creator that takes multiple arguments that are passed to a `PrepareAction` method to create the final Action.
+ * An action creator that takes multiple arguments that are passed
+ * to a `PrepareAction` method to create the final Action.
  * @typeParam Args arguments for the action creator function
  * @typeParam P `payload` type
  * @typeParam T `type` name
  * @typeParam E optional `error` type
  * @typeParam M optional `meta` type
+ *
+ * @inheritdoc {redux#ActionCreator}
  *
  * @public
  */
@@ -100,49 +105,88 @@ export interface ActionCreatorWithPreparedPayload<
   E = never,
   M = never
 > extends BaseActionCreator<P, T, M, E> {
+  /**
+   * Calling this {@link redux#ActionCreator} with `Args` will return
+   * an Action with a payload of type `P` and (depending on the `PrepareAction`
+   * method used) a `meta`- and `error` property of types `M` and `E` respectively.
+   */
   (...args: Args): PayloadAction<P, T, M, E>
 }
 
 /**
  * An action creator of type `T` that takes an optional payload of type `P`.
  *
+ * @inheritdoc {redux#ActionCreator}
+ *
  * @public
  */
 export interface ActionCreatorWithOptionalPayload<P, T extends string = string>
   extends BaseActionCreator<P, T> {
+  /**
+   * Calling this {@link redux#ActionCreator} without arguments will
+   * return a {@link PayloadAction} of type `T` with a payload of `undefined`
+   */
   (payload?: undefined): PayloadAction<undefined, T>
+  /**
+   * Calling this {@link redux#ActionCreator} with an argument will
+   * return a {@link PayloadAction} of type `T` with a payload of `P`
+   */
   <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
 }
 
 /**
  * An action creator of type `T` that takes no payload.
  *
+ * @inheritdoc {redux#ActionCreator}
+ *
  * @public
  */
 export interface ActionCreatorWithoutPayload<T extends string = string>
   extends BaseActionCreator<undefined, T> {
+  /**
+   * Calling this {@link redux#ActionCreator} will
+   * return a {@link PayloadAction} of type `T` with a payload of `undefined`
+   */
   (): PayloadAction<undefined, T>
 }
 
 /**
  * An action creator of type `T` that requires a payload of type P.
  *
+ * @inheritdoc {redux#ActionCreator}
+ *
  * @public
  */
 export interface ActionCreatorWithPayload<P, T extends string = string>
   extends BaseActionCreator<P, T> {
+  /**
+   * Calling this {@link redux#ActionCreator} with an argument will
+   * return a {@link PayloadAction} of type `T` with a payload of `P`
+   * If possible, `P` will be narrowed down to the exact type of the payload argument.
+   */
   <PT extends P>(payload: PT): PayloadAction<PT, T>
+  /**
+   * Calling this {@link redux#ActionCreator} with an argument will
+   * return a {@link PayloadAction} of type `T` with a payload of `P`
+   */
   (payload: P): PayloadAction<P, T>
 }
 
 /**
  * An action creator of type `T` whose `payload` type could not be inferred. Accepts everything as `payload`.
  *
+ * @inheritdoc {redux#ActionCreator}
+ *
  * @public
  */
 export interface ActionCreatorWithNonInferrablePayload<
   T extends string = string
 > extends BaseActionCreator<unknown, T> {
+  /**
+   * Calling this {@link redux#ActionCreator} with an argument will
+   * return a {@link PayloadAction} of type `T` with a payload
+   * of exactly the type of the argument.
+   */
   <PT extends unknown>(payload: PT): PayloadAction<PT, T>
 }
 
@@ -195,12 +239,26 @@ export type PayloadActionCreator<
  * @param type The action type to use for created actions.
  * @param prepare (optional) a method that takes any number of arguments and returns { payload } or { payload, meta }.
  *                If this is given, the resulting action creator will pass it's arguments to this method to calculate payload & meta.
+ *
+ * @public
  */
-
 export function createAction<P = void, T extends string = string>(
   type: T
 ): PayloadActionCreator<P, T>
 
+/**
+ * A utility function to create an action creator for the given action type
+ * string. The action creator accepts a single argument, which will be included
+ * in the action object as a field called payload. The action creator function
+ * will also have its toString() overriden so that it returns the action type,
+ * allowing it to be used in reducer logic that is looking for that action type.
+ *
+ * @param type The action type to use for created actions.
+ * @param prepare (optional) a method that takes any number of arguments and returns { payload } or { payload, meta }.
+ *                If this is given, the resulting action creator will pass it's arguments to this method to calculate payload & meta.
+ *
+ * @public
+ */
 export function createAction<
   PA extends PrepareAction<any>,
   T extends string = string
@@ -244,6 +302,8 @@ export function createAction(type: string, prepareAction?: Function): any {
  *
  * @param action The action creator whose action type to get.
  * @returns The action type used by the action creator.
+ *
+ * @public
  */
 export function getType<T extends string>(
   actionCreator: PayloadActionCreator<any, T>

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -14,6 +14,8 @@ import {
  * @template T the type used for the action type.
  * @template M The type of the action's meta (optional)
  * @template E The type of the action's error (optional)
+ *
+ * @public
  */
 export type PayloadAction<
   P = void,
@@ -34,12 +36,24 @@ export type PayloadAction<
         error: E
       })
 
+/**
+ * A "prepare" method to be used as the second parameter of `createAction`.
+ * Takes any number of arguments and returns a Flux Standard Action without
+ * type (will be added later) that *must* contain a payload (might be undefined).
+ *
+ * @public
+ */
 export type PrepareAction<P> =
   | ((...args: any[]) => { payload: P })
   | ((...args: any[]) => { payload: P; meta: any })
   | ((...args: any[]) => { payload: P; error: any })
   | ((...args: any[]) => { payload: P; meta: any; error: any })
 
+/**
+ * Internal version of `ActionCreatorWithPreparedPayload`. Not to be used externally.
+ *
+ * @internal
+ */
 export type _ActionCreatorWithPreparedPayload<
   PA extends PrepareAction<any> | void,
   T extends string = string
@@ -61,11 +75,24 @@ export type _ActionCreatorWithPreparedPayload<
     >
   : void
 
+/**
+ * Basic type for all action creators.
+ */
 interface BaseActionCreator<P, T extends string, M = never, E = never> {
   type: T
   match(action: Action<unknown>): action is PayloadAction<P, T, M, E>
 }
 
+/**
+ * An action creator that takes multiple arguments that are passed to a `PrepareAction` method to create the final Action.
+ * @typeParam Args arguments for the action creator function
+ * @typeParam P `payload` type
+ * @typeParam T `type` name
+ * @typeParam E optional `error` type
+ * @typeParam M optional `meta` type
+ *
+ * @public
+ */
 export interface ActionCreatorWithPreparedPayload<
   Args extends unknown[],
   P,
@@ -76,23 +103,43 @@ export interface ActionCreatorWithPreparedPayload<
   (...args: Args): PayloadAction<P, T, M, E>
 }
 
+/**
+ * An action creator of type `T` that takes an optional payload of type `P`.
+ *
+ * @public
+ */
 export interface ActionCreatorWithOptionalPayload<P, T extends string = string>
   extends BaseActionCreator<P, T> {
   (payload?: undefined): PayloadAction<undefined, T>
   <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
 }
 
+/**
+ * An action creator of type `T` that takes no payload.
+ *
+ * @public
+ */
 export interface ActionCreatorWithoutPayload<T extends string = string>
   extends BaseActionCreator<undefined, T> {
   (): PayloadAction<undefined, T>
 }
 
+/**
+ * An action creator of type `T` that requires a payload of type P.
+ *
+ * @public
+ */
 export interface ActionCreatorWithPayload<P, T extends string = string>
   extends BaseActionCreator<P, T> {
   <PT extends P>(payload: PT): PayloadAction<PT, T>
   (payload: P): PayloadAction<P, T>
 }
 
+/**
+ * An action creator of type `T` whose `payload` type could not be inferred. Accepts everything as `payload`.
+ *
+ * @public
+ */
 export interface ActionCreatorWithNonInferrablePayload<
   T extends string = string
 > extends BaseActionCreator<unknown, T> {
@@ -101,6 +148,12 @@ export interface ActionCreatorWithNonInferrablePayload<
 
 /**
  * An action creator that produces actions with a `payload` attribute.
+ *
+ * @typeParam P the `payload` type
+ * @typeParam T the `type` of the resulting action
+ * @typeParam PA if the resulting action is preprocessed by a `prepare` method, the signature of said method.
+ *
+ * @public
  */
 export type PayloadActionCreator<
   P = void,

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -1,5 +1,10 @@
 import { Action } from 'redux'
-import { IsUnknownOrNonInferrable, IfMaybeUndefined, IfVoid } from './tsHelpers'
+import {
+  IsUnknownOrNonInferrable,
+  IfMaybeUndefined,
+  IfVoid,
+  IsAny
+} from './tsHelpers'
 
 /**
  * An action with a string type and an associated payload. This is the
@@ -105,19 +110,23 @@ export type PayloadActionCreator<
   PA,
   _ActionCreatorWithPreparedPayload<PA, T>,
   // else
-  IsUnknownOrNonInferrable<
+  IsAny<
     P,
-    ActionCreatorWithNonInferrablePayload<T>,
-    // else
-    IfVoid<
+    ActionCreatorWithPayload<any, T>,
+    IsUnknownOrNonInferrable<
       P,
-      ActionCreatorWithoutPayload<T>,
+      ActionCreatorWithNonInferrablePayload<T>,
       // else
-      IfMaybeUndefined<
+      IfVoid<
         P,
-        ActionCreatorWithOptionalPayload<P, T>,
+        ActionCreatorWithoutPayload<T>,
         // else
-        ActionCreatorWithPayload<P, T>
+        IfMaybeUndefined<
+          P,
+          ActionCreatorWithOptionalPayload<P, T>,
+          // else
+          ActionCreatorWithPayload<P, T>
+        >
       >
     >
   >

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -7,6 +7,11 @@ import {
 
 /**
  * Defines a mapping from action types to corresponding action object shapes.
+ *
+ * @deprecated This should not be used manually - it is only used for internal
+ *             interference purposes and should not have any further value.
+ *             It might be removed in the future.
+ * @public
  */
 export type Actions<T extends keyof any = string> = Record<T, Action>
 
@@ -23,6 +28,8 @@ export type Actions<T extends keyof any = string> = Record<T, Action>
  * cause the store state to be mutated directly; instead, thanks to
  * [immer](https://github.com/mweststrate/immer), the mutations are
  * translated to copy operations that result in a new state.
+ *
+ * @public
  */
 export type CaseReducer<S = any, A extends Action = AnyAction> = (
   state: Draft<S>,
@@ -31,6 +38,12 @@ export type CaseReducer<S = any, A extends Action = AnyAction> = (
 
 /**
  * A mapping from action types to case reducers for `createReducer()`.
+ *
+ * @deprecated This should not be used manually - it is only used
+ *             for internal interference purposes and using it manually
+ *             would lead to type erasure.
+ *             It might be removed in the future.
+ * @public
  */
 export type CaseReducers<S, AS extends Actions> = {
   [T in keyof AS]: AS[T] extends Action ? CaseReducer<S, AS[T]> : void
@@ -51,6 +64,8 @@ export type CaseReducers<S, AS extends Actions> = {
  * @param initialState The initial state to be returned by the reducer.
  * @param actionsMap A mapping from action types to action-type-specific
  *   case reducers.
+ *
+ * @public
  */
 export function createReducer<
   S,
@@ -70,6 +85,8 @@ export function createReducer<
  * @param initialState The initial state to be returned by the reducer.
  * @param builderCallback A callback that receives a *builder* object to define
  *   case reducers via calls to `builder.addCase(actionCreatorOrType, reducer)`.
+ *
+ * @public
  */
 export function createReducer<S>(
   initialState: S,

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -9,7 +9,7 @@ import {
  * Defines a mapping from action types to corresponding action object shapes.
  *
  * @deprecated This should not be used manually - it is only used for internal
- *             interference purposes and should not have any further value.
+ *             inference purposes and should not have any further value.
  *             It might be removed in the future.
  * @public
  */
@@ -40,7 +40,7 @@ export type CaseReducer<S = any, A extends Action = AnyAction> = (
  * A mapping from action types to case reducers for `createReducer()`.
  *
  * @deprecated This should not be used manually - it is only used
- *             for internal interference purposes and using it manually
+ *             for internal inference purposes and using it manually
  *             would lead to type erasure.
  *             It might be removed in the future.
  * @public

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -103,8 +103,6 @@ export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
 
 /**
  * The type describing a slice's `reducers` option.
- * Also checks itself, so it has to be passed "itself" as it's second option.
- * See the method signature of `createSlice`.
  *
  * @public
  */
@@ -172,9 +170,11 @@ type SliceDefinedCaseReducers<CaseReducers extends SliceCaseReducers<any>> = {
 type NoInfer<T> = [T][T extends any ? 0 : never]
 
 /**
- * Used on a `reducers` object.
+ * Used on a SliceCaseReducers object.
  * Ensures that if a CaseReducer is a `CaseReducerWithPrepare`, that
  * the `reducer` and the `prepare` function use the same type of `payload`.
+ *
+ * Might do additional such checks in the future.
  *
  * This type is only ever useful if you want to write your own wrapper around
  * `createSlice`. Please don't use it otherwise!

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -48,7 +48,7 @@ export interface Slice<
   actions: CaseReducerActions<CaseReducers>
 
   /**
-   * The individual case reducer functions that were passed in the `reducers` parameter.  
+   * The individual case reducer functions that were passed in the `reducers` parameter.
    * This enables reuse and testing if they were defined inline when calling `createSlice`.
    */
   caseReducers: SliceDefinedCaseReducers<CaseReducers>

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -22,6 +22,8 @@ export type SliceActionCreator<P> = PayloadActionCreator<P>
 
 /**
  * The return value of `createSlice`
+ *
+ * @public
  */
 export interface Slice<
   State = any,
@@ -53,6 +55,8 @@ export interface Slice<
 
 /**
  * Options for `createSlice()`.
+ *
+ * @public
  */
 export interface CreateSliceOptions<
   State = any,
@@ -92,6 +96,8 @@ export interface CreateSliceOptions<
 
 /**
  * A CaseReducer with a `prepare` method.
+ *
+ * @public
  */
 export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
   reducer: CaseReducer<State, Action>
@@ -102,6 +108,8 @@ export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
  * The type describing a slice's `reducers` option.
  * Also checks itself, so it has to be passed "itself" as it's second option.
  * See the method signature of `createSlice`.
+ *
+ * @public
  */
 export type SliceCaseReducerDefinitions<State, CR> = {
   [K: string]:
@@ -111,6 +119,8 @@ export type SliceCaseReducerDefinitions<State, CR> = {
 
 /**
  * Derives the slice's `actions` property from the `reducers` options
+ *
+ * @public
  */
 export type CaseReducerActions<
   CaseReducers extends SliceCaseReducerDefinitions<any, any>
@@ -122,6 +132,8 @@ export type CaseReducerActions<
 
 /**
  * Get a `PayloadActionCreator` type for a passed `CaseReducerWithPrepare`
+ *
+ * @internal
  */
 type ActionCreatorForCaseReducerWithPrepare<
   CR extends { prepare: any }
@@ -129,6 +141,8 @@ type ActionCreatorForCaseReducerWithPrepare<
 
 /**
  * Get a `PayloadActionCreator` type for a passed `CaseReducer`
+ *
+ * @internal
  */
 type ActionCreatorForCaseReducer<CR> = CR extends (
   state: any,
@@ -142,6 +156,8 @@ type ActionCreatorForCaseReducer<CR> = CR extends (
 /**
  * Extracts the CaseReducers out of a `reducers` object, even if they are
  * tested into a `CaseReducerWithPrepare`.
+ *
+ * @internal
  */
 type SliceDefinedCaseReducers<
   CaseReducers extends SliceCaseReducerDefinitions<any, any>
@@ -157,6 +173,8 @@ type SliceDefinedCaseReducers<
  * Helper type. Passes T out again, but boxes it in a way that it cannot
  * "widen" the type by accident if it is a generic that should be inferred
  * from elsewhere.
+ *
+ * @internal
  */
 type NoInfer<T> = [T][T extends any ? 0 : never]
 
@@ -164,6 +182,8 @@ type NoInfer<T> = [T][T extends any ? 0 : never]
  * Used on a `reducers` object.
  * Ensures that if a CaseReducer is a `CaseReducerWithPrepare`, that
  * the `reducer` and the `prepare` function use the same type of `payload`.
+ *
+ * @internal
  */
 type SliceCaseReducersCheck<S, ACR> = {
   [P in keyof ACR]: ACR[P] extends {

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -42,7 +42,10 @@ export interface Slice<
    */
   actions: CaseReducerActions<CaseReducers>
 
-  caseReducers: SliceDefinedCaseReducers<CaseReducers, State>
+  /**
+   * The reducers defined by `reducers` for easy access if they were defined inline when calling createSlice.
+   */
+  caseReducers: SliceDefinedCaseReducers<CaseReducers>
 }
 
 /**
@@ -89,36 +92,23 @@ type PayloadActions<Types extends keyof any = string> = Record<
   PayloadAction
 >
 
-type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
+export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
   reducer: CaseReducer<State, Action>
   prepare: PrepareAction<Action['payload']>
 }
 
-type SliceCaseReducerDefinitions<State, CR> = {
+export type SliceCaseReducerDefinitions<State, CR> = {
   [K: string]:
     | CaseReducer<State, PayloadAction<any>>
     | CaseReducerWithPrepare<State, PayloadAction<any>>
 } & SliceCaseReducersCheck<State, CR>
 
-type ActionForReducer<R, S> = R extends (
-  state: S,
-  action: PayloadAction<infer P>
-) => S
-  ? PayloadAction<P>
-  : R extends {
-      reducer(state: any, action: PayloadAction<infer P>): any
-    }
-  ? PayloadAction<P>
-  : unknown
-
-type CaseReducerActions<
+export type CaseReducerActions<
   CaseReducers extends SliceCaseReducerDefinitions<any, any>
 > = {
   [Type in keyof CaseReducers]: CaseReducers[Type] extends { prepare: any }
     ? ActionCreatorForCaseReducerWithPrepare<CaseReducers[Type]>
-    : CaseReducers[Type] extends (state: any, action: any) => any
-    ? ActionCreatorForCaseReducer<CaseReducers[Type]>
-    : never
+    : ActionCreatorForCaseReducer<CaseReducers[Type]>
 }
 
 type ActionCreatorForCaseReducerWithPrepare<
@@ -135,13 +125,13 @@ type ActionCreatorForCaseReducer<CR> = CR extends (
   : ActionCreatorWithoutPayload
 
 type SliceDefinedCaseReducers<
-  CaseReducers extends SliceCaseReducerDefinitions<any, any>,
-  State = any
+  CaseReducers extends SliceCaseReducerDefinitions<any, any>
 > = {
-  [Type in keyof CaseReducers]: CaseReducer<
-    State,
-    ActionForReducer<CaseReducers[Type], State>
-  >
+  [Type in keyof CaseReducers]: CaseReducers[Type] extends {
+    reducer: infer Reducer
+  }
+    ? Reducer
+    : CaseReducers[Type]
 }
 
 type NoInfer<T> = [T][T extends any ? 0 : never]

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -94,11 +94,29 @@ type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
   prepare: PrepareAction<Action['payload']>
 }
 
-type SliceCaseReducerDefinitions<State, PA extends PayloadActions> = {
-  [ActionType in keyof PA]:
-    | CaseReducer<State, PA[ActionType]>
-    | CaseReducerWithPrepare<State, PA[ActionType]>
-}
+createSlice({
+  name: 'asd',
+  initialState: 5,
+  reducers: {
+    x(state, _: PayloadAction<number>) {
+      return state
+    },
+    y: {
+      prepare(payload: number) {
+        return { payload }
+      },
+      reducer(state, action) {
+        return action.payload
+      }
+    }
+  }
+}).actions.x(5)
+
+type SliceCaseReducerDefinitions<State, CR> = {
+  [type: string]:
+    | CaseReducer<State, PayloadAction<any>>
+    | CaseReducerWithPrepare<State, PayloadAction<any>>
+} & SliceCaseReducersCheck<State, CR>
 
 type IfIsReducerFunctionWithoutAction<R, True, False = never> = R extends (
   state: any
@@ -172,11 +190,6 @@ type SliceCaseReducersCheck<S, ACR> = {
     : {}
 }
 
-type RestrictCaseReducerDefinitionsToMatchReducerAndPrepare<
-  S,
-  CR extends SliceCaseReducerDefinitions<S, any>
-> = { reducers: SliceCaseReducersCheck<S, NoInfer<CR>> }
-
 function getType(slice: string, actionKey: string): string {
   return `${slice}/${actionKey}`
 }
@@ -191,11 +204,8 @@ function getType(slice: string, actionKey: string): string {
  */
 export function createSlice<
   State,
-  CaseReducers extends SliceCaseReducerDefinitions<State, any>
->(
-  options: CreateSliceOptions<State, CaseReducers> &
-    RestrictCaseReducerDefinitionsToMatchReducerAndPrepare<State, CaseReducers>
-): Slice<State, CaseReducers>
+  CaseReducers extends SliceCaseReducerDefinitions<NoInfer<State>, CaseReducers>
+>(options: CreateSliceOptions<State, CaseReducers>): Slice<State, CaseReducers>
 
 // internal definition is a little less restrictive
 export function createSlice<

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -77,7 +77,7 @@ export interface CreateSliceOptions<
    * functions. For every action type, a matching action creator will be
    * generated using `createAction()`.
    */
-  reducers: CR & ValidateSliceCaseReducers<State, CR>
+  reducers: ValidateSliceCaseReducers<State, CR>
 
   /**
    * A mapping from action types to action-type-specific *case reducer*
@@ -181,15 +181,19 @@ type NoInfer<T> = [T][T extends any ? 0 : never]
  *
  * @public
  */
-export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = {
-  [P in keyof ACR]: ACR[P] extends {
-    reducer(s: S, action?: { payload: infer O }): any
+export type ValidateSliceCaseReducers<
+  S,
+  ACR extends SliceCaseReducers<S>
+> = ACR &
+  {
+    [P in keyof ACR]: ACR[P] extends {
+      reducer(s: S, action?: { payload: infer O }): any
+    }
+      ? {
+          prepare(...a: never[]): { payload: O }
+        }
+      : {}
   }
-    ? {
-        prepare(...a: never[]): { payload: O }
-      }
-    : {}
-}
 
 function getType(slice: string, actionKey: string): string {
   return `${slice}/${actionKey}`

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -48,7 +48,8 @@ export interface Slice<
   actions: CaseReducerActions<CaseReducers>
 
   /**
-   * The reducers defined by `reducers` for easy access if they were defined inline when calling createSlice.
+   * The individual case reducer functions that were passed in the `reducers` parameter.  
+   * This enables reuse and testing if they were defined inline when calling `createSlice`.
    */
   caseReducers: SliceDefinedCaseReducers<CaseReducers>
 }

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -17,6 +17,8 @@ import {
  * An action creator atttached to a slice.
  *
  * @deprecated please use PayloadActionCreator directly
+ *
+ * @public
  */
 export type SliceActionCreator<P> = PayloadActionCreator<P>
 
@@ -206,6 +208,8 @@ function getType(slice: string, actionKey: string): string {
  * reducers and state.
  *
  * The `reducer` argument is passed to `createReducer()`.
+ *
+ * @public
  */
 export function createSlice<
   State,

--- a/src/getDefaultMiddleware.ts
+++ b/src/getDefaultMiddleware.ts
@@ -34,6 +34,8 @@ interface GetDefaultMiddlewareOptions {
  * `middleware` array but still keep the default set.
  *
  * @return The default middleware used by `configureStore()`.
+ *
+ * @public
  */
 export function getDefaultMiddleware<S = any>(
   options: GetDefaultMiddlewareOptions = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,60 @@ export * from 'redux'
 export { default as createNextState } from 'immer'
 export { createSelector } from 'reselect'
 
-export * from './configureStore'
-export * from './createAction'
-export * from './createReducer'
-export * from './createSlice'
-export * from './serializableStateInvariantMiddleware'
-export * from './getDefaultMiddleware'
-export { ActionReducerMapBuilder } from './mapBuilders'
+export {
+  // js
+  configureStore,
+  // types
+  ConfigureEnhancersCallback,
+  ConfigureStoreOptions,
+  EnhancedStore
+} from './configureStore'
+export {
+  // js
+  createAction,
+  getType,
+  // types
+  PayloadAction,
+  PayloadActionCreator,
+  ActionCreatorWithNonInferrablePayload,
+  ActionCreatorWithOptionalPayload,
+  ActionCreatorWithPayload,
+  ActionCreatorWithoutPayload,
+  ActionCreatorWithPreparedPayload,
+  PrepareAction
+} from './createAction'
+export {
+  // js
+  createReducer,
+  // types
+  Actions,
+  CaseReducer,
+  CaseReducers
+} from './createReducer'
+export {
+  // js
+  createSlice,
+  // types
+  CreateSliceOptions,
+  Slice,
+  CaseReducerActions,
+  SliceCaseReducerDefinitions,
+  CaseReducerWithPrepare,
+  SliceActionCreator
+} from './createSlice'
+export {
+  // js
+  createSerializableStateInvariantMiddleware,
+  findNonSerializableValue,
+  isPlain,
+  // types
+  SerializableStateInvariantMiddlewareOptions
+} from './serializableStateInvariantMiddleware'
+export {
+  // js
+  getDefaultMiddleware
+} from './getDefaultMiddleware'
+export {
+  // types
+  ActionReducerMapBuilder
+} from './mapBuilders'

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,8 @@ export {
   CreateSliceOptions,
   Slice,
   CaseReducerActions,
-  SliceCaseReducerDefinitions,
+  SliceCaseReducers,
+  ValidateSliceCaseReducers,
   CaseReducerWithPrepare,
   SliceActionCreator
 } from './createSlice'

--- a/src/mapBuilders.ts
+++ b/src/mapBuilders.ts
@@ -8,6 +8,8 @@ export interface TypedActionCreator<Type extends string> {
 
 /**
  * A builder for an action <-> reducer map.
+ *
+ * @public
  */
 export interface ActionReducerMapBuilder<State> {
   /**

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -7,6 +7,8 @@ import { Middleware } from 'redux'
  * or `undefined`.
  *
  * @param val The value to check.
+ *
+ * @public
  */
 export function isPlain(val: any) {
   return (
@@ -25,6 +27,9 @@ interface NonSerializableValue {
   value: unknown
 }
 
+/**
+ * @public
+ */
 export function findNonSerializableValue(
   value: unknown,
   path: ReadonlyArray<string> = [],
@@ -75,6 +80,8 @@ export function findNonSerializableValue(
 
 /**
  * Options for `createSerializableStateInvariantMiddleware()`.
+ *
+ * @public
  */
 export interface SerializableStateInvariantMiddlewareOptions {
   /**
@@ -102,6 +109,8 @@ export interface SerializableStateInvariantMiddlewareOptions {
  * state, an error is printed to the console.
  *
  * @param options Middleware options.
+ *
+ * @public
  */
 export function createSerializableStateInvariantMiddleware(
   options: SerializableStateInvariantMiddlewareOptions = {}

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -1,21 +1,38 @@
-// taken from https://github.com/joonhocho/tsdef
-// return True if T is `any`, otherwise return False
+/**
+ * return True if T is `any`, otherwise return False
+ * taken from https://github.com/joonhocho/tsdef
+ *
+ * @internal
+ */
 export type IsAny<T, True, False = never> =
   // test if we are going the left AND right path in the condition
   true | false extends (T extends never ? true : false) ? True : False
 
-// taken from https://github.com/joonhocho/tsdef
-// return True if T is `unknown`, otherwise return False
+/**
+ * return True if T is `unknown`, otherwise return False
+ * taken from https://github.com/joonhocho/tsdef
+ *
+ * @internal
+ */
 export type IsUnknown<T, True, False = never> = unknown extends T
   ? IsAny<T, False, True>
   : False
 
+/**
+ * @internal
+ */
 export type IfMaybeUndefined<P, True, False> = [undefined] extends [P]
   ? True
   : False
 
+/**
+ * @internal
+ */
 export type IfVoid<P, True, False> = [void] extends [P] ? True : False
 
+/**
+ * @internal
+ */
 export type IsEmptyObj<T, True, False = never> = T extends any
   ? keyof T extends never
     ? IsUnknown<T, False, IfMaybeUndefined<T, False, IfVoid<T, False, True>>>
@@ -27,13 +44,18 @@ export type IsEmptyObj<T, True, False = never> = T extends any
  * uses feature detection to detect TS version >= 3.5
  * * versions below 3.5 will return `{}` for unresolvable interference
  * * versions above will return `unknown`
- * */
+ *
+ * @internal
+ */
 export type AtLeastTS35<True, False> = [True, False][IsUnknown<
   ReturnType<<T>() => T>,
   0,
   1
 >]
 
+/**
+ * @internal
+ */
 export type IsUnknownOrNonInferrable<T, True, False> = AtLeastTS35<
   IsUnknown<T, True, False>,
   IsEmptyObj<T, True, IsUnknown<T, True, False>>

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -1,10 +1,8 @@
 // taken from https://github.com/joonhocho/tsdef
 // return True if T is `any`, otherwise return False
 export type IsAny<T, True, False = never> =
-  | True
-  | False extends (T extends never ? True : False)
-  ? True
-  : False
+  // test if we are going the left AND right path in the condition
+  true | false extends (T extends never ? true : false) ? True : False
 
 // taken from https://github.com/joonhocho/tsdef
 // return True if T is `unknown`, otherwise return False

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -104,9 +104,9 @@ function expectType<T>(p: T): T {
     { type: 'action' }
   ) as PayloadActionCreator<number>
 
-  const actionCreator2: ActionCreator<PayloadAction<
-    number
-  >> = payloadActionCreator2
+  const actionCreator2: ActionCreator<
+    PayloadAction<number>
+  > = payloadActionCreator2
 }
 
 /* createAction() */
@@ -342,4 +342,8 @@ function expectType<T>(p: T): T {
       meta: 3 as 3
     }))
   )
+  const anyCreator = createAction<any>('')
+  expectType<ActionCreatorWithPayload<any>>(anyCreator)
+  type AnyPayload = ReturnType<typeof anyCreator>['payload']
+  expectType<IsAny<AnyPayload, true, false>>(true)
 }

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -332,7 +332,7 @@ function expectType<T>(t: T) {
   }: {
     name: string
     initialState: GenericState<T>
-    reducers: Reducers & ValidateSliceCaseReducers<GenericState<T>, Reducers>
+    reducers: ValidateSliceCaseReducers<GenericState<T>, Reducers>
   }) => {
     return createSlice({
       name,


### PR DESCRIPTION
This is what I'm currently working on and it has already gotten a bit bigger than expected :smile: 

INCLUDED:
- [x] change signatue of `createSlice` and add new types (exported) to be used in situations like #276 and #286 :
  - `SliceCaseReducerDefinitions`
  - `CaseReducerActions`
  - `CaseReducerWithPrepare` (not really necessary to export this, but `CaseReducer` was already exported so it might not hurt to have this)
- [x] fix a bug where `PayloadActionCreator<any>` becomes `ActionCreatorWithoutPayload` which was a regression introduced in #273 (also opened https://github.com/joonhocho/tsdef/pull/4 )
- [x] type `_ActionCreatorWithPreparedPayload` is now marked `@internal` (was `ActionCreatorWithPreparedPayload` before #273, since we renamed it anyway might as well hide it completely)
- [x] `@internal` types will be stripped from the `dist/typings.d.ts` file
- [x] document ALL types
- [x] add release tags (@public or @internal) to all types
- [x] add a type test that successfully wraps `createSlice`
- [x] ~~api-extractor trims too agressively (complete removal instead of "not export") - I'll have to see if that works out. (see https://github.com/microsoft/rushstack/issues/1664 )~~ (solved by manually exporting)
- [x] fix TS 3.3
- [x] add "Wrapping createSlice" chapter to the TS docs 
- [x] add "Defining the type of your initialState"  chapter to the TS docs
