### PR TITLE
docs: Fix indent

### DIFF
--- a/docs/tutorials/advanced-tutorial.md
+++ b/docs/tutorials/advanced-tutorial.md
@@ -261,9 +261,9 @@ The main type you will use when declaring action types in reducers is **`Payload
 Let's look at a specific reducer as an example:
 
 ```ts
-    setCurrentPage(state, action: PayloadAction<number>) {
-      state.page = action.payload
-    },
+setCurrentPage(state, action: PayloadAction<number>) {
+    state.page = action.payload
+},
 ```
 
 We don't have to declare a type for `state`, because `createSlice` already knows that this should be the same type as our `initialState`: the `CurrentDisplayState` type.


### PR DESCRIPTION
Hey,

[This example](https://redux-toolkit.js.org/tutorials/advanced-tutorial/#declaring-types-for-slice-state-and-actions) looks buggy now. 
![Screenshot 2020-01-30 at 13 32 57](https://user-images.githubusercontent.com/3923527/73442108-3e0cb700-4365-11ea-869a-d8498a76cafb.png)

A simple fix here.