### PR TITLE
correctly enforce meta and error types as returned from `prepare`

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -194,21 +194,21 @@ export type SliceActionCreator<P> = PayloadActionCreator<P>;
 
 // @public
 export type SliceCaseReducers<State> = {
-    [K: string]: CaseReducer<State, PayloadAction<any>> | CaseReducerWithPrepare<State, PayloadAction<any>>;
+    [K: string]: CaseReducer<State, PayloadAction<any>> | CaseReducerWithPrepare<State, PayloadAction<any, string, any, any>>;
 };
 
 export { ThunkAction }
 
 // @public
 export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = ACR & {
-    [P in keyof ACR]: ACR[P] extends {
-        reducer(s: S, action?: {
-            payload: infer O;
-        }): any;
-    } ? {
+    [T in keyof ACR]: ACR[T] extends {
         prepare(...a: never[]): {
-            payload: O;
+            payload: infer P;
+            meta?: infer M;
+            error?: infer E;
         };
+    } ? {
+        reducer(s: S, action: PayloadAction<P, string, M, E>): any;
     } : {};
 };
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -202,13 +202,9 @@ export { ThunkAction }
 // @public
 export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = ACR & {
     [T in keyof ACR]: ACR[T] extends {
-        prepare(...a: never[]): {
-            payload: infer P;
-            meta?: infer M;
-            error?: infer E;
-        };
+        reducer(s: S, action?: infer A): any;
     } ? {
-        reducer(s: S, action: PayloadAction<P, string, M, E>): any;
+        prepare(...a: never[]): Omit<A, 'type'>;
     } : {};
 };
 

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -110,7 +110,7 @@ export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
 export type SliceCaseReducers<State> = {
   [K: string]:
     | CaseReducer<State, PayloadAction<any>>
-    | CaseReducerWithPrepare<State, PayloadAction<any>>
+    | CaseReducerWithPrepare<State, PayloadAction<any, string, any, any>>
 }
 
 /**
@@ -187,11 +187,13 @@ export type ValidateSliceCaseReducers<
   ACR extends SliceCaseReducers<S>
 > = ACR &
   {
-    [P in keyof ACR]: ACR[P] extends {
-      reducer(s: S, action?: { payload: infer O }): any
+    [T in keyof ACR]: ACR[T] extends {
+      prepare(
+        ...a: never[]
+      ): { payload: infer P; meta?: infer M; error?: infer E }
     }
       ? {
-          prepare(...a: never[]): { payload: O }
+          reducer(s: S, action: PayloadAction<P, string, M, E>): any
         }
       : {}
   }

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -12,6 +12,7 @@ import {
   ActionReducerMapBuilder,
   executeReducerBuilderCallback
 } from './mapBuilders'
+import { Omit } from './tsHelpers'
 
 /**
  * An action creator atttached to a slice.
@@ -188,12 +189,10 @@ export type ValidateSliceCaseReducers<
 > = ACR &
   {
     [T in keyof ACR]: ACR[T] extends {
-      prepare(
-        ...a: never[]
-      ): { payload: infer P; meta?: infer M; error?: infer E }
+      reducer(s: S, action?: infer A): any
     }
       ? {
-          reducer(s: S, action: PayloadAction<P, string, M, E>): any
+          prepare(...a: never[]): Omit<A, 'type'>
         }
       : {}
   }

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -87,3 +87,5 @@ type UnionToIntersection<U> = (U extends any
   : never) extends ((k: infer I) => void)
   ? I
   : never
+
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -175,6 +175,65 @@ function expectType<T>(t: T) {
   expectType<string>(counter.actions.concatMetaStrLen('test').meta)
 }
 
+/**
+ * Test: access meta and error from reducer
+ */
+{
+  const counter = createSlice({
+    name: 'test',
+    initialState: { counter: 0, concat: '' },
+    reducers: {
+      // case: meta and error not used in reducer
+      testDefaultMetaAndError: {
+        reducer(_, action: PayloadAction<number, string>) {},
+        prepare: (payload: number) => ({
+          payload,
+          meta: 'meta' as 'meta',
+          error: 'error' as 'error'
+        })
+      },
+      // case: meta and error marked as "unknown" in reducer
+      testUnknownMetaAndError: {
+        reducer(_, action: PayloadAction<number, string, unknown, unknown>) {},
+        prepare: (payload: number) => ({
+          payload,
+          meta: 'meta' as 'meta',
+          error: 'error' as 'error'
+        })
+      },
+      // case: meta and error are typed in the reducer as returned by prepare
+      testMetaAndError: {
+        reducer(_, action: PayloadAction<number, string, 'meta', 'error'>) {},
+        prepare: (payload: number) => ({
+          payload,
+          meta: 'meta' as 'meta',
+          error: 'error' as 'error'
+        })
+      },
+      // case: meta is typed differently in the reducer than returned from prepare
+      testErroneousMeta: {
+        // typings:expect-error
+        reducer(_, action: PayloadAction<number, string, 'meta', 'error'>) {},
+        prepare: (payload: number) => ({
+          payload,
+          meta: 1,
+          error: 'error' as 'error'
+        })
+      },
+      // case: error is typed differently in the reducer than returned from prepare
+      testErroneousError: {
+        // typings:expect-error
+        reducer(_, action: PayloadAction<number, string, 'meta', 'error'>) {},
+        prepare: (payload: number) => ({
+          payload,
+          meta: 'meta' as 'meta',
+          error: 1
+        })
+      }
+    }
+  })
+}
+
 /*
  * Test: returned case reducer has the correct type
  */

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -70,7 +70,7 @@ function expectType<T>(t: T) {
           ? payload.reduce((acc, val) => acc * val, state)
           : state * payload,
       addTwo: {
-        reducer: (s, { payload }) => s + payload,
+        reducer: (s, { payload }: PayloadAction<number>) => s + payload,
         prepare: (a: number, b: number) => ({
           payload: a + b
         })
@@ -212,8 +212,8 @@ function expectType<T>(t: T) {
       },
       // case: meta is typed differently in the reducer than returned from prepare
       testErroneousMeta: {
-        // typings:expect-error
         reducer(_, action: PayloadAction<number, string, 'meta', 'error'>) {},
+        // typings:expect-error
         prepare: (payload: number) => ({
           payload,
           meta: 1,
@@ -222,8 +222,8 @@ function expectType<T>(t: T) {
       },
       // case: error is typed differently in the reducer than returned from prepare
       testErroneousError: {
-        // typings:expect-error
         reducer(_, action: PayloadAction<number, string, 'meta', 'error'>) {},
+        // typings:expect-error
         prepare: (payload: number) => ({
           payload,
           meta: 'meta' as 'meta',


### PR DESCRIPTION
This fixes an error where `meta` and `error` could not be typed when using the `prepare` notation of `createSlice`.