### PR TITLE
fix(docs): typo in createEntityAdapter example

### DIFF
--- a/docs/api/createEntityAdapter.md
+++ b/docs/api/createEntityAdapter.md
@@ -65,7 +65,7 @@ const booksSlice = createSlice({
 
 const store = configureStore({
   reducer: {
-    books: booksSlice.reducer
+    books: booksSlice.reducers
   }
 })
 


### PR DESCRIPTION
Not sure if this is 100% a typo but it looks like it.

Thanks for the hard work on this!