### PR TITLE
Feature: allow re-throwing errors from createAsyncThunk()

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -89,6 +89,7 @@ An object with the following optional fields:
 
 - `condition`: a callback that can be used to skip execution of the payload creator and all action dispatches, if desired. See [Canceling Before Execution](#canceling-before-execution) for a complete description.
 - `dispatchConditionRejection`: if `condition()` returns `false`, the default behavior is that no actions will be dispatched at all. If you still want a "rejected" action to be dispatched when the thunk was canceled, set this flag to `true`.
+- `throwError`: if `true` the promise returned by the action creator will be rejected in case of a failure with the original error. (disabled by default)
 
 ## Return Value
 

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -213,6 +213,10 @@ interface AsyncThunkOptions<
    * @default `false`
    */
   dispatchConditionRejection?: boolean
+  /**
+   * If `true` the promise returned by the action creator will be rejected in case of a failure.
+   */
+  throwError?: boolean
 }
 
 type AsyncThunkPendingActionCreator<
@@ -394,6 +398,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
       }
 
       const promise = (async function() {
+        let caughtError: any
         let finalAction: ReturnType<typeof fulfilled | typeof rejected>
         try {
           if (
@@ -431,6 +436,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
           ])
         } catch (err) {
           finalAction = rejected(err, requestId, arg)
+          caughtError = err
         }
         // We dispatch the result action _after_ the catch, to avoid having any errors
         // here get swallowed by the try/catch block,
@@ -446,6 +452,11 @@ If you want to use the AbortController to react to \`abort\` events, please cons
         if (!skipDispatch) {
           dispatch(finalAction)
         }
+
+        if (options && options.throwError === true) {
+          throw caughtError
+        }
+
         return finalAction
       })()
       return Object.assign(promise, { abort })


### PR DESCRIPTION
**Related issue:** https://github.com/reduxjs/redux-toolkit/issues/734

This would allow re-throwing the original error, and would make it possible to act on the promise returned by the action.

This PR doesn't change the default way how `createAsyncThunk()` works, so is backward compatible.

```javascript
const asyncThunk = createAsyncThunk('test', () => {
    throw new Error('sample error');
}, {
    throwError: true
});

// ...

try {
    await dispatch(asyncThunk())
} catch (e) {
    // This will throw an error now that can be acted on in some exceptional scenarios
    // e = Error('sample error')
}
``` 