### PR TITLE
fix #541: invoke removeAll mutably within produce

### DIFF
--- a/src/entities/sorted_state_adapter.test.ts
+++ b/src/entities/sorted_state_adapter.test.ts
@@ -7,6 +7,7 @@ import {
   AClockworkOrange,
   AnimalFarm
 } from './fixtures/book'
+import { createNextState } from '..'
 
 describe('Sorted State Adapter', () => {
   let adapter: EntityStateAdapter<BookModel>
@@ -434,6 +435,265 @@ describe('Sorted State Adapter', () => {
         },
         [AClockworkOrange.id]: AClockworkOrange
       }
+    })
+  })
+
+  describe('can be used mutably when wrapped in createNextState', () => {
+    test('removeAll', () => {
+      const withTwo = adapter.addMany(state, [TheGreatGatsby, AnimalFarm])
+      const result = createNextState(withTwo, draft => {
+        adapter.removeAll(draft)
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {},
+          "ids": Array [],
+        }
+      `)
+    })
+
+    test('addOne', () => {
+      const result = createNextState(state, draft => {
+        adapter.addOne(draft, TheGreatGatsby)
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('addMany', () => {
+      const result = createNextState(state, draft => {
+        adapter.addMany(draft, [TheGreatGatsby, AnimalFarm])
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "af",
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('setAll', () => {
+      const result = createNextState(state, draft => {
+        adapter.setAll(draft, [TheGreatGatsby, AnimalFarm])
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "af",
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('updateOne', () => {
+      const withOne = adapter.addOne(state, TheGreatGatsby)
+      const changes = { title: 'A New Hope' }
+      const result = createNextState(withOne, draft => {
+        adapter.updateOne(draft, {
+          id: TheGreatGatsby.id,
+          changes
+        })
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "A New Hope",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('updateMany', () => {
+      const firstChange = { title: 'First Change' }
+      const secondChange = { title: 'Second Change' }
+      const withMany = adapter.setAll(state, [TheGreatGatsby, AClockworkOrange])
+
+      const result = createNextState(withMany, draft => {
+        adapter.updateMany(draft, [
+          { id: TheGreatGatsby.id, changes: firstChange },
+          { id: AClockworkOrange.id, changes: secondChange }
+        ])
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "aco": Object {
+              "id": "aco",
+              "title": "Second Change",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "First Change",
+            },
+          },
+          "ids": Array [
+            "tgg",
+            "aco",
+          ],
+        }
+      `)
+    })
+
+    test('upsertOne (insert)', () => {
+      const result = createNextState(state, draft => {
+        adapter.upsertOne(draft, TheGreatGatsby)
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('upsertOne (update)', () => {
+      const withOne = adapter.upsertOne(state, TheGreatGatsby)
+      const result = createNextState(withOne, draft => {
+        adapter.upsertOne(draft, {
+          id: TheGreatGatsby.id,
+          title: 'A New Hope'
+        })
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "A New Hope",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('upsertMany', () => {
+      const withOne = adapter.upsertOne(state, TheGreatGatsby)
+      const result = createNextState(withOne, draft => {
+        adapter.upsertMany(draft, [
+          {
+            id: TheGreatGatsby.id,
+            title: 'A New Hope'
+          },
+          AnimalFarm
+        ])
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "A New Hope",
+            },
+          },
+          "ids": Array [
+            "tgg",
+            "af",
+          ],
+        }
+      `)
+    })
+
+    test('removeOne', () => {
+      const withTwo = adapter.addMany(state, [TheGreatGatsby, AnimalFarm])
+      const result = createNextState(withTwo, draft => {
+        adapter.removeOne(draft, TheGreatGatsby.id)
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+          },
+          "ids": Array [
+            "af",
+          ],
+        }
+      `)
+    })
+
+    test('removeMany', () => {
+      const withThree = adapter.addMany(state, [
+        TheGreatGatsby,
+        AnimalFarm,
+        AClockworkOrange
+      ])
+      const result = createNextState(withThree, draft => {
+        adapter.removeMany(draft, [TheGreatGatsby.id, AnimalFarm.id])
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "aco": Object {
+              "id": "aco",
+              "title": "A Clockwork Orange",
+            },
+          },
+          "ids": Array [
+            "aco",
+          ],
+        }
+      `)
     })
   })
 })

--- a/src/entities/state_adapter.ts
+++ b/src/entities/state_adapter.ts
@@ -1,6 +1,20 @@
 import createNextState, { isDraft } from 'immer'
-import { EntityState } from './models'
+import { EntityState, PreventAny } from './models'
 import { PayloadAction, isFSA } from '../createAction'
+
+export function createSingleArgumentStateOperator<V>(
+  mutator: (state: EntityState<V>) => void
+) {
+  const operator = createStateOperator((_: undefined, state: EntityState<V>) =>
+    mutator(state)
+  )
+
+  return function operation<S extends EntityState<V>>(
+    state: PreventAny<S, V>
+  ): S {
+    return operator(state as S, undefined)
+  }
+}
 
 export function createStateOperator<V, R>(
   mutator: (arg: R, state: EntityState<V>) => void

--- a/src/entities/unsorted_state_adapter.test.ts
+++ b/src/entities/unsorted_state_adapter.test.ts
@@ -6,6 +6,7 @@ import {
   AClockworkOrange,
   AnimalFarm
 } from './fixtures/book'
+import { createNextState } from '..'
 
 describe('Unsorted State Adapter', () => {
   let adapter: EntityStateAdapter<BookModel>
@@ -350,6 +351,265 @@ describe('Unsorted State Adapter', () => {
         },
         [AClockworkOrange.id]: AClockworkOrange
       }
+    })
+  })
+
+  describe('can be used mutably when wrapped in createNextState', () => {
+    test('removeAll', () => {
+      const withTwo = adapter.addMany(state, [TheGreatGatsby, AnimalFarm])
+      const result = createNextState(withTwo, draft => {
+        adapter.removeAll(draft)
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {},
+          "ids": Array [],
+        }
+      `)
+    })
+
+    test('addOne', () => {
+      const result = createNextState(state, draft => {
+        adapter.addOne(draft, TheGreatGatsby)
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('addMany', () => {
+      const result = createNextState(state, draft => {
+        adapter.addMany(draft, [TheGreatGatsby, AnimalFarm])
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "tgg",
+            "af",
+          ],
+        }
+      `)
+    })
+
+    test('setAll', () => {
+      const result = createNextState(state, draft => {
+        adapter.setAll(draft, [TheGreatGatsby, AnimalFarm])
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "tgg",
+            "af",
+          ],
+        }
+      `)
+    })
+
+    test('updateOne', () => {
+      const withOne = adapter.addOne(state, TheGreatGatsby)
+      const changes = { title: 'A New Hope' }
+      const result = createNextState(withOne, draft => {
+        adapter.updateOne(draft, {
+          id: TheGreatGatsby.id,
+          changes
+        })
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "A New Hope",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('updateMany', () => {
+      const firstChange = { title: 'First Change' }
+      const secondChange = { title: 'Second Change' }
+      const withMany = adapter.setAll(state, [TheGreatGatsby, AClockworkOrange])
+
+      const result = createNextState(withMany, draft => {
+        adapter.updateMany(draft, [
+          { id: TheGreatGatsby.id, changes: firstChange },
+          { id: AClockworkOrange.id, changes: secondChange }
+        ])
+      })
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "aco": Object {
+              "id": "aco",
+              "title": "Second Change",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "First Change",
+            },
+          },
+          "ids": Array [
+            "tgg",
+            "aco",
+          ],
+        }
+      `)
+    })
+
+    test('upsertOne (insert)', () => {
+      const result = createNextState(state, draft => {
+        adapter.upsertOne(draft, TheGreatGatsby)
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "The Great Gatsby",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('upsertOne (update)', () => {
+      const withOne = adapter.upsertOne(state, TheGreatGatsby)
+      const result = createNextState(withOne, draft => {
+        adapter.upsertOne(draft, {
+          id: TheGreatGatsby.id,
+          title: 'A New Hope'
+        })
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "tgg": Object {
+              "id": "tgg",
+              "title": "A New Hope",
+            },
+          },
+          "ids": Array [
+            "tgg",
+          ],
+        }
+      `)
+    })
+
+    test('upsertMany', () => {
+      const withOne = adapter.upsertOne(state, TheGreatGatsby)
+      const result = createNextState(withOne, draft => {
+        adapter.upsertMany(draft, [
+          {
+            id: TheGreatGatsby.id,
+            title: 'A New Hope'
+          },
+          AnimalFarm
+        ])
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+            "tgg": Object {
+              "id": "tgg",
+              "title": "A New Hope",
+            },
+          },
+          "ids": Array [
+            "tgg",
+            "af",
+          ],
+        }
+      `)
+    })
+
+    test('removeOne', () => {
+      const withTwo = adapter.addMany(state, [TheGreatGatsby, AnimalFarm])
+      const result = createNextState(withTwo, draft => {
+        adapter.removeOne(draft, TheGreatGatsby.id)
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "af": Object {
+              "id": "af",
+              "title": "Animal Farm",
+            },
+          },
+          "ids": Array [
+            "af",
+          ],
+        }
+      `)
+    })
+
+    test('removeMany', () => {
+      const withThree = adapter.addMany(state, [
+        TheGreatGatsby,
+        AnimalFarm,
+        AClockworkOrange
+      ])
+      const result = createNextState(withThree, draft => {
+        adapter.removeMany(draft, [TheGreatGatsby.id, AnimalFarm.id])
+      })
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "entities": Object {
+            "aco": Object {
+              "id": "aco",
+              "title": "A Clockwork Orange",
+            },
+          },
+          "ids": Array [
+            "aco",
+          ],
+        }
+      `)
     })
   })
 })

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -5,7 +5,10 @@ import {
   Update,
   EntityId
 } from './models'
-import { createStateOperator } from './state_adapter'
+import {
+  createStateOperator,
+  createSingleArgumentStateOperator
+} from './state_adapter'
 import { selectIdValue } from './utils'
 
 export function createUnsortedStateAdapter<T>(
@@ -64,8 +67,8 @@ export function createUnsortedStateAdapter<T>(
     }
   }
 
-  function removeAll(state: R): any {
-    return Object.assign({}, state, {
+  function removeAllMutably(state: R): void {
+    Object.assign(state, {
       ids: [],
       entities: {}
     })
@@ -156,7 +159,7 @@ export function createUnsortedStateAdapter<T>(
   }
 
   return {
-    removeAll,
+    removeAll: createSingleArgumentStateOperator(removeAllMutably),
     addOne: createStateOperator(addOneMutably),
     addMany: createStateOperator(addManyMutably),
     setAll: createStateOperator(setAllMutably),


### PR DESCRIPTION
This should invoke removeAll as a mutable action when wrapped in createNextState/produce and close #541.
Also, lots of tests.