### PR TITLE
Add dictionary support to createEntityAdapter many methods

### DIFF
--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -57,16 +57,22 @@ export interface EntityStateAdapter<T> {
     action: PayloadAction<T>
   ): S
 
-  addMany<S extends EntityState<T>>(state: PreventAny<S, T>, entities: T[]): S
   addMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: PayloadAction<T[]>
+    entities: T[] | Record<string, T>
+  ): S
+  addMany<S extends EntityState<T>>(
+    state: PreventAny<S, T>,
+    entities: PayloadAction<T[] | Record<string, T>>
   ): S
 
-  setAll<S extends EntityState<T>>(state: PreventAny<S, T>, entities: T[]): S
   setAll<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: PayloadAction<T[]>
+    entities: T[] | Record<string, T>
+  ): S
+  setAll<S extends EntityState<T>>(
+    state: PreventAny<S, T>,
+    entities: PayloadAction<T[] | Record<string, T>>
   ): S
 
   removeOne<S extends EntityState<T>>(state: PreventAny<S, T>, key: EntityId): S
@@ -112,11 +118,11 @@ export interface EntityStateAdapter<T> {
 
   upsertMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: T[]
+    entities: T[] | Record<string, T>
   ): S
   upsertMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: PayloadAction<T[]>
+    entities: PayloadAction<T[] | Record<string, T>>
   ): S
 }
 

--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -59,20 +59,20 @@ export interface EntityStateAdapter<T> {
 
   addMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: T[] | Record<string, T>
+    entities: T[] | Record<EntityId, T>
   ): S
   addMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: PayloadAction<T[] | Record<string, T>>
+    entities: PayloadAction<T[] | Record<EntityId, T>>
   ): S
 
   setAll<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: T[] | Record<string, T>
+    entities: T[] | Record<EntityId, T>
   ): S
   setAll<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: PayloadAction<T[] | Record<string, T>>
+    entities: PayloadAction<T[] | Record<EntityId, T>>
   ): S
 
   removeOne<S extends EntityState<T>>(state: PreventAny<S, T>, key: EntityId): S
@@ -118,11 +118,11 @@ export interface EntityStateAdapter<T> {
 
   upsertMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: T[] | Record<string, T>
+    entities: T[] | Record<EntityId, T>
   ): S
   upsertMany<S extends EntityState<T>>(
     state: PreventAny<S, T>,
-    entities: PayloadAction<T[] | Record<string, T>>
+    entities: PayloadAction<T[] | Record<EntityId, T>>
   ): S
 }
 

--- a/src/entities/sorted_state_adapter.test.ts
+++ b/src/entities/sorted_state_adapter.test.ts
@@ -85,6 +85,24 @@ describe('Sorted State Adapter', () => {
     })
   })
 
+  it('should let you add many entities to the state from a dictionary', () => {
+    const withOneEntity = adapter.addOne(state, TheGreatGatsby)
+
+    const withManyMore = adapter.addMany(withOneEntity, {
+      [AClockworkOrange.id]: AClockworkOrange,
+      [AnimalFarm.id]: AnimalFarm
+    })
+
+    expect(withManyMore).toEqual({
+      ids: [AClockworkOrange.id, AnimalFarm.id, TheGreatGatsby.id],
+      entities: {
+        [TheGreatGatsby.id]: TheGreatGatsby,
+        [AClockworkOrange.id]: AClockworkOrange,
+        [AnimalFarm.id]: AnimalFarm
+      }
+    })
+  })
+
   it('should remove existing and add new ones on setAll', () => {
     const withOneEntity = adapter.addOne(state, TheGreatGatsby)
 
@@ -92,6 +110,23 @@ describe('Sorted State Adapter', () => {
       AClockworkOrange,
       AnimalFarm
     ])
+
+    expect(withAll).toEqual({
+      ids: [AClockworkOrange.id, AnimalFarm.id],
+      entities: {
+        [AClockworkOrange.id]: AClockworkOrange,
+        [AnimalFarm.id]: AnimalFarm
+      }
+    })
+  })
+
+  it('should remove existing and add new ones on setAll when passing in a dictionary', () => {
+    const withOneEntity = adapter.addOne(state, TheGreatGatsby)
+
+    const withAll = adapter.setAll(withOneEntity, {
+      [AClockworkOrange.id]: AClockworkOrange,
+      [AnimalFarm.id]: AnimalFarm
+    })
 
     expect(withAll).toEqual({
       ids: [AClockworkOrange.id, AnimalFarm.id],
@@ -368,6 +403,27 @@ describe('Sorted State Adapter', () => {
       { ...TheGreatGatsby, ...firstChange },
       AClockworkOrange
     ])
+
+    expect(withUpserts).toEqual({
+      ids: [AClockworkOrange.id, TheGreatGatsby.id],
+      entities: {
+        [TheGreatGatsby.id]: {
+          ...TheGreatGatsby,
+          ...firstChange
+        },
+        [AClockworkOrange.id]: AClockworkOrange
+      }
+    })
+  })
+
+  it('should let you upsert many entities in the state when passing in a dictionary', () => {
+    const firstChange = { title: 'Zack' }
+    const withMany = adapter.setAll(state, [TheGreatGatsby])
+
+    const withUpserts = adapter.upsertMany(withMany, {
+      [TheGreatGatsby.id]: { ...TheGreatGatsby, ...firstChange },
+      [AClockworkOrange.id]: AClockworkOrange
+    })
 
     expect(withUpserts).toEqual({
       ids: [AClockworkOrange.id, TheGreatGatsby.id],

--- a/src/entities/sorted_state_adapter.ts
+++ b/src/entities/sorted_state_adapter.ts
@@ -85,12 +85,12 @@ export function createSortedStateAdapter<T>(
     entities: T[] | Record<string, T>,
     state: R
   ): void {
-    const added: T[] = []
-    const updated: Update<T>[] = []
-
     if (!Array.isArray(entities)) {
       entities = Object.values(entities)
     }
+
+    const added: T[] = []
+    const updated: Update<T>[] = []
 
     for (const entity of entities) {
       const id = selectIdValue(entity, selectId)

--- a/src/entities/sorted_state_adapter.ts
+++ b/src/entities/sorted_state_adapter.ts
@@ -23,7 +23,11 @@ export function createSortedStateAdapter<T>(
     return addManyMutably([entity], state)
   }
 
-  function addManyMutably(newModels: T[], state: R): void {
+  function addManyMutably(newModels: T[] | Record<string, T>, state: R): void {
+    if (!Array.isArray(newModels)) {
+      newModels = Object.values(newModels)
+    }
+
     const models = newModels.filter(
       model => !(selectIdValue(model, selectId) in state.entities)
     )
@@ -33,7 +37,10 @@ export function createSortedStateAdapter<T>(
     }
   }
 
-  function setAllMutably(models: T[], state: R): void {
+  function setAllMutably(models: T[] | Record<string, T>, state: R): void {
+    if (!Array.isArray(models)) {
+      models = Object.values(models)
+    }
     state.entities = {}
     state.ids = []
 
@@ -60,7 +67,14 @@ export function createSortedStateAdapter<T>(
     return newKey !== update.id
   }
 
-  function updateManyMutably(updates: Update<T>[], state: R): void {
+  function updateManyMutably(
+    updates: Update<T>[] | Record<string, Update<T>>,
+    state: R
+  ): void {
+    if (!Array.isArray(updates)) {
+      updates = Object.values(updates)
+    }
+
     const models: T[] = []
 
     updates.forEach(update => takeUpdatedModel(models, update, state))
@@ -74,9 +88,16 @@ export function createSortedStateAdapter<T>(
     return upsertManyMutably([entity], state)
   }
 
-  function upsertManyMutably(entities: T[], state: R): void {
+  function upsertManyMutably(
+    entities: T[] | Record<string, T>,
+    state: R
+  ): void {
     const added: T[] = []
     const updated: Update<T>[] = []
+
+    if (!Array.isArray(entities)) {
+      entities = Object.values(entities)
+    }
 
     for (const entity of entities) {
       const id = selectIdValue(entity, selectId)

--- a/src/entities/sorted_state_adapter.ts
+++ b/src/entities/sorted_state_adapter.ts
@@ -67,14 +67,7 @@ export function createSortedStateAdapter<T>(
     return newKey !== update.id
   }
 
-  function updateManyMutably(
-    updates: Update<T>[] | Record<string, Update<T>>,
-    state: R
-  ): void {
-    if (!Array.isArray(updates)) {
-      updates = Object.values(updates)
-    }
-
+  function updateManyMutably(updates: Update<T>[], state: R): void {
     const models: T[] = []
 
     updates.forEach(update => takeUpdatedModel(models, update, state))

--- a/src/entities/sorted_state_adapter.ts
+++ b/src/entities/sorted_state_adapter.ts
@@ -3,7 +3,8 @@ import {
   IdSelector,
   Comparer,
   EntityStateAdapter,
-  Update
+  Update,
+  EntityId
 } from './models'
 import { createStateOperator } from './state_adapter'
 import { createUnsortedStateAdapter } from './unsorted_state_adapter'
@@ -23,7 +24,10 @@ export function createSortedStateAdapter<T>(
     return addManyMutably([entity], state)
   }
 
-  function addManyMutably(newModels: T[] | Record<string, T>, state: R): void {
+  function addManyMutably(
+    newModels: T[] | Record<EntityId, T>,
+    state: R
+  ): void {
     if (!Array.isArray(newModels)) {
       newModels = Object.values(newModels)
     }
@@ -37,7 +41,7 @@ export function createSortedStateAdapter<T>(
     }
   }
 
-  function setAllMutably(models: T[] | Record<string, T>, state: R): void {
+  function setAllMutably(models: T[] | Record<EntityId, T>, state: R): void {
     if (!Array.isArray(models)) {
       models = Object.values(models)
     }
@@ -82,7 +86,7 @@ export function createSortedStateAdapter<T>(
   }
 
   function upsertManyMutably(
-    entities: T[] | Record<string, T>,
+    entities: T[] | Record<EntityId, T>,
     state: R
   ): void {
     if (!Array.isArray(entities)) {

--- a/src/entities/unsorted_state_adapter.test.ts
+++ b/src/entities/unsorted_state_adapter.test.ts
@@ -69,6 +69,24 @@ describe('Unsorted State Adapter', () => {
     })
   })
 
+  it('should let you add many entities to the state from a dictionary', () => {
+    const withOneEntity = adapter.addOne(state, TheGreatGatsby)
+
+    const withManyMore = adapter.addMany(withOneEntity, {
+      [AClockworkOrange.id]: AClockworkOrange,
+      [AnimalFarm.id]: AnimalFarm
+    })
+
+    expect(withManyMore).toEqual({
+      ids: [TheGreatGatsby.id, AClockworkOrange.id, AnimalFarm.id],
+      entities: {
+        [TheGreatGatsby.id]: TheGreatGatsby,
+        [AClockworkOrange.id]: AClockworkOrange,
+        [AnimalFarm.id]: AnimalFarm
+      }
+    })
+  })
+
   it('should remove existing and add new ones on setAll', () => {
     const withOneEntity = adapter.addOne(state, TheGreatGatsby)
 
@@ -230,14 +248,11 @@ describe('Unsorted State Adapter', () => {
 
     /*
       Original code failed with a mish-mash of values, like:
-
       {
         ids: [ 'c' ],
         entities: { b: { id: 'b', title: 'First' }, c: { id: 'c' } }
       }
-
       We now expect that only 'c' will be left:
-
       { 
         ids: [ 'c' ], 
         entities: { c: { id: 'c', title: 'First' } } 
@@ -287,6 +302,27 @@ describe('Unsorted State Adapter', () => {
       { ...TheGreatGatsby, ...firstChange },
       AClockworkOrange
     ])
+
+    expect(withUpserts).toEqual({
+      ids: [TheGreatGatsby.id, AClockworkOrange.id],
+      entities: {
+        [TheGreatGatsby.id]: {
+          ...TheGreatGatsby,
+          ...firstChange
+        },
+        [AClockworkOrange.id]: AClockworkOrange
+      }
+    })
+  })
+
+  it('should let you upsert many entities in the state when passing in a dictionary', () => {
+    const firstChange = { title: 'Zack' }
+    const withMany = adapter.setAll(state, [TheGreatGatsby])
+
+    const withUpserts = adapter.upsertMany(withMany, {
+      [TheGreatGatsby.id]: { ...TheGreatGatsby, ...firstChange },
+      [AClockworkOrange.id]: AClockworkOrange
+    })
 
     expect(withUpserts).toEqual({
       ids: [TheGreatGatsby.id, AClockworkOrange.id],

--- a/src/entities/unsorted_state_adapter.test.ts
+++ b/src/entities/unsorted_state_adapter.test.ts
@@ -104,6 +104,23 @@ describe('Unsorted State Adapter', () => {
     })
   })
 
+  it('should remove existing and add new ones on setAll when passing in a dictionary', () => {
+    const withOneEntity = adapter.addOne(state, TheGreatGatsby)
+
+    const withAll = adapter.setAll(withOneEntity, {
+      [AClockworkOrange.id]: AClockworkOrange,
+      [AnimalFarm.id]: AnimalFarm
+    })
+
+    expect(withAll).toEqual({
+      ids: [AClockworkOrange.id, AnimalFarm.id],
+      entities: {
+        [AClockworkOrange.id]: AClockworkOrange,
+        [AnimalFarm.id]: AnimalFarm
+      }
+    })
+  })
+
   it('should let you add remove an entity from the state', () => {
     const withOneEntity = adapter.addOne(state, TheGreatGatsby)
 

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -135,12 +135,12 @@ export function createUnsortedStateAdapter<T>(
     entities: T[] | Record<string, T>,
     state: R
   ): void {
-    const added: T[] = []
-    const updated: Update<T>[] = []
-
     if (!Array.isArray(entities)) {
       entities = Object.values(entities)
     }
+
+    const added: T[] = []
+    const updated: Update<T>[] = []
 
     for (const entity of entities) {
       const id = selectIdValue(entity, selectId)

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -24,7 +24,7 @@ export function createUnsortedStateAdapter<T>(
     state.entities[key] = entity
   }
 
-  function addManyMutably(entities: T[] | Record<string, T>, state: R): void {
+  function addManyMutably(entities: T[] | Record<EntityId, T>, state: R): void {
     if (!Array.isArray(entities)) {
       entities = Object.values(entities)
     }
@@ -34,7 +34,7 @@ export function createUnsortedStateAdapter<T>(
     }
   }
 
-  function setAllMutably(entities: T[] | Record<string, T>, state: R): void {
+  function setAllMutably(entities: T[] | Record<EntityId, T>, state: R): void {
     if (!Array.isArray(entities)) {
       entities = Object.values(entities)
     }
@@ -132,7 +132,7 @@ export function createUnsortedStateAdapter<T>(
   }
 
   function upsertManyMutably(
-    entities: T[] | Record<string, T>,
+    entities: T[] | Record<EntityId, T>,
     state: R
   ): void {
     if (!Array.isArray(entities)) {

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -24,13 +24,21 @@ export function createUnsortedStateAdapter<T>(
     state.entities[key] = entity
   }
 
-  function addManyMutably(entities: T[], state: R): void {
+  function addManyMutably(entities: T[] | Record<string, T>, state: R): void {
+    if (!Array.isArray(entities)) {
+      entities = Object.values(entities)
+    }
+
     for (const entity of entities) {
       addOneMutably(entity, state)
     }
   }
 
-  function setAllMutably(entities: T[], state: R): void {
+  function setAllMutably(entities: T[] | Record<string, T>, state: R): void {
+    if (!Array.isArray(entities)) {
+      entities = Object.values(entities)
+    }
+
     state.ids = []
     state.entities = {}
 
@@ -123,9 +131,16 @@ export function createUnsortedStateAdapter<T>(
     return upsertManyMutably([entity], state)
   }
 
-  function upsertManyMutably(entities: T[], state: R): void {
+  function upsertManyMutably(
+    entities: T[] | Record<string, T>,
+    state: R
+  ): void {
     const added: T[] = []
     const updated: Update<T>[] = []
+
+    if (!Array.isArray(entities)) {
+      entities = Object.values(entities)
+    }
 
     for (const entity of entities) {
       const id = selectIdValue(entity, selectId)

--- a/type-tests/files/createEntityAdapter.typetest.ts
+++ b/type-tests/files/createEntityAdapter.typetest.ts
@@ -41,8 +41,12 @@ function extractReducers<T>(
   })
 
   expectType<ActionCreatorWithPayload<Entity>>(slice.actions.addOne)
-  expectType<ActionCreatorWithPayload<Entity[]>>(slice.actions.addMany)
-  expectType<ActionCreatorWithPayload<Entity[]>>(slice.actions.setAll)
+  expectType<ActionCreatorWithPayload<Entity[] | Record<string, Entity>>>(
+    slice.actions.addMany
+  )
+  expectType<ActionCreatorWithPayload<Entity[] | Record<string, Entity>>>(
+    slice.actions.setAll
+  )
   expectType<ActionCreatorWithPayload<EntityId>>(slice.actions.removeOne)
   expectType<ActionCreatorWithPayload<EntityId[]>>(slice.actions.removeMany)
   expectType<ActionCreatorWithoutPayload>(slice.actions.removeAll)
@@ -51,7 +55,9 @@ function extractReducers<T>(
     slice.actions.updateMany
   )
   expectType<ActionCreatorWithPayload<Entity>>(slice.actions.upsertOne)
-  expectType<ActionCreatorWithPayload<Entity[]>>(slice.actions.upsertMany)
+  expectType<ActionCreatorWithPayload<Entity[] | Record<string, Entity>>>(
+    slice.actions.upsertMany
+  )
 }
 
 /**


### PR DESCRIPTION
#### Overview
This PR allows a user to pass in an object with the shape of `{ 1: { id: 1, other: 'value' }` directly to the `upsertMany`, `addMany`, and `setAll` methods of an entity adapter. This ultimately makes integration with a normalization library like [normalizr](https://github.com/paularmstrong/normalizr) much simpler.

~~Todo~~
- [x] Review `updateMany`
- [x] Review tests
- [x] Expand type tests
