### PR TITLE
Correct npm instructions in Intermediate Tutorial

### DIFF
--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -39,7 +39,7 @@ Redux Toolkit is available as a package on NPM for use with a module bundler or 
 
 ```bash
 # NPM
-npm install --save @reduxjs/toolkit
+npm install @reduxjs/toolkit
 
 # Yarn
 yarn add @reduxjs/toolkit


### PR DESCRIPTION
This makes the `npm install` command in the [Intermediate Tutorial](https://redux-toolkit.js.org/tutorials/intermediate-tutorial) match the one in the [Quick Start](https://redux-toolkit.js.org/introduction/quick-start).