### PR TITLE
Fix typo on Usage with TypeScript docs

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -64,7 +64,7 @@ The type of the `dispatch` function type will be directly inferred from the `mid
 
 As TypeScript often widens array types when combining arrays using the spread operator, we suggest using the `.concat(...)` and `.prepend(...)` methods of the `MiddlewareArray` returned by `getDefaultMiddleware()`.
 
-Also, we suggest using the callback notation for the `middleware` option go get a correctly pre-typed version of `getDefaultMiddleware` that does not require you to specify any generics by hand.
+Also, we suggest using the callback notation for the `middleware` option to get a correctly pre-typed version of `getDefaultMiddleware` that does not require you to specify any generics by hand.
 
 ```ts {10-20}
 import { configureStore } from '@reduxjs/toolkit'


### PR DESCRIPTION
Fix typo on Usage with TypeScript docs:

```diff
- ...go get a correctly pre-typed...
+ ...to get a correctly pre-typed...
```