### PR TITLE
Match code to tutorial description / tests

### DIFF
--- a/docs/tutorials/intermediate-tutorial.md
+++ b/docs/tutorials/intermediate-tutorial.md
@@ -173,7 +173,7 @@ const todosSlice = createSlice({
       state.push({ id, text, completed: false })
     },
     toggleTodo(state, action) {
-      const todo = state.find(todo => todo.id === action.payload)
+      const todo = state.find(todo => todo.id === action.payload.id)
       if (todo) {
         todo.completed = !todo.completed
       }


### PR DESCRIPTION
For `toggleTodo` reducer, the tutorial says:

> For `toggleTodo`, the only value we need is the `id` of the todo being changed. We could have made that the `payload`, but I prefer always having `payload` be an object, so I made it `action.payload.id` instead.

But the code appears to just check the payload directly:

`const todo = state.find(todo => todo.id === action.payload)`

The tests also pass in the payload as an object, so they don't pass with the code in the tutorial:

```
{
  type: toggleTodo.type,
  payload: {
    id: 1
  }
}
```