### PR TITLE
explicitly cast `initialState` in docs examples

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -574,10 +574,10 @@ interface UsersState {
   entities: Record<string, User>
 }
 
-const initialState: UsersState = {
+const initialState = {
   entities: {},
   error: null
-}
+} as UsersState
 
 const usersSlice = createSlice({
   name: 'users',

--- a/docs/api/createReducer.mdx
+++ b/docs/api/createReducer.mdx
@@ -52,7 +52,7 @@ const increment = createAction('counter/increment')
 const decrement = createAction('counter/decrement')
 const incrementByAmount = createAction<number>('counter/incrementByAmount')
 
-const initialState: CounterState = { value: 0 }
+const initialState = { value: 0 } as CounterState
 
 const counterReducer = createReducer(initialState, builder => {
   builder

--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -22,7 +22,7 @@ interface CounterState {
   value: number
 }
 
-const initialState: CounterState = { value: 0 }
+const initialState = { value: 0 } as CounterState
 
 const counterSlice = createSlice({
   name: 'counter',

--- a/docs/api/matching-utilities.mdx
+++ b/docs/api/matching-utilities.mdx
@@ -174,10 +174,10 @@ interface ExampleState {
   isInteresting: boolean
 }
 
-const initialState: ExampleState = {
+const initialState = {
   isSpecial: false,
   isInteresting: false
-}
+} as ExampleState
 
 export const isSpecialAndInterestingThunk = createAsyncThunk(
   'isSpecialAndInterestingThunk',

--- a/docs/api/otherExports.mdx
+++ b/docs/api/otherExports.mdx
@@ -38,7 +38,7 @@ interface Todo {
 }
 const addTodo = createAction<Todo>('addTodo')
 
-const initialState: Todo[] = []
+const initialState = [] as Todo[]
 
 const todosReducer = createReducer(initialState, builder => {
   builder.addCase(addTodo, (state, action) => {

--- a/docs/tutorials/advanced-tutorial.md
+++ b/docs/tutorials/advanced-tutorial.md
@@ -204,13 +204,13 @@ type CurrentDisplayState = {
 } & CurrentDisplay &
   CurrentRepo
 
-let initialState: CurrentDisplayState = {
+let initialState = {
   org: 'rails',
   repo: 'rails',
   page: 1,
   displayType: 'issues',
   issueId: null
-}
+} as CurrentDisplayState
 
 const issuesDisplaySlice = createSlice({
   name: 'issuesDisplay',
@@ -575,10 +575,10 @@ interface RepoDetailsState {
   error: string | null
 }
 
-const initialState: RepoDetailsState = {
+const initialState = {
   openIssuesCount: -1,
   error: null
-}
+} as RepoDetailsState
 
 const repoDetails = createSlice({
   name: 'repoDetails',
@@ -761,14 +761,14 @@ interface IssuesState {
   error: string | null
 }
 
-const issuesInitialState: IssuesState = {
+const issuesInitialState = {
   issuesByNumber: {},
   currentPageIssues: [],
   pageCount: 0,
   pageLinks: {},
   isLoading: false,
   error: null
-}
+} as IssuesState
 
 function startLoading(state: IssuesState) {
   state.isLoading = true
@@ -1082,11 +1082,11 @@ interface CommentLoaded {
   comments: Comment[]
 }
 
-const initialState: CommentsState = {
+const initialState = {
   commentsByIssue: {},
   loading: false,
   error: null
-}
+} as CommentsState
 
 const comments = createSlice({
   name: 'comments',

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -277,7 +277,7 @@ The standard approach is to declare an interface or type for your state, create 
 type SliceState = { state: 'loading' } | { state: 'finished'; data: string }
 
 // First approach: define the initial state using that type
-const initialState: SliceState = { state: 'loading' }
+const initialState = { state: 'loading' }: SliceState
 
 createSlice({
   name: 'test1',
@@ -367,10 +367,10 @@ interface UsersState {
   loading: 'idle' | 'pending' | 'succeeded' | 'failed'
 }
 
-const initialState: UsersState = {
+const initialState = {
   entities: [],
   loading: 'idle'
-}
+} as UsersState
 
 const usersSlice = createSlice({
   name: 'users',

--- a/docs/virtual/matchers/index.ts
+++ b/docs/virtual/matchers/index.ts
@@ -34,10 +34,10 @@ export interface ExampleState {
   isInteresting: boolean
 }
 
-export const initialState: ExampleState = {
+export const initialState = {
   isSpecial: false,
   isInteresting: false
-}
+} as ExampleState
 
 export const isSpecialAndInterestingThunk = createAsyncThunk(
   'isSpecialAndInterestingThunk',


### PR DESCRIPTION
see #826 and #735 - copying from the latter why this is neccessary:

This is a TypeScript "feature" that is a bit unfortunate and that I've noticed in recent versions:

```ts
function identity<T>(t: T) {return t}


type SliceState = { state: "loading" } | { state: "finished"; data: string };

let initialState: SliceState = { state: "loading" };

// is inferred as  { state: "loading"; }
const derivedValue = identity(initialState)
```

TS actually does some code flow analysis and sometimes "tightens" types that you yourself declared wider.

Doing
```ts
const initialState = { state: "loading" } as SliceState;
```

would work as well here, as it is an implicit cast.

We might need to check our docs for this in a few places.

_Originally posted by @phryneas in https://github.com/reduxjs/redux-toolkit/issues/735#issuecomment-697637009_