### PR TITLE
add `requestId` property to the promise returned by `createAsyncThunk`

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -82,6 +82,7 @@ export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThu
 }, SerializedError>> & {
     abort(reason?: string): void;
     requestId: string;
+    arg: ThunkArg;
 };
 
 // @public

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -81,6 +81,7 @@ export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThu
     condition: boolean;
 }, SerializedError>> & {
     abort(reason?: string): void;
+    requestId: string;
 };
 
 // @public

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -77,6 +77,7 @@ describe('createAsyncThunk', () => {
     const thunkPromise = thunkFunction(dispatch, () => {}, undefined)
 
     expect(thunkPromise.requestId).toBe(generatedRequestId)
+    expect(thunkPromise.arg).toBe(args)
 
     await thunkPromise
 

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -74,7 +74,11 @@ describe('createAsyncThunk', () => {
 
     const thunkFunction = thunkActionCreator(args)
 
-    await thunkFunction(dispatch, () => {}, undefined)
+    const thunkPromise = thunkFunction(dispatch, () => {}, undefined)
+
+    expect(thunkPromise.requestId).toBe(generatedRequestId)
+
+    await thunkPromise
 
     expect(passedArg).toBe(args)
 
@@ -355,8 +359,9 @@ describe('createAsyncThunk with abortController', () => {
         message: 'AbortReason',
         name: 'AbortError'
       },
-      meta: { aborted: true }
+      meta: { aborted: true, requestId: promise.requestId }
     }
+
     // abortedAction with reason is dispatched after test/pending is dispatched
     expect(store.getState()).toMatchObject([
       {},

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -163,6 +163,7 @@ export type AsyncThunkAction<
 > & {
   abort(reason?: string): void
   requestId: string
+  arg: ThunkArg
 }
 
 type AsyncThunkActionCreator<
@@ -449,7 +450,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
         }
         return finalAction
       })()
-      return Object.assign(promise, { abort, requestId })
+      return Object.assign(promise, { abort, requestId, arg })
     }
   }
 

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -162,6 +162,7 @@ export type AsyncThunkAction<
     >
 > & {
   abort(reason?: string): void
+  requestId: string
 }
 
 type AsyncThunkActionCreator<
@@ -448,7 +449,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
         }
         return finalAction
       })()
-      return Object.assign(promise, { abort })
+      return Object.assign(promise, { abort, requestId })
     }
   }
 

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -34,6 +34,7 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
   const promise = defaultDispatch(async(3))
 
   expectType<string>(promise.requestId)
+  expectType<number>(promise.arg)
   expectType<(reason?: string) => void>(promise.abort)
 
   const result = await promise

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -32,6 +32,10 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
   )
 
   const promise = defaultDispatch(async(3))
+
+  expectType<string>(promise.requestId)
+  expectType<(reason?: string) => void>(promise.abort)
+
   const result = await promise
 
   if (async.fulfilled.match(result)) {


### PR DESCRIPTION
I noticed this to be lacking while experimenting with https://github.com/phryneas/rtk_simple-query - @markerikson is this okay with you?