### PR TITLE
Ignore serializability of `meta.args` by default

### DIFF
--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -385,4 +385,27 @@ describe('serializableStateInvariantMiddleware', () => {
       (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)"
     `)
   })
+
+  it('should not check serializability for meta.args by default', () => {
+    const badValue = new Map()
+
+    const reducer: Reducer = (state = 42, action) => {
+      return state
+    }
+
+    const serializableStateInvariantMiddleware = createSerializableStateInvariantMiddleware()
+
+    const store = configureStore({
+      reducer: {
+        testSlice: reducer
+      },
+      middleware: [serializableStateInvariantMiddleware]
+    })
+
+    store.dispatch({ type: 'testAction', meta: { args: { badValue } } })
+
+    const { log } = getLog()
+    expect(log).toBe('')
+    const q = 42
+  })
 })

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -35,7 +35,7 @@ export function findNonSerializableValue(
   path: ReadonlyArray<string> = [],
   isSerializable: (value: unknown) => boolean = isPlain,
   getEntries?: (value: unknown) => [string, any][],
-  ignoredPaths: string[] = []
+  ignoredPaths: string[] = ['meta.args']
 ): NonSerializableValue | false {
   let foundNestedSerializable: NonSerializableValue | false
 


### PR DESCRIPTION
Ignore `meta.args` by default in serializability checks, on the grounds that the user really isn't explicitly adding that to the action themselves and this can result in unexpected errors.