### PR TITLE
overload: call thunk matchers with actions 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,8 @@ jobs:
         if: ${{ matrix.ts < 3.9 }}
         run: |
           sed -i -e 's/"cd type-tests.*"/"npm run test type-tests"/' package.json
-          sed -i -e 's/@ts-expect-error/typings:expect-error/' type-tests/files/*
+          sed -i -e 's/@ts-expect-error/typings:expect-error/' type-tests/files/*.typetest.ts
+          sed -i -e 's/@ts-expect-error/@ts-ignore/' type-tests/files/*.ts
           mv type-tests/types.test.disabled.ts type-tests/types.test.ts
 
       - name: Test types

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -306,10 +306,16 @@ export function isAsyncThunkAction(): (action: any) => action is UnknownAsyncThu
 export function isAsyncThunkAction<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is ActionsFromAsyncThunk<AsyncThunks[number]>;
 
 // @public
+export function isAsyncThunkAction(action: any): action is UnknownAsyncThunkAction;
+
+// @public
 export function isFulfilled(): (action: any) => action is UnknownAsyncThunkFulfilledAction;
 
 // @public
 export function isFulfilled<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is FulfilledActionFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
+export function isFulfilled(action: any): action is UnknownAsyncThunkFulfilledAction;
 
 // @public
 export function isImmutableDefault(value: unknown): boolean;
@@ -319,6 +325,9 @@ export function isPending(): (action: any) => action is UnknownAsyncThunkPending
 
 // @public
 export function isPending<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is PendingActionFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
+export function isPending(action: any): action is UnknownAsyncThunkPendingAction;
 
 // @public
 export function isPlain(val: any): boolean;
@@ -333,10 +342,16 @@ export function isRejected(): (action: any) => action is UnknownAsyncThunkReject
 export function isRejected<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>;
 
 // @public
+export function isRejected(action: any): action is UnknownAsyncThunkRejectedAction;
+
+// @public
 export function isRejectedWithValue(): (action: any) => action is UnknownAsyncThunkRejectedAction;
 
 // @public
-export function isRejectedWithValue<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>;
+export function isRejectedWithValue<AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]>(...asyncThunks: AsyncThunks): (action: any) => action is RejectedWithValueActionFromAsyncThunk<AsyncThunks[number]>;
+
+// @public
+export function isRejectedWithValue(action: any): action is UnknownAsyncThunkRejectedAction;
 
 // @public (undocumented)
 export class MiddlewareArray<Middlewares extends Middleware<any, any>> extends Array<Middlewares> {

--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -10,6 +10,10 @@ import {
 import { createAction } from './createAction'
 import { createAsyncThunk } from './createAsyncThunk'
 import { createReducer } from './createReducer'
+import { ThunkAction } from 'redux-thunk'
+import { AnyAction } from 'redux'
+
+const thunk: ThunkAction<any, any, any, AnyAction> = () => {}
 
 describe('isAnyOf', () => {
   it('returns true only if any matchers match (match function)', () => {
@@ -145,6 +149,8 @@ describe('isPending', () => {
     const action = createAction<string>('action/type')('testPayload')
 
     expect(isPending()(action)).toBe(false)
+    expect(isPending(action)).toBe(false)
+    expect(isPending(thunk)).toBe(false)
   })
 
   test('should return true only for pending async thunk actions', () => {
@@ -152,6 +158,7 @@ describe('isPending', () => {
 
     const pendingAction = thunk.pending('fakeRequestId')
     expect(isPending()(pendingAction)).toBe(true)
+    expect(isPending(pendingAction)).toBe(true)
 
     const rejectedAction = thunk.rejected(
       new Error('rejected'),
@@ -169,6 +176,7 @@ describe('isPending', () => {
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
     const matchAC = isPending(thunkA, thunkC)
+    const matchB = isPending(thunkB)
 
     function testPendingAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
@@ -176,6 +184,7 @@ describe('isPending', () => {
     ) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(expected)
+      expect(matchB(pendingAction)).toBe(!expected)
 
       const rejectedAction = thunk.rejected(
         new Error('rejected'),
@@ -198,6 +207,8 @@ describe('isRejected', () => {
     const action = createAction<string>('action/type')('testPayload')
 
     expect(isRejected()(action)).toBe(false)
+    expect(isRejected(action)).toBe(false)
+    expect(isRejected(thunk)).toBe(false)
   })
 
   test('should return true only for rejected async thunk actions', () => {
@@ -211,6 +222,7 @@ describe('isRejected', () => {
       'fakeRequestId'
     )
     expect(isRejected()(rejectedAction)).toBe(true)
+    expect(isRejected(rejectedAction)).toBe(true)
 
     const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
     expect(isRejected()(fulfilledAction)).toBe(false)
@@ -222,6 +234,7 @@ describe('isRejected', () => {
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
     const matchAC = isRejected(thunkA, thunkC)
+    const matchB = isRejected(thunkB)
 
     function testRejectedAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
@@ -235,6 +248,7 @@ describe('isRejected', () => {
         'fakeRequestId'
       )
       expect(matchAC(rejectedAction)).toBe(expected)
+      expect(matchB(rejectedAction)).toBe(!expected)
 
       const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
       expect(matchAC(fulfilledAction)).toBe(false)
@@ -251,6 +265,8 @@ describe('isRejectedWithValue', () => {
     const action = createAction<string>('action/type')('testPayload')
 
     expect(isRejectedWithValue()(action)).toBe(false)
+    expect(isRejectedWithValue(action)).toBe(false)
+    expect(isRejectedWithValue(thunk)).toBe(false)
   })
 
   test('should return true only for rejected-with-value async thunk actions', async () => {
@@ -290,6 +306,7 @@ describe('isRejectedWithValue', () => {
     const thunkC = createAsyncThunk<string>('c', payloadCreator)
 
     const matchAC = isRejectedWithValue(thunkA, thunkC)
+    const matchB = isRejectedWithValue(thunkB)
 
     async function testRejectedAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
@@ -313,6 +330,7 @@ describe('isRejectedWithValue', () => {
       const rejectedWithValueAction = await thunk()(dispatch, getState, extra)
 
       expect(matchAC(rejectedWithValueAction)).toBe(expected)
+      expect(matchB(rejectedWithValueAction)).toBe(!expected)
 
       const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
       expect(matchAC(fulfilledAction)).toBe(false)
@@ -329,6 +347,8 @@ describe('isFulfilled', () => {
     const action = createAction<string>('action/type')('testPayload')
 
     expect(isFulfilled()(action)).toBe(false)
+    expect(isFulfilled(action)).toBe(false)
+    expect(isFulfilled(thunk)).toBe(false)
   })
 
   test('should return true only for fulfilled async thunk actions', () => {
@@ -345,6 +365,7 @@ describe('isFulfilled', () => {
 
     const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
     expect(isFulfilled()(fulfilledAction)).toBe(true)
+    expect(isFulfilled(fulfilledAction)).toBe(true)
   })
 
   test('should return true only for thunks provided as arguments', () => {
@@ -353,6 +374,7 @@ describe('isFulfilled', () => {
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
     const matchAC = isFulfilled(thunkA, thunkC)
+    const matchB = isFulfilled(thunkB)
 
     function testFulfilledAction(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
@@ -369,6 +391,7 @@ describe('isFulfilled', () => {
 
       const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
       expect(matchAC(fulfilledAction)).toBe(expected)
+      expect(matchB(fulfilledAction)).toBe(!expected)
     }
 
     testFulfilledAction(thunkA, true)
@@ -382,6 +405,8 @@ describe('isAsyncThunkAction', () => {
     const action = createAction<string>('action/type')('testPayload')
 
     expect(isAsyncThunkAction()(action)).toBe(false)
+    expect(isAsyncThunkAction(action)).toBe(false)
+    expect(isAsyncThunkAction(thunk)).toBe(false)
   })
 
   test('should return true for any async thunk action if no arguments were provided', () => {
@@ -407,6 +432,7 @@ describe('isAsyncThunkAction', () => {
     const thunkC = createAsyncThunk<string>('c', () => 'result')
 
     const matchAC = isAsyncThunkAction(thunkA, thunkC)
+    const matchB = isAsyncThunkAction(thunkB)
 
     function testAllActions(
       thunk: typeof thunkA | typeof thunkB | typeof thunkC,
@@ -414,15 +440,18 @@ describe('isAsyncThunkAction', () => {
     ) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(expected)
+      expect(matchB(pendingAction)).toBe(!expected)
 
       const rejectedAction = thunk.rejected(
         new Error('rejected'),
         'fakeRequestId'
       )
       expect(matchAC(rejectedAction)).toBe(expected)
+      expect(matchB(rejectedAction)).toBe(!expected)
 
       const fulfilledAction = thunk.fulfilled('result', 'fakeRequestId')
       expect(matchAC(fulfilledAction)).toBe(expected)
+      expect(matchB(fulfilledAction)).toBe(!expected)
     }
 
     testAllActions(thunkA, true)

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -10,7 +10,6 @@ import {
   AsyncThunkPendingActionCreator,
   AsyncThunkRejectedActionCreator
 } from './createAsyncThunk'
-import { Action } from 'redux'
 
 /** @public */
 export type ActionMatchingAnyOf<
@@ -122,7 +121,8 @@ export function isPending<
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is PendingActionFromAsyncThunk<AsyncThunks[number]>
 /**
- * TODO
+ * Tests if `action` is a pending thunk action
+ * @public
  */
 export function isPending(action: any): action is UnknownAsyncThunkPendingAction
 export function isPending<
@@ -183,7 +183,8 @@ export function isRejected<
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>
 /**
- * TODO
+ * Tests if `action` is a rejected thunk action
+ * @public
  */
 export function isRejected(
   action: any
@@ -251,7 +252,8 @@ export function isRejectedWithValue<
   action: any
 ) => action is RejectedWithValueActionFromAsyncThunk<AsyncThunks[number]>
 /**
- * TODO
+ * Tests if `action` is a rejected thunk action with value
+ * @public
  */
 export function isRejectedWithValue(
   action: any
@@ -317,7 +319,8 @@ export function isFulfilled<
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is FulfilledActionFromAsyncThunk<AsyncThunks[number]>
 /**
- * TODO
+ * Tests if `action` is a fulfilled thunk action
+ * @public
  */
 export function isFulfilled(
   action: any
@@ -381,6 +384,10 @@ export function isAsyncThunkAction<
 >(
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is ActionsFromAsyncThunk<AsyncThunks[number]>
+/**
+ * Tests if `action` is a thunk action
+ * @public
+ */
 export function isAsyncThunkAction(
   action: any
 ): action is UnknownAsyncThunkAction

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -10,6 +10,7 @@ import {
   AsyncThunkPendingActionCreator,
   AsyncThunkRejectedActionCreator
 } from './createAsyncThunk'
+import { Action } from 'redux'
 
 /** @public */
 export type ActionMatchingAnyOf<
@@ -79,6 +80,15 @@ export function hasExpectedRequestMetadata(action: any, validStatus: string[]) {
   return hasValidRequestId && hasValidRequestStatus
 }
 
+function isAsyncThunkArray(a: [any] | AnyAsyncThunk[]): a is AnyAsyncThunk[] {
+  return (
+    typeof a[0] === 'function' &&
+    'pending' in a[0] &&
+    'fulfilled' in a[0] &&
+    'rejected' in a[0]
+  )
+}
+
 export type UnknownAsyncThunkPendingAction = ReturnType<
   AsyncThunkPendingActionCreator<unknown>
 >
@@ -111,11 +121,19 @@ export function isPending<
 >(
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is PendingActionFromAsyncThunk<AsyncThunks[number]>
+/**
+ * TODO
+ */
+export function isPending(action: any): action is UnknownAsyncThunkPendingAction
 export function isPending<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
->(...asyncThunks: AsyncThunks) {
+>(...asyncThunks: AsyncThunks | [any]) {
   if (asyncThunks.length === 0) {
     return (action: any) => hasExpectedRequestMetadata(action, ['pending'])
+  }
+
+  if (!isAsyncThunkArray(asyncThunks)) {
+    return isPending()(asyncThunks[0])
   }
 
   return (
@@ -164,11 +182,21 @@ export function isRejected<
 >(
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>
+/**
+ * TODO
+ */
+export function isRejected(
+  action: any
+): action is UnknownAsyncThunkRejectedAction
 export function isRejected<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
->(...asyncThunks: AsyncThunks) {
+>(...asyncThunks: AsyncThunks | [any]) {
   if (asyncThunks.length === 0) {
     return (action: any) => hasExpectedRequestMetadata(action, ['rejected'])
+  }
+
+  if (!isAsyncThunkArray(asyncThunks)) {
+    return isRejected()(asyncThunks[0])
   }
 
   return (
@@ -184,6 +212,17 @@ export function isRejected<
     return combinedMatcher(action)
   }
 }
+
+export type UnknownAsyncThunkRejectedWithValueAction = ReturnType<
+  AsyncThunkRejectedActionCreator<unknown, unknown>
+>
+
+export type RejectedWithValueActionFromAsyncThunk<
+  T extends AnyAsyncThunk
+> = ActionFromMatcher<T['rejected']> &
+  (T extends AsyncThunk<any, any, { rejectValue: infer RejectedValue }>
+    ? { payload: RejectedValue }
+    : unknown)
 
 /**
  * A higher-order function that returns a function that may be used to check
@@ -208,10 +247,18 @@ export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
 >(
   ...asyncThunks: AsyncThunks
-): (action: any) => action is RejectedActionFromAsyncThunk<AsyncThunks[number]>
+): (
+  action: any
+) => action is RejectedWithValueActionFromAsyncThunk<AsyncThunks[number]>
+/**
+ * TODO
+ */
+export function isRejectedWithValue(
+  action: any
+): action is UnknownAsyncThunkRejectedAction
 export function isRejectedWithValue<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
->(...asyncThunks: AsyncThunks) {
+>(...asyncThunks: AsyncThunks | [any]) {
   const hasFlag = (action: any): action is any => {
     return action && action.meta && action.meta.rejectedWithValue
   }
@@ -222,6 +269,10 @@ export function isRejectedWithValue<
 
       return combinedMatcher(action)
     }
+  }
+
+  if (!isAsyncThunkArray(asyncThunks)) {
+    return isRejectedWithValue()(asyncThunks[0])
   }
 
   return (
@@ -265,11 +316,21 @@ export function isFulfilled<
 >(
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is FulfilledActionFromAsyncThunk<AsyncThunks[number]>
+/**
+ * TODO
+ */
+export function isFulfilled(
+  action: any
+): action is UnknownAsyncThunkFulfilledAction
 export function isFulfilled<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
->(...asyncThunks: AsyncThunks) {
+>(...asyncThunks: AsyncThunks | [any]) {
   if (asyncThunks.length === 0) {
     return (action: any) => hasExpectedRequestMetadata(action, ['fulfilled'])
+  }
+
+  if (!isAsyncThunkArray(asyncThunks)) {
+    return isFulfilled()(asyncThunks[0])
   }
 
   return (
@@ -320,12 +381,19 @@ export function isAsyncThunkAction<
 >(
   ...asyncThunks: AsyncThunks
 ): (action: any) => action is ActionsFromAsyncThunk<AsyncThunks[number]>
+export function isAsyncThunkAction(
+  action: any
+): action is UnknownAsyncThunkAction
 export function isAsyncThunkAction<
   AsyncThunks extends [AnyAsyncThunk, ...AnyAsyncThunk[]]
->(...asyncThunks: AsyncThunks) {
+>(...asyncThunks: AsyncThunks | [any]) {
   if (asyncThunks.length === 0) {
     return (action: any) =>
       hasExpectedRequestMetadata(action, ['pending', 'fulfilled', 'rejected'])
+  }
+
+  if (!isAsyncThunkArray(asyncThunks)) {
+    return isAsyncThunkAction()(asyncThunks[0])
   }
 
   return (

--- a/type-tests/files/configureStore.typetest.ts
+++ b/type-tests/files/configureStore.typetest.ts
@@ -13,11 +13,9 @@ import {
   getDefaultMiddleware
 } from '@reduxjs/toolkit'
 import thunk, { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
+import { expectType } from './helpers'
 
 const _anyMiddleware: any = () => () => () => {}
-function expectType<T>(t: T) {
-  return t
-}
 
 /*
  * Test: configureStore() requires a valid reducer or reducer map.

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -10,10 +10,7 @@ import {
   ActionCreatorWithPreparedPayload
 } from '@reduxjs/toolkit'
 import { IsAny } from '@internal/tsHelpers'
-
-function expectType<T>(p: T): T {
-  return p
-}
+import { expectType } from './helpers'
 
 /* PayloadAction */
 

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -10,10 +10,8 @@ import { ThunkDispatch } from 'redux-thunk'
 
 import apiRequest, { AxiosError } from 'axios'
 import { IsAny, IsUnknown } from '@internal/tsHelpers'
+import { expectType } from './helpers'
 
-function expectType<T>(t: T) {
-  return t
-}
 const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
 
   // basic usage

--- a/type-tests/files/createEntityAdapter.typetest.ts
+++ b/type-tests/files/createEntityAdapter.typetest.ts
@@ -8,10 +8,7 @@ import {
   EntityId,
   Update
 } from '@reduxjs/toolkit'
-
-function expectType<T>(t: T) {
-  return t
-}
+import { expectType } from './helpers'
 
 function extractReducers<T>(
   adapter: EntityAdapter<T>

--- a/type-tests/files/createReducer.typetest.ts
+++ b/type-tests/files/createReducer.typetest.ts
@@ -4,8 +4,7 @@ import {
   createAction,
   ActionReducerMapBuilder
 } from '@reduxjs/toolkit'
-
-function expectType<T>(p: T) {}
+import { expectType } from './helpers'
 
 /*
  * Test: createReducer() infers type of returned reducer.

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -12,10 +12,7 @@ import {
   SliceCaseReducers,
   ValidateSliceCaseReducers
 } from '@reduxjs/toolkit'
-
-function expectType<T>(t: T) {
-  return t
-}
+import { expectType } from './helpers'
 
 /*
  * Test: Slice name is strongly typed.

--- a/type-tests/files/helpers.ts
+++ b/type-tests/files/helpers.ts
@@ -1,0 +1,48 @@
+import { IsAny, IsUnknown } from '../../src/tsHelpers'
+
+export function expectType<T>(t: T): T {
+  return t
+}
+
+type Equals<T, U> = IsAny<
+  T,
+  never,
+  IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? any : never) : never>
+>
+export function expectExactType<T>(t: T) {
+  return <U extends Equals<T, U>>(u: U) => {}
+}
+
+type EnsureUnknown<T extends any> = IsUnknown<T, any, never>
+export function expectUnknown<T extends EnsureUnknown<T>>(t: T) {
+  return t
+}
+
+type EnsureAny<T extends any> = IsAny<T, any, never>
+export function expectExactAny<T extends EnsureAny<T>>(t: T) {
+  return t
+}
+
+type IsNotAny<T> = IsAny<T, never, any>
+export function expectNotAny<T extends IsNotAny<T>>(t: T): T {
+  return t
+}
+
+expectType<string>('5' as string)
+expectType<string>('5' as const)
+expectType<string>('5' as any)
+expectExactType('5' as const)('5' as const)
+// @ts-expect-error
+expectExactType('5' as string)('5' as const)
+// @ts-expect-error
+expectExactType('5' as any)('5' as const)
+expectUnknown('5' as unknown)
+// @ts-expect-error
+expectUnknown('5' as const)
+// @ts-expect-error
+expectUnknown('5' as any)
+expectExactAny('5' as any)
+// @ts-expect-error
+expectExactAny('5' as const)
+// @ts-expect-error
+expectExactAny('5' as unknown)

--- a/type-tests/files/mapBuilders.typetest.ts
+++ b/type-tests/files/mapBuilders.typetest.ts
@@ -1,9 +1,6 @@
 import { executeReducerBuilderCallback } from '@internal/mapBuilders'
 import { createAction, AnyAction } from '@reduxjs/toolkit'
-
-function expectType<T>(t: T) {
-  return t
-}
+import { expectType } from './helpers'
 
 /** Test:  alternative builder callback for actionMap */
 {

--- a/type-tests/files/matchers.typetest.ts
+++ b/type-tests/files/matchers.typetest.ts
@@ -1,3 +1,4 @@
+import { IsUnknown } from '@internal/tsHelpers'
 import { AnyAction } from 'redux'
 import {
   createAction,
@@ -8,7 +9,8 @@ import {
   isFulfilled,
   isPending,
   isRejected,
-  isRejectedWithValue
+  isRejectedWithValue,
+  SerializedError
 } from '../../src'
 
 /* isAnyOf */
@@ -23,7 +25,7 @@ function isAnyOfActionTest(action: AnyAction) {
         prop1: 1,
         prop3: 2
       }
-    };
+    }
   })
 
   const actionB = createAction('b', () => {
@@ -32,17 +34,17 @@ function isAnyOfActionTest(action: AnyAction) {
         prop1: 1,
         prop2: 2
       }
-    };
+    }
   })
 
   if (isAnyOf(actionA, actionB)(action)) {
     return {
       prop1: action.payload.prop1,
-      // typings:expect-error
+      // @ts-expect-error
       prop2: action.payload.prop2,
-      // typings:expect-error
+      // @ts-expect-error
       prop3: action.payload.prop3
-    };
+    }
   }
 }
 
@@ -50,36 +52,36 @@ function isAnyOfActionTest(action: AnyAction) {
  * Test: isAnyOf correctly narrows types when used with async thunks
  */
 function isAnyOfThunkTest(action: AnyAction) {
-  const asyncThunk1 = createAsyncThunk<{prop1: number, prop3: number}>(
+  const asyncThunk1 = createAsyncThunk<{ prop1: number; prop3: number }>(
     'asyncThunk1',
 
     async () => {
       return {
         prop1: 1,
         prop3: 3
-      };
+      }
     }
-  );
+  )
 
-  const asyncThunk2 = createAsyncThunk<{prop1: number, prop2: number}>(
+  const asyncThunk2 = createAsyncThunk<{ prop1: number; prop2: number }>(
     'asyncThunk2',
 
     async () => {
       return {
         prop1: 1,
         prop2: 2
-      };
+      }
     }
-  );
+  )
 
   if (isAnyOf(asyncThunk1.fulfilled, asyncThunk2.fulfilled)(action)) {
     return {
       prop1: action.payload.prop1,
-      // typings:expect-error
+      // @ts-expect-error
       prop2: action.payload.prop2,
-      // typings:expect-error
+      // @ts-expect-error
       prop3: action.payload.prop3
-    };
+    }
   }
 }
 
@@ -88,38 +90,37 @@ function isAnyOfThunkTest(action: AnyAction) {
  */
 function isAnyOfTypeGuardTest(action: AnyAction) {
   interface ActionA {
-    type: 'a';
+    type: 'a'
     payload: {
-      prop1: 1,
+      prop1: 1
       prop3: 2
-    };
+    }
   }
 
   interface ActionB {
-    type: 'b';
+    type: 'b'
     payload: {
-      prop1: 1,
+      prop1: 1
       prop2: 2
     }
   }
 
   const guardA = (v: any): v is ActionA => {
-    return v.type === 'a';
+    return v.type === 'a'
   }
 
   const guardB = (v: any): v is ActionB => {
-    return v.type === 'b';
+    return v.type === 'b'
   }
-
 
   if (isAnyOf(guardA, guardB)(action)) {
     return {
       prop1: action.payload.prop1,
-      // typings:expect-error
+      // @ts-expect-error
       prop2: action.payload.prop2,
-      // typings:expect-error
+      // @ts-expect-error
       prop3: action.payload.prop3
-    };
+    }
   }
 }
 
@@ -127,12 +128,12 @@ function isAnyOfTypeGuardTest(action: AnyAction) {
 
 interface SpecialAction {
   payload: {
-    special: boolean;
+    special: boolean
   }
 }
 
 const isSpecialAction = (v: any): v is SpecialAction => {
-  return v.meta.isSpecial;
+  return v.meta.isSpecial
 }
 
 /*
@@ -146,17 +147,17 @@ function isAllOfActionTest(action: AnyAction) {
         prop1: 1,
         prop3: 2
       }
-    };
+    }
   })
 
   if (isAllOf(actionA, isSpecialAction)(action)) {
     return {
       prop1: action.payload.prop1,
-      // typings:expect-error
+      // @ts-expect-error
       prop2: action.payload.prop2,
       prop3: action.payload.prop3,
       special: action.payload.special
-    };
+    }
   }
 }
 
@@ -165,25 +166,25 @@ function isAllOfActionTest(action: AnyAction) {
  *       and type guards
  */
 function isAllOfThunkTest(action: AnyAction) {
-  const asyncThunk1 = createAsyncThunk<{prop1: number, prop3: number}>(
+  const asyncThunk1 = createAsyncThunk<{ prop1: number; prop3: number }>(
     'asyncThunk1',
 
     async () => {
       return {
         prop1: 1,
         prop3: 3
-      };
+      }
     }
-  );
+  )
 
   if (isAllOf(asyncThunk1.fulfilled, isSpecialAction)(action)) {
     return {
       prop1: action.payload.prop1,
-      // typings:expect-error
+      // @ts-expect-error
       prop2: action.payload.prop2,
       prop3: action.payload.prop3,
       special: action.payload.special
-    };
+    }
   }
 }
 
@@ -192,25 +193,25 @@ function isAllOfThunkTest(action: AnyAction) {
  */
 function isAllOfTypeGuardTest(action: AnyAction) {
   interface ActionA {
-    type: 'a';
+    type: 'a'
     payload: {
-      prop1: 1,
+      prop1: 1
       prop3: 2
-    };
+    }
   }
 
   const guardA = (v: any): v is ActionA => {
-    return v.type === 'a';
+    return v.type === 'a'
   }
 
   if (isAllOf(guardA, isSpecialAction)(action)) {
     return {
       prop1: action.payload.prop1,
-      // typings:expect-error
+      // @ts-expect-error
       prop2: action.payload.prop2,
       prop3: action.payload.prop3,
       special: action.payload.special
-    };
+    }
   }
 }
 
@@ -218,17 +219,18 @@ function isAllOfTypeGuardTest(action: AnyAction) {
  * Test: isPending correctly narrows types
  */
 function isPendingTest(action: AnyAction) {
+  if (isPending(action)) {
+    expectExactType<undefined>(action.payload)
+    // @ts-expect-error
+    action.error
+  }
+
   const thunk = createAsyncThunk<string>('a', () => 'result')
 
   if (isPending(thunk)(action)) {
-    return {
-      // we should expect the payload to be undefined
-      // typings:expect-error
-      prop1: action.payload.charAt(0),
-      // we should not expect an error property
-      // typings:expect-error
-      prop2: action.error,
-    };
+    expectExactType<undefined>(action.payload)
+    // @ts-expect-error
+    action.error
   }
 }
 
@@ -236,18 +238,18 @@ function isPendingTest(action: AnyAction) {
  * Test: isRejected correctly narrows types
  */
 function isRejectedTest(action: AnyAction) {
+  if (isRejected(action)) {
+    // might be there if rejected with payload
+    expectUnknown(action.payload)
+    expectExactType<SerializedError>(action.error)
+  }
+
   const thunk = createAsyncThunk<string>('a', () => 'result')
 
   if (isRejected(thunk)(action)) {
-    return {
-      // we should expect the payload to be defined ...
-      prop1a: action.payload,
-      // ... but of unknown type
-      // typings:expect-error
-      prop1b: action.payload.charAt(0),
-      // we should expect the error property to be defined
-      prop2: action.error,
-    };
+    // might be there if rejected with payload
+    expectUnknown(action.payload)
+    expectExactType<SerializedError>(action.error)
   }
 }
 
@@ -255,16 +257,17 @@ function isRejectedTest(action: AnyAction) {
  * Test: isFulfilled correctly narrows types
  */
 function isFulfilledTest(action: AnyAction) {
-  const thunk = createAsyncThunk<string>('a', () => 'result')
+  if (isFulfilled(action)) {
+    expectUnknown(action.payload)
+    // @ts-expect-error
+    action.error
+  }
 
+  const thunk = createAsyncThunk<string>('a', () => 'result')
   if (isFulfilled(thunk)(action)) {
-    return {
-      // we should expect the payload to be defined (in this case a string)
-      prop1: action.payload.charAt(0),
-      // we should not expect an error property
-      // typings:expect-error
-      prop2: action.error,
-    };
+    expectExactType('' as string)(action.payload)
+    // @ts-expect-error
+    action.error
   }
 }
 
@@ -272,19 +275,20 @@ function isFulfilledTest(action: AnyAction) {
  * Test: isAsyncThunkAction correctly narrows types
  */
 function isAsyncThunkActionTest(action: AnyAction) {
-  const thunk = createAsyncThunk<string>('a', () => 'result')
+  if (isAsyncThunkAction(action)) {
+    expectUnknown(action.payload)
+    // do not expect an error property because pending/fulfilled lack it
+    // @ts-expect-error
+    action.error
+  }
 
+  const thunk = createAsyncThunk<string>('a', () => 'result')
   if (isAsyncThunkAction(thunk)(action)) {
-    return {
-      // we should expect the payload to be defined ...
-      prop1a: action.payload,
-      // ... but of unknown type because the action may be pending/rejected
-      // typings:expect-error
-      prop1b: action.payload.charAt(0),
-      // do not expect an error property because pending/fulfilled lack it
-      // typings:expect-error
-      prop2: action.error,
-    };
+    // we should expect the payload to be available, but of unknown type because the action may be pending/rejected
+    expectUnknown(action.payload)
+    // do not expect an error property because pending/fulfilled lack it
+    // @ts-expect-error
+    action.error
   }
 }
 
@@ -292,17 +296,20 @@ function isAsyncThunkActionTest(action: AnyAction) {
  * Test: isRejectedWithValue correctly narrows types
  */
 function isRejectedWithValueTest(action: AnyAction) {
-  const thunk = createAsyncThunk<string>('a', () => 'result')
+  if (isRejectedWithValue(action)) {
+    expectUnknown(action.payload)
+    expectExactType<SerializedError>(action.error)
+  }
 
+  const thunk = createAsyncThunk<
+    string,
+    void,
+    { rejectValue: { message: string } }
+  >('a', () => 'result')
   if (isRejectedWithValue(thunk)(action)) {
-    return {
-      // we should expect the payload to be defined ...
-      prop1a: action.payload,
-      // ... but of unknown type
-      // typings:expect-error
-      prop1b: action.payload.charAt(0),
-      // we should expect the error property to be defined
-      prop2: action.error,
-    };
+    expectExactType({ message: '' as string })(action.payload)
+    expectExactType<SerializedError>(action.error)
   }
 }
+
+import { expectExactType, expectUnknown } from './helpers'


### PR DESCRIPTION
adds the ability to call
```js
isRejected(action)
```
in addition to the existing behaviour
```js
isRejected()(action)
isRejected(thunk, ...moreThunks)(action)
```
