### PR TITLE
createAsyncThunk return fulfilled/rejected action instead of re-…

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -121,6 +121,13 @@ export function createAsyncThunk<ActionType extends string, Returned, ActionPara
         args: ActionParams;
         requestId: string;
     }>;
+    unwrapResult: (returned: import("./createAction").PayloadAction<Returned, string, {
+        args: ActionParams;
+        requestId: string;
+    }, never> | import("./createAction").PayloadAction<undefined, string, {
+        args: ActionParams;
+        requestId: string;
+    }, Error>) => Returned;
 };
 
 // @alpha (undocumented)

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -102,8 +102,13 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @alpha (undocumented)
-export function createAsyncThunk<ActionType extends string, Returned, ActionParams = void, TA extends AsyncThunksArgs<any, any, any> = AsyncThunksArgs<unknown, unknown, Dispatch>>(type: ActionType, payloadCreator: (args: ActionParams, thunkArgs: TA) => Promise<Returned> | Returned): {
-    (args: ActionParams): (dispatch: TA["dispatch"], getState: TA["getState"], extra: TA["extra"]) => Promise<any>;
+export function createAsyncThunk<ActionType extends string, Returned, ActionParams = void, TA extends AsyncThunksArgs<any, any, any> = AsyncThunksArgs<unknown, unknown, Dispatch>>(type: ActionType, payloadCreator: (args: ActionParams, thunkArgs: TA) => Promise<Returned> | Returned): ((args: ActionParams) => (dispatch: TA["dispatch"], getState: TA["getState"], extra: TA["extra"]) => Promise<import("./createAction").PayloadAction<Returned, string, {
+    args: ActionParams;
+    requestId: string;
+}, never> | import("./createAction").PayloadAction<undefined, string, {
+    args: ActionParams;
+    requestId: string;
+}, Error>>) & {
     pending: import("./createAction").ActionCreatorWithPreparedPayload<[string, ActionParams], undefined, string, never, {
         args: ActionParams;
         requestId: string;

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -101,34 +101,33 @@ export function createAsyncThunk<
     ) => {
       const requestId = nanoid()
 
-      let result: Returned
+      let finalAction: ReturnType<typeof fulfilled | typeof rejected>
       try {
         dispatch(pending(requestId, args))
 
-        result = (await payloadCreator(args, {
-          dispatch,
-          getState,
-          extra,
-          requestId
-        } as TA)) as Returned
+        finalAction = fulfilled(
+          await payloadCreator(args, {
+            dispatch,
+            getState,
+            extra,
+            requestId
+          } as TA),
+          requestId,
+          args
+        )
       } catch (err) {
         const serializedError = miniSerializeError(err)
-        dispatch(rejected(serializedError, requestId, args))
-        // Rethrow this so the user can handle if desired
-        throw err
+        finalAction = rejected(serializedError, requestId, args)
       }
 
       // We dispatch "success" _after_ the catch, to avoid having any errors
       // here get swallowed by the try/catch block,
       // per https://twitter.com/dan_abramov/status/770914221638942720
       // and https://redux-toolkit.js.org/tutorials/advanced-tutorial#async-error-handling-logic-in-thunks
-      return dispatch(fulfilled(result!, requestId, args))
+      dispatch(finalAction)
+      return finalAction
     }
   }
 
-  actionCreator.pending = pending
-  actionCreator.rejected = rejected
-  actionCreator.fulfilled = fulfilled
-
-  return actionCreator
+  return Object.assign(actionCreator, { pending, rejected, fulfilled })
 }

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -2,6 +2,8 @@ import { Dispatch } from 'redux'
 import nanoid from 'nanoid'
 import { createAction } from './createAction'
 
+type Await<P> = P extends PromiseLike<infer T> ? T : P
+
 type AsyncThunksArgs<S, E, D extends Dispatch = Dispatch> = {
   dispatch: D
   getState: S
@@ -129,5 +131,19 @@ export function createAsyncThunk<
     }
   }
 
-  return Object.assign(actionCreator, { pending, rejected, fulfilled })
+  function unwrapResult(
+    returned: Await<ReturnType<ReturnType<typeof actionCreator>>>
+  ) {
+    if (rejected.match(returned)) {
+      throw returned.error
+    }
+    return returned.payload
+  }
+
+  return Object.assign(actionCreator, {
+    pending,
+    rejected,
+    fulfilled,
+    unwrapResult
+  })
 }

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, Dispatch, createReducer, AnyAction } from 'src'
 import { ThunkDispatch } from 'redux-thunk'
+import { promises } from 'fs'
 
 function expectType<T>(t: T) {
   return t
@@ -29,7 +30,8 @@ function fn() {}
       })
   )
 
-  const result = await dispatch(async(3))
+  const promise = dispatch(async(3))
+  const result = await promise
 
   if (async.fulfilled.match(result)) {
     expectType<ReturnType<typeof async['fulfilled']>>(result)
@@ -40,4 +42,15 @@ function fn() {}
     // typings:expect-error
     expectType<ReturnType<typeof async['fulfilled']>>(result)
   }
+
+  promise
+    .then(async.unwrapResult)
+    .then(result => {
+      expectType<number>(result)
+      // typings:expect-error
+      expectType<Error>(result)
+    })
+    .catch(error => {
+      // catch is always any-typed, nothing we can do here
+    })
 })()

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -1,4 +1,4 @@
-import { createAsyncThunk, Dispatch, createReducer } from 'src'
+import { createAsyncThunk, Dispatch, createReducer, AnyAction } from 'src'
 import { ThunkDispatch } from 'redux-thunk'
 
 function expectType<T>(t: T) {
@@ -7,20 +7,37 @@ function expectType<T>(t: T) {
 function fn() {}
 
 // basic usage
-{
-  const dispatch = fn as ThunkDispatch<any, any, any>
+;(async function() {
+  const dispatch = fn as ThunkDispatch<{}, any, AnyAction>
 
   const async = createAsyncThunk('test', (id: number) =>
     Promise.resolve(id * 2)
   )
-  dispatch(async(3))
 
   const reducer = createReducer({}, builder =>
     builder
-      .addCase(async.pending, (_, action) => {})
+      .addCase(async.pending, (_, action) => {
+        expectType<ReturnType<typeof async['pending']>>(action)
+      })
       .addCase(async.fulfilled, (_, action) => {
+        expectType<ReturnType<typeof async['fulfilled']>>(action)
         expectType<number>(action.payload)
       })
-      .addCase(async.rejected, (_, action) => {})
+      .addCase(async.rejected, (_, action) => {
+        expectType<ReturnType<typeof async['rejected']>>(action)
+        expectType<Error>(action.error)
+      })
   )
-}
+
+  const result = await dispatch(async(3))
+
+  if (async.fulfilled.match(result)) {
+    expectType<ReturnType<typeof async['fulfilled']>>(result)
+    // typings:expect-error
+    expectType<ReturnType<typeof async['rejected']>>(result)
+  } else {
+    expectType<ReturnType<typeof async['rejected']>>(result)
+    // typings:expect-error
+    expectType<ReturnType<typeof async['fulfilled']>>(result)
+  }
+})()


### PR DESCRIPTION
This is an alternative suggestion to #359.

I've created [a codesandbox](https://codesandbox.io/s/still-pond-7208i) that references the current alpha and implements a small data-fetching workflow.
The problem that becomes apparent is that, if there is an error within fetch and that error is not caught from dispatch, CRA in Dev Mode displays the red overlay of "something went terribly wrong":
![image](https://user-images.githubusercontent.com/4282439/74591497-dfa82f80-5018-11ea-883e-bca2f0fc02c2.png)

This happens during an event handler as well as during `useEffect`.

In production, this would probably not happen, but realisticly, devs would react to this by wrapping every `dispatch` call in an async function with try/catch or append a `.catch()` to it.
Doing the first thing is quite complicated, because you can't just change an effect to an async function (because that would return a promise), so you come up with something like 
```
  React.useEffect(() => {
    async function doFetch() {
      try {
        dispatch(fetchDataThunk({}));
      } catch {
        // do nothing
      }
    }
    if (state === "initial") {
      doFetch();
    }
  }, [state, dispatch]);
```
for something that would otherwise just have been
```
  React.useEffect(() => {
    if (state === "initial") {
        dispatch(fetchDataThunk({}));
    }
  }, [state, dispatch]);
```

So this makes stuff *much*  more complicated - also, event handlers that would just have been `() => dispatch(fetchDataThunk({}))` now become either `() => dispatch(fetchDataThunk({})).catch()` or `async () => { try {dispatch(fetchDataThunk({}))} catch {} }`.

What I want to say: avoiding this gets really messy.

So this is my suggestion of another solution:
The thunk would not return the promise return value in this case, but the "last dispatched action", which means either the `fulfilled` or the `rejected` action. That way, the error *can* be accessed from React, but not everyone is forced to handle it correctly.