### PR TITLE
Docs Idea: Showing a simple TS example of passing args to a matcher func

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -234,8 +234,12 @@ createReducer({ value: 0 }, builder =>
 Additionally, you may want to pass arguments to a matcher function to create reusable helpers. A pattern for that would look like:
 
 ```ts
-const isScopedNumberValueAction = (scope: string) => (action: AnyAction): action is PayloadAction<{ value: number }> => {
-  return action.type.startsWith(scope) && typeof action.payload.value === 'number'
+const isScopedNumberValueAction = (scope: string) => (
+  action: AnyAction
+): action is PayloadAction<{ value: number }> => {
+  return (
+    action.type.startsWith(scope) && typeof action.payload.value === 'number'
+  )
 }
 
 const slice = createSlice({
@@ -243,9 +247,12 @@ const slice = createSlice({
   initialState: { value: 0 },
   reducers: {},
   extraReducers: builder => {
-    builder.addMatcher(isScopedNumberValueAction('counter/'), (state, action) => {
-       state.value += action.payload.value
-    })
+    builder.addMatcher(
+      isScopedNumberValueAction('counter/'),
+      (state, action) => {
+        state.value += action.payload.value
+      }
+    )
   }
 })
 ```

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -234,7 +234,7 @@ createReducer({ value: 0 }, builder =>
 Additionally, you may want to pass arguments to a matcher function to create reusable helpers. A pattern for that would look like:
 
 ```ts
-const isScopedNumberValueAction = (scope: string) => (action: AnyAction): action is PayloadAction<{ value: number }> {
+const isScopedNumberValueAction = (scope: string) => (action: AnyAction): action is PayloadAction<{ value: number }> => {
   return action.type.startsWith(scope) && typeof action.payload.value === 'number'
 }
 

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -231,6 +231,25 @@ createReducer({ value: 0 }, builder =>
 })
 ```
 
+Additionally, you may want to pass arguments to a matcher function to create reusable helpers. A pattern for that would look like:
+
+```ts
+const isScopedNumberValueAction = (scope: string) => (action: AnyAction): action is PayloadAction<{ value: number }> {
+  return action.type.startsWith(scope) && typeof action.payload.value === 'number'
+}
+
+const slice = createSlice({
+  name: 'counter',
+  initialState: { value: 0 },
+  reducers: {},
+  extraReducers: builder => {
+    builder.addMatcher(isScopedNumberValueAction('counter/'), (state, action) => {
+       state.value += action.payload.value
+    })
+  }
+})
+```
+
 ## `createSlice`
 
 As `createSlice` creates your actions as well as your reducer for you, you don't have to worry about type safety here.


### PR DESCRIPTION
I'm not sure if there is a lot of value here, but we currently don't show this kind of example anywhere and this could potentially save someone time. 

For a more realistic generic use case: https://codesandbox.io/s/rtk-14-addmatcher-counter-test-l11mt?file=/src/features/counter/counterSlice.ts:2037-2492

Let me know what you think.