### PR TITLE
Add ignoredPaths option to ignore serializability check

### DIFF
--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -15,7 +15,26 @@ Redux Toolkit exports some of its internal utilities, and re-exports additional 
 
 Creates an instance of the `serializable-state-invariant` middleware described in [`getDefaultMiddleware`](./getDefaultMiddleware.md).
 
-Accepts an options object with `isSerializable` and `getEntries` parameters. The former, `isSerializable`, will be used to determine if a value is considered serializable or not. If not provided, this defaults to `isPlain`. The latter, `getEntries`, will be used to retrieve nested values. If not provided, `Object.entries` will be used by default.
+Accepts a single configuration object parameter, with the following options:
+
+```ts
+function createSerializableStateInvariantMiddleware({
+  // The function to check if a value is considered serializable.
+  // This function is applied recursively to every value contained in the state.
+  // Defaults to `isPlain()`.
+  isSerializable?: (value: any) => boolean
+  // The function that will be used to retrieve entries from each value.
+  // If unspecified, `Object.entries` will be used.
+  // Defaults to `undefined`.
+  getEntries?: (value: any) => [string, any][]
+  // An array of action types to ignore when checking for serializability.
+  // Defaults to []
+  ignoredActions?: string[]
+  // An array of dot-separated path strings to ignore when checking for serializability.
+  // Defaults to []
+  ignoredPaths?: string[]
+})
+```
 
 Example:
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -130,7 +130,7 @@ export interface EnhancedStore<S = any, A extends Action = AnyAction, M extends 
 }
 
 // @public (undocumented)
-export function findNonSerializableValue(value: unknown, path?: ReadonlyArray<string>, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][], ignoredSlices?: string[]): NonSerializableValue | false;
+export function findNonSerializableValue(value: unknown, path?: ReadonlyArray<string>, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][], ignoredPaths?: string[]): NonSerializableValue | false;
 
 // @public
 export function getDefaultMiddleware<S = any, O extends Partial<GetDefaultMiddlewareOptions> = {
@@ -177,7 +177,7 @@ export type PrepareAction<P> = ((...args: any[]) => {
 export interface SerializableStateInvariantMiddlewareOptions {
     getEntries?: (value: any) => [string, any][];
     ignoredActions?: string[];
-    ignoredSlices?: string[];
+    ignoredPaths?: string[];
     isSerializable?: (value: any) => boolean;
 }
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -130,7 +130,7 @@ export interface EnhancedStore<S = any, A extends Action = AnyAction, M extends 
 }
 
 // @public (undocumented)
-export function findNonSerializableValue(value: unknown, path?: ReadonlyArray<string>, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][]): NonSerializableValue | false;
+export function findNonSerializableValue(value: unknown, path?: ReadonlyArray<string>, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][], ignoredSlices?: string[]): NonSerializableValue | false;
 
 // @public
 export function getDefaultMiddleware<S = any, O extends Partial<GetDefaultMiddlewareOptions> = {
@@ -177,6 +177,7 @@ export type PrepareAction<P> = ((...args: any[]) => {
 export interface SerializableStateInvariantMiddlewareOptions {
     getEntries?: (value: any) => [string, any][];
     ignoredActions?: string[];
+    ignoredSlices?: string[];
     isSerializable?: (value: any) => boolean;
 }
 

--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -329,4 +329,44 @@ describe('serializableStateInvariantMiddleware', () => {
 
     expect(numTimesCalled).toBeGreaterThan(0)
   })
+
+  it('should not check serializability for ignored slice names', () => {
+    const ACTION_TYPE = 'TEST_ACTION'
+    const SLICE_NAME = 'testSlice'
+
+    const initialState = {
+      a: 0
+    }
+
+    const badValue = new Map()
+
+    const reducer: Reducer = (state = initialState, action) => {
+      switch (action.type) {
+        case ACTION_TYPE: {
+          return {
+            a: badValue
+          }
+        }
+        default:
+          return state
+      }
+    }
+
+    const serializableStateInvariantMiddleware = createSerializableStateInvariantMiddleware(
+      {
+        ignoredSlices: [SLICE_NAME]
+      }
+    )
+
+    const store = configureStore({
+      reducer: {
+        [SLICE_NAME]: reducer
+      },
+      middleware: [serializableStateInvariantMiddleware]
+    })
+
+    store.dispatch({ type: ACTION_TYPE })
+
+    expect(getLog().log).toBe('')
+  })
 })

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -52,10 +52,12 @@ export function findNonSerializableValue(
 
   const entries = getEntries != null ? getEntries(value) : Object.entries(value)
 
+  const hasIgnoredPaths = ignoredPaths.length > 0
+
   for (const [property, nestedValue] of entries) {
     const nestedPath = path.concat(property)
 
-    if (ignoredPaths.indexOf(nestedPath.join('.')) >= 0) {
+    if (hasIgnoredPaths && ignoredPaths.indexOf(nestedPath.join('.')) >= 0) {
       continue
     }
 

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -39,7 +39,7 @@ export function findNonSerializableValue(
 ): NonSerializableValue | false {
   let foundNestedSerializable: NonSerializableValue | false
 
-  if (path.length && ignoredSlices.includes(path[0])) {
+  if (ignoredSlices.includes(path[0])) {
     return false
   }
 


### PR DESCRIPTION
Fix #319

Add a new option to `createSerializableStateInvariantMiddleware` called `ignoredPaths`. It accepts an array of dot-separated path strings to be ignored when checking for serializability in state.

```js
const serializableStateInvariantMiddleware = createSerializableStateInvariantMiddleware(
  {
    ignoredPaths: ["testSlice.a", "testSlice.b.c"]
  }
);
```
