### PR TITLE
createAsyncThunk: serializeError option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,12 @@ jobs:
         run: |
           sed -i -e 's|@reduxjs/toolkit": \["./src"\]|@reduxjs/toolkit": ["."]|' ./type-tests/files/tsconfig.json
 
+      - name: Prefix `freeze` re-export for pre-3.7 TS versions with @ts-ignore
+        if: ${{ matrix.ts < 3.7 }}
+        run: |
+          sed -i -e "/import .* freeze .* from 'immer'/s/^/\/\/ @ts-ignore\n/" dist/typings.d.ts
+          sed -i -e "/export .* freeze .* from 'immer'/s/^/\/\/ @ts-ignore\n/" src/index.ts
+
       - name: Use typings-tester for old TS versions
         if: ${{ matrix.ts < 3.9 }}
         run: |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { enableES5 } from 'immer'
 export * from 'redux'
+// @ts-ignore
 export { default as createNextState, Draft, current, freeze } from 'immer'
 export {
   createSelector,

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -376,10 +376,10 @@ const anyAction = { type: 'foo' } as AnyAction
     return { somethingElse: 'Funky!' }
   }
 
-  const shouldFail = createAsyncThunk('without generics', () => {}, {
-    // @ts-expect-error
-    serializeError: funkySerializeError
-  })
+  // has to stay on one line or type tests fail in older TS versions
+  // prettier-ignore
+  // @ts-expect-error
+  const shouldFail = createAsyncThunk('without generics', () => {}, { serializeError: funkySerializeError })
 
   const shouldWork = createAsyncThunk<
     any,

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -13,6 +13,7 @@ import { IsAny, IsUnknown } from '@internal/tsHelpers'
 import { expectType } from './helpers'
 
 const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
+const anyAction = { type: 'foo' } as AnyAction
 
   // basic usage
 ;(async function() {
@@ -366,5 +367,29 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
     asyncThunk(5)
     // @ts-expect-error
     asyncThunk()
+  }
+}
+
+{
+  type Funky = { somethingElse: 'Funky!' }
+  function funkySerializeError(err: any): Funky {
+    return { somethingElse: 'Funky!' }
+  }
+
+  const shouldFail = createAsyncThunk('without generics', () => {}, {
+    // @ts-expect-error
+    serializeError: funkySerializeError
+  })
+
+  const shouldWork = createAsyncThunk<
+    any,
+    void,
+    { serializedErrorType: Funky }
+  >('with generics', () => {}, {
+    serializeError: funkySerializeError
+  })
+
+  if (shouldWork.rejected.match(anyAction)) {
+    expectType<Funky>(anyAction.error)
   }
 }


### PR DESCRIPTION
This *would* address two requests from #792:

1. adding a `serializeError` option to `createAsyncThunk`
2. the option to call `await dispatch(async(3, { unwrap: true }))` and return it with the unwrapped result and otherwise throw an error. So, essentially an inlined version of `unwrapResult`.

I say *would*  because I'm still not a fan of Nr 2. Even less, after writing all this, tbh.
The amount of code (and especially types) required to support a second way of doing something we already have in the lib makes me uneasy.
Yes, it might be slightly "nicer". But only slightly. And it's a lot of code. And a lot of new behaviour (especially type-wise) that we have to commit to keep running.

So my personal suggestion would be to keep 1. (even though it also does something comparable to `rejectWithValue` as well)  and not merge 2 (no matter the amount of work I put into this).