### PR TITLE
Immutable middleware cleanup

### DIFF
--- a/docs/api/getDefaultMiddleware.md
+++ b/docs/api/getDefaultMiddleware.md
@@ -58,9 +58,7 @@ provide runtime checks for two common issues:
 - [`immutable-state-invariant`](./otherExports.md#createimmutablestateinvariantmiddleware): deeply compares
   state values for mutations. It can detect mutations in reducers during a dispatch, and also mutations that occur between
   dispatches (such as in a component or a selector). When a mutation is detected, it will throw an error and indicate the key
-  path for where the mutated value was detected in the state tree.
-
-  Forked from [`redux-immutable-state-invariant`](https://github.com/leoasis/redux-immutable-state-invariant)
+  path for where the mutated value was detected in the state tree. (Forked from [`redux-immutable-state-invariant`](https://github.com/leoasis/redux-immutable-state-invariant).)
 
 - [`serializable-state-invariant-middleware`](./otherExports.md#createserializablestateinvariantmiddleware): a custom middleware created specifically for use in Redux Toolkit. Similar in
   concept to `immutable-state-invariant`, but deeply checks your state tree and your actions for non-serializable values

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -11,7 +11,7 @@ Redux Toolkit exports some of its internal utilities, and re-exports additional 
 
 ## Internal Exports
 
-### `createImmutalStateInvariantMiddleware`
+### `createImmutableStateInvariantMiddleware`
 
 Creates an instance of the `immutable-state-invariant` middleware described in [`getDefaultMiddleware`](./getDefaultMiddleware.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,12 +1278,6 @@
         "@types/node": "*"
       }
     },
-    "@types/invariant": {
-      "version": "2.2.31",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.31.tgz",
-      "integrity": "sha512-jMlgg9pIURvy9jgBHCjQp/CyBjYHUwj91etVcDdXkFl2CwTFiQlB+8tcsMeXpXf2PFE5X2pjk4Gm43hQSMHAdA==",
-      "dev": true
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1346,6 +1340,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/nanoid/-/nanoid-2.1.0.tgz",
       "integrity": "sha512-xdkn/oRTA0GSNPLIKZgHWqDTWZsVrieKomxJBOQUK9YDD+zfSgmwD5t4WJYra5S7XyhTw7tfvwznW+pFexaepQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1353,22 +1348,14 @@
     "@types/node": {
       "version": "10.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-      "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+      "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
-    },
-    "@types/redux-immutable-state-invariant": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.1.tgz",
-      "integrity": "sha512-eosvcaKraeX8fyEKViFZ2vh3xSWF8teCSw+mEMjlwoN0Ai6ZAevczQr3YyZxZFfwH1LXUiV3aXcSAlsNKAnjNg==",
-      "dev": true,
-      "requires": {
-        "redux": "^3.6.0 || ^4.0.0"
-      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -4689,6 +4676,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -5726,7 +5714,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "2.1.1",
@@ -6932,15 +6921,6 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
-      }
-    },
-    "redux-immutable-state-invariant": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz",
-      "integrity": "sha512-3czbDKs35FwiBRsx/3KabUk5zSOoTXC+cgVofGkpBNv3jQcqIe5JrHcF5AmVt7B/4hyJ8MijBIpCJ8cife6yJg==",
-      "requires": {
-        "invariant": "^2.1.0",
-        "json-stringify-safe": "^5.0.1"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   "license": "MIT",
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.0",
-    "@types/invariant": "^2.2.31",
     "@types/jest": "^24.0.11",
     "@types/json-stringify-safe": "^5.0.0",
+    "@types/nanoid": "^2.1.0",
     "@types/node": "^10.14.4",
-    "@types/redux-immutable-state-invariant": "^2.1.1",
     "console-testing-library": "^0.3.1",
     "eslint-config-react-app": "^5.0.1",
     "invariant": "^2.2.4",
@@ -58,11 +57,9 @@
     "src"
   ],
   "dependencies": {
-    "@types/nanoid": "^2.1.0",
     "immer": "^4.0.1",
     "nanoid": "^2.1.11",
     "redux": "^4.0.0",
-    "redux-immutable-state-invariant": "^2.1.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0"
   },


### PR DESCRIPTION
Cleaned up the immutable middleware by removing `invariant` and `json-stringify-safe`, which were still showing up in prod output, and inlining `tiny-invariant` and `json-stringify-safe`.  Also removed now-unused deps.