### PR TITLE
createEntityAdapter Examples reducer changed to reducers

### DIFF
--- a/docs/api/createEntityAdapter.md
+++ b/docs/api/createEntityAdapter.md
@@ -312,7 +312,7 @@ const booksSlice = createSlice({
   initialState: booksAdapter.getInitialState({
     loading: 'idle'
   }),
-  reducer: {
+  reducers: {
     // Can pass adapter functions directly as case reducers.  Because we're passing this
     // as a value, `createSlice` will auto-generate the `bookAdded` action type / creator
     bookAdded: booksAdapter.addOne,


### PR DESCRIPTION
https://redux-starter-kit.js.org/api/createEntityAdapter#examples
Code example word error, "reducer" changed to "reducers"

![20200329110236](https://user-images.githubusercontent.com/28357731/77839149-d7611980-71ac-11ea-80aa-a343be589eb7.png)
