### PR TITLE
Exposed Immer's PatchListener

### DIFF
--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -1,4 +1,9 @@
-import createNextState, { Draft, isDraft, isDraftable } from 'immer'
+import createNextState, {
+  Draft,
+  isDraft,
+  isDraftable,
+  PatchListener
+} from 'immer'
 import { AnyAction, Action, Reducer } from 'redux'
 import {
   executeReducerBuilderCallback,
@@ -183,7 +188,8 @@ export function createReducer<
   initialState: S,
   actionsMap: CR,
   actionMatchers?: ActionMatcherDescriptionCollection<S>,
-  defaultCaseReducer?: CaseReducer<S>
+  defaultCaseReducer?: CaseReducer<S>,
+  patchListener?: PatchListener
 ): Reducer<S>
 
 export function createReducer<S>(
@@ -192,7 +198,8 @@ export function createReducer<S>(
     | CaseReducers<S, any>
     | ((builder: ActionReducerMapBuilder<S>) => void),
   actionMatchers: ActionMatcherDescriptionCollection<S> = [],
-  defaultCaseReducer?: CaseReducer<S>
+  defaultCaseReducer?: CaseReducer<S>,
+  patchListener?: PatchListener
 ): Reducer<S> {
   let [actionsMap, finalActionMatchers, finalDefaultCaseReducer] =
     typeof mapOrBuilderCallback === 'function'
@@ -243,9 +250,13 @@ export function createReducer<S>(
           // @ts-ignore createNextState() produces an Immutable<Draft<S>> rather
           // than an Immutable<S>, and TypeScript cannot find out how to reconcile
           // these two types.
-          return createNextState(previousState, (draft: Draft<S>) => {
-            return caseReducer(draft, action)
-          })
+          return createNextState(
+            previousState,
+            (draft: Draft<S>) => {
+              return caseReducer(draft, action)
+            },
+            patchListener
+          )
         }
       }
 

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -13,6 +13,7 @@ import {
   executeReducerBuilderCallback
 } from './mapBuilders'
 import { Omit, NoInfer } from './tsHelpers'
+import { PatchListener } from 'immer'
 
 /**
  * An action creator attached to a slice.
@@ -131,6 +132,8 @@ createSlice({
   extraReducers?:
     | CaseReducers<NoInfer<State>, any>
     | ((builder: ActionReducerMapBuilder<NoInfer<State>>) => void)
+
+  patchListener?: PatchListener
 }
 
 /**
@@ -249,7 +252,7 @@ export function createSlice<
 >(
   options: CreateSliceOptions<State, CaseReducers, Name>
 ): Slice<State, CaseReducers, Name> {
-  const { name, initialState } = options
+  const { name, initialState, patchListener } = options
   if (!name) {
     throw new Error('`name` is a required option for createSlice')
   }
@@ -297,7 +300,8 @@ export function createSlice<
     initialState,
     finalCaseReducers as any,
     actionMatchers,
-    defaultCaseReducer
+    defaultCaseReducer,
+    patchListener
   )
 
   return {


### PR DESCRIPTION
Recently I've been experimenting more with the Toolkit, including using it on the server, syncing state between two stores via WebSockets, and writing a debugging tool with easy diffing due to Immer patches.

I must say at the moment I'm absolutely not sure how useful other people would find it, but would you, by any chance, consider exposing it via RTK's `createSlice` and `createReducer` API?