### PR TITLE
Add basic createEntityAdapter usage docs

### DIFF
--- a/docs/api/createEntityAdapter.md
+++ b/docs/api/createEntityAdapter.md
@@ -196,14 +196,14 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
 The primary content of an entity adapter is a set of generated reducer functions for adding, updating, and removing entity instances from an entity state object:
 
 - `addOne`: accepts a single entity, and adds it
-- `addMany`: accepts an array of entities, and adds them
-- `setAll`: accepts an array of entities, and replaces the existing entity contents with the values in the array
+- `addMany`: accepts an array of entities or an object in the shape of `Record<EntityId, T>`, and adds them.
+- `setAll`: accepts an array of entities or an object in the shape of `Record<EntityId, T>`, and replaces the existing entity contents with the values in the array
 - `removeOne`: accepts a single entity ID value, and removes the entity with that ID if it exists
 - `removeMany`: accepts an array of entity ID values, and removes each entity with those IDs if they exist
 - `updateOne`: accepts an "update object" containing an entity ID and an object containing one or more new field values to update inside a `changes` field, and updates the corresponding entity
 - `updateMany`: accepts an array of update objects, and updates all corresponding entities
 - `upsertOne`: accepts a single entity. If an entity with that ID exists, the fields in the update will be merged into the existing entity, with any matching fields overwriting the existing values. If the entity does not exist, it will be added.
-- `upsertMany`: accepts an array of entities that will be upserted.
+- `upsertMany`: accepts an array of entities or an object in the shape of `Record<EntityId, T>` that will be upserted.
 
 Each method has a signature that looks like:
 

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -755,7 +755,9 @@ const userEntity = new schema.Entity('users')
 
 export const fetchUsers = createAsyncThunk('users/fetchAll', async () => {
   const response = await userAPI.fetchAll()
-  return response.data
+  // Normalize the data before passing it to our reducer
+  const normalized = normalize(response.data, [userEntity])
+  return normalized.entities
 })
 
 export const slice = createSlice({
@@ -767,9 +769,8 @@ export const slice = createSlice({
   reducers: {},
   extraReducers: builder => {
     builder.addCase(fetchUsers.fulfilled, (state, action) => {
-      const normalizedData = normalize(action.payload, userEntity)
-      state.entities = normalizedData.entities.users
-      state.ids = Object.keys(normalizedData.entities.users)
+      state.entities = action.payload.users
+      state.ids = Object.keys(action.payload.users)
     })
   }
 })

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -816,6 +816,8 @@ export default reducer
 export const { removeUser } = slice.actions
 ```
 
+You can view the full code of this example usage on [CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-1xubt)
+
 #### Combining a normalization library and `createEntityAdapter`
 
 If you're already using `normalizr` or another normalization library, you could consider using it along with `createEntityAdapter`. To expand on the examples above, here is a demonstration of how we could use `normalizr` to format a payload, then leverage the utilities `createEntityAdapter` provides.
@@ -913,6 +915,8 @@ const reducer = slice.reducer
 export default reducer
 ```
 
+You can view the full code of this example normalizr usage on [CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-with-normalizr-bm3ie)
+
 #### Using selectors with `createEntityAdapter`
 
 The entity adapter providers a selector factory that generates the most common selectors for you. Taking the examples above, we can add selectors to our `usersSlice` like this:
@@ -957,8 +961,6 @@ export function UsersList() {
   )
 }
 ```
-
-To see this all working together, you can view the full code of this example usage on [CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-4jg0m)
 
 #### Working with entities without an id property
 

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -792,14 +792,15 @@ import userAPI from './userAPI'
 
 export const fetchUsers = createAsyncThunk('users/fetchAll', async () => {
   const response = await userAPI.fetchAll()
-  // In this case, `response.data` would be [{id: 1, first_name: 'Example', last_name: 'User'}]
+  // In this case, `response.data` would be:
+  //  [{id: 1, first_name: 'Example', last_name: 'User'}]
   return response.data
 })
 
 export const usersAdapter = createEntityAdapter()
 
 // By default, `createEntityAdapter` gives you `{ ids: [], entities: {} }`.
-// If you want to track 'loading' or other keys, you would initialize them here like this:
+// If you want to track 'loading' or other keys, you would initialize them here:
 // `getInitialState({ loading: false, activeRequestId: null })`
 const initialState = usersAdapter.getInitialState()
 
@@ -855,7 +856,7 @@ export const fetchArticle = createAsyncThunk(
   'articles/fetchArticle',
   async id => {
     const data = await fakeAPI.articles.show(id)
-    // Normalize the data so reducers can responded to a predictable payload, in this case:
+    // Normalize the data so reducers can load a predictable payload, like:
     // `action.payload = { users: {}, articles: {}, comments: {} }`
     const normalized = normalize(data, articleEntity)
     return normalized.entities
@@ -968,7 +969,7 @@ export function UsersList() {
 }
 ```
 
-### Working with entities without an id property
+### Specifying Alternate ID Fields
 
 By default, `createEntityAdapter` assumes that your data has unique IDs in an `entity.id` field. If your data set stores its ID in a different field, you can pass in a `selectId` argument that returns the appropriate field.
 
@@ -981,13 +982,14 @@ const userData = {
   ]
 }
 
-// Since our primary key is `idx` and not `id`, pass in an ID selector to return that field instead
+// Since our primary key is `idx` and not `id`,
+// pass in an ID selector to return that field instead
 export const usersAdapter = createEntityAdapter({
   selectId: user => user.idx
 })
 ```
 
-### Sorting your entities by a default key
+### Sorting Entities
 
 `createEntityAdapter` provides a `sortComparer` argument that you can leverage to sort the collection of `ids` in state. This can be very useful for when you want to guarantee a sort order and your data doesn't come presorted.
 
@@ -1000,8 +1002,9 @@ const userData = {
   ]
 }
 
-// Sort by `first_name`. `state.ids` would be ordered like `ids: [ 2, 1 ]`, since B comes before T
-// When using the provided `selectAll` selector, your collection would be returned sorted as:
+// Sort by `first_name`. `state.ids` would be ordered as
+// `ids: [ 2, 1 ]`, since 'B' comes before 'T'.
+// When using the provided `selectAll` selector, the result would be sorted:
 // [{ id: 2, first_name: 'Banana' }, { id: 1, first_name: 'Test' }]
 export const usersAdapter = createEntityAdapter({
   sortComparer: (a, b) => a.first_name.localeCompare(b.first_name)

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -703,9 +703,9 @@ You can use any of these as needed inside the payload callback to determine what
 
 ## Managing Normalized Data
 
-Most applications typically deal with data that is deeply nested or relational. The goal of normalizing data is to efficiently organize the data in your state. This is typically done by storing collections as dictionaries with the key of an `id`, while storing a sorted array of those `ids`. For a more in-depth explanation and further examples, there is a great reference in the [Redux docs page on "Normalizing State Shape"](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape).
+Most applications typically deal with data that is deeply nested or relational. The goal of normalizing data is to efficiently organize the data in your state. This is typically done by storing collections as objects with the key of an `id`, while storing a sorted array of those `ids`. For a more in-depth explanation and further examples, there is a great reference in the [Redux docs page on "Normalizing State Shape"](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape).
 
-#### Normalizing by hand
+### Normalizing by hand
 
 Normalizing data doesn't require any special libraries. Here's a basic example of how you might normalize the response from a `fetchAll` API request that returns data in the shape of `{ users: [{id: 1, first_name: 'normalized', last_name: 'person'}] }`, using some hand-written logic:
 
@@ -741,7 +741,7 @@ export const slice = createSlice({
 
 Although we're capable of writing this code, it does become repetitive, especially if you're handling multiple types of data. In addition, this example only handles loading entries into the state, not updating them.
 
-#### Normalizing with `normalizr`
+### Normalizing with `normalizr`
 
 [`normalizr`](https://github.com/paularmstrong/normalizr) is a popular existing library for normalizing data. You can use it on its own without Redux, but it is very commonly used with Redux. The typical usage is to format collections from an API response and then process them in your reducers.
 
@@ -778,7 +778,7 @@ export const slice = createSlice({
 
 As with the hand-written version, this doesn't handle adding additional entries into the state, or updating them later - it's just loading in everything that was received.
 
-#### Normalizing with `createEntityAdapter`
+### Normalizing with `createEntityAdapter`
 
 Redux Toolkit's `createEntityAdapter` API provides a standardized way to store your data in a slice by taking a collection and putting it into the shape of `{ ids: [], entities: {} }`. Along with this predefined state shape, it generates a set of reducer functions and selectors that know how to work with the data.
 
@@ -822,7 +822,7 @@ export const { removeUser } = slice.actions
 
 You can [view the full code of this example usage on CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-1xubt)
 
-#### Using `createEntityAdapter` with Normalization Libraries
+### Using `createEntityAdapter` with Normalization Libraries
 
 If you're already using `normalizr` or another normalization library, you could consider using it along with `createEntityAdapter`. To expand on the examples above, here is a demonstration of how we could use `normalizr` to format a payload, then leverage the utilities `createEntityAdapter` provides.
 
@@ -924,7 +924,7 @@ export default reducer
 
 You can [view the full code of this example `normalizr` usage on CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-with-normalizr-bm3ie)
 
-#### Using selectors with `createEntityAdapter`
+### Using selectors with `createEntityAdapter`
 
 The entity adapter providers a selector factory that generates the most common selectors for you. Taking the examples above, we can add selectors to our `usersSlice` like this:
 
@@ -968,7 +968,7 @@ export function UsersList() {
 }
 ```
 
-#### Working with entities without an id property
+### Working with entities without an id property
 
 By default, `createEntityAdapter` assumes that your data has unique IDs in an `entity.id` field. If your data set stores its ID in a different field, you can pass in a `selectId` argument that returns the appropriate field.
 
@@ -987,7 +987,7 @@ export const usersAdapter = createEntityAdapter({
 })
 ```
 
-#### Sorting your entities by a default key
+### Sorting your entities by a default key
 
 `createEntityAdapter` provides a `sortComparer` argument that you can leverage to sort the collection of `ids` in state. This can be very useful for when you want to guarantee a sort order and your data doesn't come presorted.
 

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -709,7 +709,7 @@ To better understand the purpose of the entity adapter, let's take a look at som
 
 #### Normalizing by hand
 
-The below is a very basic example of normalizing the response from a our `fetchAll` api request that returns data in the shape of `{ users: [{id: 1, first_name: 'normalized', last_name: 'person'}] }`
+Normalizing data doesn't require any special libraries. Here's a basic example of how you might normalize the response from a `fetchAll` APIrequest that returns data in the shape of `{ users: [{id: 1, first_name: 'normalized', last_name: 'person'}] }`, using some hand-written logic:
 
 ```js
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
@@ -804,9 +804,7 @@ export const slice = createSlice({
     removeUser: usersAdapter.removeOne
   },
   extraReducers: builder => {
-    builder.addCase(fetchUsers.fulfilled, (state, action) => {
-      usersAdapter.upsertMany(state, action.payload)
-    })
+    builder.addCase(fetchUsers.fulfilled, usersAdapter.upsertMany)
   }
 })
 
@@ -868,7 +866,7 @@ To see this all working together, you can view the full code of this example usa
 
 #### Working with entities without an id property
 
-If your data set does not have an `id` property, createEntityAdapter offers a `selectId` argument that you can use.
+By default, `createEntityAdapter` assumes that your data has unique IDs in an `entity.id` field.  If your data set stores its ID in a different field, you can pass in a `selectId` argument that returns the appropriate field.
 
 ```js
 // In this instance, our user data always has a primary key of `idx`
@@ -879,7 +877,7 @@ const userData = {
   ]
 }
 
-// Being that our primary key is `idx` and not `id`, let the entity adapter know that with `selectId`
+// Since our primary key is `idx` and not `id`, pass in an ID selector to return that field instead
 export const usersAdapter = createEntityAdapter({
   selectId: user => user.idx
 })

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -820,6 +820,8 @@ export const { removeUser } = slice.actions
 
 If you're already using `normalizr` or another normalization library, you could consider using it along with `createEntityAdapter`. To expand on the examples above, here is a demonstration of how we could use `normalizr` to format a payload, then leverage the utilities `createEntityAdapter` provides.
 
+**Note:** `upsertMany` (as well as `addMany` and `setAll`) allows you to pass in an object that is in the shape of `{ 1: { id: 1, ... }}` as an alternative to `T[]` and is shown here.
+
 ```js
 // features/articles/articlesSlice.js
 import {
@@ -860,8 +862,7 @@ export const slice = createSlice({
   reducers: {},
   extraReducers: {
     [fetchArticle.fulfilled]: (state, action) => {
-      // We use `Object.values()` being that the payload was processed with normalizr
-      articlesAdapter.upsertMany(state, Object.values(action.payload.articles))
+      articlesAdapter.upsertMany(state, action.payload.articles)
     }
   }
 })
@@ -882,8 +883,7 @@ export const slice = createSlice({
   reducers: {},
   extraReducers: builder => {
     builder.addCase(fetchArticle.fulfilled, (state, action) => {
-      // We use `Object.values()` being that the payload was processed with normalizr in the `fetchArticle` thunk
-      usersAdapter.upsertMany(state, Object.values(action.payload.users))
+      usersAdapter.upsertMany(state, action.payload.users)
     })
   }
 })
@@ -904,8 +904,7 @@ export const slice = createSlice({
   reducers: {},
   extraReducers: {
     [fetchArticle.fulfilled]: (state, action) => {
-      // We use `Object.values()` being that the payload was processed with normalizr in the `fetchArticle` thunk
-      commentsAdapter.upsertMany(state, Object.values(action.payload.comments))
+      commentsAdapter.upsertMany(state, action.payload.comments)
     }
   }
 })

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -732,6 +732,7 @@ export const slice = createSlice({
       // reduce the collection by the id property into a shape of { 1: { ...user }}
       const byId = action.payload.users.reduce((byId, user) => {
         byId[user.id] = user
+        return byId
       }, {})
       state.entities = byId
       state.ids = Object.keys(byId)

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -570,9 +570,9 @@ const booksSlice = createSlice({
 })
 ```
 
-### Using `createEntityAdapter` along with `normalizr`
+### Using `createEntityAdapter` with `normalizr`
 
-When using a library like [normalizr](), your normalized data will resemble this shape:
+When using a library like [`normalizr`](https://github.com/paularmstrong/normalizr/), your normalized data will resemble this shape:
 
 ```js
 {
@@ -584,7 +584,9 @@ When using a library like [normalizr](), your normalized data will resemble this
 }
 ```
 
-The methods `addMany`, `upsertMany`, and `setAll` all allow you to pass in the `entities` portion of this directly with no extra conversion steps. Here is an example of how that would look:
+The methods `addMany`, `upsertMany`, and `setAll` all allow you to pass in the `entities` portion of this directly with no extra conversion steps. However, the `normalizr` TS typings currently do not correctly reflect that multiple data types may be included in the results, so you will need to specify that type structure yourself.
+
+Here is an example of how that would look:
 
 ```ts
 type Author = { id: number; name: string }
@@ -595,8 +597,9 @@ export const fetchArticle = createAsyncThunk(
   'articles/fetchArticle',
   async (id: number) => {
     const data = await fakeAPI.articles.show(id)
-    // Normalize the data so reducers can responded to a predictable payload, in this case: `action.payload = { users: { 1: { id: 1 }}, articles: {1: { id: 1 }}, comments: {1: { id: 1 }} }`
-    // Note: at the time of writing, normalizr does not automatically infer the result, so we provide that to the Generic
+    // Normalize the data so reducers can responded to a predictable payload.
+    // Note: at the time of writing, normalizr does not automatically infer the result,
+    // so we explicitly declare the shape of the returned normalized data as a generic arg.
     const normalized = normalize<
       any,
       {
@@ -615,7 +618,7 @@ export const slice = createSlice({
   reducers: {},
   extraReducers: builder => {
     builder.addCase(fetchArticle.fulfilled, (state, action) => {
-      // The type signature on action.payload matches what we passed into the Generic for `normalize`, allowing us to access specific properties on `payload.articles` if desired
+      // The type signature on action.payload matches what we passed into the generic for `normalize`, allowing us to access specific properties on `payload.articles` if desired
       articlesAdapter.upsertMany(state, action.payload.articles)
     })
   }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "website"
-  publish = "build"
+  publish = "website/build"
   command = "npm run build"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "website"
-  publish = "website/build"
+  publish = "build"
   command = "npm run build"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
   base    = "website"
   publish = "build"
   command = "npm run build"
+  ignore = "git diff --quiet HEAD^ HEAD docs website"
 
 [build.environment]
 NODE_VERSION = "10"


### PR DESCRIPTION
Addresses #441 

- Adds basic usage for `createEntityAdapter`
- Example usage for basic `createEntityAdapter` [CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-4jg0m) _(currently linked in usage guide)_
- Combined normalizr/createEntityAdapter shown in this [CodeSandbox](https://codesandbox.io/s/rtk-entities-basic-example-with-normalizr-j30td)

Pending changes from #444:
- [x] Make a brief note of this in the "Usage with TS" page
- [ ] Create CodeSandbox to reference `normalizr` usage example