### PR TITLE
docs: implement dark mode

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,7 +27,6 @@ module.exports = {
     repoUrl: 'https://github.com/reduxjs/redux-toolkit'
   },
   themeConfig: {
-    disableDarkMode: true,
     prism: {
       theme: require('./src/js/monokaiTheme.js')
     },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -20,7 +20,7 @@
 
   --ifm-blockquote-color: #ecf4f9;
   --ifm-blockquote-color-dark: #cbddea;
-  
+
   --ifm-code-padding-vertical: 0.1rem;
   --ifm-code-padding-horizontal: 0.2rem;
 
@@ -74,9 +74,21 @@ code {
   border-radius: 0.2rem;
 }
 
+html[data-theme='dark'] code {
+  background-color: var(--ifm-color-emphasis-200);
+  border-radius: 0.2rem;
+}
+
 a code,
 code a {
+  background-color: var(--ifm-color-emphasis-200);
   color: inherit;
+}
+
+html[data-theme='dark'] a code,
+html[data-theme='dark'] code a {
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-primary-lighter);
 }
 
 a.contents__link > code {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -110,7 +110,7 @@ const otherLibraries = [
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        ariaHidden="true"
+        aria-hidden="true"
         data-icon="external-link-square-alt"
         data-prefix="fas"
         viewBox="0 0 448 512"


### PR DESCRIPTION
Picking up from #247, I've implemented changes for the following:

In dark mode:
- inline code
- inline code with links

In light mode:
- inline code with links

There was also a warning with the `aria-hidden` tag on the landing page that has been fixed.

Attaching a screenshot to highlight the changes for the dark mode below; I had tweak the shade of purple being used for the `code a` elements. There were infima-based vars available in the `custom.css` file, so I went ahead and used those.

Since accessibility was one of the reasons that previous attempts didn't go through, I tried to make sure that there was enough contrast with the shades chosen (purple isn't easy to implement dark mode with 😅). Here's the results:


Before:
| Mode  | Element | Contrast |
| ----- | ------- | -------- |
| Light | code a  | 4.43     |
| Dark  | code    | 5.26     |
| Dark  | code a  | 1.06     |

After:
| Mode  | Element | Variation        | Contrast |
| ----- | ------- | ---------------- | -------- |
| Light | code a  |                  | 5.15     |
| Dark  | code    |                  | 8.38     |
| Dark  | code a  | inherited color  | 2.77     |
| Dark  | code a  | "light" purple   | 3.33     |
| Dark  | code a  | "lighter" purple | 4.87     |

Would love to see dark mode getting finally enabled for the docs, please feel free to make any tweaks/suggestions that you'd like.



<img width="1440" alt="image" src="https://user-images.githubusercontent.com/11270438/82525437-03669e80-9b4f-11ea-957c-bd962ce3e824.png">
