### PR TITLE
Update compressed-size action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,9 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2-beta
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Hoping this fixes the action as it fails often.

- Use @v2 instead of @v2-beta
- Remove fetch-depth as the default is 1