### PR TITLE
Bump immer to v7, export current util, add usage docs

### DIFF
--- a/docs/api/createReducer.md
+++ b/docs/api/createReducer.md
@@ -141,16 +141,17 @@ const todosReducer = createReducer([], {
 It's very common for a developer to call `console.log(state)` during the development process. When using either `createSlice` or `createReducer`, you will need to use the [`current`](./otherExports#current.md) utility that we re-export from the [`immer` library](https://immerjs.github.io/immer). This awesome utility allows us to peek into the Proxy while it's being modified.
 
 ```ts
+// todosSlice.js
+import { createSlice, current } from '@reduxjs/toolkit'
+
 const slice = createSlice({
   name: 'todos',
   initialState: [{ id: 1, title: 'Example todo' }],
   reducers: {
-    updateTodo: (state, action) => {
+    addTodo: (state, action) => {
       console.log('before', current(state))
-      state.push(action)
-      console.log('after push', current(state))
-      state = state.filter(todos => todo.id !== 1)
-      console.log('final, after filtering one', current(state))
+      state.push(action.payload)
+      console.log('after', current(state))
     }
   }
 })

--- a/docs/api/createReducer.md
+++ b/docs/api/createReducer.md
@@ -135,3 +135,23 @@ const todosReducer = createReducer([], {
   }
 })
 ```
+
+## Debugging your state
+
+It's very common for a developer to call `console.log(state)` during the development process. When using either `createSlice` or `createReducer`, you will need to use the [`current`](./otherExports#current.md) utility that we re-export from the [`immer` library](https://immerjs.github.io/immer). This awesome utility allows us to peek into the Proxy while it's being modified.
+
+```ts
+const slice = createSlice({
+  name: 'todos',
+  initialState: [{ id: 1, title: 'Example todo' }],
+  reducers: {
+    updateTodo: (state, action) => {
+      console.log('before', current(state))
+      state.push(action)
+      console.log('after push', current(state))
+      state = state.filter(todos => todo.id !== 1)
+      console.log('final, after filtering one', current(state))
+    }
+  }
+})
+```

--- a/docs/api/createReducer.md
+++ b/docs/api/createReducer.md
@@ -138,7 +138,9 @@ const todosReducer = createReducer([], {
 
 ## Debugging your state
 
-It's very common for a developer to call `console.log(state)` during the development process. When using either `createSlice` or `createReducer`, you will need to use the [`current`](./otherExports#current.md) utility that we re-export from the [`immer` library](https://immerjs.github.io/immer). This awesome utility allows us to peek into the Proxy while it's being modified.
+It's very common for a developer to call `console.log(state)` during the development process. However, browsers display Proxies in a format that is hard to read, which can make console logging of Immer-based state difficult.
+
+When using either `createSlice` or `createReducer`, you may use the [`current`](./otherExports#current.md) utility that we re-export from the [`immer` library](https://immerjs.github.io/immer). This utility creates a separate plain copy of the current Immer `Draft` state value, which can then be logged for viewing as normal.
 
 ```ts
 // todosSlice.js

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -158,7 +158,7 @@ The default immutable update function from the [`immer` library](https://immerjs
 
 ### `current`
 
-The `current` function from the [`immer` library](https://immerjs.github.io/immer/), which takes a snapshot of the current state of a draft and finalizes it (but without freezing). Current is a great utility to print the current state during debugging, and the output of current can also be safely leaked outside the producer.
+[The `current` function](https://immerjs.github.io/immer/docs/current) from the [`immer` library](https://immerjs.github.io/immer/), which takes a snapshot of the current state of a draft and finalizes it (but without freezing). Current is a great utility to print the current state during debugging, and the output of `current` can also be safely leaked outside the producer.
 
 ```js
 import { createReducer, createAction, current } from '@reduxjs/toolkit'

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -160,7 +160,18 @@ The default immutable update function from the [`immer` library](https://immerjs
 
 The `current` function from the [`immer` library](https://immerjs.github.io/immer/), which takes a snapshot of the current state of a draft and finalizes it (but without freezing). Current is a great utility to print the current state during debugging, and the output of current can also be safely leaked outside the producer.
 
-The default immutable update function from the [`immer` library](https://immerjs.github.io/immer/), re-exported here as `createNextState` (also commonly referred to as [`produce`](https://immerjs.github.io/immer/docs/produce))
+```js
+import { createReducer, createAction, current } from '@reduxjs/toolkit'
+
+const addTodo = createAction('addTodo')
+
+const todosReducer = createReducer([], {
+  [addTodo]: (state, action) => {
+    state.push(action.payload)
+    console.log(current(state))
+  }
+})
+```
 
 ### `combineReducers`
 

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -156,6 +156,12 @@ console.log(nanoid())
 
 The default immutable update function from the [`immer` library](https://immerjs.github.io/immer/), re-exported here as `createNextState` (also commonly referred to as [`produce`](https://immerjs.github.io/immer/docs/produce))
 
+### `current`
+
+The `current` function from the [`immer` library](https://immerjs.github.io/immer/), which takes a snapshot of the current state of a draft and finalizes it (but without freezing). Current is a great utility to print the current state during debugging, and the output of current can also be safely leaked outside the producer.
+
+The default immutable update function from the [`immer` library](https://immerjs.github.io/immer/), re-exported here as `createNextState` (also commonly referred to as [`produce`](https://immerjs.github.io/immer/docs/produce))
+
 ### `combineReducers`
 
 Redux's [`combineReducers`](https://redux.js.org/api/combinereducers), re-exported for convenience. While `configureStore` calls this internally, you may wish to call it yourself to compose multiple levels of slice reducers.

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -9,6 +9,7 @@ import { ActionCreator } from 'redux';
 import { AnyAction } from 'redux';
 import { default as createNextState } from 'immer';
 import { createSelector } from 'reselect';
+import { current } from 'immer';
 import { DeepPartial } from 'redux';
 import { Dispatch } from 'redux';
 import { Draft } from 'immer';
@@ -174,6 +175,8 @@ export interface CreateSliceOptions<State = any, CR extends SliceCaseReducers<St
     name: Name;
     reducers: ValidateSliceCaseReducers<State, CR>;
 }
+
+export { current }
 
 // @public (undocumented)
 export interface Dictionary<T> extends DictionaryNum<T> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,9 +4563,9 @@
       "dev": true
     },
     "immer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.1.tgz",
-      "integrity": "sha512-oXwigCKgznQywsXi1VgrqgWbQEU3wievNCVc4Fcwky6mwXU6YHj6JuYp0WEM/B1EphkqsLr0x18lm5OiuemPcA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.0.tgz",
+      "integrity": "sha512-fDG+mIa2se3ICnLYtYGazWwKN9L7rtvrIDK56IMisJ53JHY223g01nLvmYs8SXNSmnOYP7OeYfNJMT0aBT4pdA=="
     },
     "import-fresh": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,9 +4563,9 @@
       "dev": true
     },
     "immer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.0.tgz",
-      "integrity": "sha512-fDG+mIa2se3ICnLYtYGazWwKN9L7rtvrIDK56IMisJ53JHY223g01nLvmYs8SXNSmnOYP7OeYfNJMT0aBT4pdA=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.1.tgz",
+      "integrity": "sha512-DpWL/ES2Ba8KwW+A5AgNRoJPZP8LxdHejKXar1VfbF5a7ATvvekzmmNSQxje+WG0DIhuanvFEumFffVqyCLmBQ=="
     },
     "import-fresh": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "dependencies": {
-    "immer": "^7.0.0",
+    "immer": "7.0.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "dependencies": {
-    "immer": "^6.0.1",
+    "immer": "^7.0.0",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0"

--- a/src/createReducer.test.ts
+++ b/src/createReducer.test.ts
@@ -149,6 +149,38 @@ describe('createReducer', () => {
       expect(reducer(0, increment(5))).toBe(5)
       expect(reducer(5, decrement(5))).toBe(0)
     })
+    test('will throw an error when returning undefined from a non-draftable state', () => {
+      const reducer = createReducer(0, builder =>
+        builder.addCase(
+          'decrement',
+          (state, action: { type: 'decrement'; payload: number }) => {}
+        )
+      )
+      expect(() => reducer(5, decrement(5))).toThrowErrorMatchingInlineSnapshot(
+        `"A case reducer on a non-draftable value must not return undefined"`
+      )
+    })
+    test('allows you to return null', () => {
+      const reducer = createReducer(0 as number | null, builder =>
+        builder.addCase(
+          'decrement',
+          (state, action: { type: 'decrement'; payload: number }) => {
+            return null
+          }
+        )
+      )
+      expect(reducer(5, decrement(5))).toBe(null)
+    })
+    test('allows you to return 0', () => {
+      const reducer = createReducer(0, builder =>
+        builder.addCase(
+          'decrement',
+          (state, action: { type: 'decrement'; payload: number }) =>
+            state - action.payload
+        )
+      )
+      expect(reducer(5, decrement(5))).toBe(0)
+    })
     test('will throw if the same type is used twice', () => {
       expect(() =>
         createReducer(0, builder =>

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -1,4 +1,4 @@
-import createNextState, { Draft, isDraft } from 'immer'
+import createNextState, { Draft, isDraft, isDraftable } from 'immer'
 import { AnyAction, Action, Reducer } from 'redux'
 import {
   executeReducerBuilderCallback,
@@ -107,11 +107,11 @@ export function createReducer<S>(
   return function(state = initialState, action): S {
     const caseReducer = actionsMap[action.type]
     if (caseReducer) {
-      if (isDraft(state)) {
+      if (isDraft(state) || !isDraftable(state)) {
         // we must already be inside a `createNextState` call, likely because
         // this is being wrapped in `createReducer`, `createSlice`, or nested
         // inside an existing draft. It's safe to just pass the draft to the mutator.
-        const draft = state as Draft<S> // We can aassume this is already a draft
+        const draft = state as Draft<S> // We can assume this is already a draft
         return caseReducer(draft, action) || state
       } else {
         // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -108,11 +108,13 @@ export function createReducer<S>(
     const caseReducer = actionsMap[action.type]
     if (caseReducer) {
       if (isDraft(state) || !isDraftable(state)) {
-        // we must already be inside a `createNextState` call, likely because
-        // this is being wrapped in `createReducer`, `createSlice`, or nested
-        // inside an existing draft. It's safe to just pass the draft to the mutator.
+        // 1. If it's already a draft, we must already be inside a `createNextState` call,
+        //    likely because this is being wrapped in `createReducer`, `createSlice`, or nested
+        //    inside an existing draft. It's safe to just pass the draft to the mutator.
+        // 2. If state is not draftable (ex: a primitive, such as 0), we want to directly
+        //    return the caseReducer func and not wrap it with produce.
         const draft = state as Draft<S> // We can assume this is already a draft
-        return caseReducer(draft, action) || state
+        return caseReducer(draft, action) as S
       } else {
         // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather
         // than an Immutable<S>, and TypeScript cannot find out how to reconcile

--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -181,7 +181,7 @@ describe('createSlice', () => {
     })
 
     it('should call the reducer function', () => {
-      const reducer = jest.fn()
+      const reducer = jest.fn(() => 5)
 
       const testSlice = createSlice({
         name: 'test',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { enableES5 } from 'immer'
 export * from 'redux'
-export { default as createNextState, Draft } from 'immer'
+export { default as createNextState, Draft, current } from 'immer'
 export {
   createSelector,
   Selector,


### PR DESCRIPTION
- [x] Review comment about adding an `isDraftable` check inside `createReducer` from Discord

  > and mweststrate pinged me about adding an isDraftable check to createReducer.

- [x] Figure out how to best warn about a non-draftable state

- [x] Review selector usage inside of a reducer and references to 'leaking outside of the draft' - https://github.com/immerjs/immer/issues/561, would need reproduction in a test