### PR TITLE
Fix typo in addMatcher TS example

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -220,7 +220,7 @@ As the first `matcher` argument to `builder.addMatcher`, a [type predicate](http
 As a result, the `action` argument for the second `reducer` argument can be inferred by TypeScript:
 
 ```ts
-function isNumberValueAction(action: AnyAction): Action is PayloadAction<{ value: number }> {
+function isNumberValueAction(action: AnyAction): action is PayloadAction<{ value: number }> {
   return typeof action.payload.value === 'number'
 }
 


### PR DESCRIPTION
Fixes a typo in the event someone copy + pasted this code (like me!)