### PR TITLE
Add optional thunk configuration object

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -102,7 +102,7 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @alpha (undocumented)
-export function createAsyncThunk<ActionType extends string, Returned, ActionParams = void, TA extends AsyncThunksArgs<any, any, any> = AsyncThunksArgs<unknown, unknown, Dispatch>>(type: ActionType, payloadCreator: (args: ActionParams, thunkArgs: TA) => Promise<Returned> | Returned): {
+export function createAsyncThunk<ActionType extends string | ThunkActionCreatorConfig, Returned, ActionParams = void, TA extends AsyncThunksArgs<any, any, any> = AsyncThunksArgs<unknown, unknown, Dispatch>>(config: ActionType, payloadCreator: (args: ActionParams, thunkArgs: TA) => Promise<Returned> | Returned): {
     (args: ActionParams): (dispatch: TA["dispatch"], getState: TA["getState"], extra: TA["extra"]) => Promise<any>;
     pending: import("./createAction").ActionCreatorWithPreparedPayload<[string, ActionParams], undefined, string, never, {
         args: ActionParams;

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -11,6 +11,46 @@ describe('createAsyncThunk', () => {
     expect(thunkActionCreator.rejected.type).toBe('testType/rejected')
   })
 
+  it('should accept a config object', () => {
+    const thunkActionCreator = createAsyncThunk(
+      { type: 'testType' },
+      async () => 42
+    )
+
+    expect(thunkActionCreator.fulfilled.type).toBe('testType/fulfilled')
+    expect(thunkActionCreator.pending.type).toBe('testType/pending')
+    expect(thunkActionCreator.finished.type).toBe('testType/finished')
+    expect(thunkActionCreator.rejected.type).toBe('testType/rejected')
+  })
+
+  it('should rethrow error', async () => {
+    const dispatch = jest.fn()
+
+    const args = 123
+    let generatedRequestId = ''
+
+    const error = new Error('Panic!')
+
+    const thunkActionCreator = createAsyncThunk(
+      { type: 'testType', rethrow: true },
+      async (args: number, { requestId }) => {
+        generatedRequestId = requestId
+        throw error
+      }
+    )
+
+    const thunkFunction = thunkActionCreator(args)
+
+    await expect(thunkFunction(dispatch, undefined, undefined)).rejects.toThrow(
+      error
+    )
+
+    expect(dispatch).toHaveBeenNthCalledWith(
+      2,
+      thunkActionCreator.rejected(error, generatedRequestId, args)
+    )
+  })
+
   it('works without passing arguments to the payload creator', async () => {
     const thunkActionCreator = createAsyncThunk('testType', async () => 42)
 


### PR DESCRIPTION
I sometimes find it useful to catch and respond to errors when dispatching Thunk. Maybe I'm thinking about this incorrectly? I suppose you could argue that createAsyncThunk just isn't the tool for this use case, but the effort to accomodate the feature was minimal and I think it's useful.

This PR introduces using a config object, instead of a string, for the action. The config objects only property currently is whether or not to rethrow an error. A string type can still be used for simple use cases. 

- User can specify a simple string for type or a config object.
- Config can choose to rethrow an error.
- Other possible use cases;
  - Prime result function to transform result before return.
  - Prime error function to transform error before return.