### PR TITLE
fix: UMD dev build by removing runtime usage of require statement

### DIFF
--- a/src/getDefaultMiddleware.ts
+++ b/src/getDefaultMiddleware.ts
@@ -1,8 +1,8 @@
 import { Middleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
-/* START_REMOVE_UMD */
+/* PROD_START_REMOVE_UMD */
 import createImmutableStateInvariantMiddleware from 'redux-immutable-state-invariant'
-/* STOP_REMOVE_UMD */
+/* PROD_STOP_REMOVE_UMD */
 
 import {
   createSerializableStateInvariantMiddleware,
@@ -61,9 +61,6 @@ export function getDefaultMiddleware<S = any>(
   if (process.env.NODE_ENV !== 'production') {
     if (immutableCheck) {
       /* PROD_START_REMOVE_UMD */
-
-      // UMD-ONLY: const createImmutableStateInvariantMiddleware = require('redux-immutable-state-invariant').default
-
       let immutableOptions: ImmutableStateInvariantMiddlewareOptions = {}
 
       if (!isBoolean(immutableCheck)) {
@@ -73,7 +70,6 @@ export function getDefaultMiddleware<S = any>(
       middlewareArray.unshift(
         createImmutableStateInvariantMiddleware(immutableOptions)
       )
-
       /* PROD_STOP_REMOVE_UMD */
     }
 

--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -1,6 +1,5 @@
 const { join } = require('path')
 
-const replace = require('rollup-plugin-replace')
 const stripCode = require('rollup-plugin-strip-code')
 
 const pkg = require('./package.json')
@@ -15,19 +14,6 @@ module.exports = {
       case 'umd':
         delete config.external
         config.output.indent = false
-        config.plugins.unshift(
-          replace({
-            '// UMD-ONLY: ': '',
-            delimiters: ['', '']
-          })
-        )
-        config.plugins.unshift(
-          stripCode({
-            // Remove the `import` of RISI so we use the dynamic `require()` statement
-            start_comment: 'START_REMOVE_UMD',
-            end_comment: 'STOP_REMOVE_UMD'
-          })
-        )
         if (env === 'production') {
           config.plugins.unshift(
             stripCode({


### PR DESCRIPTION
closes #297 

Thanks for your patience on this @phryneas.
I've simplified the build a little. Now it just uses the `PROD_START_REMOVE_UMD` comments throughout, and avoids a dynamic `require` statement.
The dev (unminified) UMD bundle is a few KB bigger, but the production one hasn't changed.