### PR TITLE
simplify signatures of `ActionCreatorWithOptionalPayload` and `A…

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -28,8 +28,7 @@ export interface ActionCreatorWithNonInferrablePayload<T extends string = string
 
 // @public
 export interface ActionCreatorWithOptionalPayload<P, T extends string = string> extends BaseActionCreator<P, T> {
-    (payload?: undefined): PayloadAction<undefined, T>;
-    <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>;
+    (payload?: P): PayloadAction<P, T>;
 }
 
 // @public
@@ -39,7 +38,6 @@ export interface ActionCreatorWithoutPayload<T extends string = string> extends 
 
 // @public
 export interface ActionCreatorWithPayload<P, T extends string = string> extends BaseActionCreator<P, T> {
-    <PT extends P>(payload: PT): PayloadAction<PT, T>;
     (payload: P): PayloadAction<P, T>;
 }
 

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -124,15 +124,11 @@ export interface ActionCreatorWithPreparedPayload<
 export interface ActionCreatorWithOptionalPayload<P, T extends string = string>
   extends BaseActionCreator<P, T> {
   /**
-   * Calling this {@link redux#ActionCreator} without arguments will
-   * return a {@link PayloadAction} of type `T` with a payload of `undefined`
-   */
-  (payload?: undefined): PayloadAction<undefined, T>
-  /**
    * Calling this {@link redux#ActionCreator} with an argument will
-   * return a {@link PayloadAction} of type `T` with a payload of `P`
+   * return a {@link PayloadAction} of type `T` with a payload of `P`.
+   * Calling it without an argument will return a PayloadAction with a payload of `undefined`.
    */
-  <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
+  (payload?: P): PayloadAction<P, T>
 }
 
 /**
@@ -160,12 +156,6 @@ export interface ActionCreatorWithoutPayload<T extends string = string>
  */
 export interface ActionCreatorWithPayload<P, T extends string = string>
   extends BaseActionCreator<P, T> {
-  /**
-   * Calling this {@link redux#ActionCreator} with an argument will
-   * return a {@link PayloadAction} of type `T` with a payload of `P`
-   * If possible, `P` will be narrowed down to the exact type of the payload argument.
-   */
-  <PT extends P>(payload: PT): PayloadAction<PT, T>
   /**
    * Calling this {@link redux#ActionCreator} with an argument will
    * return a {@link PayloadAction} of type `T` with a payload of `P`
@@ -332,8 +322,6 @@ export function getType<T extends string>(
 }
 
 // helper types for more readable typings
-
-type Diff<T, U> = T extends U ? never : T
 
 type IfPrepareActionMethodProvided<
   PA extends PrepareAction<any> | void,

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -73,9 +73,9 @@ function expectType<T>(p: T): T {
     { type: 'action' }
   ) as PayloadActionCreator<number | undefined>
 
-  expectType<PayloadAction<number>>(actionCreator(1))
-  expectType<PayloadAction<undefined>>(actionCreator())
-  expectType<PayloadAction<undefined>>(actionCreator(undefined))
+  expectType<PayloadAction<number | undefined>>(actionCreator(1))
+  expectType<PayloadAction<number | undefined>>(actionCreator())
+  expectType<PayloadAction<number | undefined>>(actionCreator(undefined))
 
   // typings:expect-error
   expectType<PayloadAction<number>>(actionCreator())
@@ -104,9 +104,9 @@ function expectType<T>(p: T): T {
     { type: 'action' }
   ) as PayloadActionCreator<number>
 
-  const actionCreator2: ActionCreator<
-    PayloadAction<number>
-  > = payloadActionCreator2
+  const actionCreator2: ActionCreator<PayloadAction<
+    number
+  >> = payloadActionCreator2
 }
 
 /* createAction() */


### PR DESCRIPTION
This would probably reduce the pain of #426, #399 and a few other issues where people had `strictNullChecks: false`. Also, it might improve IntelliSense for `ActionCreatorWithPayload` with a little tradeoff.

Changes for `ActionCreatorWithOptionalPayload`:
Before, assuming actionCreator was a `ActionCreatorWithOptionalPayload<string|undefined>
* calling actionCreator() returned a `PayloadAction<undefined>`
* calling actionCreator(undefined) returned a `PayloadAction<undefined>`
* calling actionCreator("test") returned a `PayloadAction<"test">`
* calling actionCreator(someStringTypedVariable) returned a `PayloadAction<string>`

Now, all those calls will return `PayloadAction<string | undefined>` - but autocompletion will work quite better for object types payloads.

Simlarily, assuming actionCreator was a `ActionCreatorWithPayload<string>
* calling actionCreator("test") returned a `PayloadAction<"test">`
* calling actionCreator(someStringTypedVariable) returned a `PayloadAction<string>`

Now, both those cases will return `PayloadAction<string>`, but autocompletion will probably work better for object type payloads.

I've been thinking about this for a bit and I believe the extra granularity we had before might not be worth the frustration people are having with this. What do you think about this simplification?