### PR TITLE
Add missing parameters to docs for serializable middleware

### DIFF
--- a/docs/api/getDefaultMiddleware.md
+++ b/docs/api/getDefaultMiddleware.md
@@ -133,9 +133,21 @@ interface SerializableStateInvariantMiddlewareOptions {
   ignoredActions?: string[]
 
   /**
+   * An array of dot-separated path strings to ignore when checking for serializability, Defaults to ['meta.arg']
+   * If you use this parameter, the default value 'meta.arg' will be removed, so we recommend re-adding it unless you
+   * specifically do not want to ignore it. Example: ['meta.arg', 'your.path', 'other.path', ...etc]
+   */
+  ignoredActionPaths?: string[]
+
+  /**
    * An array of dot-separated path strings to ignore when checking for serializability, Defaults to []
    */
   ignoredPaths?: string[]
+
+  /**
+   * Execution time warning threshold. If the middleware takes longer than `warnAfter` ms, a warning will be displayed in the console. Defaults to 32
+   */
+  warnAfter?: number
 }
 
 interface GetDefaultMiddlewareOptions {

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -80,9 +80,15 @@ function createSerializableStateInvariantMiddleware({
   // An array of action types to ignore when checking for serializability.
   // Defaults to []
   ignoredActions?: string[]
-  // An array of dot-separated path strings to ignore when checking for serializability.
-  // Defaults to []
+  // An array of dot-separated path strings to ignore when
+  // checking for serializability, Defaults to ['meta.arg']
+  ignoredActionPaths?: string[]
+  // An array of dot-separated path strings to ignore when
+  // checking for serializability, Defaults to []
   ignoredPaths?: string[]
+  // Execution time warning threshold. If the middleware takes longer
+  // than `warnAfter` ms, a warning will be displayed in the console. Defaults to 32
+  warnAfter?: number
 })
 ```
 


### PR DESCRIPTION
- Adds missing parameters to the `getDefaultMiddleware` and `otherExports` docs for `SerializableStateInvariantMiddlewareOptions`
- Adds a note about the behavior to `ignoreActionPaths` that its recommended to replace `meta.arg` unless it's explicitly ignored when using that option