### PR TITLE
payloadCreator arg argument => asyncThunk arg type

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -111,7 +111,7 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @public (undocumented)
-export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>): ((arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>): IsAny<ThunkArg, (arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
     arg: ThunkArg;
     requestId: string;
 }, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
@@ -119,8 +119,44 @@ export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig exten
     requestId: string;
     aborted: boolean;
 }, SerializedError>> & {
-    abort: (reason?: string | undefined) => void;
-}) & {
+    abort(reason?: string | undefined): void;
+}, unknown extends ThunkArg ? (arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+    arg: ThunkArg;
+    requestId: string;
+}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
+    arg: ThunkArg;
+    requestId: string;
+    aborted: boolean;
+}, SerializedError>> & {
+    abort(reason?: string | undefined): void;
+} : [ThunkArg] extends [void] | [undefined] ? () => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+    arg: ThunkArg;
+    requestId: string;
+}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
+    arg: ThunkArg;
+    requestId: string;
+    aborted: boolean;
+}, SerializedError>> & {
+    abort(reason?: string | undefined): void;
+} : [undefined] extends [] | [ThunkArg] ? (arg?: ThunkArg | undefined) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+    arg: ThunkArg;
+    requestId: string;
+}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
+    arg: ThunkArg;
+    requestId: string;
+    aborted: boolean;
+}, SerializedError>> & {
+    abort(reason?: string | undefined): void;
+} : (arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+    arg: ThunkArg;
+    requestId: string;
+}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
+    arg: ThunkArg;
+    requestId: string;
+    aborted: boolean;
+}, SerializedError>> & {
+    abort(reason?: string | undefined): void;
+}> & {
     pending: ActionCreatorWithPreparedPayload<[string, ThunkArg], undefined, string, never, {
         arg: ThunkArg;
         requestId: string;

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -138,7 +138,16 @@ export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig exten
     aborted: boolean;
 }, SerializedError>> & {
     abort(reason?: string | undefined): void;
-} : [undefined] extends [] | [ThunkArg] ? (arg?: ThunkArg | undefined) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+} : [void] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+    arg: ThunkArg;
+    requestId: string;
+}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
+    arg: ThunkArg;
+    requestId: string;
+    aborted: boolean;
+}, SerializedError>> & {
+    abort(reason?: string | undefined): void;
+} : [undefined] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
     arg: ThunkArg;
     requestId: string;
 }, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -60,6 +60,11 @@ export interface ActionReducerMapBuilder<State> {
 export type Actions<T extends keyof any = string> = Record<T, Action>;
 
 // @public
+export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThunkConfig> = (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<AsyncThunkReturnValue<ThunkArg, Returned, GetRejectValue<ThunkApiConfig>>> & {
+    abort(reason?: string): void;
+};
+
+// @public
 export type AsyncThunkPayloadCreator<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}> = (arg: ThunkArg, thunkAPI: GetThunkAPI<ThunkApiConfig>) => AsyncThunkPayloadCreatorReturnValue<Returned, ThunkApiConfig>;
 
 // @public
@@ -111,61 +116,7 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @public (undocumented)
-export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>): IsAny<ThunkArg, (arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
-    arg: ThunkArg;
-    requestId: string;
-}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
-    arg: ThunkArg;
-    requestId: string;
-    aborted: boolean;
-}, SerializedError>> & {
-    abort(reason?: string | undefined): void;
-}, unknown extends ThunkArg ? (arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
-    arg: ThunkArg;
-    requestId: string;
-}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
-    arg: ThunkArg;
-    requestId: string;
-    aborted: boolean;
-}, SerializedError>> & {
-    abort(reason?: string | undefined): void;
-} : [ThunkArg] extends [void] | [undefined] ? () => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
-    arg: ThunkArg;
-    requestId: string;
-}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
-    arg: ThunkArg;
-    requestId: string;
-    aborted: boolean;
-}, SerializedError>> & {
-    abort(reason?: string | undefined): void;
-} : [void] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
-    arg: ThunkArg;
-    requestId: string;
-}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
-    arg: ThunkArg;
-    requestId: string;
-    aborted: boolean;
-}, SerializedError>> & {
-    abort(reason?: string | undefined): void;
-} : [undefined] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
-    arg: ThunkArg;
-    requestId: string;
-}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
-    arg: ThunkArg;
-    requestId: string;
-    aborted: boolean;
-}, SerializedError>> & {
-    abort(reason?: string | undefined): void;
-} : (arg: ThunkArg) => (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
-    arg: ThunkArg;
-    requestId: string;
-}, never> | PayloadAction<GetRejectValue<ThunkApiConfig> | undefined, string, {
-    arg: ThunkArg;
-    requestId: string;
-    aborted: boolean;
-}, SerializedError>> & {
-    abort(reason?: string | undefined): void;
-}> & {
+export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>): IsAny<ThunkArg, (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>, unknown extends ThunkArg ? (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [ThunkArg] extends [void] | [undefined] ? () => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [void] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [undefined] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>> & {
     pending: ActionCreatorWithPreparedPayload<[string, ThunkArg], undefined, string, never, {
         arg: ThunkArg;
         requestId: string;

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -226,13 +226,22 @@ If you want to use the AbortController to react to \`abort\` events, please cons
 
   type ActionCreator = IsAny<
     ThunkArg,
+    // any handling
     (arg: ThunkArg) => AsyncActionThunkAction,
+    // unknown handling
     unknown extends ThunkArg
-      ? (arg: ThunkArg) => AsyncActionThunkAction
+      ? (arg: ThunkArg) => AsyncActionThunkAction // argument not specified or specified as void or undefined
       : [ThunkArg] extends [void] | [undefined]
-      ? () => AsyncActionThunkAction
-      : [undefined] extends [ThunkArg] | []
-      ? (arg?: ThunkArg) => AsyncActionThunkAction
+      ? () => AsyncActionThunkAction // argument contains void
+      : [void] extends [ThunkArg] // make optional
+      ? (arg?: ThunkArg) => AsyncActionThunkAction // argument contains undefined
+      : [undefined] extends [ThunkArg]
+      ? WithStrictNullChecks<
+          // with strict nullChecks: make optional
+          (arg?: ThunkArg) => AsyncActionThunkAction,
+          // without strict null checks this will match everything, so don't make it optional
+          (arg: ThunkArg) => AsyncActionThunkAction
+        > // default case: normal argument
       : (arg: ThunkArg) => AsyncActionThunkAction
   >
 
@@ -320,3 +329,7 @@ export function unwrapResult<R extends ActionTypesWithOptionalErrorAction>(
   }
   return (returned as any).payload
 }
+
+type WithStrictNullChecks<True, False> = undefined extends boolean
+  ? False
+  : True

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export {
 } from './entities/models'
 
 export {
+  AsyncThunkAction,
   AsyncThunkPayloadCreatorReturnValue,
   AsyncThunkPayloadCreator,
   createAsyncThunk,

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -317,7 +317,7 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
 
   // two arguments, first specified as any: asyncThunk has required any argument
   {
-    const asyncThunk = createAsyncThunk('test', (arg: any) => 0)
+    const asyncThunk = createAsyncThunk('test', (arg: any, thunkApi) => 0)
     expectType<IsAny<Parameters<typeof asyncThunk>[0], true, false>>(true)
     asyncThunk(5)
     // typings:expect-error
@@ -326,7 +326,7 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
 
   // two arguments, first specified as unknown: asyncThunk has required unknown argument
   {
-    const asyncThunk = createAsyncThunk('test', (arg: unknown) => 0)
+    const asyncThunk = createAsyncThunk('test', (arg: unknown, thunkApi) => 0)
     expectType<IsUnknown<Parameters<typeof asyncThunk>[0], true, false>>(true)
     asyncThunk(5)
     // typings:expect-error
@@ -335,7 +335,7 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
 
   // two arguments, first specified as number: asyncThunk has required number argument
   {
-    const asyncThunk = createAsyncThunk('test', (arg: number) => 0)
+    const asyncThunk = createAsyncThunk('test', (arg: number, thunkApi) => 0)
     expectType<(arg: number) => any>(asyncThunk)
     asyncThunk(5)
     // typings:expect-error

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -186,45 +186,159 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
  * payloadCreator first argument type has impact on asyncThunk argument
  */
 {
-  const voidAsyncThunk = createAsyncThunk('test', () => 0)
-  expectType<() => any>(voidAsyncThunk)
-  // typings:expect-error cannot be called with an argument
-  voidAsyncThunk(0 as any)
+  // no argument: asyncThunk has no argument
+  {
+    const asyncThunk = createAsyncThunk('test', () => 0)
+    expectType<() => any>(asyncThunk)
+    // typings:expect-error cannot be called with an argument
+    asyncThunk(0 as any)
+  }
 
-  const undefinedAsyncThunk = createAsyncThunk('test', (arg: undefined) => 0)
-  expectType<() => any>(undefinedAsyncThunk)
-  // typings:expect-error cannot be called with an argument
-  undefinedAsyncThunk(0 as any)
+  // one argument, specified as undefined: asyncThunk has no argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: undefined) => 0)
+    expectType<() => any>(asyncThunk)
+    // typings:expect-error cannot be called with an argument
+    asyncThunk(0 as any)
+  }
 
-  const unspecifiedAsyncThunk = createAsyncThunk('test', () => 0)
-  expectType<() => any>(unspecifiedAsyncThunk)
-  // typings:expect-error cannot be called with an argument
-  unspecifiedAsyncThunk(0 as any)
+  // one argument, specified as void: asyncThunk has no argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: void) => 0)
+    expectType<() => any>(asyncThunk)
+    // typings:expect-error cannot be called with an argument
+    asyncThunk(0 as any)
+  }
 
-  const optionalNumberAsyncThunk = createAsyncThunk('test', (arg?: number) => 0)
-  expectType<(arg?: number) => any>(optionalNumberAsyncThunk)
-  optionalNumberAsyncThunk()
-  optionalNumberAsyncThunk(5)
-  // typings:expect-error
-  optionalNumberAsyncThunk('string')
+  // one argument, specified as optional number: asyncThunk has optional number argument
+  // this test will fail with strictNullChecks: false, that is to be expected
+  // in that case, we have to forbid this behaviour or it will make arguments optional everywhere
+  {
+    const asyncThunk = createAsyncThunk('test', (arg?: number) => 0)
+    expectType<(arg?: number) => any>(asyncThunk)
+    asyncThunk()
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk('string')
+  }
 
-  const anyAsyncThunk = createAsyncThunk('test', (arg: any) => 0)
-  expectType<IsAny<Parameters<typeof anyAsyncThunk>[0], true, false>>(true)
-  anyAsyncThunk(5)
-  // typings:expect-error
-  anyAsyncThunk()
+  // one argument, specified as number|undefined: asyncThunk has optional number argument
+  // this test will fail with strictNullChecks: false, that is to be expected
+  // in that case, we have to forbid this behaviour or it will make arguments optional everywhere
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: number | undefined) => 0)
+    expectType<(arg?: number) => any>(asyncThunk)
+    asyncThunk()
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk('string')
+  }
 
-  const unknownAsyncThunk = createAsyncThunk('test', (arg: unknown) => 0)
-  expectType<IsUnknown<Parameters<typeof unknownAsyncThunk>[0], true, false>>(
-    true
-  )
-  unknownAsyncThunk(5)
-  // typings:expect-error
-  unknownAsyncThunk()
+  // one argument, specified as number|void: asyncThunk has optional number argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: number | void) => 0)
+    expectType<(arg?: number) => any>(asyncThunk)
+    asyncThunk()
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk('string')
+  }
 
-  const numberAsyncThunk = createAsyncThunk('test', (arg: number) => 0)
-  expectType<(arg: number) => any>(numberAsyncThunk)
-  numberAsyncThunk(5)
-  // typings:expect-error
-  numberAsyncThunk()
+  // one argument, specified as any: asyncThunk has required any argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: any) => 0)
+    expectType<IsAny<Parameters<typeof asyncThunk>[0], true, false>>(true)
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk()
+  }
+
+  // one argument, specified as unknown: asyncThunk has required unknown argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: unknown) => 0)
+    expectType<IsUnknown<Parameters<typeof asyncThunk>[0], true, false>>(true)
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk()
+  }
+
+  // one argument, specified as number: asyncThunk has required number argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: number) => 0)
+    expectType<(arg: number) => any>(asyncThunk)
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk()
+  }
+
+  // two arguments, first specified as undefined: asyncThunk has no argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: undefined, thunkApi) => 0)
+    expectType<() => any>(asyncThunk)
+    // typings:expect-error cannot be called with an argument
+    asyncThunk(0 as any)
+  }
+
+  // two arguments, first specified as void: asyncThunk has no argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: void, thunkApi) => 0)
+    expectType<() => any>(asyncThunk)
+    // typings:expect-error cannot be called with an argument
+    asyncThunk(0 as any)
+  }
+
+  // two arguments, first specified as number|undefined: asyncThunk has optional number argument
+  // this test will fail with strictNullChecks: false, that is to be expected
+  // in that case, we have to forbid this behaviour or it will make arguments optional everywhere
+  {
+    const asyncThunk = createAsyncThunk(
+      'test',
+      (arg: number | undefined, thunkApi) => 0
+    )
+    expectType<(arg?: number) => any>(asyncThunk)
+    asyncThunk()
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk('string')
+  }
+
+  // two arguments, first specified as number|void: asyncThunk has optional number argument
+  {
+    const asyncThunk = createAsyncThunk(
+      'test',
+      (arg: number | void, thunkApi) => 0
+    )
+    expectType<(arg?: number) => any>(asyncThunk)
+    asyncThunk()
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk('string')
+  }
+
+  // two arguments, first specified as any: asyncThunk has required any argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: any) => 0)
+    expectType<IsAny<Parameters<typeof asyncThunk>[0], true, false>>(true)
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk()
+  }
+
+  // two arguments, first specified as unknown: asyncThunk has required unknown argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: unknown) => 0)
+    expectType<IsUnknown<Parameters<typeof asyncThunk>[0], true, false>>(true)
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk()
+  }
+
+  // two arguments, first specified as number: asyncThunk has required number argument
+  {
+    const asyncThunk = createAsyncThunk('test', (arg: number) => 0)
+    expectType<(arg: number) => any>(asyncThunk)
+    asyncThunk(5)
+    // typings:expect-error
+    asyncThunk()
+  }
 }

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -3,7 +3,7 @@ import { ThunkDispatch } from 'redux-thunk'
 import { unwrapResult, SerializedError } from 'src/createAsyncThunk'
 
 import apiRequest, { AxiosError } from 'axios'
-import { IsAny } from 'src/tsHelpers'
+import { IsAny, IsUnknown } from 'src/tsHelpers'
 
 function expectType<T>(t: T) {
   return t
@@ -180,4 +180,51 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
       }
     }
   })
+}
+
+/**
+ * payloadCreator first argument type has impact on asyncThunk argument
+ */
+{
+  const voidAsyncThunk = createAsyncThunk('test', () => 0)
+  expectType<() => any>(voidAsyncThunk)
+  // typings:expect-error cannot be called with an argument
+  voidAsyncThunk(0 as any)
+
+  const undefinedAsyncThunk = createAsyncThunk('test', (arg: undefined) => 0)
+  expectType<() => any>(undefinedAsyncThunk)
+  // typings:expect-error cannot be called with an argument
+  undefinedAsyncThunk(0 as any)
+
+  const unspecifiedAsyncThunk = createAsyncThunk('test', () => 0)
+  expectType<() => any>(unspecifiedAsyncThunk)
+  // typings:expect-error cannot be called with an argument
+  unspecifiedAsyncThunk(0 as any)
+
+  const optionalNumberAsyncThunk = createAsyncThunk('test', (arg?: number) => 0)
+  expectType<(arg?: number) => any>(optionalNumberAsyncThunk)
+  optionalNumberAsyncThunk()
+  optionalNumberAsyncThunk(5)
+  // typings:expect-error
+  optionalNumberAsyncThunk('string')
+
+  const anyAsyncThunk = createAsyncThunk('test', (arg: any) => 0)
+  expectType<IsAny<Parameters<typeof anyAsyncThunk>[0], true, false>>(true)
+  anyAsyncThunk(5)
+  // typings:expect-error
+  anyAsyncThunk()
+
+  const unknownAsyncThunk = createAsyncThunk('test', (arg: unknown) => 0)
+  expectType<IsUnknown<Parameters<typeof unknownAsyncThunk>[0], true, false>>(
+    true
+  )
+  unknownAsyncThunk(5)
+  // typings:expect-error
+  unknownAsyncThunk()
+
+  const numberAsyncThunk = createAsyncThunk('test', (arg: number) => 0)
+  expectType<(arg: number) => any>(numberAsyncThunk)
+  numberAsyncThunk(5)
+  // typings:expect-error
+  numberAsyncThunk()
 }


### PR DESCRIPTION
This would address #489 without changing any external signatures to this point. So @stephen-dahl and @msutkowski  please take a look.

The complete behavioral change should be covered by this test:

https://github.com/phryneas/redux-toolkit/blob/47eac023cd18e86cf888224381a77b9776a97677/type-tests/files/createAsyncThunk.typetest.ts#L185-L230

My only concern is the handling of optional parameters. For people with `strictNullChecks: false` in their `tsconfig.json`, this would make the parameter optional for all their asyncThunks - which is only consequent, but may be undesirable.
I've gotta take a second look if this can be done better - on the other hand, we have the same behavior with `createSlice` actions already, so I would not try too much there.

Also, this *might* make extending createAsyncThunk with Typescript (#486) a little more difficult (we'd have to do some things for that anyways, but it might be simpler before this change), so I've got to evaluate that before we merge it.

But please already take a look.