### PR TITLE
Fix reference to new fetchIssuesCount

### DIFF
--- a/docs/tutorials/advanced-tutorial.md
+++ b/docs/tutorials/advanced-tutorial.md
@@ -733,7 +733,7 @@ export const IssuesListPage = ({
 
 In `<IssuesListPage>`, we import the new `fetchIssuesCount` thunk, and rewrite the component to read the open issues count value from the Redux store.
 
-Inside our `useEffect`, we drop the `fetchIssueCount` function, and dispatch `fetchIssueCount` instead.
+Inside our `useEffect`, we drop the `fetchIssueCount` function, and dispatch `fetchIssuesCount` instead.
 
 ### Logic for Fetching Issues for a Repo
 


### PR DESCRIPTION
Minor doc update that confused me a bit on first read.  the new thunk creator function is called fetchIssuesCount and it replaces fetchIssueCount.