### PR TITLE
fix(typescript): fix `serialize` types

### DIFF
--- a/src/devtoolsExtension.ts
+++ b/src/devtoolsExtension.ts
@@ -28,25 +28,27 @@ export interface EnhancerOptions {
    */
   maxAge?: number
   /**
-   * - `undefined` - will use regular `JSON.stringify` to send data (it's the fast mode).
-   * - `false` - will handle also circular references.
-   * - `true` - will handle also date, regex, undefined, error objects, symbols, maps, sets and functions.
-   * - object, which contains `date`, `regex`, `undefined`, `error`, `symbol`, `map`, `set` and `function` keys.
-   *   For each of them you can indicate if to include (by setting as `true`).
-   *   For `function` key you can also specify a custom function which handles serialization.
-   *   See [`jsan`](https://github.com/kolodny/jsan) for more details.
+   * See detailed documentation at http://extension.remotedev.io/docs/API/Arguments.html#serialize
    */
   serialize?:
     | boolean
     | {
-        date?: boolean
-        regex?: boolean
-        undefined?: boolean
-        error?: boolean
-        symbol?: boolean
-        map?: boolean
-        set?: boolean
-        function?: boolean | Function
+        options?:
+          | boolean
+          | {
+              date?: boolean
+              regex?: boolean
+              undefined?: boolean
+              error?: boolean
+              symbol?: boolean
+              map?: boolean
+              set?: boolean
+              function?: boolean | Function
+            }
+        replacer?: (key: string, value: unknown) => unknown
+        reviver?: (key: string, value: unknown) => unknown
+        immutable?: unknown
+        refs?: unknown[]
       }
   /**
    * function which takes `action` object and id number as arguments, and should return `action` object back.


### PR DESCRIPTION
Fix for #751

The `serialize` property can be an object which can have many different properties. Those properties are described at https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize The current type only mentions what is inside the `options` property, and puts it directly inside `serialize`, which doesn't match the docs so I'm updating the types so they match the docs more closely, as well as the source code at https://github.com/reduxjs/redux-devtools/blob/master/packages/redux-devtools-serialize/src/immutable/index.ts

I tested this locally in my own project by linking the npm package and initializing the store with:
```ts
const store = configureStore({
  reducer: webReducers,
  middleware: [thunk, sagaMiddleware],
  devTools: {
    actionSanitizer,
    stateSanitizer,
    serialize: {
      replacer: (_key, value) => {
        if (value instanceof Element) {
          return "DOMElement";
        }
        if (
          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
          // @ts-ignore
          window.google?.maps &&
          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
          // @ts-ignore
          value instanceof window.google.maps?.MVCObject
        ) {
          return "GoogleMaps";
        }
        return value;
      },
    },
  },
});
```

I used to have a TS error for `replacer` and I don't anymore, proving that this fixes the issue.