### PR TITLE
RFC: Add predicate to `createSlice` reducers.

### DIFF
--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -202,3 +202,65 @@ describe('createSlice', () => {
     })
   })
 })
+
+test('createSlice with predicate for reducer', () => {
+  const slice = createSlice({
+    name: 'test',
+    initialState: {
+      status: 'idle'
+    } as { status: 'working' | 'idle'; workItem?: string },
+    reducers: {
+      startWork: {
+        predicate: state => state.status === 'idle',
+        reducer(state, action: PayloadAction<string>) {
+          state.status = 'working'
+          state.workItem = action.payload
+        }
+      },
+      finishWork: {
+        predicate: state => state.status === 'working',
+        reducer(state) {
+          state.status = 'idle'
+          state.workItem = undefined
+        }
+      }
+    }
+  })
+
+  expect(slice.reducer({ status: 'idle' }, slice.actions.startWork('workItem')))
+    .toMatchInlineSnapshot(`
+    Object {
+      "status": "working",
+      "workItem": "workItem",
+    }
+  `)
+  expect(
+    slice.reducer(
+      { status: 'working', workItem: 'shouldNotChange' },
+      slice.actions.startWork('workItem')
+    )
+  ).toMatchInlineSnapshot(`
+    Object {
+      "status": "working",
+      "workItem": "shouldNotChange",
+    }
+  `)
+  expect(
+    slice.reducer(
+      { status: 'idle', workItem: 'shouldNotChange' },
+      slice.actions.finishWork()
+    )
+  ).toMatchInlineSnapshot(`
+    Object {
+      "status": "idle",
+      "workItem": "shouldNotChange",
+    }
+  `)
+  expect(slice.reducer({ status: 'working' }, slice.actions.finishWork()))
+    .toMatchInlineSnapshot(`
+    Object {
+      "status": "idle",
+      "workItem": undefined,
+    }
+  `)
+})

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -89,3 +89,5 @@ type UnionToIntersection<U> = (U extends any
   : never
 
 export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>
+
+export type AnyFunction = (...args: any[]) => any


### PR DESCRIPTION
This would make it more natural to write slice reducers as state machines.

It's just an idea on how to handle this and we'll definitely release 1.3 before we'll add this, but why not get some early feedback? :)

@davidkpiano, I think especially your feedback would be very valuable. Could you take a look?

Usage would look like this:
https://github.com/reduxjs/redux-toolkit/blob/26271da274a673f402ba024776c0ca9a53a53e4b/src/createSlice.test.ts#L207-L228