### PR TITLE
add `addMatcher` to builder notations & `actionMatchers` argumen…

### DIFF
--- a/docs/api/createReducer.md
+++ b/docs/api/createReducer.md
@@ -7,6 +7,8 @@ hide_title: true
 
 # `createReducer()`
 
+## Overview
+
 A utility that simplifies creating Redux reducer functions, by defining them as lookup tables of functions to handle each action type. It also allows you to drastically simplify immutable update logic, by writing "mutative" code inside your reducers.
 
 Redux [reducers](https://redux.js.org/basics/reducers) are often implemented using a `switch` statement, with one `case` for every handled action type.
@@ -24,9 +26,19 @@ function counterReducer(state = 0, action) {
 }
 ```
 
-This approach works well, but is a bit boilerplate-y and error-prone. For instance, it is easy to forget the `default` case or setting the initial state.
+This approach works well, but is a bit boilerplate-y and error-prone. For instance, it is easy to forget the `default` case or setting the initial state.The `createReducer` helper streamlines the implementation of such reducers.
 
-The `createReducer` helper streamlines the implementation of such reducers. It takes two arguments. The first one is the initial state. The second is an object mapping from action types to _case reducers_, each of which handles one specific action type.
+## Parameters
+
+`createReducer` accepts four possible parameters, with the first two required.
+
+### `initialState`
+
+The initial state that should be used when the reducer is called the first time.
+
+### `caseReducers`
+
+An object mapping from action types to _case reducers_, each of which handles one specific action type.
 
 ```js
 const counterReducer = createReducer(0, {
@@ -36,10 +48,7 @@ const counterReducer = createReducer(0, {
 ```
 
 Action creators that were generated using [`createAction`](./createAction.md) may be used directly as the keys here, using
-computed property syntax.
-
-> **Note**: If you are using TypeScript, we recommend using the `builder callback` API that is shown below. If you do not use the `builder callback` and are using TypeScript, you will need to use `actionCreator.type` or `actionCreator.toString()`
-> to force the TS compiler to accept the computed property. Please see [Usage With TypeScript](./../usage/usage-with-typescript.md#type-safety-with-extraReducers) for further details.
+computed property syntax:
 
 ```js
 const increment = createAction('increment')
@@ -51,23 +60,146 @@ const counterReducer = createReducer(0, {
 })
 ```
 
-### The "builder callback" API
+Alternately, the second argument may be a "builder callback" function that can be used to add case handlers for specific action types, match against a range of action types, or provide a fallback default case if no other actions matched:
 
-Instead of using a simple object as an argument to `createReducer`, you can also provide a callback that receives an `ActionReducerMapBuilder` instance:
+```js
+const initialState = {
+  counter: 0,
+  rejectedActions: 0,
+  unhandledActions: 0
+}
+
+const exampleReducer = createReducer(initialState, builder => {
+  builder
+    .addCase('counter', state => {
+      state.counter++
+    })
+    .addMatcher(
+      action => action.endsWith('/rejected'),
+      (state, action) => {
+        state.rejectedActions++
+      }
+    )
+    .addDefaultCase((state, action) => {
+      state.unhandledActions++
+    })
+})
+```
+
+See [the `builder callback` API](#the-builder-callback-api) below for details on defining reducers using this syntax.
+
+> **Note**: If you are using TypeScript, we specifically recommend using the builder callback API to get proper inference of TS types for action objects. If you do not use the builder callback and are using TypeScript, you will need to use `actionCreator.type` or `actionCreator.toString()` as the key to force the TS compiler to accept the computed property. Please see [Usage With TypeScript](./../usage/usage-with-typescript.md#type-safety-with-extraReducers) for further details.
+
+### `actionMatchers`
+
+An optional array of objects that include a `matcher` function to determine if an action should be handled, and a `reducer` function that updates the state. This argument will be ignored if the second argument is a builder callback.
+
+### `defaultCase`
+
+A reducer that will be run if no other case reducers or matchers handle a given action. This argument will be ignored if the second argument is a builder callback.
+
+## Direct State Mutation
+
+Redux requires reducer functions to be pure and treat state values as immutable. While this is essential for making state updates predictable and observable, it can sometimes make the implementation of such updates awkward. Consider the following example:
+
+```js
+const addTodo = createAction('todos/add')
+const toggleTodo = createAction('todos/toggle')
+
+const todosReducer = createReducer([], {
+  [addTodo]: (state, action) => {
+    const todo = action.payload
+    return [...state, todo]
+  },
+  [toggleTodo]: (state, action) => {
+    const index = action.payload
+    const todo = state[index]
+    return [
+      ...state.slice(0, index),
+      { ...todo, completed: !todo.completed }
+      ...state.slice(index + 1)
+    ]
+  }
+})
+```
+
+The `addTodo` reducer is straightforward if you know the [ES6 spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). However, the code for `toggleTodo` is much less straightforward, especially considering that it only sets a single flag.
+
+To make things easier, `createReducer` uses [immer](https://github.com/mweststrate/immer) to let you write reducers as if they were mutating the state directly. In reality, the reducer receives a proxy state that translates all mutations into equivalent copy operations.
+
+```js
+const addTodo = createAction('todos/add')
+const toggleTodo = createAction('todos/toggle')
+
+const todosReducer = createReducer([], {
+  [addTodo]: (state, action) => {
+    // This push() operation gets translated into the same
+    // extended-array creation as in the previous example.
+    const todo = action.payload
+    state.push(todo)
+  },
+  [toggleTodo]: (state, action) => {
+    // The "mutating" version of this case reducer is much
+    //  more direct than the explicitly pure one.
+    const index = action.payload
+    const todo = state[index]
+    todo.completed = !todo.completed
+  }
+})
+```
+
+Writing "mutating" reducers simplifies the code. It's shorter, there's less indirection, and it eliminates common mistakes made while spreading nested state. However, the use of Immer does add some "magic", and Immer has its own nuances in behavior. You should read through [pitfalls mentioned in the immer docs](https://immerjs.github.io/immer/docs/pitfalls) . Most importantly, **you need to ensure that you either mutate the `state` argument or return a new state, _but not both_**. For example, the following reducer would throw an exception if a `toggleTodo` action is passed:
+
+```js
+const todosReducer = createReducer([], {
+  [toggleTodo]: (state, action) => {
+    const index = action.payload
+    const todo = state[index]
+
+    // This case reducer both mutates the passed-in state...
+    todo.completed = !todo.completed
+
+    // ... and returns a new value. This will throw an
+    // exception. In this example, the easiest fix is
+    // to remove the `return` statement.
+    return [...state.slice(0, index), todo, ...state.slice(index + 1)]
+  }
+})
+```
+
+## The "builder callback" API
+
+Instead of using a plain object as an argument to `createReducer`, you can also provide a "builder callback" function that receives an `ActionReducerMapBuilder` instance:
 
 ```typescript
 createReducer(0, builder =>
-  builder.addCase(increment, (state, action) => {
-    // action is inferred correctly here
-  })
+  builder
+    .addCase(increment, (state, action) => {
+      // action is inferred correctly here
+    })
+    // You can chain calls, or have separate `builder.addCase()` lines each time
+    .addCase(decrement, (state, action) => {})
+    // You can match a range of action types
+    .addMatcher(
+      action => action.endsWith('rejected'),
+      (state, action) => {}
+    )
+    // and provide a default case if no other handlers matched
+    .addDefaultCase((state, action) => {})
 )
 ```
 
-This is intended for use with TypeScript, as passing a plain object full of reducer functions cannot infer their types correctly in this case. It has no real benefit when used with plain JS.
+While the object syntax is shorter, the builder callback syntax allows adding multiple forms of reducers. It also provides better type inference, as passing a plain object full of reducer functions cannot infer their types correctly in this case.
 
 We recommend using this API if stricter type safety is necessary when defining reducer argument objects.
 
-#### `builder.addMatcher`
+### `builder.addCase`
+
+Adds a case reducer to handle a single exact action type. The first argument may be either a plain action type string, or an action creator generated by [`createAction`](./createAction.md) that can be used to determine the action type. The second argument is the actual case reducer function.
+
+All calls to `builder.addCase` must come before any calls to `builder.addMatcher` or `builder.addDefaultCase`.
+
+### `builder.addMatcher`
 
 `builder.addMatcher` allows you to match your reducer against your own filter function instead of only the `action.type` property.
 This allows for a lot of generic behaviour, so you could for example write a "generic loading tracker" state based on an approach like this:
@@ -102,7 +234,7 @@ const reducer = createReducer(initialState, builder => {
 
 Note that _all_ matching matcher reducers will execute in order, even if a case reducer has already executed.
 
-#### `builder.addDefaultCase`
+### `builder.addDefaultCase`
 
 `builder.addDefaultCase` allows you to add a "default" reducer that will execute if no case reducer or matcher reducer was executed.
 
@@ -119,9 +251,9 @@ const reducer = createReducer(initialState, builder => {
 })
 ```
 
-## Matchers and "default" Cases
+### Matchers and Default Cases as Arguments
 
-The most readable approach to define matcher cases and default cases is by using the `builder.addMatcher` and `builder.addDefaultCase` methods described above, but it is also possible to use these with the object notation:
+The most readable approach to define matcher cases and default cases is by using the `builder.addMatcher` and `builder.addDefaultCase` methods described above, but it is also possible to use these with the object notation by passing an array of `{matcher, reducer}` objects as the third argument, and a default case reducer as the fourth argument:
 
 ```js
 const isStringPayloadAction = action => typeof action.payload === 'string'
@@ -143,86 +275,53 @@ const lengthOfAllStringsReducer = createReducer(
     }
   ],
   // default reducer
-  () => {
+  state => {
     state.nonStringActions++
   }
 )
 ```
 
-## Direct State Mutation
+## Multiple Case Reducer Execution
 
-Redux requires reducer functions to be pure and treat state values as immutable. While this is essential for making state updates predictable and observable, it can sometimes make the implementation of such updates awkward. Consider the following example:
+Originally, `createReducer` always matched a given action type to a single case reducer, and only that one case reducer would execute for a given action.
 
-```js
-const addTodo = createAction('todos/add')
-const toggleTodo = createAction('todos/toggle')
+The action matcher support changes that behavior, as multiple matchers may handle a single action.
 
-const todosReducer = createReducer([], {
-  [addTodo]: (state, action) => {
-    const todo = action.payload
-    return [...state, todo]
-  },
-  [toggleTodo]: (state, action) => {
-    const index = action.payload
-    const todo = state[index]
-    return [
-      ...state.slice(0, index),
-      { ...todo, completed: !todo.completed }
-      ...state.slice(index + 1)
-    ]
-  }
-})
-```
+For any dispatched action, the behavior is:
 
-The `addTodo` reducer is pretty easy to follow if you know the [ES6 spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). However, the code for `toggleTodo` is much less straightforward, especially considering that it only sets a single flag.
+- If there is an exact match for the action type, the corresponding case reducer will execute first
+- Any matchers that return `true` will execute in the order they were defined
+- If a default case reducer is provided, and _no_ case or matcher reducers ran, the default case reducer will execute
+- If no case or matcher reducers ran, the original existing state value will be returned unchanged
 
-To make things easier, `createReducer` uses [immer](https://github.com/mweststrate/immer) to let you write reducers as if they were mutating the state directly. In reality, the reducer receives a proxy state that translates all mutations into equivalent copy operations.
+The executing reducers form a pipeline, and each of them will receive the output of the previous reducer:
 
 ```js
-const addTodo = createAction('todos/add')
-const toggleTodo = createAction('todos/toggle')
-
-const todosReducer = createReducer([], {
-  [addTodo]: (state, action) => {
-    // This push() operation gets translated into the same
-    // extended-array creation as in the previous example.
-    const todo = action.payload
-    state.push(todo)
-  },
-  [toggleTodo]: (state, action) => {
-    // The "mutating" version of this case reducer is much
-    //  more direct than the explicitly pure one.
-    const index = action.payload
-    const todo = state[index]
-    todo.completed = !todo.completed
-  }
+const reducer = createReducer(0, builder => {
+  builder
+    .addCase('increment', state => state + 1)
+    .addMatcher(
+      action => action.type.startsWith('i'),
+      state => state * 5
+    )
+    .addMatcher(
+      action => action.type.endsWith('t'),
+      state => state + 2
+    )
 })
-```
 
-If you choose to write reducers in this style, make sure to learn about the [pitfalls mentioned in the immer docs](https://immerjs.github.io/immer/docs/pitfalls) . Most importantly, you need to ensure that you either mutate the `state` argument or return a new state, _but not both_. For example, the following reducer would throw an exception if a `toggleTodo` action is passed:
-
-```js
-const todosReducer = createReducer([], {
-  [toggleTodo]: (state, action) => {
-    const index = action.payload
-    const todo = state[index]
-
-    // This case reducer both mutates the passed-in state...
-    todo.completed = !todo.completed
-
-    // ... and returns a new value. This will throw an
-    // exception. In this example, the easiest fix is
-    // to remove the `return` statement.
-    return [...state.slice(0, index), todo, ...state.slice(index + 1)]
-  }
-})
+console.log(reducer(0, { type: 'increment' }))
+// Returns 7, as the 'increment' case and both matchers all ran in sequence:
+// - case 'increment": 0 => 1
+// - matcher starts with 'i': 1 => 5
+// - matcher ends with 't': 5 => 7
 ```
 
 ## Debugging your state
 
 It's very common for a developer to call `console.log(state)` during the development process. However, browsers display Proxies in a format that is hard to read, which can make console logging of Immer-based state difficult.
 
-When using either `createSlice` or `createReducer`, you may use the [`current`](./otherExports#current.md) utility that we re-export from the [`immer` library](https://immerjs.github.io/immer). This utility creates a separate plain copy of the current Immer `Draft` state value, which can then be logged for viewing as normal.
+When using either `createSlice` or `createReducer`, you may use the [`current`](./otherExports#current.md) utility that we re-export from the [`immer` library](https://immerjs.github.io/immer/docs/current). This utility creates a separate plain copy of the current Immer `Draft` state value, which can then be logged for viewing as normal.
 
 ```ts
 // todosSlice.js

--- a/docs/api/createReducer.md
+++ b/docs/api/createReducer.md
@@ -172,6 +172,8 @@ const todosReducer = createReducer([], {
 Instead of using a plain object as an argument to `createReducer`, you can also provide a "builder callback" function that receives an `ActionReducerMapBuilder` instance:
 
 ```typescript
+const increment = createAction('increment')
+const decrement = createAction('decrement')
 createReducer(0, builder =>
   builder
     .addCase(increment, (state, action) => {

--- a/docs/api/createSlice.md
+++ b/docs/api/createSlice.md
@@ -94,6 +94,8 @@ createSlice({
 
 Instead of using a simple object as `extraReducers`, you can also use a callback that receives a `ActionReducerMapBuilder` instance.
 
+This builder notation is also the only way to add matcher reducers and default case reducers to your slice.
+
 ```typescript
 const incrementBy = createAction<number>('incrementBy')
 

--- a/docs/api/createSlice.md
+++ b/docs/api/createSlice.md
@@ -16,18 +16,27 @@ and automatically generates action creators and action types that correspond to 
 
 ```ts
 function createSlice({
+      // A name, used in action types
+    name: string,
+        // The initial state for the reducer
+    initialState: any,
     // An object of "case reducers". Key names will be used to generate actions.
     reducers: Object<string, ReducerFunction | ReducerAndPrepareObject>
-    // The initial state for the reducer
-    initialState: any,
-    // A name, used in action types
-    name: string,
-    // An additional object of "case reducers". Keys should be other action types.
+    // An additional object of "case reducers", where the keys should be other
+    // action types, or a "builder callback" function used to add more reducers
     extraReducers?:
     | Object<string, ReducerFunction>
     | ((builder: ActionReducerMapBuilder<State>) => void)
 })
 ```
+
+### `initialState`
+
+The initial state value for this slice of state.
+
+### `name`
+
+A string name for this slice of state. Generated action type constants will use this as a prefix.
 
 ### `reducers`
 
@@ -42,17 +51,38 @@ descriptive names.
 This object will be passed to [`createReducer`](./createReducer.md), so the reducers may safely "mutate" the
 state they are given.
 
+```js
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState: 0,
+  reducers: {
+    increment: state => state + 1
+  }
+})
+// Will handle the action type `'counter/increment'`
+```
+
 #### Customizing Generated Action Creators
 
-If you need to customize the creation of the payload value of an action creator by means of a [`prepare callback`](./createAction.md#using-prepare-callbacks-to-customize-action-contents), the value of the appropriate field of the `reducers` argument object should be an object instead of a function. This object must contain two properties: `reducer` and `prepare`. The value of the `reducer` field should be the case reducer function while the value of the `prepare` field should be the prepare callback function.
+If you need to customize the creation of the payload value of an action creator by means of a [`prepare callback`](./createAction.md#using-prepare-callbacks-to-customize-action-contents), the value of the appropriate field of the `reducers` argument object should be an object instead of a function. This object must contain two properties: `reducer` and `prepare`. The value of the `reducer` field should be the case reducer function while the value of the `prepare` field should be the prepare callback function:
 
-### `initialState`
-
-The initial state value for this slice of state.
-
-### `name`
-
-A string name for this slice of state. Generated action type constants will use this as a prefix.
+```js
+const todosSlice = createSlice({
+  name: 'todos',
+  initialState: [],
+  reducers: {
+    addTodo: {
+      reducer: (state, action) => {
+        state.push(action.payload)
+      },
+      prepare: text => {
+        const id = nanoid()
+        return { payload: { id, text } }
+      }
+    }
+  }
+})
+```
 
 ### `extraReducers`
 
@@ -60,11 +90,11 @@ One of the key concepts of Redux is that each slice reducer "owns" its slice of 
 can independently respond to the same action type. `extraReducers` allows `createSlice` to respond to other action types
 besides the types it has generated.
 
-Like `reducers`, `extraReducers` should be an object containing Redux case reducer functions. However, the keys should
+Like `reducers`, `extraReducers` can be an object containing Redux case reducer functions. However, the keys should
 be other Redux string action type constants, and `createSlice` will _not_ auto-generate action types or action creators
 for reducers included in this parameter.
 
-As with `reducers`, these reducers will also be passed to `createReducer` and may "mutate" their state safely.
+As with `reducers`, these case reducers will also be passed to `createReducer` and may "mutate" their state safely.
 
 If two fields from `reducers` and `extraReducers` happen to end up with the same action type string,
 the function from `reducers` will be used to handle that action type.
@@ -82,7 +112,8 @@ createSlice({
   extraReducers: {
     [incrementBy]: (state, action) => {
       return state + action.payload
-    }
+    },
+    'some/other/action': (state, action) => {}
   }
 })
 ```
@@ -92,27 +123,38 @@ createSlice({
 
 ### The "builder callback" API for `extraReducers`
 
-Instead of using a simple object as `extraReducers`, you can also use a callback that receives a `ActionReducerMapBuilder` instance.
+Instead of using an object as `extraReducers`, you can also use a callback that receives a `ActionReducerMapBuilder` instance.
 
 This builder notation is also the only way to add matcher reducers and default case reducers to your slice.
 
 ```typescript
 const incrementBy = createAction<number>('incrementBy')
+const decrement = createAction('decrement')
 
 createSlice({
   name: 'counter',
   initialState: 0,
   reducers: {},
-  extraReducers: builder => {
-    builder.addCase(incrementBy, (state, action) => {
-      // action is inferred correctly here with `action.payload` as a `number`
-      return state + action.payload
-    })
-  }
+  extraReducers: builder =>
+    builder
+      .addCase(incrementBy, (state, action) => {
+        // action is inferred correctly here if using TS
+      })
+      // You can chain calls, or have separate `builder.addCase()` lines each time
+      .addCase(decrement, (state, action) => {})
+      // You can match a range of action types
+      .addMatcher(
+        action => action.endsWith('rejected'),
+        (state, action) => {}
+      )
+      // and provide a default case if no other handlers matched
+      .addDefaultCase((state, action) => {})
 })
 ```
 
-We recommend using this API if stricter type safety is necessary when defining reducer argument objects. It's particularly useful for working with actions produced by `createAction` and `createAsyncThunk`.
+We recommend using this API if stricter type safety is necessary when defining reducer argument objects, as it will correctly infer the action type in the reducer based on the provided action creator. It's particularly useful for working with actions produced by `createAction` and `createAsyncThunk`.
+
+See [the "builder callback API" section of the `createReducer` reference](./createReducer.md#the-builder-callback-api) for details on how to use `builder.addCase`, `builder.addMatcher`, and `builder.addDefault`
 
 ## Return Value
 
@@ -122,7 +164,8 @@ We recommend using this API if stricter type safety is necessary when defining r
 {
     name : string,
     reducer : ReducerFunction,
-    actions : Object<string, ActionCreator>,
+    actions : Record<string, ActionCreator>,
+    caseReducers: Record<string, CaseReducer>
 }
 ```
 

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -214,6 +214,24 @@ createReducer(0, builder =>
 
 We recommend using this API if stricter type safety is necessary when defining reducer argument objects.
 
+#### Typing `builder.addMatcher`
+
+As the first `matcher` argument to `builder.addMatcher`, a [type predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates) function should be used.
+As a result, the `action` argument for the second `reducer` argument can be inferred by TypeScript:
+
+```ts
+function isStringAction(action: AnyAction): action is PayloadAction<string> {
+  return typeof action.payload === 'string'
+}
+
+createReducer(0, builder =>
+  builder.addMatcher(isStringAction, (state, action) => {
+    // action is automatically inferred as `PayloadAction<string>` here due to the
+    // signature of `isStringAction`
+  })
+})
+```
+
 ## `createSlice`
 
 As `createSlice` creates your actions as well as your reducer for you, you don't have to worry about type safety here.
@@ -371,6 +389,8 @@ const usersSlice = createSlice({
   }
 })
 ```
+
+Like the `builder` in `createReducer`, this `builder` also accepts `addMatcher` (see [typing `builder.matcher`](#typing-builderaddmatcher)) and `addDefaultCase`.
 
 ### Wrapping `createSlice`
 

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -220,15 +220,14 @@ As the first `matcher` argument to `builder.addMatcher`, a [type predicate](http
 As a result, the `action` argument for the second `reducer` argument can be inferred by TypeScript:
 
 ```ts
-function isStringAction(action: AnyAction): action is PayloadAction<string> {
-  return typeof action.payload === 'string'
+function isNumberValueAction(action: AnyAction): Action is PayloadAction<{ value: number }> {
+  return typeof action.payload.value === 'number'
 }
 
-createReducer(0, builder =>
-  builder.addMatcher(isStringAction, (state, action) => {
-    // action is automatically inferred as `PayloadAction<string>` here due to the
-    // signature of `isStringAction`
-  })
+createReducer({ value: 0 }, builder =>
+   builder.addMatcher(isNumberValueAction, (state, action) => {
+      state.value += action.payload.value
+   })
 })
 ```
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -55,6 +55,7 @@ export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T e
 export interface ActionReducerMapBuilder<State> {
     addCase<ActionCreator extends TypedActionCreator<string>>(actionCreator: ActionCreator, reducer: CaseReducer<State, ReturnType<ActionCreator>>): ActionReducerMapBuilder<State>;
     addCase<Type extends string, A extends Action<Type>>(type: Type, reducer: CaseReducer<State, A>): ActionReducerMapBuilder<State>;
+    addMatcher<A extends AnyAction>(matcher: ActionMatcher<A>, reducer: CaseReducer<State, A>): Omit<ActionReducerMapBuilder<State>, 'addCase'>;
 }
 
 // @public @deprecated
@@ -147,7 +148,7 @@ export function createImmutableStateInvariantMiddleware(options?: ImmutableState
 export { createNextState }
 
 // @public
-export function createReducer<S, CR extends CaseReducers<S, any> = CaseReducers<S, any>>(initialState: S, actionsMap: CR): Reducer<S>;
+export function createReducer<S, CR extends CaseReducers<S, any> = CaseReducers<S, any>>(initialState: S, actionsMap: CR, actionMatchers?: ActionMatcherDescriptionCollection<S>): Reducer<S>;
 
 // @public
 export function createReducer<S>(initialState: S, builderCallback: (builder: ActionReducerMapBuilder<S>) => void): Reducer<S>;

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -55,6 +55,8 @@ export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T e
 export interface ActionReducerMapBuilder<State> {
     addCase<ActionCreator extends TypedActionCreator<string>>(actionCreator: ActionCreator, reducer: CaseReducer<State, ReturnType<ActionCreator>>): ActionReducerMapBuilder<State>;
     addCase<Type extends string, A extends Action<Type>>(type: Type, reducer: CaseReducer<State, A>): ActionReducerMapBuilder<State>;
+    // (undocumented)
+    addDefaultCase(reducer: CaseReducer<State, AnyAction>): {};
     addMatcher<A extends AnyAction>(matcher: ActionMatcher<A>, reducer: CaseReducer<State, A>): Omit<ActionReducerMapBuilder<State>, 'addCase'>;
 }
 
@@ -148,7 +150,7 @@ export function createImmutableStateInvariantMiddleware(options?: ImmutableState
 export { createNextState }
 
 // @public
-export function createReducer<S, CR extends CaseReducers<S, any> = CaseReducers<S, any>>(initialState: S, actionsMap: CR, actionMatchers?: ActionMatcherDescriptionCollection<S>): Reducer<S>;
+export function createReducer<S, CR extends CaseReducers<S, any> = CaseReducers<S, any>>(initialState: S, actionsMap: CR, actionMatchers?: ActionMatcherDescriptionCollection<S>, defaultCaseReducer?: CaseReducer<S>): Reducer<S>;
 
 // @public
 export function createReducer<S>(initialState: S, builderCallback: (builder: ActionReducerMapBuilder<S>) => void): Reducer<S>;

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -55,7 +55,6 @@ export interface ActionCreatorWithPreparedPayload<Args extends unknown[], P, T e
 export interface ActionReducerMapBuilder<State> {
     addCase<ActionCreator extends TypedActionCreator<string>>(actionCreator: ActionCreator, reducer: CaseReducer<State, ReturnType<ActionCreator>>): ActionReducerMapBuilder<State>;
     addCase<Type extends string, A extends Action<Type>>(type: Type, reducer: CaseReducer<State, A>): ActionReducerMapBuilder<State>;
-    // (undocumented)
     addDefaultCase(reducer: CaseReducer<State, AnyAction>): {};
     addMatcher<A extends AnyAction>(matcher: ActionMatcher<A>, reducer: CaseReducer<State, A>): Omit<ActionReducerMapBuilder<State>, 'addCase'>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,9 +4563,9 @@
       "dev": true
     },
     "immer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.1.tgz",
-      "integrity": "sha512-DpWL/ES2Ba8KwW+A5AgNRoJPZP8LxdHejKXar1VfbF5a7ATvvekzmmNSQxje+WG0DIhuanvFEumFffVqyCLmBQ=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.3.tgz",
+      "integrity": "sha512-1f/jaF27WVb3X5Tk1AmOYZE+JZgMl50pIS5I8e/Je+HpYHjHwPfzm6dTEvOAUi6jq+/anFXev7agoOgJaL5RFw=="
     },
     "import-fresh": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "dependencies": {
-    "immer": "7.0.1",
+    "immer": "^7.0.3",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0"

--- a/src/createReducer.test.ts
+++ b/src/createReducer.test.ts
@@ -129,13 +129,13 @@ describe('createReducer', () => {
     const numberActionsCounter = {
       matcher: numberActionMatcher,
       reducer(state: typeof initialState) {
-        state.numberActions++
+        state.numberActions = state.numberActions * 10 + 1
       }
     }
     const stringActionsCounter = {
       matcher: stringActionMatcher,
       reducer(state: typeof initialState) {
-        state.stringActions++
+        state.stringActions = state.stringActions * 10 + 1
       }
     }
 
@@ -157,22 +157,31 @@ describe('createReducer', () => {
         stringActions: 1
       })
     })
-    test('prefers explicit reducer cases over actionMatchers', () => {
+    test('runs reducer cases followed by all matching actionMatchers', () => {
       const reducer = createReducer(
         initialState,
         {
           [incrementBy.type](state) {
-            state.numberActions += 100
+            state.numberActions = state.numberActions * 10 + 2
           }
         },
-        [numberActionsCounter, stringActionsCounter]
+        [
+          {
+            matcher: numberActionMatcher,
+            reducer(state) {
+              state.numberActions = state.numberActions * 10 + 3
+            }
+          },
+          numberActionsCounter,
+          stringActionsCounter
+        ]
       )
       expect(reducer(undefined, incrementBy(1))).toEqual({
-        numberActions: 100,
+        numberActions: 231,
         stringActions: 0
       })
       expect(reducer(undefined, decrementBy(1))).toEqual({
-        numberActions: 1,
+        numberActions: 31,
         stringActions: 0
       })
       expect(reducer(undefined, concatWith('foo'))).toEqual({
@@ -191,18 +200,6 @@ describe('createReducer', () => {
       ])
       expect(reducer(undefined, incrementBy(1))).toEqual({
         numberActions: 100,
-        stringActions: 0
-      })
-    })
-    test('matches only the first actionMatcher', () => {
-      const reducer = createReducer(initialState, {}, [
-        numberActionsCounter,
-        numberActionsCounter,
-        numberActionsCounter,
-        numberActionsCounter
-      ])
-      expect(reducer(undefined, incrementBy(1))).toEqual({
-        numberActions: 1,
         stringActions: 0
       })
     })
@@ -351,25 +348,28 @@ describe('createReducer', () => {
         stringActions: 1
       })
     })
-    test('prefers explicit reducer cases over actionMatchers', () => {
+    test('runs reducer cases followed by all matching actionMatchers', () => {
       const reducer = createReducer(initialState, builder =>
         builder
           .addCase(incrementBy, state => {
-            state.numberActions += 100
+            state.numberActions = state.numberActions * 10 + 1
           })
           .addMatcher(numberActionMatcher, state => {
-            state.numberActions += 1
+            state.numberActions = state.numberActions * 10 + 2
           })
           .addMatcher(stringActionMatcher, state => {
-            state.stringActions += 1
+            state.stringActions = state.stringActions * 10 + 1
+          })
+          .addMatcher(numberActionMatcher, state => {
+            state.numberActions = state.numberActions * 10 + 3
           })
       )
       expect(reducer(undefined, incrementBy(1))).toEqual({
-        numberActions: 100,
+        numberActions: 123,
         stringActions: 0
       })
       expect(reducer(undefined, decrementBy(1))).toEqual({
-        numberActions: 1,
+        numberActions: 23,
         stringActions: 0
       })
       expect(reducer(undefined, concatWith('foo'))).toEqual({
@@ -385,27 +385,6 @@ describe('createReducer', () => {
       )
       expect(reducer(undefined, incrementBy(1))).toEqual({
         numberActions: 100,
-        stringActions: 0
-      })
-    })
-    test('matches only the first actionMatcher', () => {
-      const reducer = createReducer(initialState, builder =>
-        builder
-          .addMatcher(numberActionMatcher, state => {
-            state.numberActions += 1
-          })
-          .addMatcher(numberActionMatcher, state => {
-            state.numberActions += 1
-          })
-          .addMatcher(numberActionMatcher, state => {
-            state.numberActions += 1
-          })
-          .addMatcher(numberActionMatcher, state => {
-            state.numberActions += 1
-          })
-      )
-      expect(reducer(undefined, incrementBy(1))).toEqual({
-        numberActions: 1,
         stringActions: 0
       })
     })

--- a/src/createReducer.test.ts
+++ b/src/createReducer.test.ts
@@ -117,9 +117,9 @@ describe('createReducer', () => {
     })
 
     const numberActionMatcher = (a: AnyAction): a is PayloadAction<number> =>
-      a.meta.type === 'number_action'
+      a.meta && a.meta.type === 'number_action'
     const stringActionMatcher = (a: AnyAction): a is PayloadAction<string> =>
-      a.meta.type === 'string_action'
+      a.meta && a.meta.type === 'string_action'
 
     const incrementBy = createAction('increment', prepareNumberAction)
     const decrementBy = createAction('decrement', prepareNumberAction)
@@ -155,6 +155,21 @@ describe('createReducer', () => {
       expect(reducer(undefined, concatWith('foo'))).toEqual({
         numberActions: 0,
         stringActions: 1
+      })
+    })
+    test('fallback to default case', () => {
+      const reducer = createReducer(
+        initialState,
+        {},
+        [numberActionsCounter, stringActionsCounter],
+        state => {
+          state.numberActions = -1
+          state.stringActions = -1
+        }
+      )
+      expect(reducer(undefined, { type: 'somethingElse' })).toEqual({
+        numberActions: -1,
+        stringActions: -1
       })
     })
     test('runs reducer cases followed by all matching actionMatchers', () => {
@@ -315,9 +330,9 @@ describe('createReducer', () => {
     })
 
     const numberActionMatcher = (a: AnyAction): a is PayloadAction<number> =>
-      a.meta.type === 'number_action'
+      a.meta && a.meta.type === 'number_action'
     const stringActionMatcher = (a: AnyAction): a is PayloadAction<string> =>
-      a.meta.type === 'string_action'
+      a.meta && a.meta.type === 'string_action'
 
     const incrementBy = createAction('increment', prepareNumberAction)
     const decrementBy = createAction('decrement', prepareNumberAction)
@@ -346,6 +361,25 @@ describe('createReducer', () => {
       expect(reducer(undefined, concatWith('foo'))).toEqual({
         numberActions: 0,
         stringActions: 1
+      })
+    })
+    test('falls back to defaultCase', () => {
+      const reducer = createReducer(initialState, builder =>
+        builder
+          .addCase(concatWith, state => {
+            state.stringActions += 1
+          })
+          .addMatcher(numberActionMatcher, state => {
+            state.numberActions += 1
+          })
+          .addDefaultCase(state => {
+            state.numberActions = -1
+            state.stringActions = -1
+          })
+      )
+      expect(reducer(undefined, { type: 'somethingElse' })).toEqual({
+        numberActions: -1,
+        stringActions: -1
       })
     })
     test('runs reducer cases followed by all matching actionMatchers', () => {
@@ -388,7 +422,7 @@ describe('createReducer', () => {
         stringActions: 0
       })
     })
-    test('calling addMatcher followed by addCase should result in an error in development mode', () => {
+    test('calling addCase, addMatcher and addDefaultCase in a nonsensical order should result in an error in development mode', () => {
       expect(() =>
         createReducer(initialState, (builder: any) =>
           builder
@@ -397,6 +431,29 @@ describe('createReducer', () => {
         )
       ).toThrowErrorMatchingInlineSnapshot(
         `"\`builder.addCase\` should only be called before calling \`builder.addMatcher\`"`
+      )
+      expect(() =>
+        createReducer(initialState, (builder: any) =>
+          builder.addDefaultCase(() => {}).addCase(incrementBy, () => {})
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"\`builder.addCase\` should only be called before calling \`builder.addDefaultCase\`"`
+      )
+      expect(() =>
+        createReducer(initialState, (builder: any) =>
+          builder
+            .addDefaultCase(() => {})
+            .addMatcher(numberActionMatcher, () => {})
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"\`builder.addMatcher\` should only be called before calling \`builder.addDefaultCase\`"`
+      )
+      expect(() =>
+        createReducer(initialState, (builder: any) =>
+          builder.addDefaultCase(() => {}).addDefaultCase(() => {})
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"\`builder.addDefaultCase\` can only be called once"`
       )
     })
   })

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -78,7 +78,10 @@ export type CaseReducers<S, AS extends Actions> = {
  * @param initialState The initial state to be returned by the reducer.
  * @param actionsMap A mapping from action types to action-type-specific
  *   case reducers.
- * @param actionMatchers TODO documentation
+ * @param actionMatchers An array of matcher definitions in the form `{matcher, reducer}`.
+ *   All matching reducers will be executed in order, independently if a case reducer matched or not.
+ * @param defaultCaseReducer A "default case" reducer that is executed if no case reducer and no matcher
+ *   reducer was executed for this action.
  *
  * @public
  */

--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -154,6 +154,21 @@ describe('createSlice', () => {
         )
       })
 
+      test('can be used with addMatcher and type guard functions', () => {
+        const slice = createSlice({
+          name: 'counter',
+          initialState: 0,
+          reducers: {},
+          extraReducers: builder =>
+            builder.addMatcher(
+              increment.match,
+              (state, action: { type: 'increment'; payload: number }) =>
+                state + action.payload
+            )
+        })
+        expect(slice.reducer(0, increment(5))).toBe(5)
+      })
+
       // for further tests, see the test of createReducer that goes way more into depth on this
     })
   })

--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -169,6 +169,17 @@ describe('createSlice', () => {
         expect(slice.reducer(0, increment(5))).toBe(5)
       })
 
+      test('can be used with addDefaultCase', () => {
+        const slice = createSlice({
+          name: 'counter',
+          initialState: 0,
+          reducers: {},
+          extraReducers: builder =>
+            builder.addDefaultCase((state, action) => state + action.payload)
+        })
+        expect(slice.reducer(0, increment(5))).toBe(5)
+      })
+
       // for further tests, see the test of createReducer that goes way more into depth on this
     })
   })

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -216,7 +216,11 @@ export function createSlice<
     throw new Error('`name` is a required option for createSlice')
   }
   const reducers = options.reducers || {}
-  const [extraReducers = {}, actionMatchers = []] =
+  const [
+    extraReducers = {},
+    actionMatchers = [],
+    defaultCaseReducer = undefined
+  ] =
     typeof options.extraReducers === 'undefined'
       ? []
       : typeof options.extraReducers === 'function'
@@ -254,7 +258,8 @@ export function createSlice<
   const reducer = createReducer(
     initialState,
     finalCaseReducers as any,
-    actionMatchers
+    actionMatchers,
+    defaultCaseReducer
   )
 
   return {

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -12,7 +12,7 @@ import {
   ActionReducerMapBuilder,
   executeReducerBuilderCallback
 } from './mapBuilders'
-import { Omit } from './tsHelpers'
+import { Omit, NoInfer } from './tsHelpers'
 
 /**
  * An action creator attached to a slice.
@@ -165,15 +165,6 @@ type SliceDefinedCaseReducers<CaseReducers extends SliceCaseReducers<any>> = {
 }
 
 /**
- * Helper type. Passes T out again, but boxes it in a way that it cannot
- * "widen" the type by accident if it is a generic that should be inferred
- * from elsewhere.
- *
- * @internal
- */
-type NoInfer<T> = [T][T extends any ? 0 : never]
-
-/**
  * Used on a SliceCaseReducers object.
  * Ensures that if a CaseReducer is a `CaseReducerWithPrepare`, that
  * the `reducer` and the `prepare` function use the same type of `payload`.
@@ -225,12 +216,12 @@ export function createSlice<
     throw new Error('`name` is a required option for createSlice')
   }
   const reducers = options.reducers || {}
-  const extraReducers =
+  const [extraReducers = {}, actionMatchers = []] =
     typeof options.extraReducers === 'undefined'
-      ? {}
+      ? []
       : typeof options.extraReducers === 'function'
       ? executeReducerBuilderCallback(options.extraReducers)
-      : options.extraReducers
+      : [options.extraReducers]
 
   const reducerNames = Object.keys(reducers)
 
@@ -260,7 +251,11 @@ export function createSlice<
   })
 
   const finalCaseReducers = { ...extraReducers, ...sliceCaseReducersByType }
-  const reducer = createReducer(initialState, finalCaseReducers as any)
+  const reducer = createReducer(
+    initialState,
+    finalCaseReducers as any,
+    actionMatchers
+  )
 
   return {
     name,

--- a/src/mapBuilders.ts
+++ b/src/mapBuilders.ts
@@ -37,8 +37,11 @@ export interface ActionReducerMapBuilder<State> {
   ): ActionReducerMapBuilder<State>
 
   /**
-   * TODO documentation
-   * @param matcher
+   * Adds a reducer for all actions, using `matcher` as a filter function.
+   * If multiple matcher reducers match, all of them will be executed in the order
+   * they were defined if - even if a case reducer already matched.
+   * @param matcher A matcher function. In TypeScript, this should be a [type predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates)
+   *   function
    * @param reducer
    */
   addMatcher<A extends AnyAction>(
@@ -46,6 +49,11 @@ export interface ActionReducerMapBuilder<State> {
     reducer: CaseReducer<State, A>
   ): Omit<ActionReducerMapBuilder<State>, 'addCase'>
 
+  /**
+   * Adds a "default case" reducer that is executed if no case reducer and no matcher
+   * reducer was executed for this action.
+   * @param reducer
+   */
   addDefaultCase(reducer: CaseReducer<State, AnyAction>): {}
 }
 

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -90,4 +90,13 @@ type UnionToIntersection<U> = (U extends any
   ? I
   : never
 
+/**
+ * Helper type. Passes T out again, but boxes it in a way that it cannot
+ * "widen" the type by accident if it is a generic that should be inferred
+ * from elsewhere.
+ *
+ * @internal
+ */
+export type NoInfer<T> = [T][T extends any ? 0 : never]
+
 export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>

--- a/type-tests/files/mapBuilders.typetest.ts
+++ b/type-tests/files/mapBuilders.typetest.ts
@@ -50,5 +50,27 @@ function expectType<T>(t: T) {
       'decrement',
       (state, action: ReturnType<typeof increment>) => state
     )
+
+    // action type is inferred
+    builder.addMatcher(increment.match, (state, action) => {
+      expectType<ReturnType<typeof increment>>(action)
+    })
+
+    // addCase().addMatcher() is possible
+    builder
+      .addCase(
+        'increment',
+        (state, action: ReturnType<typeof increment>) => state
+      )
+      .addMatcher(decrement.match, (state, action) => {
+        expectType<ReturnType<typeof decrement>>(action)
+      })
+
+    // addMatcher().addCase() is not possible as `addCase` should be removed after calling `addMatcher`
+    expectType<{ addCase?: never; addMatcher: Function }>(
+      builder.addMatcher(increment.match, (state, action) => {
+        expectType<ReturnType<typeof increment>>(action)
+      })
+    )
   })
 }


### PR DESCRIPTION
Still experimenting with some types & this will need some additional documentation, but I already want to put this through the CI.

The idea behind this is to enable usages such as this:

```ts
type Status = 'pending' | 'rejected' | 'fulfilled';

// Type guard function
function isPendingAction(action: AnyAction): action is PendingAction {
  return action.type.endsWith('/pending') && 'requestId'  in action.meta
};

const thunkStateSlice = createSlice({
  name: "thunkState",
  initialState: {} as {[requestId: string]: Status},
  reducers: {
    reset(){ return {} }
  },
  extraReducers: builder => builder
    // kind of "wildcard-y" extraReducer with a guard function - action is automatically inferred as `PendingAction` due to the signature of `isPendingAction`
    .addMatcher(isPendingAction, (state, action) => {
      state[action.meta.requestId] = 'pending'
    })
})
```