### PR TITLE
Update nanoid and export it

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -291,6 +291,9 @@ export function isImmutableDefault(value: unknown): boolean;
 // @public
 export function isPlain(val: any): boolean;
 
+// @public (undocumented)
+export let nanoid: (size?: number) => string;
+
 export { OutputParametricSelector }
 
 export { OutputSelector }

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,3 +100,5 @@ export {
   unwrapResult,
   SerializedError
 } from './createAsyncThunk'
+
+export { nanoid } from './nanoid'

--- a/src/nanoid.ts
+++ b/src/nanoid.ts
@@ -4,6 +4,10 @@
 let urlAlphabet =
   'ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW'
 
+/**
+ *
+ * @public
+ */
 export let nanoid = (size = 21) => {
   let id = ''
   // A compact alternative for `for (var i = 0; i < step; i++)`.

--- a/src/nanoid.ts
+++ b/src/nanoid.ts
@@ -1,27 +1,16 @@
-// Borrowed from https://github.com/ai/nanoid/tree/master/non-secure
-// This alphabet uses a-z A-Z 0-9 _- symbols.
-// Symbols are generated for smaller size.
-// -_zyxwvutsrqponmlkjihgfedcba9876543210ZYXWVUTSRQPONMLKJIHGFEDCBA
-let url = '-_'
-// Loop from 36 to 0 (from z to a and 9 to 0 in Base36).
-let i = 36
-while (i--) {
-  // 36 is radix. Number.prototype.toString(36) returns number
-  // in Base36 representation. Base36 is like hex, but it uses 0–9 and a-z.
-  url += i.toString(36)
-}
-// Loop from 36 to 10 (from Z to A in Base36).
-i = 36
-while (i-- - 10) {
-  url += i.toString(36).toUpperCase()
-}
+// Borrowed from https://github.com/ai/nanoid/blob/3.0.2/non-secure/index.js
+// This alphabet uses `A-Za-z0-9_-` symbols. A genetic algorithm helped
+// optimize the gzip compression for this alphabet.
+let urlAlphabet =
+  'ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW'
 
-export function nanoid(size = 21) {
+export let nanoid = (size = 21) => {
   let id = ''
-  // Compact alternative for `for (var i = 0; i < size; i++)`
-  while (size--) {
-    // `| 0` is compact and faster alternative for `Math.floor()`
-    id += url[(Math.random() * 64) | 0]
+  // A compact alternative for `for (var i = 0; i < step; i++)`.
+  let i = size
+  while (i--) {
+    // `| 0` is more compact and faster than `Math.floor()`.
+    id += urlAlphabet[(Math.random() * 64) | 0]
   }
   return id
 }


### PR DESCRIPTION
Nanoid recently put out 3.0, which rewrote a bunch of their
implementation, and 3.0.2 made further tweaks to the non-secure
ID function.

Since we've inlined this, we might as well swipe their updates,
and export it ourselves if anyone wants to use it.