### PR TITLE
Allow nested Immer produce statements with createReducer

### DIFF
--- a/src/createReducer.test.ts
+++ b/src/createReducer.test.ts
@@ -1,5 +1,6 @@
 import { createReducer, CaseReducer } from './createReducer'
 import { PayloadAction, createAction } from './createAction'
+import { createNextState, Draft } from './'
 import { Reducer } from 'redux'
 
 interface Todo {
@@ -73,6 +74,36 @@ describe('createReducer', () => {
     })
 
     behavesLikeReducer(todosReducer)
+  })
+
+  describe('given draft state from immer', () => {
+    const addTodo: AddTodoReducer = (state, action) => {
+      const { newTodo } = action.payload
+
+      // Can safely call state.push() here
+      state.push({ ...newTodo, completed: false })
+    }
+
+    const toggleTodo: ToggleTodoReducer = (state, action) => {
+      const { index } = action.payload
+
+      const todo = state[index]
+      // Can directly modify the todo object
+      todo.completed = !todo.completed
+    }
+
+    const todosReducer = createReducer([] as TodoState, {
+      ADD_TODO: addTodo,
+      TOGGLE_TODO: toggleTodo
+    })
+
+    const wrappedReducer: TodosReducer = (state = [], action) => {
+      return createNextState(state, (draft: Draft<TodoState>) => {
+        todosReducer(draft, action)
+      })
+    }
+
+    behavesLikeReducer(wrappedReducer)
   })
 
   describe('alternative builder callback for actionMap', () => {

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -111,7 +111,8 @@ export function createReducer<S>(
         // we must already be inside a `createNextState` call, likely because
         // this is being wrapped in `createReducer` or `createSlice`.
         // It's safe to just pass the draft to the mutator.
-        return caseReducer(state, action)
+        const draft = state as Draft<S> // We can aassume this is already a draft
+        return caseReducer(draft, action) || state
       } else {
         // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather
         // than an Immutable<S>, and TypeScript cannot find out how to reconcile

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -1,4 +1,4 @@
-import createNextState, { Draft } from 'immer'
+import createNextState, { Draft, isDraft } from 'immer'
 import { AnyAction, Action, Reducer } from 'redux'
 import {
   executeReducerBuilderCallback,
@@ -105,12 +105,23 @@ export function createReducer<S>(
       : mapOrBuilderCallback
 
   return function(state = initialState, action): S {
-    // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather
-    // than an Immutable<S>, and TypeScript cannot find out how to reconcile
-    // these two types.
-    return createNextState(state, (draft: Draft<S>) => {
-      const caseReducer = actionsMap[action.type]
-      return caseReducer ? caseReducer(draft, action) : undefined
-    })
+    const caseReducer = actionsMap[action.type]
+    if (caseReducer) {
+      if (isDraft(state)) {
+        // we must already be inside a `createNextState` call, likely because
+        // this is being wrapped in `createReducer` or `createSlice`.
+        // It's safe to just pass the draft to the mutator.
+        return caseReducer(state, action)
+      } else {
+        // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather
+        // than an Immutable<S>, and TypeScript cannot find out how to reconcile
+        // these two types.
+        return createNextState(state, (draft: Draft<S>) => {
+          return caseReducer(draft, action)
+        })
+      }
+    }
+
+    return state
   }
 }


### PR DESCRIPTION
Fixes issue #508, where passing an Immer `draft` object to a reducer created with `createReducer` will swallow any changes made, and they won't affect the initial `draft` object. This means any top-level `produce` statement will not be able to detect any change to the state, even if changes occurred.

This bumps into some typing issues, since `CaseReducers` are configured to contain a `Draft<S>` and return `S | void`. Someone will need to review this and advise how best to fix the typing issues, as I've just used the `as` keyword to assume a type on lines 114-115.