### PR TITLE
move CI from travis to github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,82 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: Lint, Test, Build & Pack on Node ${{ matrix.node }}
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['12.x']
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - uses: c-hive/gha-npm-cache@v1
+
+      - name: Install deps
+        run: npm ci --ignore-scripts
+
+      - name: Pack (including Prepare)
+        run: npm pack
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: package
+          path: reduxjs-toolkit*.tgz
+
+  test:
+    name: Test Types with TypeScript ${{ matrix.ts }}
+
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['12.x']
+        ts: ['3.5', '3.6', '3.7', '3.8', '3.9', '4.0', '4.1', 'next']
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - uses: c-hive/gha-npm-cache@v1
+
+      - name: Install deps
+        run: npm ci --ignore-scripts
+
+      - name: Install TypeScript ${{ matrix.ts }}
+        run: npm install typescript@${{ matrix.ts }} --ignore-scripts
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: package
+
+      - name: Unpack build artifact to dist
+        run: tar -xzvf reduxjs-toolkit-1.4.0.tgz --strip-components=1 package/dist
+
+      - name: Remap @redux/toolkit from src to dist
+        run: |
+          sed -i -e 's|@reduxjs/toolkit": \["./src"\]|@reduxjs/toolkit": ["."]|' ./type-tests/files/tsconfig.json
+
+      - name: Use typings-tester for old TS versions
+        if: ${{ matrix.ts < 3.9 }}
+        run: |
+          sed -i -e 's/"cd type-tests.*"/"npm run test type-tests"/' package.json
+          sed -i -e 's/@ts-expect-error/typings:expect-error/' type-tests/files/*
+          mv type-tests/types.test.disabled.ts type-tests/types.test.ts
+
+      - name: Test types
+        run: |
+          ./node_modules/.bin/tsc --version
+          npm run type-tests

--- a/type-tests/files/MiddlewareArray.typetest.ts
+++ b/type-tests/files/MiddlewareArray.typetest.ts
@@ -1,6 +1,6 @@
-import { getDefaultMiddleware } from 'src/getDefaultMiddleware'
+import { getDefaultMiddleware } from '@reduxjs/toolkit'
 import { Middleware } from 'redux'
-import { DispatchForMiddlewares } from 'src/tsHelpers'
+import { DispatchForMiddlewares } from '@internal/tsHelpers'
 
 declare const expectType: <T>(t: T) => T
 

--- a/type-tests/files/configureStore.typetest.ts
+++ b/type-tests/files/configureStore.typetest.ts
@@ -7,7 +7,11 @@ import {
   Reducer,
   Store
 } from 'redux'
-import { configureStore, PayloadAction, getDefaultMiddleware } from 'src'
+import {
+  configureStore,
+  PayloadAction,
+  getDefaultMiddleware
+} from '@reduxjs/toolkit'
 import thunk, { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
 
 const _anyMiddleware: any = () => () => () => {}

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -8,8 +8,8 @@ import {
   ActionCreatorWithPayload,
   ActionCreatorWithNonInferrablePayload,
   ActionCreatorWithPreparedPayload
-} from '../../src'
-import { IsAny } from 'src/tsHelpers'
+} from '@reduxjs/toolkit'
+import { IsAny } from '@internal/tsHelpers'
 
 function expectType<T>(p: T): T {
   return p

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -1,10 +1,15 @@
 /* eslint-disable no-lone-blocks */
-import { createAsyncThunk, Dispatch, createReducer, AnyAction } from 'src'
+import {
+  createAsyncThunk,
+  createReducer,
+  AnyAction,
+  unwrapResult,
+  SerializedError
+} from '@reduxjs/toolkit'
 import { ThunkDispatch } from 'redux-thunk'
-import { unwrapResult, SerializedError } from 'src/createAsyncThunk'
 
 import apiRequest, { AxiosError } from 'axios'
-import { IsAny, IsUnknown } from 'src/tsHelpers'
+import { IsAny, IsUnknown } from '@internal/tsHelpers'
 
 function expectType<T>(t: T) {
   return t

--- a/type-tests/files/createEntityAdapter.typetest.ts
+++ b/type-tests/files/createEntityAdapter.typetest.ts
@@ -3,9 +3,11 @@ import {
   createEntityAdapter,
   EntityAdapter,
   ActionCreatorWithPayload,
-  ActionCreatorWithoutPayload
-} from 'src'
-import { EntityStateAdapter, EntityId, Update } from 'src/entities/models'
+  ActionCreatorWithoutPayload,
+  EntityStateAdapter,
+  EntityId,
+  Update
+} from '@reduxjs/toolkit'
 
 function expectType<T>(t: T) {
   return t

--- a/type-tests/files/createReducer.typetest.ts
+++ b/type-tests/files/createReducer.typetest.ts
@@ -1,5 +1,9 @@
 import { Reducer } from 'redux'
-import { createReducer, createAction, ActionReducerMapBuilder } from '../../src'
+import {
+  createReducer,
+  createAction,
+  ActionReducerMapBuilder
+} from '@reduxjs/toolkit'
 
 function expectType<T>(p: T) {}
 

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -1,5 +1,4 @@
 import { Action, AnyAction, Reducer } from 'redux'
-import { ValidateSliceCaseReducers } from 'src/createSlice'
 import {
   ActionCreatorWithNonInferrablePayload,
   ActionCreatorWithOptionalPayload,
@@ -10,8 +9,9 @@ import {
   createAction,
   createSlice,
   PayloadAction,
-  SliceCaseReducers
-} from '../../src'
+  SliceCaseReducers,
+  ValidateSliceCaseReducers
+} from '@reduxjs/toolkit'
 
 function expectType<T>(t: T) {
   return t

--- a/type-tests/files/mapBuilders.typetest.ts
+++ b/type-tests/files/mapBuilders.typetest.ts
@@ -1,5 +1,5 @@
-import { executeReducerBuilderCallback } from 'src/mapBuilders'
-import { createAction, AnyAction } from 'src'
+import { executeReducerBuilderCallback } from '@internal/mapBuilders'
+import { createAction, AnyAction } from '@reduxjs/toolkit'
 
 function expectType<T>(t: T) {
   return t

--- a/type-tests/files/tsconfig.json
+++ b/type-tests/files/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es2018",
     "baseUrl": "../..",
     "paths": {
-      "redux-toolkit": ["src/typings.d.ts"]
-    }    
+      "@reduxjs/toolkit": ["./src"],
+      "@internal/*": ["./src/*"]
+    }
   }
 }


### PR DESCRIPTION
Travis is ...flaky... recently, to say it friendly.

This would move the CI from travis to GH actions.
Also, it makes some changes:

* Linting, runtime tests and build now happen with only the project's current TypeScript version.
* The `dist` folder from that build is then thrown against all currently supported TS versions and only the TypeScript-tests are run with that. (before, the type-tests would run against `src`)

Time for all tests combined is down to 3 minutes with that change.

@markerikson what do you think, should I pull the trigger on this? We could run it side-by-side with travis for a while.