### PR TITLE
Docs: Use configureStore in createAction example

### DIFF
--- a/docs/tutorials/basic-tutorial.md
+++ b/docs/tutorials/basic-tutorial.md
@@ -157,7 +157,9 @@ function counter(state = 0, action) {
   }
 }
 
-const store = Redux.createStore(counter)
+const store = configureStore({
+  reducer: counter
+})
 
 document.getElementById('increment').addEventListener('click', () => {
   store.dispatch(increment())


### PR DESCRIPTION
In the Basic Tutorial, `configureStore` is introduced with an example before `createAction`. This implies that the app example at this point would use `configureStore` instead of `createStore`.

However in the `createAction` example, it still uses `createStore`. This change updates the docs to use `configureStore` in the `createAction` example since `configureStore` was introduced earlier.