### PR TITLE
fix(int-tutorial): adds a link for jsconfig.json

### DIFF
--- a/docs/tutorials/intermediate-tutorial.md
+++ b/docs/tutorials/intermediate-tutorial.md
@@ -39,7 +39,7 @@ On the one hand, this is a small example app. It's meant to illustrate the basic
 
 ### Adding Redux Toolkit to the Project
 
-Since the original todos example is in the Redux repo, we start by copying the Redux "todos" source code to a fresh Create-React-App project, and adding Prettier to the project to help make sure the code is formatted consistently. There's also a `jsconfig.json` file to enable us to use "absolute import paths" that start from the `/src` folder.
+Since the original todos example is in the Redux repo, we start by copying the Redux "todos" source code to a fresh Create-React-App project, and adding Prettier to the project to help make sure the code is formatted consistently. There's also a [jsconfig.json](https://code.visualstudio.com/docs/languages/jsconfig) file to enable us to use "absolute import paths" that start from the `/src` folder.
 
 > - [Initial commit](https://github.com/reduxjs/rtk-convert-todos-example/commit/a8e0a9a9d77b9dcd9e881079e7cca449084ca7b1).
 > - [Add jsconfig.json to support absolute imports](https://github.com/reduxjs/rtk-convert-todos-example/commit/b866e205b9ebece84367f11d2faabc557bd08e23)


### PR DESCRIPTION
I saw a reference to `jsconfig.json` for the first time (though I am familiar with tsconfig.json) and it was a bit confusing what reads that config. Adding link to documentation will definitely help all subsequent readers with that same "gap" in knowledge :)