### PR TITLE
Allow CaseReducers to also return `Draft<T>`

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -90,7 +90,7 @@ export type AsyncThunkPayloadCreator<Returned, ThunkArg = void, ThunkApiConfig e
 export type AsyncThunkPayloadCreatorReturnValue<Returned, ThunkApiConfig extends AsyncThunkConfig> = Promise<Returned | RejectWithValue<GetRejectValue<ThunkApiConfig>>> | Returned | RejectWithValue<GetRejectValue<ThunkApiConfig>>;
 
 // @public
-export type CaseReducer<S = any, A extends Action = AnyAction> = (state: Draft<S>, action: A) => S | void;
+export type CaseReducer<S = any, A extends Action = AnyAction> = (state: Draft<S>, action: A) => S | void | Draft<S>;
 
 // @public
 export type CaseReducerActions<CaseReducers extends SliceCaseReducers<any>> = {

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -48,7 +48,7 @@ export type ActionMatcherDescriptionCollection<S> = Array<
 export type CaseReducer<S = any, A extends Action = AnyAction> = (
   state: Draft<S>,
   action: A
-) => S | void
+) => S | void | Draft<S>
 
 /**
  * A mapping from action types to case reducers for `createReducer()`.
@@ -153,7 +153,7 @@ export function createReducer<S>(
             return previousState
           }
 
-          return result
+          return result as S
         } else if (!isDraftable(previousState)) {
           // If state is not draftable (ex: a primitive, such as 0), we want to directly
           // return the caseReducer func and not wrap it with produce.
@@ -168,7 +168,7 @@ export function createReducer<S>(
             )
           }
 
-          return result
+          return result as S
         } else {
           // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather
           // than an Immutable<S>, and TypeScript cannot find out how to reconcile

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -460,3 +460,39 @@ const value = actionCreators.anyKey
   expectType<ActionCreatorWithPayload<string>>(wrappedSlice.actions.success)
   expectType<ActionCreatorWithoutPayload<string>>(wrappedSlice.actions.magic)
 }
+
+{
+  interface GenericState<T> {
+    data: T | null
+  }
+
+  function createDataSlice<
+    T,
+    Reducers extends SliceCaseReducers<GenericState<T>>
+  >(
+    name: string,
+    reducers: ValidateSliceCaseReducers<GenericState<T>, Reducers>,
+    initialState: GenericState<T>
+  ) {
+    const doNothing = createAction<undefined>('doNothing')
+    const setData = createAction<T>('setData')
+
+    const slice = createSlice({
+      name,
+      initialState,
+      reducers,
+      extraReducers: builder => {
+        builder.addCase(doNothing, state => {
+          return { ...state }
+        })
+        builder.addCase(setData, (state, { payload }) => {
+          return {
+            ...state,
+            data: payload
+          }
+        })
+      }
+    })
+    return { doNothing, setData, slice }
+  }
+}


### PR DESCRIPTION
To help in situations where `T` contains an unresolved generic.
Thanks to @amcsi for reporting this and providing a reproduction
for this issue.