### PR TITLE
Updated docusaurus.config.js with a proper copyright symbol and…

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -84,7 +84,7 @@ module.exports = {
           ]
         }
       ],
-      copyright: `Copyright (c) 2015-present Dan Abramov and the Redux documentation authors.`
+      copyright: `Copyright © 2015–${new Date().getFullYear()} Dan Abramov and the Redux documentation authors.`
     },
     image: 'img/redux-logo-landscape.png',
     navbar: {


### PR DESCRIPTION
Updated docusaurus.config.js with a proper copyright symbol and the current year in the footer.

_Currently_:
Copyright (c) 2015-present Dan Abramov and the Redux documentation authors.

_With this change_:
Copyright © 2015–2020 Dan Abramov and the Redux documentation authors.

(The changes in the end year would be dynamic, using the same code that Docusaurus uses on their own site.)