### PR TITLE
Export createImmutableStateInvariantMiddleware, fix typo

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -136,7 +136,7 @@ export function createEntityAdapter<T>(options?: {
     sortComparer?: false | Comparer<T>;
 }): EntityAdapter<T>;
 
-// @public (undocumented)
+// @public
 export function createImmutableStateInvariantMiddleware(options?: ImmutableStateInvariantMiddlewareOptions): Middleware;
 
 export { createNextState }
@@ -216,7 +216,7 @@ export function getType<T extends string>(actionCreator: PayloadActionCreator<an
 // @alpha (undocumented)
 export type IdSelector<T> = (model: T) => EntityId;
 
-// @public (undocumented)
+// @public
 export interface ImmutableStateInvariantMiddlewareOptions {
     // (undocumented)
     ignoredPaths?: string[];
@@ -226,7 +226,7 @@ export interface ImmutableStateInvariantMiddlewareOptions {
     warnAfter?: number;
 }
 
-// @public (undocumented)
+// @public
 export function isImmutableDefault(value: unknown): boolean;
 
 // @public

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -136,6 +136,9 @@ export function createEntityAdapter<T>(options?: {
     sortComparer?: false | Comparer<T>;
 }): EntityAdapter<T>;
 
+// @public (undocumented)
+export function createImmutableStateInvariantMiddleware(options?: ImmutableStateInvariantMiddlewareOptions): Middleware;
+
 export { createNextState }
 
 // @public
@@ -212,6 +215,19 @@ export function getType<T extends string>(actionCreator: PayloadActionCreator<an
 
 // @alpha (undocumented)
 export type IdSelector<T> = (model: T) => EntityId;
+
+// @public (undocumented)
+export interface ImmutableStateInvariantMiddlewareOptions {
+    // (undocumented)
+    ignoredPaths?: string[];
+    // (undocumented)
+    isImmutable?: IsImmutableFunc;
+    // (undocumented)
+    warnAfter?: number;
+}
+
+// @public (undocumented)
+export function isImmutableDefault(value: unknown): boolean;
 
 // @public
 export function isPlain(val: any): boolean;

--- a/src/immutableStateInvariantMiddleware.ts
+++ b/src/immutableStateInvariantMiddleware.ts
@@ -61,6 +61,11 @@ function getSerialize(
   }
 }
 
+/**
+ * The default `isImmutable` function.
+ *
+ * @public
+ */
 export function isImmutableDefault(value: unknown): boolean {
   return (
     typeof value !== 'object' || value === null || typeof value === 'undefined'
@@ -172,12 +177,27 @@ function detectMutations(
 }
 
 type IsImmutableFunc = (value: any) => boolean
+
+/**
+ * Options for `createImmutableStateInvariantMiddleware()`.
+ *
+ * @public
+ */
 export interface ImmutableStateInvariantMiddlewareOptions {
   isImmutable?: IsImmutableFunc
   ignoredPaths?: string[]
   warnAfter?: number
 }
 
+/**
+ * Creates a middleware that checks whether any state was mutated in between
+ * dispatches or during a dispatch. If any mutations are detected, an error is
+ * thrown.
+ *
+ * @param options Middleware options.
+ *
+ * @public
+ */
 export function createImmutableStateInvariantMiddleware(
   options: ImmutableStateInvariantMiddlewareOptions = {}
 ): Middleware {

--- a/src/immutableStateInvariantMiddleware.ts
+++ b/src/immutableStateInvariantMiddleware.ts
@@ -69,13 +69,13 @@ export function isImmutableDefault(value: unknown): boolean {
 
 export function trackForMutations(
   isImmutable: IsImmutableFunc,
-  ingorePaths: string[] | undefined,
+  ignorePaths: string[] | undefined,
   obj: any
 ) {
-  const trackedProperties = trackProperties(isImmutable, ingorePaths, obj)
+  const trackedProperties = trackProperties(isImmutable, ignorePaths, obj)
   return {
     detectMutations() {
-      return detectMutations(isImmutable, ingorePaths, trackedProperties, obj)
+      return detectMutations(isImmutable, ignorePaths, trackedProperties, obj)
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,13 @@ export {
 } from './createSlice'
 export {
   // js
+  createImmutableStateInvariantMiddleware,
+  isImmutableDefault,
+  // types
+  ImmutableStateInvariantMiddlewareOptions
+} from './immutableStateInvariantMiddleware'
+export {
+  // js
   createSerializableStateInvariantMiddleware,
   findNonSerializableValue,
   isPlain,


### PR DESCRIPTION
This adds `createImmutableStateInvariantMiddleware` (and the default `isImmutable`, and options type) to the package exports.

Also noticed a typo in an argument name: `ingorePaths` -> `ignorePaths` (doesn't change the API as it's just a normal arg and not an options object or anything).

Fixes #448 