### PR TITLE
display a warning if `immutableStateInvariantMiddleware` or `ser…

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -251,6 +251,7 @@ export interface SerializableStateInvariantMiddlewareOptions {
     ignoredActions?: string[];
     ignoredPaths?: string[];
     isSerializable?: (value: any) => boolean;
+    warnAfter?: number;
 }
 
 // @alpha (undocumented)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,21 @@
+export function getTimeMeasureUtils(maxDelay: number, fnName: string) {
+  let elapsed = 0
+  return {
+    measureTime<T>(fn: () => T): T {
+      const started = Date.now()
+      try {
+        return fn()
+      } finally {
+        const finished = Date.now()
+        elapsed += finished - started
+      }
+    },
+    warnIfExceeded() {
+      if (elapsed > maxDelay) {
+        console.warn(`${fnName} took ${elapsed}ms, which is more than the warning threshold of ${maxDelay}ms. 
+If you are passing very large objects into your state, you might to disable the middleware as it might cause too much of a slowdown in development mode. 
+It is disabled in production builds, so you don't need to worry about that.`)
+      }
+    }
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export function getTimeMeasureUtils(maxDelay: number, fnName: string) {
     warnIfExceeded() {
       if (elapsed > maxDelay) {
         console.warn(`${fnName} took ${elapsed}ms, which is more than the warning threshold of ${maxDelay}ms. 
-If you are passing very large objects into your state, you might to disable the middleware as it might cause too much of a slowdown in development mode. 
+If your state or actions are very large, you may want to disable the middleware as it might cause too much of a slowdown in development mode. See https://redux-toolkit.js.org/api/getDefaultMiddleware for instructions.
 It is disabled in production builds, so you don't need to worry about that.`)
       }
     }


### PR DESCRIPTION
This should address #412. I had to split up the measurement so that `next(action)` is excluded and it only warns for the time taken by the middleware itself, not by something else.
We *could*  add a general "slow reducer" warning while we're at it though.

| Filename | Size | Change | |
|:--- |:---:|:---:|:---:|
| `dist/redux-toolkit.cjs.development.js` | 10.4 kB | +406 B (3%) |  |
| `dist/redux-toolkit.esm.js` | 10.3 kB | +410 B (3%) |  |
| `dist/redux-toolkit.umd.js` | 21.5 kB | +374 B (1%) |  |

<details><summary>ℹ️ <strong>View Unchanged</strong></summary>

| Filename | Size | Change | |
|:--- |:---:|:---:|:---:|
| `dist/index.js` | 149 B | 0 B |  |
| `dist/redux-toolkit.cjs.production.min.js` | 3.69 kB | 0 B |  |
| `dist/redux-toolkit.umd.min.js` | 9.22 kB | 0 B |  |


</details>

