### PR TITLE
Docs: add missing imports to the Redux-Persist usage guide

### DIFF
--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -1051,6 +1051,7 @@ configureStore({
 If using Redux-Persist, you should specifically ignore all the action types it dispatches:
 
 ```jsx
+import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit'
 import {
   persistStore,
   persistReducer,


### PR DESCRIPTION
### The problem 
In the example for how to use it with `redux-persist` there were some missing imports from `@reduxjs/toolkit`.

**Link to the docs page:** https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist

```javascript
// The missing imports:
import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit'
```

### The solition
Added the missing imports to the usage-guide docs.