### PR TITLE
use ThunkApiConfig for optional type arguments

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -18,6 +18,7 @@ import { ReducersMapObject } from 'redux';
 import { Store } from 'redux';
 import { StoreEnhancer } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import { ThunkDispatch } from 'redux-thunk';
 import { ThunkMiddleware } from 'redux-thunk';
 
 // @public
@@ -102,7 +103,7 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @alpha (undocumented)
-export function createAsyncThunk<Returned, ThunkArg = void, State = unknown, Extra = unknown, DispatchType extends Dispatch = Dispatch, ActionType extends string = string, ThunkAPI extends BaseThunkAPI<any, any, any> = BaseThunkAPI<State, Extra, DispatchType>>(type: ActionType, payloadCreator: (arg: ThunkArg, thunkAPI: ThunkAPI) => Promise<Returned> | Returned): ((arg: ThunkArg) => (dispatch: ThunkAPI["dispatch"], getState: ThunkAPI["getState"], extra: ThunkAPI["extra"]) => Promise<PayloadAction<undefined, string, {
+export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: (arg: ThunkArg, thunkAPI: GetThunkAPI<ThunkApiConfig>) => Promise<Returned> | Returned): ((arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<undefined, string, {
     arg: ThunkArg;
     requestId: string;
     aborted: boolean;

--- a/src/combinedTest.test.ts
+++ b/src/combinedTest.test.ts
@@ -1,5 +1,4 @@
-import { Dispatch } from 'redux'
-import { createAsyncThunk, BaseThunkAPI } from './createAsyncThunk'
+import { createAsyncThunk } from './createAsyncThunk'
 import { createAction, PayloadAction } from './createAction'
 import { createSlice } from './createSlice'
 import { configureStore } from './configureStore'
@@ -38,7 +37,9 @@ describe('Combined entity slice', () => {
     const fetchBooksTAC = createAsyncThunk<
       BookModel[],
       void,
-      { books: BooksState }
+      {
+        state: { books: BooksState }
+      }
     >(
       'books/fetch',
       async (arg, { getState, dispatch, extra, requestId, signal }) => {

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -20,6 +20,8 @@ export type IsUnknown<T, True, False = never> = unknown extends T
   ? IsAny<T, False, True>
   : False
 
+export type FallbackIfUnknown<T, Fallback> = IsUnknown<T, Fallback, T>
+
 /**
  * @internal
  */

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -6,12 +6,10 @@ import { unwrapResult } from 'src/createAsyncThunk'
 function expectType<T>(t: T) {
   return t
 }
-function fn() {}
+const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
 
-// basic usage
+  // basic usage
 ;(async function() {
-  const dispatch = fn as ThunkDispatch<{}, any, AnyAction>
-
   const async = createAsyncThunk('test', (id: number) =>
     Promise.resolve(id * 2)
   )
@@ -31,7 +29,7 @@ function fn() {}
       })
   )
 
-  const promise = dispatch(async(3))
+  const promise = defaultDispatch(async(3))
   const result = await promise
 
   if (async.fulfilled.match(result)) {
@@ -70,12 +68,20 @@ function fn() {}
     { id: 'a', title: 'First' }
   ]
 
+  const correctDispatch = (() => {}) as ThunkDispatch<
+    BookModel[],
+    { userAPI: Function },
+    AnyAction
+  >
+
   // Verify that the the first type args to createAsyncThunk line up right
   const fetchBooksTAC = createAsyncThunk<
     BookModel[],
     number,
-    BooksState,
-    { userAPI: Function }
+    {
+      state: BooksState
+      extra: { userAPI: Function }
+    }
   >(
     'books/fetch',
     async (arg, { getState, dispatch, extra, requestId, signal }) => {
@@ -87,4 +93,8 @@ function fn() {}
       return fakeBooks
     }
   )
+
+  correctDispatch(fetchBooksTAC(1))
+  // typings:expect-error
+  defaultDispatch(fetchBooksTAC(1))
 })()


### PR DESCRIPTION
I think this is what @Ethan-Arrowood suggested in [this tweet](https://twitter.com/ArrowoodTech/status/1228908646551183360).

It actually is quite a different pattern from what we've been using, but also quite interesting.

@markerikson, @Ethan-Arrowood could you take a look?