### PR TITLE
fix createAsyncThunk test for TS3.5, temporarily reference immer PR build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4544,9 +4544,8 @@
       "dev": true
     },
     "immer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.0.tgz",
-      "integrity": "sha512-vqOfnW3+VEV6vVxniMLPxTI+tEz1w7POYwOE1okOfnOS9Zl/mCObxino2lxiDC5l9o4NdWy+Rkxk9Em6ThBZBA=="
+      "version": "https://pkg.csb.dev/immerjs/immer/commit/12561009/immer",
+      "integrity": "sha512-JVV4TeDbjZNdF7mx7xcDM6Ag1EuotFb3HuqQgRoH9t2sBYNU+t/0xLlCzlq8WZkHJpzA4caiomMBHGTbpxE0Dg=="
     },
     "import-fresh": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "dependencies": {
-    "immer": "^6.0.0",
+    "immer": "https://pkg.csb.dev/immerjs/immer/commit/12561009/immer",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0"

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -12,6 +12,12 @@ import {
   getLog
 } from 'console-testing-library/pure'
 
+declare global {
+  interface Window {
+    AbortController: AbortController
+  }
+}
+
 describe('createAsyncThunk', () => {
   it('creates the action types', () => {
     const thunkActionCreator = createAsyncThunk('testType', async () => 42)
@@ -416,7 +422,7 @@ describe('createAsyncThunk with abortController', () => {
   })
 
   describe('behaviour with missing AbortController', () => {
-    let keepAbortController: typeof AbortController
+    let keepAbortController: typeof window['AbortController']
     let freshlyLoadedModule: typeof import('./createAsyncThunk')
     let restore: () => void
     let nodeEnv: string


### PR DESCRIPTION
This is just to test the CI with TS>=3.5. 
Temporarily uses a CodeSandbox CI build of immer - based on https://github.com/immerjs/immer/pull/549

Apparently, 3.5. needed a fix with a test, also providing that.