### PR TITLE
AsyncThunk Matchers

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -422,7 +422,7 @@ export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = ACR
     [T in keyof ACR]: ACR[T] extends {
         reducer(s: S, action?: infer A): any;
     } ? {
-        prepare(...a: never[]): Omit_2<A, 'type'>;
+        prepare(...a: never[]): Omit<A, 'type'>;
     } : {};
 };
 

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -85,6 +85,7 @@ export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThu
     arg: ThunkArg;
     requestId: string;
     requestStatus: 'rejected';
+    isRejectedWithValue?: boolean;
     aborted: boolean;
     condition: boolean;
 }, SerializedError>> & {
@@ -310,10 +311,40 @@ export function isAllOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(...m
 export function isAnyOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(...matchers: Matchers): (action: any) => action is ActionFromMatcher<Matchers[number]>;
 
 // @public
+export function isAsyncThunkAction(): (action: any) => action is UnknownAsyncThunkAction;
+
+// @public
+export function isAsyncThunkAction<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is ActionsFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
+export function isFulfilled(): (action: any) => action is UnknownAsyncThunkFulfilledAction;
+
+// @public
+export function isFulfilled<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is FulfilledActionFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
 export function isImmutableDefault(value: unknown): boolean;
 
 // @public
+export function isPending(): (action: any) => action is UnknownAsyncThunkPendingAction;
+
+// @public
+export function isPending<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is PendingActionFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
 export function isPlain(val: any): boolean;
+
+// @public
+export function isRejected(): (action: any) => action is UnknownAsyncThunkRejectedAction;
+
+// @public
+export function isRejected<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
+export function isRejectedWithValue(): (action: any) => action is UnknownAsyncThunkRejectedAction;
+
+// @public
+export function isRejectedWithValue<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>;
 
 // @public (undocumented)
 export class MiddlewareArray<Middlewares extends Middleware<any, any>> extends Array<Middlewares> {

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -80,9 +80,11 @@ export type AsyncThunk<Returned, ThunkArg, ThunkApiConfig extends AsyncThunkConf
 export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThunkConfig> = (dispatch: GetDispatch<ThunkApiConfig>, getState: () => GetState<ThunkApiConfig>, extra: GetExtra<ThunkApiConfig>) => Promise<PayloadAction<Returned, string, {
     arg: ThunkArg;
     requestId: string;
+    requestStatus: 'fulfilled';
 }> | PayloadAction<undefined | GetRejectValue<ThunkApiConfig>, string, {
     arg: ThunkArg;
     requestId: string;
+    requestStatus: 'rejected';
     aborted: boolean;
     condition: boolean;
 }, SerializedError>> & {
@@ -420,7 +422,7 @@ export type ValidateSliceCaseReducers<S, ACR extends SliceCaseReducers<S>> = ACR
     [T in keyof ACR]: ACR[T] extends {
         reducer(s: S, action?: infer A): any;
     } ? {
-        prepare(...a: never[]): Omit<A, 'type'>;
+        prepare(...a: never[]): Omit_2<A, 'type'>;
     } : {};
 };
 

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -588,7 +588,8 @@ describe('conditional skipping of asyncThunks', () => {
           aborted: false,
           arg: arg,
           condition: true,
-          requestId: expect.stringContaining('')
+          requestId: expect.stringContaining(''),
+          requestStatus: 'rejected'
         },
         payload: undefined,
         type: 'test/rejected'

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -253,6 +253,7 @@ export type AsyncThunkRejectedActionCreator<
     arg: ThunkArg
     requestId: string
     requestStatus: 'rejected'
+    isRejectedWithValue?: boolean;
     aborted: boolean
     condition: boolean
   }
@@ -343,7 +344,8 @@ export function createAsyncThunk<
       error: Error | null,
       requestId: string,
       arg: ThunkArg,
-      payload?: RejectedValue
+      payload?: RejectedValue,
+      isRejectedWithValue?: boolean,
     ) => {
       const aborted = !!error && error.name === 'AbortError'
       const condition = !!error && error.name === 'ConditionError'
@@ -354,6 +356,7 @@ export function createAsyncThunk<
           arg,
           requestId,
           requestStatus: 'rejected' as const,
+          isRejectedWithValue,
           aborted,
           condition
         }
@@ -443,7 +446,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
               })
             ).then(result => {
               if (result instanceof RejectWithValue) {
-                return rejected(null, requestId, arg, result.value)
+                return rejected(null, requestId, arg, result.value, true)
               }
               return fulfilled(result, requestId, arg)
             })

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -253,7 +253,7 @@ export type AsyncThunkRejectedActionCreator<
     arg: ThunkArg
     requestId: string
     requestStatus: 'rejected'
-    isRejectedWithValue?: boolean;
+    rejectedWithValue?: boolean;
     aborted: boolean
     condition: boolean
   }
@@ -345,7 +345,7 @@ export function createAsyncThunk<
       requestId: string,
       arg: ThunkArg,
       payload?: RejectedValue,
-      isRejectedWithValue?: boolean,
+      rejectedWithValue?: boolean,
     ) => {
       const aborted = !!error && error.name === 'AbortError'
       const condition = !!error && error.name === 'ConditionError'
@@ -356,7 +356,7 @@ export function createAsyncThunk<
           arg,
           requestId,
           requestStatus: 'rejected' as const,
-          isRejectedWithValue,
+          isRejectedWithValue: rejectedWithValue,
           aborted,
           condition
         }

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -148,13 +148,18 @@ export type AsyncThunkAction<
   getState: () => GetState<ThunkApiConfig>,
   extra: GetExtra<ThunkApiConfig>
 ) => Promise<
-  | PayloadAction<Returned, string, { arg: ThunkArg; requestId: string }>
+  | PayloadAction<
+      Returned,
+      string,
+      { arg: ThunkArg; requestId: string; requestStatus: 'fulfilled' }
+    >
   | PayloadAction<
       undefined | GetRejectValue<ThunkApiConfig>,
       string,
       {
         arg: ThunkArg
         requestId: string
+        requestStatus: 'rejected'
         aborted: boolean
         condition: boolean
       },
@@ -227,6 +232,7 @@ type AsyncThunkPendingActionCreator<
   {
     arg: ThunkArg
     requestId: string
+    requestStatus: 'pending'
   }
 >
 
@@ -246,6 +252,7 @@ type AsyncThunkRejectedActionCreator<
   {
     arg: ThunkArg
     requestId: string
+    requestStatus: 'rejected'
     aborted: boolean
     condition: boolean
   }
@@ -262,6 +269,7 @@ type AsyncThunkFulfilledActionCreator<
   {
     arg: ThunkArg
     requestId: string
+    requestStatus: 'fulfilled'
   }
 >
 
@@ -306,7 +314,11 @@ export function createAsyncThunk<
     (result: Returned, requestId: string, arg: ThunkArg) => {
       return {
         payload: result,
-        meta: { arg, requestId }
+        meta: {
+          arg,
+          requestId,
+          requestStatus: 'fulfilled' as const
+        }
       }
     }
   )
@@ -316,7 +328,11 @@ export function createAsyncThunk<
     (requestId: string, arg: ThunkArg) => {
       return {
         payload: undefined,
-        meta: { arg, requestId }
+        meta: {
+          arg,
+          requestId,
+          requestStatus: 'pending' as const
+        }
       }
     }
   )
@@ -337,6 +353,7 @@ export function createAsyncThunk<
         meta: {
           arg,
           requestId,
+          requestStatus: 'rejected' as const,
           aborted,
           condition
         }

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -222,7 +222,7 @@ interface AsyncThunkOptions<
   dispatchConditionRejection?: boolean
 }
 
-type AsyncThunkPendingActionCreator<
+export type AsyncThunkPendingActionCreator<
   ThunkArg
 > = ActionCreatorWithPreparedPayload<
   [string, ThunkArg],
@@ -236,7 +236,7 @@ type AsyncThunkPendingActionCreator<
   }
 >
 
-type AsyncThunkRejectedActionCreator<
+export type AsyncThunkRejectedActionCreator<
   ThunkArg,
   ThunkApiConfig
 > = ActionCreatorWithPreparedPayload<
@@ -258,7 +258,7 @@ type AsyncThunkRejectedActionCreator<
   }
 >
 
-type AsyncThunkFulfilledActionCreator<
+export type AsyncThunkFulfilledActionCreator<
   Returned,
   ThunkArg
 > = ActionCreatorWithPreparedPayload<

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -254,7 +254,7 @@ export type AsyncThunkRejectedActionCreator<
     arg: ThunkArg
     requestId: string
     requestStatus: 'rejected'
-    isRejectedWithValue?: boolean;
+    isRejectedWithValue?: boolean
     aborted: boolean
     condition: boolean
   }
@@ -346,7 +346,7 @@ export function createAsyncThunk<
       requestId: string,
       arg: ThunkArg,
       payload?: RejectedValue,
-      isRejectedWithValue?: boolean,
+      isRejectedWithValue?: boolean
     ) => {
       const aborted = !!error && error.name === 'AbortError'
       const condition = !!error && error.name === 'ConditionError'

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -356,7 +356,7 @@ export function createAsyncThunk<
           arg,
           requestId,
           requestStatus: 'rejected' as const,
-          isRejectedWithValue: rejectedWithValue,
+          rejectedWithValue: rejectedWithValue,
           aborted,
           condition
         }

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -160,6 +160,7 @@ export type AsyncThunkAction<
         arg: ThunkArg
         requestId: string
         requestStatus: 'rejected'
+        isRejectedWithValue?: boolean
         aborted: boolean
         condition: boolean
       },
@@ -253,7 +254,7 @@ export type AsyncThunkRejectedActionCreator<
     arg: ThunkArg
     requestId: string
     requestStatus: 'rejected'
-    rejectedWithValue?: boolean;
+    isRejectedWithValue?: boolean;
     aborted: boolean
     condition: boolean
   }
@@ -345,7 +346,7 @@ export function createAsyncThunk<
       requestId: string,
       arg: ThunkArg,
       payload?: RejectedValue,
-      rejectedWithValue?: boolean,
+      isRejectedWithValue?: boolean,
     ) => {
       const aborted = !!error && error.name === 'AbortError'
       const condition = !!error && error.name === 'ConditionError'
@@ -356,7 +357,7 @@ export function createAsyncThunk<
           arg,
           requestId,
           requestStatus: 'rejected' as const,
-          rejectedWithValue: rejectedWithValue,
+          isRejectedWithValue: isRejectedWithValue,
           aborted,
           condition
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,10 @@ export {
   // js
   isAllOf,
   isAnyOf,
+  isPending,
+  isRejected,
+  isFulfilled,
+  isAsyncThunkAction,
   // types
   ActionMatchingAllOf,
   ActionMatchingAnyOf

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ export {
   isRejected,
   isFulfilled,
   isAsyncThunkAction,
+  isRejectedWithValue,
   // types
   ActionMatchingAllOf,
   ActionMatchingAnyOf

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -142,7 +142,7 @@ describe('isAllOf', () => {
 
 describe('isPending', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('a')
+    const action = createAction<string>('action/type')('testPayload');
 
     expect(isPending(action)).toBe(false)
   })
@@ -166,7 +166,7 @@ describe('isPending', () => {
 
 describe('isRejected', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('a')
+    const action = createAction<string>('action/type')('testPayload');
 
     expect(isRejected(action)).toBe(false)
   })
@@ -190,7 +190,7 @@ describe('isRejected', () => {
 
 describe('isFulfilled', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('a')
+    const action = createAction<string>('action/type')('testPayload');
 
     expect(isFulfilled(action)).toBe(false)
   })
@@ -214,7 +214,7 @@ describe('isFulfilled', () => {
 
 describe('isAnyAsyncThunkAction', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('a')
+    const action = createAction<string>('action/type')('testPayload');
 
     expect(isAnyAsyncThunkAction(action)).toBe(false)
   })

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -212,32 +212,14 @@ describe('isFulfilled', () => {
   })
 })
 
-describe('isAnyAsyncThunkAction', () => {
+describe('isAsyncThunkAction', () => {
   test('should return false for a regular action', () => {
     const action = createAction<string>('action/type')('testPayload');
 
-    expect(isAnyAsyncThunkAction(action)).toBe(false)
+    expect(isAsyncThunkAction()(action)).toBe(false)
   })
 
-  test('should return true for any async thunk action', () => {
-    const thunk = createAsyncThunk<string>('a', () => 'result')
-
-    const pendingAction = thunk.pending('fakeRequestId')
-    expect(isAnyAsyncThunkAction(pendingAction)).toBe(true)
-
-    const rejectedAction = thunk.rejected(
-      new Error('rejected'),
-      'fakeRequestId'
-    )
-    expect(isAnyAsyncThunkAction(rejectedAction)).toBe(true)
-
-    const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
-    expect(isAnyAsyncThunkAction(fulfilledAction)).toBe(true)
-  })
-})
-
-describe('isAsyncThunkAction', () => {
-  test('should return true for any async thunk if no arguments were provided', () => {
+  test('should return true for any async thunk action if no arguments were provided', () => {
     const thunk = createAsyncThunk<string>('a', () => 'result')
     const matcher = isAsyncThunkAction()
 

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -255,7 +255,7 @@ describe('isRejectedWithValue', () => {
 
   test('should return true only for rejected-with-value async thunk actions', async () => {
     const thunk = createAsyncThunk<string>('a', (_, { rejectWithValue }) => {
-      return rejectWithValue('rejectWithValue!');
+      return rejectWithValue('rejectWithValue!')
     })
 
     const pendingAction = thunk.pending('fakeRequestId')
@@ -272,9 +272,9 @@ describe('isRejectedWithValue', () => {
     const extra = {}
 
     // note: doesn't throw because we don't unwrap it
-    const rejectedWithValueAction = await thunk()(dispatch, getState, extra);
+    const rejectedWithValueAction = await thunk()(dispatch, getState, extra)
 
-    expect(isRejectedWithValue()(rejectedWithValueAction)).toBe(true);
+    expect(isRejectedWithValue()(rejectedWithValueAction)).toBe(true)
 
     const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
     expect(isRejectedWithValue()(fulfilledAction)).toBe(false)
@@ -282,8 +282,8 @@ describe('isRejectedWithValue', () => {
 
   test('should return true only for thunks provided as arguments', async () => {
     const payloadCreator = (_: any, { rejectWithValue }: any) => {
-      return rejectWithValue('rejectWithValue!');
-    };
+      return rejectWithValue('rejectWithValue!')
+    }
 
     const thunkA = createAsyncThunk<string>('a', payloadCreator)
     const thunkB = createAsyncThunk<string>('b', payloadCreator)
@@ -310,9 +310,9 @@ describe('isRejectedWithValue', () => {
       const extra = {}
 
       // note: doesn't throw because we don't unwrap it
-      const rejectedWithValueAction = await thunk()(dispatch, getState, extra);
+      const rejectedWithValueAction = await thunk()(dispatch, getState, extra)
 
-      expect(matchAC(rejectedWithValueAction)).toBe(expected);
+      expect(matchAC(rejectedWithValueAction)).toBe(expected)
 
       const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
       expect(matchAC(fulfilledAction)).toBe(false)

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -167,7 +167,7 @@ describe('isPending', () => {
     const thunkB = createAsyncThunk<string>('b', () => 'result')
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
-    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+    const matchAC = isPending(thunkA, thunkC)
 
     function testPendingAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
@@ -175,6 +175,15 @@ describe('isPending', () => {
     ) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(expected)
+
+      const rejectedAction = thunk.rejected(
+        new Error('rejected'),
+        'fakeRequestId'
+      )
+      expect(matchAC(rejectedAction)).toBe(false)
+
+      const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+      expect(matchAC(fulfilledAction)).toBe(false)
     }
 
     testPendingAction(thunkA, true)
@@ -190,7 +199,7 @@ describe('isRejected', () => {
     expect(isRejected()(action)).toBe(false)
   })
 
-  test('should return true only for pending async thunk actions', () => {
+  test('should return true only for rejected async thunk actions', () => {
     const thunk = createAsyncThunk<string>('a', () => 'result')
 
     const pendingAction = thunk.pending('fakeRequestId')
@@ -211,17 +220,23 @@ describe('isRejected', () => {
     const thunkB = createAsyncThunk<string>('b', () => 'result')
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
-    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+    const matchAC = isRejected(thunkA, thunkC)
 
     function testRejectedAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
       expected: boolean
     ) {
+      const pendingAction = thunk.pending('fakeRequestId')
+      expect(matchAC(pendingAction)).toBe(false)
+
       const rejectedAction = thunk.rejected(
         new Error('rejected'),
         'fakeRequestId'
       )
       expect(matchAC(rejectedAction)).toBe(expected)
+
+      const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+      expect(matchAC(fulfilledAction)).toBe(false)
     }
 
     testRejectedAction(thunkA, true)
@@ -237,7 +252,7 @@ describe('isFulfilled', () => {
     expect(isFulfilled()(action)).toBe(false)
   })
 
-  test('should return true only for pending async thunk actions', () => {
+  test('should return true only for fulfilled async thunk actions', () => {
     const thunk = createAsyncThunk<string>('a', () => 'result')
 
     const pendingAction = thunk.pending('fakeRequestId')
@@ -258,12 +273,21 @@ describe('isFulfilled', () => {
     const thunkB = createAsyncThunk<string>('b', () => 'result')
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
-    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+    const matchAC = isFulfilled(thunkA, thunkC)
 
     function testFulfilledAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
       expected: boolean
     ) {
+      const pendingAction = thunk.pending('fakeRequestId')
+      expect(matchAC(pendingAction)).toBe(false)
+
+      const rejectedAction = thunk.rejected(
+        new Error('rejected'),
+        'fakeRequestId'
+      )
+      expect(matchAC(rejectedAction)).toBe(false)
+
       const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
       expect(matchAC(fulfilledAction)).toBe(expected)
     }

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -1,6 +1,5 @@
 import {
   isAllOf,
-  isAnyAsyncThunkAction,
   isAnyOf,
   isAsyncThunkAction,
   isFulfilled,
@@ -144,23 +143,43 @@ describe('isPending', () => {
   test('should return false for a regular action', () => {
     const action = createAction<string>('action/type')('testPayload');
 
-    expect(isPending(action)).toBe(false)
+    expect(isPending()(action)).toBe(false)
   })
 
   test('should return true only for pending async thunk actions', () => {
     const thunk = createAsyncThunk<string>('a', () => 'result')
 
     const pendingAction = thunk.pending('fakeRequestId')
-    expect(isPending(pendingAction)).toBe(true)
+    expect(isPending()(pendingAction)).toBe(true)
 
     const rejectedAction = thunk.rejected(
       new Error('rejected'),
       'fakeRequestId'
     )
-    expect(isPending(rejectedAction)).toBe(false)
+    expect(isPending()(rejectedAction)).toBe(false)
 
     const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
-    expect(isPending(fulfilledAction)).toBe(false)
+    expect(isPending()(fulfilledAction)).toBe(false)
+  })
+
+  test('should return true only for thunks provided as arguments', () => {
+    const thunkA = createAsyncThunk<string>('a', () => 'result')
+    const thunkB = createAsyncThunk<string>('b', () => 'result')
+    const thunkC = createAsyncThunk<string>('c', () => 'result')
+
+    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+
+    function testPendingAction(
+      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
+      expected: boolean
+    ) {
+      const pendingAction = thunk.pending('fakeRequestId')
+      expect(matchAC(pendingAction)).toBe(expected)
+    }
+
+    testPendingAction(thunkA, true)
+    testPendingAction(thunkC, true)
+    testPendingAction(thunkB, false)
   })
 })
 
@@ -168,23 +187,46 @@ describe('isRejected', () => {
   test('should return false for a regular action', () => {
     const action = createAction<string>('action/type')('testPayload');
 
-    expect(isRejected(action)).toBe(false)
+    expect(isRejected()(action)).toBe(false)
   })
 
   test('should return true only for pending async thunk actions', () => {
     const thunk = createAsyncThunk<string>('a', () => 'result')
 
     const pendingAction = thunk.pending('fakeRequestId')
-    expect(isRejected(pendingAction)).toBe(false)
+    expect(isRejected()(pendingAction)).toBe(false)
 
     const rejectedAction = thunk.rejected(
       new Error('rejected'),
       'fakeRequestId'
     )
-    expect(isRejected(rejectedAction)).toBe(true)
+    expect(isRejected()(rejectedAction)).toBe(true)
 
     const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
-    expect(isRejected(fulfilledAction)).toBe(false)
+    expect(isRejected()(fulfilledAction)).toBe(false)
+  })
+
+  test('should return true only for thunks provided as arguments', () => {
+    const thunkA = createAsyncThunk<string>('a', () => 'result')
+    const thunkB = createAsyncThunk<string>('b', () => 'result')
+    const thunkC = createAsyncThunk<string>('c', () => 'result')
+
+    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+
+    function testRejectedAction(
+      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
+      expected: boolean
+    ) {
+      const rejectedAction = thunk.rejected(
+        new Error('rejected'),
+        'fakeRequestId'
+      )
+      expect(matchAC(rejectedAction)).toBe(expected)
+    }
+
+    testRejectedAction(thunkA, true)
+    testRejectedAction(thunkC, true)
+    testRejectedAction(thunkB, false)
   })
 })
 
@@ -192,23 +234,43 @@ describe('isFulfilled', () => {
   test('should return false for a regular action', () => {
     const action = createAction<string>('action/type')('testPayload');
 
-    expect(isFulfilled(action)).toBe(false)
+    expect(isFulfilled()(action)).toBe(false)
   })
 
   test('should return true only for pending async thunk actions', () => {
     const thunk = createAsyncThunk<string>('a', () => 'result')
 
     const pendingAction = thunk.pending('fakeRequestId')
-    expect(isFulfilled(pendingAction)).toBe(false)
+    expect(isFulfilled()(pendingAction)).toBe(false)
 
     const rejectedAction = thunk.rejected(
       new Error('rejected'),
       'fakeRequestId'
     )
-    expect(isFulfilled(rejectedAction)).toBe(false)
+    expect(isFulfilled()(rejectedAction)).toBe(false)
 
     const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
-    expect(isFulfilled(fulfilledAction)).toBe(true)
+    expect(isFulfilled()(fulfilledAction)).toBe(true)
+  })
+
+  test('should return true only for thunks provided as arguments', () => {
+    const thunkA = createAsyncThunk<string>('a', () => 'result')
+    const thunkB = createAsyncThunk<string>('b', () => 'result')
+    const thunkC = createAsyncThunk<string>('c', () => 'result')
+
+    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+
+    function testFulfilledAction(
+      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
+      expected: boolean
+    ) {
+      const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+      expect(matchAC(fulfilledAction)).toBe(expected)
+    }
+
+    testFulfilledAction(thunkA, true)
+    testFulfilledAction(thunkC, true)
+    testFulfilledAction(thunkB, false)
   })
 })
 

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -1,4 +1,12 @@
-import { isAllOf, isAnyOf } from './matchers'
+import {
+  isAllOf,
+  isAnyAsyncThunkAction,
+  isAnyOf,
+  isAsyncThunkAction,
+  isFulfilled,
+  isPending,
+  isRejected
+} from './matchers'
 import { createAction } from './createAction'
 import { createAsyncThunk } from './createAsyncThunk'
 import { createReducer } from './createReducer'
@@ -129,5 +137,149 @@ describe('isAllOf', () => {
     expect(
       isAllOf(thunkA.fulfilled, isActionSpecial)(ordinaryThunkAction)
     ).toBe(false)
+  })
+})
+
+describe('isPending', () => {
+  test('should return false for a regular action', () => {
+    const action = createAction<string>('a')
+
+    expect(isPending(action)).toBe(false)
+  })
+
+  test('should return true only for pending async thunk actions', () => {
+    const thunk = createAsyncThunk<string>('a', () => 'result')
+
+    const pendingAction = thunk.pending('fakeRequestId')
+    expect(isPending(pendingAction)).toBe(true)
+
+    const rejectedAction = thunk.rejected(
+      new Error('rejected'),
+      'fakeRequestId'
+    )
+    expect(isPending(rejectedAction)).toBe(false)
+
+    const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+    expect(isPending(fulfilledAction)).toBe(false)
+  })
+})
+
+describe('isRejected', () => {
+  test('should return false for a regular action', () => {
+    const action = createAction<string>('a')
+
+    expect(isRejected(action)).toBe(false)
+  })
+
+  test('should return true only for pending async thunk actions', () => {
+    const thunk = createAsyncThunk<string>('a', () => 'result')
+
+    const pendingAction = thunk.pending('fakeRequestId')
+    expect(isRejected(pendingAction)).toBe(false)
+
+    const rejectedAction = thunk.rejected(
+      new Error('rejected'),
+      'fakeRequestId'
+    )
+    expect(isRejected(rejectedAction)).toBe(true)
+
+    const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+    expect(isRejected(fulfilledAction)).toBe(false)
+  })
+})
+
+describe('isFulfilled', () => {
+  test('should return false for a regular action', () => {
+    const action = createAction<string>('a')
+
+    expect(isFulfilled(action)).toBe(false)
+  })
+
+  test('should return true only for pending async thunk actions', () => {
+    const thunk = createAsyncThunk<string>('a', () => 'result')
+
+    const pendingAction = thunk.pending('fakeRequestId')
+    expect(isFulfilled(pendingAction)).toBe(false)
+
+    const rejectedAction = thunk.rejected(
+      new Error('rejected'),
+      'fakeRequestId'
+    )
+    expect(isFulfilled(rejectedAction)).toBe(false)
+
+    const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+    expect(isFulfilled(fulfilledAction)).toBe(true)
+  })
+})
+
+describe('isAnyAsyncThunkAction', () => {
+  test('should return false for a regular action', () => {
+    const action = createAction<string>('a')
+
+    expect(isAnyAsyncThunkAction(action)).toBe(false)
+  })
+
+  test('should return true for any async thunk action', () => {
+    const thunk = createAsyncThunk<string>('a', () => 'result')
+
+    const pendingAction = thunk.pending('fakeRequestId')
+    expect(isAnyAsyncThunkAction(pendingAction)).toBe(true)
+
+    const rejectedAction = thunk.rejected(
+      new Error('rejected'),
+      'fakeRequestId'
+    )
+    expect(isAnyAsyncThunkAction(rejectedAction)).toBe(true)
+
+    const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+    expect(isAnyAsyncThunkAction(fulfilledAction)).toBe(true)
+  })
+})
+
+describe('isAsyncThunkAction', () => {
+  test('should return true for any async thunk if no arguments were provided', () => {
+    const thunk = createAsyncThunk<string>('a', () => 'result')
+    const matcher = isAsyncThunkAction()
+
+    const pendingAction = thunk.pending('fakeRequestId')
+    expect(matcher(pendingAction)).toBe(true)
+
+    const rejectedAction = thunk.rejected(
+      new Error('rejected'),
+      'fakeRequestId'
+    )
+    expect(matcher(rejectedAction)).toBe(true)
+
+    const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+    expect(matcher(fulfilledAction)).toBe(true)
+  })
+
+  test('should return true only for thunks provided as arguments', () => {
+    const thunkA = createAsyncThunk<string>('a', () => 'result')
+    const thunkB = createAsyncThunk<string>('b', () => 'result')
+    const thunkC = createAsyncThunk<string>('c', () => 'result')
+
+    const matchAC = isAsyncThunkAction(thunkA, thunkC)
+
+    function testAllActions(
+      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
+      expected: boolean
+    ) {
+      const pendingAction = thunk.pending('fakeRequestId')
+      expect(matchAC(pendingAction)).toBe(expected)
+
+      const rejectedAction = thunk.rejected(
+        new Error('rejected'),
+        'fakeRequestId'
+      )
+      expect(matchAC(rejectedAction)).toBe(expected)
+
+      const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
+      expect(matchAC(fulfilledAction)).toBe(expected)
+    }
+
+    testAllActions(thunkA, true)
+    testAllActions(thunkC, true)
+    testAllActions(thunkB, false)
   })
 })

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -141,7 +141,7 @@ describe('isAllOf', () => {
 
 describe('isPending', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('action/type')('testPayload');
+    const action = createAction<string>('action/type')('testPayload')
 
     expect(isPending()(action)).toBe(false)
   })
@@ -185,7 +185,7 @@ describe('isPending', () => {
 
 describe('isRejected', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('action/type')('testPayload');
+    const action = createAction<string>('action/type')('testPayload')
 
     expect(isRejected()(action)).toBe(false)
   })
@@ -232,7 +232,7 @@ describe('isRejected', () => {
 
 describe('isFulfilled', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('action/type')('testPayload');
+    const action = createAction<string>('action/type')('testPayload')
 
     expect(isFulfilled()(action)).toBe(false)
   })
@@ -276,7 +276,7 @@ describe('isFulfilled', () => {
 
 describe('isAsyncThunkAction', () => {
   test('should return false for a regular action', () => {
-    const action = createAction<string>('action/type')('testPayload');
+    const action = createAction<string>('action/type')('testPayload')
 
     expect(isAsyncThunkAction()(action)).toBe(false)
   })

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -113,11 +113,9 @@ export function isPending<
     action: any
   ): action is PendingActionFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
-
-    for (const asyncThunk of asyncThunks) {
-      matchers.push(asyncThunk.pending)
-    }
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = (
+      asyncThunks.map((asyncThunk => asyncThunk.pending))
+    ) as any;
 
     const combinedMatcher = isAnyOf(...matchers)
 
@@ -159,11 +157,9 @@ export function isRejected<
     action: any
   ): action is RejectedActionFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
-
-    for (const asyncThunk of asyncThunks) {
-      matchers.push(asyncThunk.rejected)
-    }
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = (
+      asyncThunks.map((asyncThunk => asyncThunk.rejected))
+    ) as any;
 
     const combinedMatcher = isAnyOf(...matchers)
 
@@ -205,11 +201,9 @@ export function isFulfilled<
     action: any
   ): action is FulfilledActionFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
-
-    for (const asyncThunk of asyncThunks) {
-      matchers.push(asyncThunk.fulfilled)
-    }
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = (
+      asyncThunks.map((asyncThunk => asyncThunk.fulfilled))
+    ) as any;
 
     const combinedMatcher = isAnyOf(...matchers)
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -206,23 +206,21 @@ export function isRejectedWithValue(): (
  */
 export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
-  >(
+>(
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>
 export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
-  >(...asyncThunks: AsyncThunks) {
+>(...asyncThunks: AsyncThunks) {
   const hasFlag = (action: any): action is any => {
-    return action && action.meta && action.meta.isRejectedWithValue;
+    return action && action.meta && action.meta.isRejectedWithValue
   }
 
   if (asyncThunks.length === 0) {
-    return (
-      action: any
-    ) => {
-      const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasFlag);
+    return (action: any) => {
+      const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasFlag)
 
-      return combinedMatcher(action);
+      return combinedMatcher(action)
     }
   }
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -213,7 +213,7 @@ export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
   >(...asyncThunks: AsyncThunks) {
   const hasFlag = (action: any): action is any => {
-    return action && action.meta && action.meta.isRejectedWithValue;
+    return action && action.meta && action.meta.rejectedWithValue;
   }
 
   if (asyncThunks.length === 0) {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -185,6 +185,54 @@ export function isRejected<
   }
 }
 
+/**
+ * A higher-order function that returns a function that may be used to check
+ * whether an action was created by an async thunk action creator, and that
+ * the action is rejected with value.
+ *
+ * @public
+ */
+export function isRejectedWithValue(): (
+  action: any
+) => action is UnknownAsyncThunkRejectedAction
+/**
+ * A higher-order function that returns a function that may be used to check
+ * whether an action belongs to one of the provided async thunk action creators,
+ * and that the action is rejected with value.
+ *
+ * @param asyncThunks (optional) The async thunk action creators to match against.
+ *
+ * @public
+ */
+export function isRejectedWithValue<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+  >(
+  ...asyncThunks: AsyncThunks
+): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>
+export function isRejectedWithValue<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+  >(...asyncThunks: AsyncThunks) {
+  const hasPayload = (action: any): action is any => !!action.payload;
+
+  if (asyncThunks.length === 0) {
+    return (
+      action: any
+    ) => {
+      const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasPayload);
+
+      return combinedMatcher(action);
+    }
+  }
+
+  return (
+    action: any
+  ): action is RejectedActionFromAsyncThunk<AsyncThunks[number]> => {
+    const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasPayload)
+
+    return combinedMatcher(action)
+  }
+}
+
 export type UnknownAsyncThunkFulfilledAction = ReturnType<
   AsyncThunkFulfilledActionCreator<unknown, unknown>
 >

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -83,9 +83,9 @@ export type UnknownAsyncThunkPendingAction = ReturnType<
   AsyncThunkPendingActionCreator<unknown>
 >
 
-export type PendingActionFromAsyncThunk<T extends AnyAsyncThunk> = (
-  ActionFromMatcher<T['pending']>
-)
+export type PendingActionFromAsyncThunk<
+  T extends AnyAsyncThunk
+> = ActionFromMatcher<T['pending']>
 
 /**
  * A higher-order function that returns a function that may be used to check
@@ -108,16 +108,16 @@ export function isPending<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(...asyncThunks: AsyncThunks) {
   if (asyncThunks.length === 0) {
-    return (action: any) => hasExpectedRequestMetadata(action, ['pending']);
+    return (action: any) => hasExpectedRequestMetadata(action, ['pending'])
   }
 
   return (
     action: any
   ): action is PendingActionFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = (
-      asyncThunks.map((asyncThunk => asyncThunk.pending))
-    ) as any;
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = asyncThunks.map(
+      asyncThunk => asyncThunk.pending
+    ) as any
 
     const combinedMatcher = isAnyOf(...matchers)
 
@@ -129,9 +129,9 @@ export type UnknownAsyncThunkRejectedAction = ReturnType<
   AsyncThunkRejectedActionCreator<unknown, unknown>
 >
 
-export type RejectedActionFromAsyncThunk<T extends AnyAsyncThunk> = (
-  ActionFromMatcher<T['rejected']>
-)
+export type RejectedActionFromAsyncThunk<
+  T extends AnyAsyncThunk
+> = ActionFromMatcher<T['rejected']>
 
 /**
  * A higher-order function that returns a function that may be used to check
@@ -154,16 +154,16 @@ export function isRejected<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(...asyncThunks: AsyncThunks) {
   if (asyncThunks.length === 0) {
-    return (action: any) => hasExpectedRequestMetadata(action, ['rejected']);
+    return (action: any) => hasExpectedRequestMetadata(action, ['rejected'])
   }
 
   return (
     action: any
   ): action is RejectedActionFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = (
-      asyncThunks.map((asyncThunk => asyncThunk.rejected))
-    ) as any;
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = asyncThunks.map(
+      asyncThunk => asyncThunk.rejected
+    ) as any
 
     const combinedMatcher = isAnyOf(...matchers)
 
@@ -175,9 +175,9 @@ export type UnknownAsyncThunkFulfilledAction = ReturnType<
   AsyncThunkFulfilledActionCreator<unknown, unknown>
 >
 
-export type FulfilledActionFromAsyncThunk<T extends AnyAsyncThunk> = (
-  ActionFromMatcher<T['fulfilled']>
-)
+export type FulfilledActionFromAsyncThunk<
+  T extends AnyAsyncThunk
+> = ActionFromMatcher<T['fulfilled']>
 
 /**
  * A higher-order function that returns a function that may be used to check
@@ -200,16 +200,16 @@ export function isFulfilled<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(...asyncThunks: AsyncThunks) {
   if (asyncThunks.length === 0) {
-    return (action: any) => hasExpectedRequestMetadata(action, ['fulfilled']);
+    return (action: any) => hasExpectedRequestMetadata(action, ['fulfilled'])
   }
 
   return (
     action: any
   ): action is FulfilledActionFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = (
-      asyncThunks.map((asyncThunk => asyncThunk.fulfilled))
-    ) as any;
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = asyncThunks.map(
+      asyncThunk => asyncThunk.fulfilled
+    ) as any
 
     const combinedMatcher = isAnyOf(...matchers)
 
@@ -249,18 +249,15 @@ export function isAsyncThunkAction<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(...asyncThunks: AsyncThunks) {
   if (asyncThunks.length === 0) {
-    return (action: any) => hasExpectedRequestMetadata(action, [
-      'pending',
-      'fulfilled',
-      'rejected'
-    ])
+    return (action: any) =>
+      hasExpectedRequestMetadata(action, ['pending', 'fulfilled', 'rejected'])
   }
 
   return (
     action: any
   ): action is ActionsFromAsyncThunk<AsyncThunks[number]> => {
     // note: this type will be correct because we have at least 1 asyncThunk
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any
 
     for (const asyncThunk of asyncThunks) {
       matchers.push(

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -4,6 +4,12 @@ import {
   Matcher,
   UnionToIntersection
 } from './tsHelpers'
+import {
+  AsyncThunk,
+  AsyncThunkFulfilledActionCreator,
+  AsyncThunkPendingActionCreator,
+  AsyncThunkRejectedActionCreator
+} from './createAsyncThunk'
 
 /** @public */
 export type ActionMatchingAnyOf<
@@ -54,5 +60,140 @@ export function isAllOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(
 ) {
   return (action: any): action is ActionMatchingAllOf<Matchers> => {
     return matchers.every(matcher => matches(matcher, action))
+  }
+}
+
+/**
+ * @internal
+ *
+ * @param action
+ * @param validStatus
+ */
+export function hasExpectedRequestMetadata(action: any, validStatus: string[]) {
+  if (!action || !action.meta) return false
+
+  const hasValidRequestId = typeof action.meta.requestId === 'string'
+  const hasValidRequestStatus =
+    validStatus.indexOf(action.meta.requestStatus) > -1
+
+  return hasValidRequestId && hasValidRequestStatus
+}
+
+export type UnknownAsyncThunkPendingAction = ReturnType<
+  AsyncThunkPendingActionCreator<unknown>
+>
+
+/**
+ * @public
+ *
+ * @param action
+ */
+export function isPending(
+  action: any
+): action is UnknownAsyncThunkPendingAction {
+  return hasExpectedRequestMetadata(action, ['pending'])
+}
+
+export type UnknownAsyncThunkRejectedAction = ReturnType<
+  AsyncThunkRejectedActionCreator<unknown, unknown>
+>
+
+/**
+ * @public
+ *
+ * @param action
+ */
+export function isRejected(
+  action: any
+): action is UnknownAsyncThunkRejectedAction {
+  return hasExpectedRequestMetadata(action, ['rejected'])
+}
+
+export type UnknownAsyncThunkFulfilledAction = ReturnType<
+  AsyncThunkFulfilledActionCreator<unknown, unknown>
+>
+
+/**
+ * @public
+ *
+ * @param action
+ */
+export function isFulfilled(
+  action: any
+): action is UnknownAsyncThunkFulfilledAction {
+  return hasExpectedRequestMetadata(action, ['fulfilled'])
+}
+
+export type UnknownAsyncThunkAction =
+  | UnknownAsyncThunkPendingAction
+  | UnknownAsyncThunkRejectedAction
+  | UnknownAsyncThunkFulfilledAction
+
+/**
+ * @internal
+ *
+ * @param action
+ */
+export function isAnyAsyncThunkAction(
+  action: any
+): action is UnknownAsyncThunkAction {
+  return hasExpectedRequestMetadata(action, [
+    'pending',
+    'fulfilled',
+    'rejected'
+  ])
+}
+
+export type AnyAsyncThunk = AsyncThunk<any, any, any>
+
+export type ActionsFromAsyncThunk<T extends AnyAsyncThunk> =
+  | ActionFromMatcher<T['pending']>
+  | ActionFromMatcher<T['fulfilled']>
+  | ActionFromMatcher<T['rejected']>
+
+/**
+ * A higher-order function that returns a function that may be used to check
+ * whether an action belongs to one of the provided async thunk action creators.
+ *
+ * @param asyncThunks The async thunk action creators to match against.
+ *
+ * @public
+ */
+export function isAsyncThunkAction(): (
+  action: any
+) => action is UnknownAsyncThunkAction
+export function isAsyncThunkAction<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(
+  ...asyncThunks: AsyncThunks
+): (action: any) => action is ActionsFromAsyncThunk<AsyncThunks[number]>
+export function isAsyncThunkAction<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(...asyncThunks: AsyncThunks) {
+  if (asyncThunks.length === 0) {
+    return isAnyAsyncThunkAction
+  }
+
+  return (
+    action: any
+  ): action is ActionsFromAsyncThunk<AsyncThunks[number]> => {
+    const [firstAsyncThunk, ...restAsyncThunks] = asyncThunks
+
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = [
+      firstAsyncThunk.pending,
+      firstAsyncThunk.rejected,
+      firstAsyncThunk.fulfilled
+    ]
+
+    for (const asyncThunk of restAsyncThunks) {
+      matchers.push(
+        asyncThunk.pending,
+        asyncThunk.rejected,
+        asyncThunk.fulfilled
+      )
+    }
+
+    const combinedMatcher = isAllOf(isAnyAsyncThunkAction, isAnyOf(...matchers))
+    return combinedMatcher(action)
   }
 }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -88,7 +88,9 @@ export type PendingActionFromAsyncThunk<T extends AnyAsyncThunk> = (
 )
 
 /**
- * A type guard function that matches any pending async thunk action.
+ * A higher-order function that returns a function that may be used to check
+ * whether an action belongs to one of the provided async thunk action creators,
+ * and that the action is pending.
  *
  * @param asyncThunks (optional) The async thunk action creators to match against.
  *
@@ -132,7 +134,9 @@ export type RejectedActionFromAsyncThunk<T extends AnyAsyncThunk> = (
 )
 
 /**
- * A type guard function that matches any rejected async thunk action.
+ * A higher-order function that returns a function that may be used to check
+ * whether an action belongs to one of the provided async thunk action creators,
+ * and that the action is rejected.
  *
  * @param asyncThunks (optional) The async thunk action creators to match against.
  *
@@ -176,7 +180,9 @@ export type FulfilledActionFromAsyncThunk<T extends AnyAsyncThunk> = (
 )
 
 /**
- * A type guard function that matches any fulfilled async thunk action.
+ * A higher-order function that returns a function that may be used to check
+ * whether an action belongs to one of the provided async thunk action creators,
+ * and that the action is fulfilled.
  *
  * @param asyncThunks (optional) The async thunk action creators to match against.
  *

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -135,23 +135,6 @@ export type UnknownAsyncThunkAction =
   | UnknownAsyncThunkRejectedAction
   | UnknownAsyncThunkFulfilledAction
 
-/**
- * A type guard function that matches any async thunk action.
- *
- * @param action
- *
- * @internal
- */
-export function isAnyAsyncThunkAction(
-  action: any
-): action is UnknownAsyncThunkAction {
-  return hasExpectedRequestMetadata(action, [
-    'pending',
-    'fulfilled',
-    'rejected'
-  ])
-}
-
 export type AnyAsyncThunk = AsyncThunk<any, any, any>
 
 export type ActionsFromAsyncThunk<T extends AnyAsyncThunk> =
@@ -179,7 +162,11 @@ export function isAsyncThunkAction<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(...asyncThunks: AsyncThunks) {
   if (asyncThunks.length === 0) {
-    return isAnyAsyncThunkAction
+    return (action: any) => hasExpectedRequestMetadata(action, [
+      'pending',
+      'fulfilled',
+      'rejected'
+    ])
   }
 
   return (

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -64,10 +64,10 @@ export function isAllOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(
 }
 
 /**
- * @internal
+ * @param action A redux action
+ * @param validStatus An array of valid meta.requestStatus values
  *
- * @param action
- * @param validStatus
+ * @internal
  */
 export function hasExpectedRequestMetadata(action: any, validStatus: string[]) {
   if (!action || !action.meta) return false
@@ -84,9 +84,11 @@ export type UnknownAsyncThunkPendingAction = ReturnType<
 >
 
 /**
- * @public
+ * A type guard function that matches any pending async thunk action.
  *
- * @param action
+ * @param action A redux action
+ *
+ * @public
  */
 export function isPending(
   action: any
@@ -99,9 +101,11 @@ export type UnknownAsyncThunkRejectedAction = ReturnType<
 >
 
 /**
- * @public
+ * A type guard function that matches any rejected async thunk action.
  *
- * @param action
+ * @param action A redux action
+ *
+ * @public
  */
 export function isRejected(
   action: any
@@ -114,9 +118,11 @@ export type UnknownAsyncThunkFulfilledAction = ReturnType<
 >
 
 /**
- * @public
+ * A type guard function that matches any fulfilled async thunk action.
  *
- * @param action
+ * @param action A redux action
+ *
+ * @public
  */
 export function isFulfilled(
   action: any
@@ -130,9 +136,11 @@ export type UnknownAsyncThunkAction =
   | UnknownAsyncThunkFulfilledAction
 
 /**
- * @internal
+ * A type guard function that matches any async thunk action.
  *
  * @param action
+ *
+ * @internal
  */
 export function isAnyAsyncThunkAction(
   action: any
@@ -155,7 +163,7 @@ export type ActionsFromAsyncThunk<T extends AnyAsyncThunk> =
  * A higher-order function that returns a function that may be used to check
  * whether an action belongs to one of the provided async thunk action creators.
  *
- * @param asyncThunks The async thunk action creators to match against.
+ * @param asyncThunks (optional) The async thunk action creators to match against.
  *
  * @public
  */

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -213,7 +213,7 @@ export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
   >(...asyncThunks: AsyncThunks) {
   const hasFlag = (action: any): action is any => {
-    return action && action.meta && action.meta.rejectedWithValue;
+    return action && action.meta && action.meta.isRejectedWithValue;
   }
 
   if (asyncThunks.length === 0) {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -212,13 +212,15 @@ export function isRejectedWithValue<
 export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
   >(...asyncThunks: AsyncThunks) {
-  const hasPayload = (action: any): action is any => !!action.payload;
+  const hasFlag = (action: any): action is any => {
+    return action && action.meta && action.meta.isRejectedWithValue;
+  }
 
   if (asyncThunks.length === 0) {
     return (
       action: any
     ) => {
-      const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasPayload);
+      const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasFlag);
 
       return combinedMatcher(action);
     }
@@ -227,7 +229,7 @@ export function isRejectedWithValue<
   return (
     action: any
   ): action is RejectedActionFromAsyncThunk<AsyncThunks[number]> => {
-    const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasPayload)
+    const combinedMatcher = isAllOf(isRejected(...asyncThunks), hasFlag)
 
     return combinedMatcher(action)
   }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -185,15 +185,10 @@ export function isAsyncThunkAction<
   return (
     action: any
   ): action is ActionsFromAsyncThunk<AsyncThunks[number]> => {
-    const [firstAsyncThunk, ...restAsyncThunks] = asyncThunks
+    // note: this type will be correct because we have at least 1 asyncThunk
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
 
-    const matchers: [Matcher<any>, ...Matcher<any>[]] = [
-      firstAsyncThunk.pending,
-      firstAsyncThunk.rejected,
-      firstAsyncThunk.fulfilled
-    ]
-
-    for (const asyncThunk of restAsyncThunks) {
+    for (const asyncThunk of asyncThunks) {
       matchers.push(
         asyncThunk.pending,
         asyncThunk.rejected,
@@ -201,7 +196,8 @@ export function isAsyncThunkAction<
       )
     }
 
-    const combinedMatcher = isAllOf(isAnyAsyncThunkAction, isAnyOf(...matchers))
+    const combinedMatcher = isAnyOf(...matchers)
+
     return combinedMatcher(action)
   }
 }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -89,6 +89,16 @@ export type PendingActionFromAsyncThunk<
 
 /**
  * A higher-order function that returns a function that may be used to check
+ * whether an action was created by an async thunk action creator, and that
+ * the action is pending.
+ *
+ * @public
+ */
+export function isPending(): (
+  action: any
+) => action is UnknownAsyncThunkPendingAction
+/**
+ * A higher-order function that returns a function that may be used to check
  * whether an action belongs to one of the provided async thunk action creators,
  * and that the action is pending.
  *
@@ -96,9 +106,6 @@ export type PendingActionFromAsyncThunk<
  *
  * @public
  */
-export function isPending(): (
-  action: any
-) => action is UnknownAsyncThunkPendingAction
 export function isPending<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(
@@ -135,6 +142,16 @@ export type RejectedActionFromAsyncThunk<
 
 /**
  * A higher-order function that returns a function that may be used to check
+ * whether an action was created by an async thunk action creator, and that
+ * the action is rejected.
+ *
+ * @public
+ */
+export function isRejected(): (
+  action: any
+) => action is UnknownAsyncThunkRejectedAction
+/**
+ * A higher-order function that returns a function that may be used to check
  * whether an action belongs to one of the provided async thunk action creators,
  * and that the action is rejected.
  *
@@ -142,9 +159,6 @@ export type RejectedActionFromAsyncThunk<
  *
  * @public
  */
-export function isRejected(): (
-  action: any
-) => action is UnknownAsyncThunkRejectedAction
 export function isRejected<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(
@@ -181,6 +195,16 @@ export type FulfilledActionFromAsyncThunk<
 
 /**
  * A higher-order function that returns a function that may be used to check
+ * whether an action was created by an async thunk action creator, and that
+ * the action is fulfilled.
+ *
+ * @public
+ */
+export function isFulfilled(): (
+  action: any
+) => action is UnknownAsyncThunkFulfilledAction
+/**
+ * A higher-order function that returns a function that may be used to check
  * whether an action belongs to one of the provided async thunk action creators,
  * and that the action is fulfilled.
  *
@@ -188,9 +212,6 @@ export type FulfilledActionFromAsyncThunk<
  *
  * @public
  */
-export function isFulfilled(): (
-  action: any
-) => action is UnknownAsyncThunkFulfilledAction
 export function isFulfilled<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(
@@ -231,15 +252,21 @@ export type ActionsFromAsyncThunk<T extends AnyAsyncThunk> =
 
 /**
  * A higher-order function that returns a function that may be used to check
- * whether an action belongs to one of the provided async thunk action creators.
- *
- * @param asyncThunks (optional) The async thunk action creators to match against.
+ * whether an action was created by an async thunk action creator.
  *
  * @public
  */
 export function isAsyncThunkAction(): (
   action: any
 ) => action is UnknownAsyncThunkAction
+/**
+ * A higher-order function that returns a function that may be used to check
+ * whether an action belongs to one of the provided async thunk action creators.
+ *
+ * @param asyncThunks (optional) The async thunk action creators to match against.
+ *
+ * @public
+ */
 export function isAsyncThunkAction<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -83,51 +83,138 @@ export type UnknownAsyncThunkPendingAction = ReturnType<
   AsyncThunkPendingActionCreator<unknown>
 >
 
+export type PendingActionFromAsyncThunk<T extends AnyAsyncThunk> = (
+  ActionFromMatcher<T['pending']>
+)
+
 /**
  * A type guard function that matches any pending async thunk action.
  *
- * @param action A redux action
+ * @param asyncThunks (optional) The async thunk action creators to match against.
  *
  * @public
  */
-export function isPending(
+export function isPending(): (
   action: any
-): action is UnknownAsyncThunkPendingAction {
-  return hasExpectedRequestMetadata(action, ['pending'])
+) => action is UnknownAsyncThunkPendingAction
+export function isPending<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(
+  ...asyncThunks: AsyncThunks
+): (action: any) => action is PendingActionFromAsyncThunk<AsyncThunks[number]>
+export function isPending<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(...asyncThunks: AsyncThunks) {
+  if (asyncThunks.length === 0) {
+    return (action: any) => hasExpectedRequestMetadata(action, ['pending']);
+  }
+
+  return (
+    action: any
+  ): action is PendingActionFromAsyncThunk<AsyncThunks[number]> => {
+    // note: this type will be correct because we have at least 1 asyncThunk
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
+
+    for (const asyncThunk of asyncThunks) {
+      matchers.push(asyncThunk.pending)
+    }
+
+    const combinedMatcher = isAnyOf(...matchers)
+
+    return combinedMatcher(action)
+  }
 }
 
 export type UnknownAsyncThunkRejectedAction = ReturnType<
   AsyncThunkRejectedActionCreator<unknown, unknown>
 >
 
+export type RejectedActionFromAsyncThunk<T extends AnyAsyncThunk> = (
+  ActionFromMatcher<T['rejected']>
+)
+
 /**
  * A type guard function that matches any rejected async thunk action.
  *
- * @param action A redux action
+ * @param asyncThunks (optional) The async thunk action creators to match against.
  *
  * @public
  */
-export function isRejected(
+export function isRejected(): (
   action: any
-): action is UnknownAsyncThunkRejectedAction {
-  return hasExpectedRequestMetadata(action, ['rejected'])
+) => action is UnknownAsyncThunkRejectedAction
+export function isRejected<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(
+  ...asyncThunks: AsyncThunks
+): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>
+export function isRejected<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(...asyncThunks: AsyncThunks) {
+  if (asyncThunks.length === 0) {
+    return (action: any) => hasExpectedRequestMetadata(action, ['rejected']);
+  }
+
+  return (
+    action: any
+  ): action is RejectedActionFromAsyncThunk<AsyncThunks[number]> => {
+    // note: this type will be correct because we have at least 1 asyncThunk
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
+
+    for (const asyncThunk of asyncThunks) {
+      matchers.push(asyncThunk.rejected)
+    }
+
+    const combinedMatcher = isAnyOf(...matchers)
+
+    return combinedMatcher(action)
+  }
 }
 
 export type UnknownAsyncThunkFulfilledAction = ReturnType<
   AsyncThunkFulfilledActionCreator<unknown, unknown>
 >
 
+export type FulfilledActionFromAsyncThunk<T extends AnyAsyncThunk> = (
+  ActionFromMatcher<T['fulfilled']>
+)
+
 /**
  * A type guard function that matches any fulfilled async thunk action.
  *
- * @param action A redux action
+ * @param asyncThunks (optional) The async thunk action creators to match against.
  *
  * @public
  */
-export function isFulfilled(
+export function isFulfilled(): (
   action: any
-): action is UnknownAsyncThunkFulfilledAction {
-  return hasExpectedRequestMetadata(action, ['fulfilled'])
+) => action is UnknownAsyncThunkFulfilledAction
+export function isFulfilled<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(
+  ...asyncThunks: AsyncThunks
+): (action: any) => action is FulfilledActionFromAsyncThunk<AsyncThunks[number]>
+export function isFulfilled<
+  AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
+>(...asyncThunks: AsyncThunks) {
+  if (asyncThunks.length === 0) {
+    return (action: any) => hasExpectedRequestMetadata(action, ['fulfilled']);
+  }
+
+  return (
+    action: any
+  ): action is FulfilledActionFromAsyncThunk<AsyncThunks[number]> => {
+    // note: this type will be correct because we have at least 1 asyncThunk
+    const matchers: [Matcher<any>, ...Matcher<any>[]] = [] as any;
+
+    for (const asyncThunk of asyncThunks) {
+      matchers.push(asyncThunk.fulfilled)
+    }
+
+    const combinedMatcher = isAnyOf(...matchers)
+
+    return combinedMatcher(action)
+  }
 }
 
 export type UnknownAsyncThunkAction =

--- a/type-tests/files/matchers.typetest.ts
+++ b/type-tests/files/matchers.typetest.ts
@@ -1,6 +1,15 @@
 import { AnyAction } from 'redux'
-import { createAction, createAsyncThunk, isAllOf, isAnyOf } from '../../src'
-import { isAsyncThunkAction, isFulfilled, isPending, isRejected } from '../../src/matchers'
+import {
+  createAction,
+  createAsyncThunk,
+  isAllOf,
+  isAnyOf,
+  isAsyncThunkAction,
+  isFulfilled,
+  isPending,
+  isRejected,
+  isRejectedWithValue
+} from '../../src'
 
 /* isAnyOf */
 
@@ -274,6 +283,25 @@ function isAsyncThunkActionTest(action: AnyAction) {
       prop1b: action.payload.charAt(0),
       // do not expect an error property because pending/fulfilled lack it
       // typings:expect-error
+      prop2: action.error,
+    };
+  }
+}
+
+/*
+ * Test: isRejectedWithValue correctly narrows types
+ */
+function isRejectedWithValueTest(action: AnyAction) {
+  const thunk = createAsyncThunk<string>('a', () => 'result')
+
+  if (isRejectedWithValue(thunk)(action)) {
+    return {
+      // we should expect the payload to be defined ...
+      prop1a: action.payload,
+      // ... but of unknown type
+      // typings:expect-error
+      prop1b: action.payload.charAt(0),
+      // we should expect the error property to be defined
       prop2: action.error,
     };
   }

--- a/type-tests/files/matchers.typetest.ts
+++ b/type-tests/files/matchers.typetest.ts
@@ -1,5 +1,6 @@
 import { AnyAction } from 'redux'
 import { createAction, createAsyncThunk, isAllOf, isAnyOf } from '../../src'
+import { isAsyncThunkAction, isFulfilled, isPending, isRejected } from '../../src/matchers'
 
 /* isAnyOf */
 
@@ -200,6 +201,80 @@ function isAllOfTypeGuardTest(action: AnyAction) {
       prop2: action.payload.prop2,
       prop3: action.payload.prop3,
       special: action.payload.special
+    };
+  }
+}
+
+/*
+ * Test: isPending correctly narrows types
+ */
+function isPendingTest(action: AnyAction) {
+  const thunk = createAsyncThunk<string>('a', () => 'result')
+
+  if (isPending(thunk)(action)) {
+    return {
+      // we should expect the payload to be undefined
+      // typings:expect-error
+      prop1: action.payload.charAt(0),
+      // we should not expect an error property
+      // typings:expect-error
+      prop2: action.error,
+    };
+  }
+}
+
+/*
+ * Test: isRejected correctly narrows types
+ */
+function isRejectedTest(action: AnyAction) {
+  const thunk = createAsyncThunk<string>('a', () => 'result')
+
+  if (isRejected(thunk)(action)) {
+    return {
+      // we should expect the payload to be defined ...
+      prop1a: action.payload,
+      // ... but of unknown type
+      // typings:expect-error
+      prop1b: action.payload.charAt(0),
+      // we should expect the error property to be defined
+      prop2: action.error,
+    };
+  }
+}
+
+/*
+ * Test: isFulfilled correctly narrows types
+ */
+function isFulfilledTest(action: AnyAction) {
+  const thunk = createAsyncThunk<string>('a', () => 'result')
+
+  if (isFulfilled(thunk)(action)) {
+    return {
+      // we should expect the payload to be defined (in this case a string)
+      prop1: action.payload.charAt(0),
+      // we should not expect an error property
+      // typings:expect-error
+      prop2: action.error,
+    };
+  }
+}
+
+/*
+ * Test: isAsyncThunkAction correctly narrows types
+ */
+function isAsyncThunkActionTest(action: AnyAction) {
+  const thunk = createAsyncThunk<string>('a', () => 'result')
+
+  if (isAsyncThunkAction(thunk)(action)) {
+    return {
+      // we should expect the payload to be defined ...
+      prop1a: action.payload,
+      // ... but of unknown type because the action may be pending/rejected
+      // typings:expect-error
+      prop1b: action.payload.charAt(0),
+      // do not expect an error property because pending/fulfilled lack it
+      // typings:expect-error
+      prop2: action.error,
     };
   }
 }


### PR DESCRIPTION
AsyncThunk-related functionality: `isAsyncThunkAction`, `isFulfilled`, `isRejected`, `isPending`.

Does not yet include `isRejectedWithValue`.  Also, `isFulfilled`, `isRejected`, `isPending` do not yet accept async thunk parameters to narrow the resulting matcher, but `isAsyncThunkAction` does.

This is a Draft PR because I still need to add the functionality above and type tests.

Feedback is appreciated!