### PR TITLE
Prevent unhandled promises in createAsyncThunk

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js']
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,7 @@
+process.on('unhandledRejection', error => {
+  console.error(
+    `We throw this specifically to break tests if a promise is not handled`,
+    error
+  )
+  throw error
+})

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,4 @@
 process.on('unhandledRejection', error => {
-  console.error(
-    `We throw this specifically to break tests if a promise is not handled`,
-    error
-  )
-  throw error
+  // eslint-disable-next-line no-undef
+  fail(error)
 })

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -549,6 +549,21 @@ describe('conditional skipping of asyncThunks', () => {
     expect(dispatch).toHaveBeenCalledTimes(0)
   })
 
+  test('does not throw when attempting to abort a canceled promise', async () => {
+    const asyncPayloadCreator = jest.fn(async (x: typeof arg) => {
+      await new Promise(resolve => setTimeout(resolve, 2000))
+      return 10
+    })
+
+    const asyncThunk = createAsyncThunk('test', asyncPayloadCreator, {
+      condition
+    })
+    const promise = asyncThunk(arg)(dispatch, getState, extra)
+    promise.abort(
+      `If we didn't abortedPromise.catch(), this would crash the tests`
+    )
+  })
+
   test('rejected action can be dispatched via option', async () => {
     const asyncThunk = createAsyncThunk('test', payloadCreator, {
       condition,

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -549,7 +549,7 @@ describe('conditional skipping of asyncThunks', () => {
     expect(dispatch).toHaveBeenCalledTimes(0)
   })
 
-  test('does not throw when attempting to abort a canceled promise', async () => {
+  test('does not fail when attempting to abort a canceled promise', async () => {
     const asyncPayloadCreator = jest.fn(async (x: typeof arg) => {
       await new Promise(resolve => setTimeout(resolve, 2000))
       return 10
@@ -560,7 +560,7 @@ describe('conditional skipping of asyncThunks', () => {
     })
     const promise = asyncThunk(arg)(dispatch, getState, extra)
     promise.abort(
-      `If we didn't abortedPromise.catch(), this would crash the tests`
+      `If the promise was 1. somehow canceled, 2. in a 'started' state and 3. we attempted to abort, this would crash the tests`
     )
   })
 

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -339,6 +339,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
             options.condition &&
             options.condition(arg, { getState, extra }) === false
           ) {
+            abortedPromise.catch(() => {})
             throw {
               name: 'ConditionError',
               message: 'Aborted due to condition callback returning false.'

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -326,9 +326,12 @@ If you want to use the AbortController to react to \`abort\` events, please cons
         )
       )
 
+      let started = false
       function abort(reason?: string) {
-        abortReason = reason
-        abortController.abort()
+        if (started) {
+          abortReason = reason
+          abortController.abort()
+        }
       }
 
       const promise = (async function() {
@@ -339,12 +342,12 @@ If you want to use the AbortController to react to \`abort\` events, please cons
             options.condition &&
             options.condition(arg, { getState, extra }) === false
           ) {
-            abortedPromise.catch(() => {})
             throw {
               name: 'ConditionError',
               message: 'Aborted due to condition callback returning false.'
             }
           }
+          started = true
           dispatch(pending(requestId, arg))
           finalAction = await Promise.race([
             abortedPromise,


### PR DESCRIPTION
- Fixes #567 

Note: There is currently not a good way to test that `unhandledRejection` errors happen or not. This PR introduces a method that will 'crash' the test runner if you happen to forget to resolve a promise.

Things tried before going to the 'crash the test runner' route: 
- using `process.on('unhandledRejection', {})` to use a callback function, and check that it is fired.
- logging in various ways and test with `getLog()`.

After some research, it seems that jest doesn't handle process.on in the test file itself, which is why it's moved into the config. See: https://github.com/facebook/jest/issues/5620