### PR TITLE
change default ThunkArg of cAT to OptionalUnknown

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -129,7 +129,7 @@ export function createAction<P = void, T extends string = string>(type: T): Payl
 export function createAction<PA extends PrepareAction<any>, T extends string = string>(type: T, prepareAction: PA): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>;
 
 // @public (undocumented)
-export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}>(typePrefix: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>, options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>): AsyncThunk<Returned, ThunkArg, ThunkApiConfig>;
+export function createAsyncThunk<Returned, ThunkArg = OptionalUnknown, ThunkApiConfig extends AsyncThunkConfig = {}>(typePrefix: string, payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>, options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>): AsyncThunk<Returned, ThunkArg, ThunkApiConfig>;
 
 // @public (undocumented)
 export function createEntityAdapter<T>(options?: {

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -213,7 +213,8 @@ const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
   {
     const asyncThunk = createAsyncThunk('test', () => 0)
     expectType<() => any>(asyncThunk)
-    // @ts-expect-error cannot be called with an argument
+    // we have to allow anything to be passed in in this case, to allow
+    // for compatibility with allowJs & checkJS
     asyncThunk(0 as any)
   }
 


### PR DESCRIPTION
Since TypeScript 4.0, the following example will cause an error when checking JavaScript files (with allowJs & checkJs):
```js
const thunk = createAsyncThunk('', arg => {})
thunk()
// @ts-expect-error Expected 0 arguments, but got 1.ts(2554)
thunk('something')
```
The only way around that without breaking too much explicit existing behaviour is this type "OptionalUnknown".
On the flip side, using a payloadcreator without a defined argument, like
```ts
const thunk = createAsyncThunk('', () => {})
```
will now generate a thunk that can optionally be called with any first argument opposed to a thunk that would not accept any argument before.

This is not nice, but there's not much way around it without significantly changing `createAsyncThunk` types that are public. (And even then I'm not sure if I could find a better solution).
This is a change as well, but only one that will lead to more relaxed typechecking, so nobody upgrading should get any errors.

@markerikson, opinions on this?