### PR TITLE
Avoid unnecesary prototype loop

### DIFF
--- a/src/isPlainObject.ts
+++ b/src/isPlainObject.ts
@@ -7,12 +7,9 @@
  * @returns {boolean} True if the argument appears to be a plain object.
  */
 export default function isPlainObject(value: unknown): value is object {
-  if (typeof value !== 'object' || value === null) return false
-
-  let proto = value
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
-  }
-
-  return Object.getPrototypeOf(value) === proto
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.getPrototypeOf(Object.getPrototypeOf(value) || 0) === null
+  )
 }


### PR DESCRIPTION
As the whole purpose of the `while (Object.getPrototypeOf(proto) !== null)` loop seems to counter validate there was nothing else to loop, I believe it's a performance benefit, as well as smaller code, to simply check the prototype never more than 2 levels, with a graceful fallback in case the first check resulted into `null` already:
  * the amount of `Object.getPrototypeOf` is fixed as `2` and never more
  * there is less code to shrink/optimize for bundlers or minifiers