### PR TITLE
add ignoredActionPaths to createSerializableStateInvariantMiddleware

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -271,6 +271,7 @@ export { Selector }
 // @public
 export interface SerializableStateInvariantMiddlewareOptions {
     getEntries?: (value: any) => [string, any][];
+    ignoredActionPaths?: string[];
     ignoredActions?: string[];
     ignoredPaths?: string[];
     isSerializable?: (value: any) => boolean;

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -463,3 +463,16 @@ describe('createAsyncThunk with abortController', () => {
     })
   })
 })
+
+test('non-serializable arguments are ignored by serializableStateInvariantMiddleware', async () => {
+  const restore = mockConsole(createConsole())
+  const nonSerializableValue = new Map()
+  const asyncThunk = createAsyncThunk('test', (arg: Map<any, any>) => {})
+
+  configureStore({
+    reducer: () => 0
+  }).dispatch(asyncThunk(nonSerializableValue))
+
+  expect(getLog().log).toMatchInlineSnapshot(`""`)
+  restore()
+})

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -36,7 +36,7 @@ export function findNonSerializableValue(
   path: ReadonlyArray<string> = [],
   isSerializable: (value: unknown) => boolean = isPlain,
   getEntries?: (value: unknown) => [string, any][],
-  ignoredPaths: string[] = ['meta.args']
+  ignoredPaths: string[] = []
 ): NonSerializableValue | false {
   let foundNestedSerializable: NonSerializableValue | false
 
@@ -112,6 +112,11 @@ export interface SerializableStateInvariantMiddlewareOptions {
   ignoredActions?: string[]
 
   /**
+   * An array of dot-separated path strings to ignore when checking for serializability, Defaults to ['meta.arg']
+   */
+  ignoredActionPaths?: string[]
+
+  /**
    * An array of dot-separated path strings to ignore when checking for serializability, Defaults to []
    */
   ignoredPaths?: string[]
@@ -140,6 +145,7 @@ export function createSerializableStateInvariantMiddleware(
     isSerializable = isPlain,
     getEntries,
     ignoredActions = [],
+    ignoredActionPaths = ['meta.arg'],
     ignoredPaths = [],
     warnAfter = 32
   } = options
@@ -158,7 +164,8 @@ export function createSerializableStateInvariantMiddleware(
         action,
         [],
         isSerializable,
-        getEntries
+        getEntries,
+        ignoredActionPaths
       )
 
       if (foundActionNonSerializableValue) {


### PR DESCRIPTION
allow configuration of createSerializableStateInvariantMiddleware ignoredActionPaths, update default value, add tests

fixes #453

I've opted for the additional `ignoredActionPaths` option now, but I'm open for discussion :)