### PR TITLE
add createMiddleware utility

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Action } from 'redux';
+import { ActionCreator } from 'redux';
 import { AnyAction } from 'redux';
 import { default as createNextState } from 'immer';
 import { createSelector } from 'reselect';
@@ -48,6 +49,12 @@ export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T e
 }
 
 // @public
+export interface ActionMiddlewareMapBuilder {
+    addCase<TAC extends TypedActionCreator>(actionCreator: TAC, middleware: CaseMiddleware<ReturnType<TAC>>): ActionMiddlewareMapBuilder;
+    addCase(type: string, mid: CaseMiddleware): ActionMiddlewareMapBuilder;
+}
+
+// @public
 export interface ActionReducerMapBuilder<State> {
     addCase<ActionCreator extends TypedActionCreator<string>>(actionCreator: ActionCreator, reducer: CaseReducer<State, ReturnType<ActionCreator>>): ActionReducerMapBuilder<State>;
     addCase<Type extends string, A extends Action<Type>>(type: Type, reducer: CaseReducer<State, A>): ActionReducerMapBuilder<State>;
@@ -55,6 +62,9 @@ export interface ActionReducerMapBuilder<State> {
 
 // @public @deprecated
 export type Actions<T extends keyof any = string> = Record<T, Action>;
+
+// @public
+export type CaseMiddleware<A extends Action = AnyAction> = (action: A, dispatch: Dispatch) => Promise<void> | void;
 
 // @public
 export type CaseReducer<S = any, A extends Action = AnyAction> = (state: Draft<S>, action: A) => S | void;
@@ -97,6 +107,9 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 
 // @public
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
+
+// @public
+export function createMiddleware(builderCallback: (builder: ActionMiddlewareMapBuilder) => void): Middleware;
 
 export { createNextState }
 

--- a/src/createMiddleware.test.ts
+++ b/src/createMiddleware.test.ts
@@ -1,0 +1,93 @@
+import { createMiddleware } from './createMiddleware'
+import { createAction } from './createAction'
+
+describe('createMiddleware', () => {
+  const action1 = createAction('a1')
+  const action2 = createAction('a2')
+  const action3 = createAction('a3')
+  const action4 = createAction('a4')
+  const action5 = createAction('a5')
+  const action6 = createAction('a6')
+  const actionWithPayload1 = createAction<string>('ap1')
+  const actionWithPayload2 = createAction<number>('ap2')
+
+  describe('without payload', () => {
+    const dispatchSpy = jest.fn()
+    const store = { dispatch: dispatchSpy, getState: () => ({}) }
+    const next = jest.fn()
+
+    it('should dispatch action from synchronous case', () => {
+      const middleware = createMiddleware(builder =>
+        builder.addCase(action1, (action, dispatch) => {
+          dispatch(action2())
+        })
+      )
+      middleware(store)(next)(action1())
+      expect(dispatchSpy).toHaveBeenCalledWith(action2())
+    })
+
+    it('should dispatch action from asynchronous case', () => {
+      const middleware = createMiddleware(builder =>
+        builder.addCase(action1, async (action, dispatch) => {
+          await new Promise(res => setTimeout(res, 0))
+          dispatch(action2())
+        })
+      )
+      middleware(store)(next)(action1())
+      expect(dispatchSpy).toHaveBeenCalledWith(action2())
+    })
+  })
+
+  describe('with payload', () => {
+    const dispatchSpy = jest.fn()
+    const store = { dispatch: dispatchSpy, getState: () => ({}) }
+    const next = jest.fn()
+
+    it('should dispatch action from synchronous case', () => {
+      const middleware = createMiddleware(builder =>
+        builder.addCase(actionWithPayload1, (action, dispatch) => {
+          dispatch(actionWithPayload2(Number(action.payload)))
+        })
+      )
+      middleware(store)(next)(actionWithPayload1('123'))
+      expect(dispatchSpy).toHaveBeenCalledWith(actionWithPayload2(123))
+    })
+
+    it('should dispatch action from asynchronous case', () => {
+      const middleware = createMiddleware(builder =>
+        builder.addCase(actionWithPayload1, async (action, dispatch) => {
+          await new Promise(res => res)
+          dispatch(actionWithPayload2(Number(action.payload)))
+        })
+      )
+      middleware(store)(next)(actionWithPayload1('123'))
+      expect(dispatchSpy).toHaveBeenCalledWith(actionWithPayload2(123))
+    })
+  })
+
+  describe('multiple cases', () => {
+    const dispatchSpy = jest.fn()
+    const store = { dispatch: dispatchSpy, getState: () => ({}) }
+    const next = jest.fn()
+
+    const middleware = createMiddleware(builder =>
+      builder
+        .addCase(action1, (action, dispatch) => {
+          dispatch(action4)
+        })
+        .addCase(action2, (action, dispatch) => {
+          dispatch(action5)
+        })
+        .addCase(action3, (action, dispatch) => {
+          dispatch(action6)
+        })
+    )
+    middleware(store)(next)(action4())
+    expect(dispatchSpy).not.toHaveBeenCalled()
+
+    middleware(store)(next)(action2())
+    expect(dispatchSpy).not.toHaveBeenCalledWith(action4)
+    expect(dispatchSpy).not.toHaveBeenCalledWith(action6)
+    expect(dispatchSpy).toHaveBeenCalledWith(action5)
+  })
+})

--- a/src/createMiddleware.ts
+++ b/src/createMiddleware.ts
@@ -1,0 +1,41 @@
+import { Action, AnyAction, Dispatch, Middleware } from 'redux'
+import {
+  ActionMiddlewareMapBuilder,
+  executeMiddlewareBuilderCallback
+} from './mapBuilders'
+
+/**
+ * A *case middleware* is a middleware function for a specific action type.
+ *
+ * @public
+ */
+export type CaseMiddleware<A extends Action = AnyAction> = (
+  action: A,
+  dispatch: Dispatch
+) => Promise<void> | void
+
+/**
+ * A utility function that allows defining middleware as a mapping from action
+ * type to *case reducer* functions that handle these action types.
+ *
+ * @param builderCallback A callback that receives a *builder* object to define
+ * case middleware via calls to:
+ * `builder.addCase(actionCreatorOrType, (action, dispatch) => void)`.
+ *
+ * @public
+ */
+export function createMiddleware(
+  builderCallback: (builder: ActionMiddlewareMapBuilder) => void
+): Middleware {
+  const actionsMap = executeMiddlewareBuilderCallback(builderCallback)
+
+  return store => next => action => {
+    const midCase = actionsMap[action.type]
+
+    if (midCase) {
+      midCase(action, store.dispatch)
+    }
+
+    return next(action)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,12 @@ export {
 } from './createAction'
 export {
   // js
+  createMiddleware,
+  // types
+  CaseMiddleware
+} from './createMiddleware'
+export {
+  // js
   createReducer,
   // types
   Actions,
@@ -59,5 +65,6 @@ export {
 } from './getDefaultMiddleware'
 export {
   // types
+  ActionMiddlewareMapBuilder,
   ActionReducerMapBuilder
 } from './mapBuilders'


### PR DESCRIPTION
This is to accompany https://github.com/reduxjs/redux-toolkit/issues/431

I haven't written any docs yet; thought I'd wait for feedback first.

Allows for middleware to be written using the `builder` pattern:

```js
const customMiddleware = createMiddleware(builder =>
  builder
    .addCase(actionName, (action, dispatch) => {
      setInterval(() => dispatch(asyncActionHappened(action.payload)), 5000);
    })
    .addCase(anotherActionName, async (action, dispatch) => {
      const data = await fetch(action.payload).then(resp => resp.json());
      dispatch(dataFulfilled(data));
    })
);
```