### PR TITLE
Export isPlainObject

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -301,6 +301,9 @@ export function isImmutableDefault(value: unknown): boolean;
 // @public
 export function isPlain(val: any): boolean;
 
+// @public
+export function isPlainObject(value: unknown): value is object;
+
 // @public (undocumented)
 export class MiddlewareArray<Middlewares extends Middleware<any, any>> extends Array<Middlewares> {
     // (undocumented)

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,3 +107,5 @@ export {
 } from './createAsyncThunk'
 
 export { nanoid } from './nanoid'
+
+export { default as isPlainObject } from './isPlainObject'

--- a/src/isPlainObject.ts
+++ b/src/isPlainObject.ts
@@ -5,6 +5,8 @@
  *
  * @param {any} value The value to inspect.
  * @returns {boolean} True if the argument appears to be a plain object.
+ *
+ * @public
  */
 export default function isPlainObject(value: unknown): value is object {
   if (typeof value !== 'object' || value === null) return false


### PR DESCRIPTION
Just exports `isPlainObject` to consume with other RTK-based libs. I don't think this needs to be documented under `Other exports` in the docs, but I can add it if necessary.