### PR TITLE
chore: add TS 3.7 to travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js: node
 env:
   - TYPESCRIPT_VERSION=rc
+  - TYPESCRIPT_VERSION=3.7
   - TYPESCRIPT_VERSION=3.6
   - TYPESCRIPT_VERSION=3.5
   - TYPESCRIPT_VERSION=3.4


### PR DESCRIPTION
And a quick one - currently CI is only running the latest RC, which is still a RC for TS 3.7, but that will soon change :)