### PR TITLE
Use consistent middleware option type

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -117,7 +117,7 @@ export type Comparer<T> = (a: T, b: T) => number;
 export type ConfigureEnhancersCallback = (defaultEnhancers: StoreEnhancer[]) => StoreEnhancer[];
 
 // @public
-export function configureStore<S = any, A extends Action = AnyAction, M extends Middlewares<S> = [ThunkMiddlewareFor<S>]>(options: ConfigureStoreOptions<S, A, M>): EnhancedStore<S, A, M>;
+export function configureStore<S = any, A extends Action = AnyAction, M extends Middlewares<S> = Array<ThunkMiddlewareFor<S>>>(options: ConfigureStoreOptions<S, A, M>): EnhancedStore<S, A, M>;
 
 // @public
 export interface ConfigureStoreOptions<S = any, A extends Action = AnyAction, M extends Middlewares<S> = Middlewares<S>> {

--- a/src/configureStore.test.ts
+++ b/src/configureStore.test.ts
@@ -70,11 +70,11 @@ describe('configureStore', () => {
 
   describe('given custom middleware', () => {
     it('calls createStore with custom middleware and without default middleware', () => {
-      const thank: redux.Middleware = _store => next => action => next(action)
-      expect(configureStore({ middleware: [thank], reducer })).toBeInstanceOf(
+      const thunk: redux.Middleware = _store => next => action => next(action)
+      expect(configureStore({ middleware: [thunk], reducer })).toBeInstanceOf(
         Object
       )
-      expect(redux.applyMiddleware).toHaveBeenCalledWith(thank)
+      expect(redux.applyMiddleware).toHaveBeenCalledWith(thunk)
       expect(devtools.composeWithDevTools).toHaveBeenCalled()
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
@@ -86,14 +86,14 @@ describe('configureStore', () => {
 
   describe('middleware builder notation', () => {
     it('calls builder, passes getDefaultMiddleware and uses returned middlewares', () => {
-      const thank = jest.fn((_store => next => action =>
+      const thunk = jest.fn((_store => next => action =>
         'foobar') as redux.Middleware)
 
       const builder = jest.fn(getDefaultMiddleware => {
         expect(getDefaultMiddleware).toEqual(expect.any(Function))
         expect(getDefaultMiddleware()).toEqual(expect.any(Array))
 
-        return [thank]
+        return [thunk]
       })
 
       const store = configureStore({ middleware: builder, reducer })

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -123,7 +123,7 @@ export interface EnhancedStore<
 export function configureStore<
   S = any,
   A extends Action = AnyAction,
-  M extends Middlewares<S> = [ThunkMiddlewareFor<S>]
+  M extends Middlewares<S> = Array<ThunkMiddlewareFor<S>>
 >(options: ConfigureStoreOptions<S, A, M>): EnhancedStore<S, A, M> {
   const curriedGetDefaultMiddleware = curryGetDefaultMiddleware<S>()
 


### PR DESCRIPTION
The default type of the `middleware` option in `configureStore` is a [tuple](https://github.com/reduxjs/redux-toolkit/blob/master/src/configureStore.ts#L126). However, the type of the `middleware` option in `ConfigureStoreOption` is an [array](https://github.com/reduxjs/redux-toolkit/blob/master/src/configureStore.ts#L48). As a result, if someone type `configureStore` partially, such as `configureStore<State>(...)`. The default tuple type is used to type the `middleware` option and an error of tuple and array mismatching is generated: 
```
Property '0' is missing in type 'MiddlewareArray<ThunkMiddleware<any, AnyAction, null> | ThunkMiddleware<any, AnyAction, undefined> | Middleware<{}, any, Dispatch<AnyAction>>>' but required in type '[ThunkMiddleware<any, AnyAction, null> | ThunkMiddleware<any, AnyAction, undefined>]'.
```
This error was not seen before 775da05287100afc363fa346196e3ef865402851.
Although the doc says `configureStore` doesn't need typing now, changing the type of the `middleware` option in `configureStore` from tuple to array can ensure type consistency and avoid this kind of meaningless error when upgrading the package.