### PR TITLE
Export createStructuredSelector

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -9,6 +9,7 @@ import { ActionCreator } from 'redux';
 import { AnyAction } from 'redux';
 import { default as createNextState } from 'immer';
 import { createSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 import { current } from 'immer';
 import { DeepPartial } from 'redux';
 import { Dispatch } from 'redux';
@@ -169,6 +170,8 @@ export interface CreateSliceOptions<State = any, CR extends SliceCaseReducers<St
     name: Name;
     reducers: ValidateSliceCaseReducers<State, CR>;
 }
+
+export { createStructuredSelector }
 
 export { current }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from 'redux'
 export { default as createNextState, Draft, current } from 'immer'
 export {
   createSelector,
+  createStructuredSelector,
   Selector,
   OutputParametricSelector,
   OutputSelector,


### PR DESCRIPTION
Add `createStructuredSelector` to exported types as this allows not to install `reselect` manually