### PR TITLE
Export ThunkDispatch from redux-thunk.

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -307,6 +307,8 @@ export type SliceCaseReducers<State> = {
 
 export { ThunkAction }
 
+export { ThunkDispatch }
+
 // @alpha (undocumented)
 export function unwrapResult<R extends ActionTypesWithOptionalErrorAction>(returned: R): PayloadForActionTypesExcludingErrorActions<R>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {
   OutputSelector,
   ParametricSelector
 } from 'reselect'
-export { ThunkAction } from 'redux-thunk'
+export { ThunkAction, ThunkDispatch } from 'redux-thunk'
 
 // We deliberately enable Immer's ES5 support, on the grounds that
 // we assume RTK will be used with React Native and other Proxy-less


### PR DESCRIPTION
Provide the `ThunkDispatch` type as an export for developer utility and to fix a nasty TypeScript problem.

Fixes #472  (see the issue for details on what this is solving)