### PR TITLE
Clarify docs on useDispatch origin

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -48,6 +48,7 @@ If you want to get the `Dispatch` type from your store, you can extract it after
 
 ```typescript {6}
 import { configureStore } from '@reduxjs/toolkit'
+import { useDispatch } from 'react-redux'
 import rootReducer from './rootReducer'
 
 const store = configureStore({


### PR DESCRIPTION
It might not be obvious where did useDispatch hook comes from, could be worth it to clarify it with import statement.