### PR TITLE
allow to return undefined for null-states in caseReducers

### DIFF
--- a/src/createReducer.test.ts
+++ b/src/createReducer.test.ts
@@ -274,6 +274,20 @@ describe('createReducer', () => {
         `"A case reducer on a non-draftable value must not return undefined"`
       )
     })
+    test('allows you to return undefined if the state was null, thus skipping an update', () => {
+      const reducer = createReducer(null as number | null, builder =>
+        builder.addCase(
+          'decrement',
+          (state, action: { type: 'decrement'; payload: number }) => {
+            if (typeof state === 'number') {
+              return state - action.payload
+            }
+          }
+        )
+      )
+      expect(reducer(0, decrement(5))).toBe(-5)
+      expect(reducer(null, decrement(5))).toBe(null)
+    })
     test('allows you to return null', () => {
       const reducer = createReducer(0 as number | null, builder =>
         builder.addCase(

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -160,6 +160,9 @@ export function createReducer<S>(
           const result = caseReducer(previousState as any, action)
 
           if (typeof result === 'undefined') {
+            if (previousState === null) {
+              return previousState
+            }
             throw Error(
               'A case reducer on a non-draftable value must not return undefined'
             )


### PR DESCRIPTION
This was just brought up in the chat. `null` is non-draftable, but we should accept the reducer not returning anything in that specific case & not modify the state (keeping it `null`).
This might be the case where a reducer has the state `S | null` and just skips state modification while `draft` is `null`.