### PR TITLE
Fix Docusaurus style - Fix dark theme blockquote color contrast

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -80,7 +80,6 @@ blockquote {
 
 html[data-theme='dark'] blockquote {
   border-left-color: var(--ifm-color-primary);
-  color: #000;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
Removes the black text color from dark theme blockquotes in order to let it fall back to `--ifm-font-base-color`.  

Issue mentioned previously [here](https://github.com/reduxjs/redux-toolkit/pull/724#issuecomment-693297620) on PR #724 