### PR TITLE
allow to skip AsyncThunks using a condition callback

### DIFF
--- a/docs/api/createAsyncThunk.md
+++ b/docs/api/createAsyncThunk.md
@@ -52,7 +52,7 @@ dispatch(fetchUserById(123))
 
 ## Parameters
 
-`createAsyncThunk` accepts two parameters: a string action `type` value, and a `payloadCreator` callback.
+`createAsyncThunk` accepts three parameters: a string action `type` value, a `payloadCreator` callback, and an `options` object.
 
 ### `type`
 
@@ -82,6 +82,13 @@ The `payloadCreator` function will be called with two arguments:
   - `rejectWithValue`: rejectWithValue is a utility function that you can `return` in your action creator to return a rejected response with a defined payload. It will pass whatever value you give it and return it in the payload of the rejected action.
 
 The logic in the `payloadCreator` function may use any of these values as needed to calculate the result.
+
+### Options
+
+An object with the following optional fields:
+
+- `condition`: a callback that can be used to skip execution of the payload creator and all action dispatches, if desired. See [Canceling Before Execution](#canceling-before-execution) for a complete description.
+- `dispatchConditionRejection`: if `condition()` returns `false`, the default behavior is that no actions will be dispatched at all. If you still want a "rejected" action to be dispatched when the thunk was canceled, set this flag to `true`.
 
 ## Return Value
 
@@ -264,6 +271,8 @@ const fetchUserById = createAsyncThunk(
   }
 )
 ```
+
+If `condition()` returns `false`, the default behavior is that no actions will be dispatched at all. If you still want a "rejected" action to be dispatched when the thunk was canceled, pass in `{condition, dispatchConditionRejection: true}`.
 
 ### Canceling While Running
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -60,7 +60,15 @@ export interface ActionReducerMapBuilder<State> {
 export type Actions<T extends keyof any = string> = Record<T, Action>;
 
 // @public
-export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThunkConfig> = (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<AsyncThunkReturnValue<ThunkArg, Returned, GetRejectValue<ThunkApiConfig>>> & {
+export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThunkConfig> = (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
+    arg: ThunkArg;
+    requestId: string;
+}> | PayloadAction<undefined | GetRejectValue<ThunkApiConfig>, string, {
+    arg: ThunkArg;
+    requestId: string;
+    aborted: boolean;
+    condition: boolean;
+}, SerializedError>> & {
     abort(reason?: string): void;
 };
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -116,7 +116,7 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @public (undocumented)
-export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>): IsAny<ThunkArg, (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>, unknown extends ThunkArg ? (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [ThunkArg] extends [void] | [undefined] ? () => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [void] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [undefined] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>> & {
+export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(type: string, payloadCreator: (arg: ThunkArg, thunkAPI: GetThunkAPI<ThunkApiConfig>) => Promise<Returned | RejectWithValue<GetRejectValue<ThunkApiConfig>>> | Returned | RejectWithValue<GetRejectValue<ThunkApiConfig>>, options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>): IsAny<ThunkArg, (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>, unknown extends ThunkArg ? (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [ThunkArg] extends [void] | [undefined] ? () => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [void] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : [undefined] extends [ThunkArg] ? (arg?: ThunkArg | undefined) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> : (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>> & {
     pending: ActionCreatorWithPreparedPayload<[string, ThunkArg], undefined, string, never, {
         arg: ThunkArg;
         requestId: string;
@@ -125,6 +125,7 @@ export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig exten
         arg: ThunkArg;
         requestId: string;
         aborted: boolean;
+        condition: boolean;
     }>;
     fulfilled: ActionCreatorWithPreparedPayload<[Returned, string, ThunkArg], Returned, string, never, {
         arg: ThunkArg;

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -502,6 +502,18 @@ describe('conditional skipping of asyncThunks', () => {
     expect((result as any).meta.condition).toBe(true)
   })
 
+  test('return falsy from condition does not skip payload creator', async () => {
+    // Override TS's expectation that this is a boolean
+    condition.mockReturnValueOnce((undefined as unknown) as boolean)
+    const asyncThunk = createAsyncThunk('test', payloadCreator, { condition })
+    const result = await asyncThunk(arg)(dispatch, getState, extra)
+
+    expect(condition).toHaveBeenCalled()
+    expect(payloadCreator).toHaveBeenCalled()
+    expect(asyncThunk.fulfilled.match(result)).toBe(true)
+    expect(result.payload).toBe(10)
+  })
+
   test('returning true from condition executes payloadCreator', async () => {
     condition.mockReturnValueOnce(true)
     const asyncThunk = createAsyncThunk('test', payloadCreator, { condition })

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -4,7 +4,7 @@ import {
   unwrapResult
 } from './createAsyncThunk'
 import { configureStore } from './configureStore'
-import { AnyAction, Dispatch } from 'redux'
+import { AnyAction } from 'redux'
 
 import {
   mockConsole,
@@ -536,8 +536,18 @@ describe('conditional skipping of asyncThunks', () => {
     )
   })
 
-  test('rejected action is dispatched by default', async () => {
+  test('rejected action is not dispatched by default', async () => {
     const asyncThunk = createAsyncThunk('test', payloadCreator, { condition })
+    await asyncThunk(arg)(dispatch, getState, extra)
+
+    expect(dispatch).toHaveBeenCalledTimes(0)
+  })
+
+  test('rejected action can be dispatched via option', async () => {
+    const asyncThunk = createAsyncThunk('test', payloadCreator, {
+      condition,
+      dispatchConditionRejection: true
+    })
     await asyncThunk(arg)(dispatch, getState, extra)
 
     expect(dispatch).toHaveBeenCalledTimes(1)
@@ -557,15 +567,5 @@ describe('conditional skipping of asyncThunks', () => {
         type: 'test/rejected'
       })
     )
-  })
-
-  test('rejected action can be prevented from being dispatched', async () => {
-    const asyncThunk = createAsyncThunk('test', payloadCreator, {
-      condition,
-      dispatchConditionRejection: false
-    })
-    await asyncThunk(arg)(dispatch, getState, extra)
-
-    expect(dispatch).toHaveBeenCalledTimes(0)
   })
 })

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -188,10 +188,35 @@ type AsyncThunkActionCreator<
     : (arg: ThunkArg) => AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig>
 >
 
+interface AsyncThunkOptions<
+  ThunkArg = void,
+  ThunkApiConfig extends AsyncThunkConfig = {}
+> {
+  /**
+   * A method to control whether the asyncThunk should be executed. Has access to the
+   * `arg`, `api.getState()` and `api.extra` arguments.
+   *
+   * @returns `true` if the asyncThunk should be executed, `false` if it should be skipped
+   */
+  condition?(
+    arg: ThunkArg,
+    api: Pick<GetThunkAPI<ThunkApiConfig>, 'getState' | 'extra'>
+  ): boolean
+  /**
+   * If `condition` returns `false`, the asyncThunk will be skipped.
+   * This option allows you to control whether a `rejected` action with `meta.condition == false`
+   * will be dispatched or not.
+   *
+   * @default `true`
+   */
+  dispatchConditionRejection?: boolean
+}
+
 /**
  *
  * @param type
  * @param payloadCreator
+ * @param options
  *
  * @public
  */
@@ -201,7 +226,14 @@ export function createAsyncThunk<
   ThunkApiConfig extends AsyncThunkConfig = {}
 >(
   type: string,
-  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>
+  payloadCreator: (
+    arg: ThunkArg,
+    thunkAPI: GetThunkAPI<ThunkApiConfig>
+  ) =>
+    | Promise<Returned | RejectWithValue<GetRejectValue<ThunkApiConfig>>>
+    | Returned
+    | RejectWithValue<GetRejectValue<ThunkApiConfig>>,
+  options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>
 ) {
   type RejectedValue = GetRejectValue<ThunkApiConfig>
 
@@ -234,13 +266,15 @@ export function createAsyncThunk<
       payload?: RejectedValue
     ) => {
       const aborted = !!error && error.name === 'AbortError'
+      const condition = !!error && error.name === 'ConditionError'
       return {
         payload,
         error: miniSerializeError(error || 'Rejected'),
         meta: {
           arg,
           requestId,
-          aborted
+          aborted,
+          condition
         }
       }
     }
@@ -297,6 +331,16 @@ If you want to use the AbortController to react to \`abort\` events, please cons
       const promise = (async function() {
         let finalAction: ReturnType<typeof fulfilled | typeof rejected>
         try {
+          if (
+            options &&
+            options.condition &&
+            !options.condition(arg, { getState, extra })
+          ) {
+            throw {
+              name: 'ConditionError',
+              message: 'Aborted due to condition callback returning false.'
+            }
+          }
           dispatch(pending(requestId, arg))
           finalAction = await Promise.race([
             abortedPromise,
@@ -326,7 +370,15 @@ If you want to use the AbortController to react to \`abort\` events, please cons
         // per https://twitter.com/dan_abramov/status/770914221638942720
         // and https://redux-toolkit.js.org/tutorials/advanced-tutorial#async-error-handling-logic-in-thunks
 
-        dispatch(finalAction)
+        const skipDispatch =
+          options &&
+          options.dispatchConditionRejection === false &&
+          rejected.match(finalAction) &&
+          finalAction.meta.condition
+
+        if (!skipDispatch) {
+          dispatch(finalAction)
+        }
         return finalAction
       })()
       return Object.assign(promise, { abort })

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -334,7 +334,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
           if (
             options &&
             options.condition &&
-            !options.condition(arg, { getState, extra })
+            options.condition(arg, { getState, extra }) === false
           ) {
             throw {
               name: 'ConditionError',

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -210,7 +210,7 @@ interface AsyncThunkOptions<
    * This option allows you to control whether a `rejected` action with `meta.condition == false`
    * will be dispatched or not.
    *
-   * @default `true`
+   * @default `false`
    */
   dispatchConditionRejection?: boolean
 }
@@ -375,7 +375,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
 
         const skipDispatch =
           options &&
-          options.dispatchConditionRejection === false &&
+          !options.dispatchConditionRejection &&
           rejected.match(finalAction) &&
           finalAction.meta.condition
 

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -135,7 +135,12 @@ type AsyncThunkReturnValue<ThunkArg, FulfilledValue, RejectedValue> =
   | PayloadAction<
       undefined | RejectedValue,
       string,
-      { arg: ThunkArg; requestId: string; aborted: boolean },
+      {
+        arg: ThunkArg
+        requestId: string
+        aborted: boolean
+        condition: boolean
+      },
       SerializedError
     >
 /**

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -130,19 +130,6 @@ export type AsyncThunkPayloadCreator<
   thunkAPI: GetThunkAPI<ThunkApiConfig>
 ) => AsyncThunkPayloadCreatorReturnValue<Returned, ThunkApiConfig>
 
-type AsyncThunkReturnValue<ThunkArg, FulfilledValue, RejectedValue> =
-  | PayloadAction<FulfilledValue, string, { arg: ThunkArg; requestId: string }>
-  | PayloadAction<
-      undefined | RejectedValue,
-      string,
-      {
-        arg: ThunkArg
-        requestId: string
-        aborted: boolean
-        condition: boolean
-      },
-      SerializedError
-    >
 /**
  * A ThunkAction created by `createAsyncThunk`.
  * Dispatching it returns a Promise for either a
@@ -161,7 +148,18 @@ export type AsyncThunkAction<
   getState: () => GetState<ThunkApiConfig>,
   extra: GetExtra<ThunkApiConfig>
 ) => Promise<
-  AsyncThunkReturnValue<ThunkArg, Returned, GetRejectValue<ThunkApiConfig>>
+  | PayloadAction<Returned, string, { arg: ThunkArg; requestId: string }>
+  | PayloadAction<
+      undefined | GetRejectValue<ThunkApiConfig>,
+      string,
+      {
+        arg: ThunkArg
+        requestId: string
+        aborted: boolean
+        condition: boolean
+      },
+      SerializedError
+    >
 > & {
   abort(reason?: string): void
 }


### PR DESCRIPTION
This is my first attempt at adding a `condition` callback so that people can skip `asyncThunk` execution before it even enters `pending` state, depending on `arg`, `getState()` and `extra`.


(Please don't merge this before #502 and #512, I guess order of merging might be of importance for merge conflicts here :laughing:)