### PR TITLE
Update references to useAppDispatch in docs and advanced tutorial

### DIFF
--- a/docs/tutorials/advanced-tutorial.md
+++ b/docs/tutorials/advanced-tutorial.md
@@ -383,7 +383,7 @@ Unlike typical `connect` + `mapDispatch` usage, here we call `dispatch()` direct
 
 Let's see if this works!
 
-<iframe  src="https://codesandbox.io/s/rtk-github-issues-example-02-issues-display-w-useappdispatch-wg591?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2FApp.tsx&theme=dark&view=preview"
+<iframe  src="https://codesandbox.io/embed/rtk-github-issues-example-02-issues-display-w-useappdispatch-wg591?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2FApp.tsx&theme=dark&view=preview"
      style={{ width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden' }}
      title="rtk-github-issues-example-02-issues-display"
      allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
@@ -1225,7 +1225,7 @@ Hopefully you now have a solid understanding of how Redux Toolkit looks in a rea
 
 Let's wrap this up with one more look at the complete source code and the running app:
 
-<iframe src="https://codesandbox.io/s/rtk-github-issues-example-03-final-w-useappdispatch-vh15y?fontsize=14&hidenavigation=1&module=%2Fsrc%2Ffeatures%2FissueDetails%2FcommentsSlice.ts&theme=dark&view=editor"
+<iframe src="https://codesandbox.io/embed/rtk-github-issues-example-03-final-w-useappdispatch-vh15y?fontsize=14&hidenavigation=1&module=%2Fsrc%2Ffeatures%2FissueDetails%2FcommentsSlice.ts&theme=dark&view=editor"
      style={{ width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden' }}
      title="rtk-github-issues-example03-final"
      allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"

--- a/docs/tutorials/advanced-tutorial.md
+++ b/docs/tutorials/advanced-tutorial.md
@@ -93,6 +93,7 @@ Next, we'll create the store instance, including hot-reloading the root reducer.
 
 ```ts
 import { configureStore } from '@reduxjs/toolkit'
+import { useDispatch } from 'react-redux'
 
 import rootReducer from './rootReducer'
 
@@ -382,7 +383,7 @@ Unlike typical `connect` + `mapDispatch` usage, here we call `dispatch()` direct
 
 Let's see if this works!
 
-<iframe  src="https://codesandbox.io/embed/rtk-github-issues-example-02-issues-display-tdx2w?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2FApp.tsx&theme=dark&view=preview"
+<iframe  src="https://codesandbox.io/s/rtk-github-issues-example-02-issues-display-w-useappdispatch-wg591?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2FApp.tsx&theme=dark&view=preview"
      style={{ width: '100%', height: '500px', border: 0, borderRadius: '4px', overflow: 'hidden' }}
      title="rtk-github-issues-example-02-issues-display"
      allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -31,15 +31,17 @@ export type RootState = ReturnType<typeof rootReducer>
 ### Getting the `Dispatch` type
 
 If you want to get the `Dispatch` type from your store, you can extract it after creating the store.  
-It is recommend to give the type a different name like `AppDispatch` to prevent confusion, as the type name `Dispatch` is usually overused.
+It is recommended to give the type a different name like `AppDispatch` to prevent confusion, as the type name `Dispatch` is usually overused. You may also find it to be more convenient to export a hook like `useAppDispatch` shown below, then using it wherever you'd call `useDispatch`.
 
 ```typescript {6}
 import { configureStore } from '@reduxjs/toolkit'
+import { useDispatch } from 'react-redux'
 import rootReducer from './rootReducer'
 const store = configureStore({
   reducer: rootReducer
 })
 export type AppDispatch = typeof store.dispatch
+export const useAppDispatch = () => useDispatch<AppDispatch>()
 ```
 
 ### Correct typings for the `Dispatch` type
@@ -76,7 +78,7 @@ const store = configureStore({
 type AppDispatch = typeof store.dispatch
 ```
 
-If you need any additional reference or examples, [the type tests for `configureStore`](https://github.com/reduxjs/redux-toolkit/blob/master/type-tests/files/configureStore.typetest.ts) contain many different scenarios on how to type this.
+If you need any additional reference or examples, [the type tests for `configureStore`](https://github.com/reduxjs/redux-toolkit/blob/master/type-tests/files/configureStore.typetest.ts) contains many different scenarios on how to type this.
 
 ### Using the extracted `Dispatch` type with React-Redux
 


### PR DESCRIPTION
Per various thread and #485, updates code examples to show the possible usage of `const dispatch: AppDispatch = useDispatch()`, but recommends exporting a `useAppDispatch()` hook for convenience.

- [x] Update advanced tutorial codesandbox 02
- [x] Update advanced tutorial codesandbox 03