### PR TITLE
experiment: specific entityId type

### DIFF
--- a/src/entities/create_adapter.ts
+++ b/src/entities/create_adapter.ts
@@ -1,4 +1,10 @@
-import { EntityDefinition, Comparer, IdSelector, EntityAdapter } from './models'
+import {
+  EntityDefinition,
+  Comparer,
+  IdSelector,
+  EntityAdapter,
+  EntityId
+} from './models'
 import { createInitialStateFactory } from './entity_state'
 import { createSelectorsFactory } from './state_selectors'
 import { createSortedStateAdapter } from './sorted_state_adapter'
@@ -10,12 +16,23 @@ import { createUnsortedStateAdapter } from './unsorted_state_adapter'
  *
  * @public
  */
-export function createEntityAdapter<T>(
+export function createEntityAdapter<
+  T extends { id: EntityId },
+  IdType extends EntityId = T['id']
+>(options?: {
+  selectId?: IdSelector<T, IdType>
+  sortComparer?: false | Comparer<T>
+}): EntityAdapter<T, IdType>
+export function createEntityAdapter<T, IdType extends EntityId>(options: {
+  selectId: IdSelector<T, IdType>
+  sortComparer?: false | Comparer<T>
+}): EntityAdapter<T, IdType>
+export function createEntityAdapter<T, IdType extends EntityId>(
   options: {
-    selectId?: IdSelector<T>
+    selectId?: IdSelector<T, IdType>
     sortComparer?: false | Comparer<T>
   } = {}
-): EntityAdapter<T> {
+): EntityAdapter<T, EntityId> {
   const { selectId, sortComparer }: EntityDefinition<T> = {
     sortComparer: false,
     selectId: (instance: any) => instance.id,

--- a/src/entities/entity_state.test.ts
+++ b/src/entities/entity_state.test.ts
@@ -4,7 +4,7 @@ import { createSlice } from '../createSlice'
 import { BookModel } from './fixtures/book'
 
 describe('Entity State', () => {
-  let adapter: EntityAdapter<BookModel>
+  let adapter: EntityAdapter<BookModel, string>
 
   beforeEach(() => {
     adapter = createEntityAdapter({

--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -14,7 +14,9 @@ export type Comparer<T> = (a: T, b: T) => number
 /**
  * @public
  */
-export type IdSelector<T> = (model: T) => EntityId
+export type IdSelector<T, IdType extends EntityId = EntityId> = (
+  model: T
+) => IdType
 
 /**
  * @public
@@ -33,101 +35,119 @@ export interface Dictionary<T> extends DictionaryNum<T> {
 /**
  * @public
  */
-export type Update<T> = { id: EntityId; changes: Partial<T> }
+export type Update<T, IdType extends EntityId = EntityId> = {
+  id: IdType
+  changes: Partial<T>
+}
 
 /**
  * @public
  */
-export interface EntityState<T> {
-  ids: EntityId[]
+export interface EntityState<T, IdType extends EntityId = EntityId> {
+  ids: IdType[]
   entities: Dictionary<T>
 }
 
 /**
  * @public
  */
-export interface EntityDefinition<T> {
-  selectId: IdSelector<T>
+export interface EntityDefinition<T, IdType extends EntityId = EntityId> {
+  selectId: IdSelector<T, IdType>
   sortComparer: false | Comparer<T>
 }
 
-export type PreventAny<S, T> = IsAny<S, EntityState<T>, S>
+export type PreventAny<S, T, IdType extends EntityId = EntityId> = IsAny<
+  S,
+  EntityState<T, IdType>,
+  S
+>
 
 /**
  * @public
  */
-export interface EntityStateAdapter<T> {
-  addOne<S extends EntityState<T>>(state: PreventAny<S, T>, entity: T): S
-  addOne<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
+export interface EntityStateAdapter<T, IdType extends EntityId = EntityId> {
+  addOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    entity: T
+  ): S
+  addOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
     action: PayloadAction<T>
   ): S
 
-  addMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    entities: T[] | Record<EntityId, T>
+  addMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    entities: T[] | Record<IdType, T>
   ): S
-  addMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    entities: PayloadAction<T[] | Record<EntityId, T>>
-  ): S
-
-  setAll<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    entities: T[] | Record<EntityId, T>
-  ): S
-  setAll<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    entities: PayloadAction<T[] | Record<EntityId, T>>
+  addMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    entities: PayloadAction<T[] | Record<IdType, T>>
   ): S
 
-  removeOne<S extends EntityState<T>>(state: PreventAny<S, T>, key: EntityId): S
-  removeOne<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    key: PayloadAction<EntityId>
+  setAll<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    entities: T[] | Record<IdType, T>
+  ): S
+  setAll<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    entities: PayloadAction<T[] | Record<IdType, T>>
   ): S
 
-  removeMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    keys: EntityId[]
+  removeOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    key: IdType
   ): S
-  removeMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    keys: PayloadAction<EntityId[]>
-  ): S
-
-  removeAll<S extends EntityState<T>>(state: PreventAny<S, T>): S
-
-  updateOne<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    update: Update<T>
-  ): S
-  updateOne<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    update: PayloadAction<Update<T>>
+  removeOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    key: PayloadAction<IdType>
   ): S
 
-  updateMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    updates: Update<T>[]
+  removeMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    keys: IdType[]
   ): S
-  updateMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
-    updates: PayloadAction<Update<T>[]>
+  removeMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    keys: PayloadAction<IdType[]>
   ): S
 
-  upsertOne<S extends EntityState<T>>(state: PreventAny<S, T>, entity: T): S
-  upsertOne<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
+  removeAll<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>
+  ): S
+
+  updateOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    update: Update<T, IdType>
+  ): S
+  updateOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    update: PayloadAction<Update<T, IdType>>
+  ): S
+
+  updateMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    updates: Update<T, IdType>[]
+  ): S
+  updateMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    updates: PayloadAction<Update<T, IdType>[]>
+  ): S
+
+  upsertOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
+    entity: T
+  ): S
+  upsertOne<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
     entity: PayloadAction<T>
   ): S
 
-  upsertMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
+  upsertMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
     entities: T[] | Record<EntityId, T>
   ): S
-  upsertMany<S extends EntityState<T>>(
-    state: PreventAny<S, T>,
+  upsertMany<S extends EntityState<T, IdType>>(
+    state: PreventAny<S, T, IdType>,
     entities: PayloadAction<T[] | Record<EntityId, T>>
   ): S
 }
@@ -135,24 +155,25 @@ export interface EntityStateAdapter<T> {
 /**
  * @public
  */
-export interface EntitySelectors<T, V> {
-  selectIds: (state: V) => EntityId[]
+export interface EntitySelectors<T, V, IdType extends EntityId = EntityId> {
+  selectIds: (state: V) => IdType[]
   selectEntities: (state: V) => Dictionary<T>
   selectAll: (state: V) => T[]
   selectTotal: (state: V) => number
-  selectById: (state: V, id: EntityId) => T | undefined
+  selectById: (state: V, id: IdType) => T | undefined
 }
 
 /**
  * @public
  */
-export interface EntityAdapter<T> extends EntityStateAdapter<T> {
-  selectId: IdSelector<T>
+export interface EntityAdapter<T, IdType extends EntityId = EntityId>
+  extends EntityStateAdapter<T> {
+  selectId: IdSelector<T, IdType>
   sortComparer: false | Comparer<T>
-  getInitialState(): EntityState<T>
-  getInitialState<S extends object>(state: S): EntityState<T> & S
-  getSelectors(): EntitySelectors<T, EntityState<T>>
+  getInitialState(): EntityState<T, IdType>
+  getInitialState<S extends object>(state: S): EntityState<T, IdType> & S
+  getSelectors(): EntitySelectors<T, EntityState<T, IdType>, IdType>
   getSelectors<V>(
-    selectState: (state: V) => EntityState<T>
-  ): EntitySelectors<T, V>
+    selectState: (state: V) => EntityState<T, IdType>
+  ): EntitySelectors<T, V, IdType>
 }

--- a/type-tests/files/createEntityAdapter.typetest.ts
+++ b/type-tests/files/createEntityAdapter.typetest.ts
@@ -10,9 +10,11 @@ import {
 } from '@reduxjs/toolkit'
 import { expectType } from './helpers'
 
-function extractReducers<T>(
-  adapter: EntityAdapter<T>
-): Omit<EntityStateAdapter<T>, 'map'> {
+type SpecificEntityId = 1 | 3 | 'five'
+
+function extractReducers<T, Id extends EntityId>(
+  adapter: EntityAdapter<T, Id>
+): Omit<EntityStateAdapter<T, Id>, 'map'> {
   const {
     selectId,
     sortComparer,
@@ -28,6 +30,7 @@ function extractReducers<T>(
  */
 {
   type Entity = {
+    id: SpecificEntityId
     value: string
   }
   const adapter = createEntityAdapter<Entity>()
@@ -40,17 +43,23 @@ function extractReducers<T>(
   })
 
   expectType<ActionCreatorWithPayload<Entity>>(slice.actions.addOne)
-  expectType<ActionCreatorWithPayload<Entity[] | Record<string, Entity>>>(
-    slice.actions.addMany
+  expectType<
+    ActionCreatorWithPayload<Entity[] | Record<SpecificEntityId, Entity>>
+  >(slice.actions.addMany)
+  expectType<
+    ActionCreatorWithPayload<Entity[] | Record<SpecificEntityId, Entity>>
+  >(slice.actions.setAll)
+  expectType<ActionCreatorWithPayload<SpecificEntityId>>(
+    slice.actions.removeOne
   )
-  expectType<ActionCreatorWithPayload<Entity[] | Record<string, Entity>>>(
-    slice.actions.setAll
+  expectType<ActionCreatorWithPayload<SpecificEntityId[]>>(
+    slice.actions.removeMany
   )
-  expectType<ActionCreatorWithPayload<EntityId>>(slice.actions.removeOne)
-  expectType<ActionCreatorWithPayload<EntityId[]>>(slice.actions.removeMany)
   expectType<ActionCreatorWithoutPayload>(slice.actions.removeAll)
-  expectType<ActionCreatorWithPayload<Update<Entity>>>(slice.actions.updateOne)
-  expectType<ActionCreatorWithPayload<Update<Entity>[]>>(
+  expectType<ActionCreatorWithPayload<Update<Entity, SpecificEntityId>>>(
+    slice.actions.updateOne
+  )
+  expectType<ActionCreatorWithPayload<Update<Entity, SpecificEntityId>[]>>(
     slice.actions.updateMany
   )
   expectType<ActionCreatorWithPayload<Entity>>(slice.actions.upsertOne)
@@ -64,9 +73,11 @@ function extractReducers<T>(
  */
 {
   type Entity = {
+    id: string
     value: string
   }
   type Entity2 = {
+    id: string
     value2: string
   }
   const adapter = createEntityAdapter<Entity>()
@@ -87,6 +98,7 @@ function extractReducers<T>(
  */
 {
   type Entity = {
+    id: SpecificEntityId
     value: string
   }
   const adapter = createEntityAdapter<Entity>()
@@ -104,6 +116,7 @@ function extractReducers<T>(
  */
 {
   type Entity = {
+    id: SpecificEntityId
     value: string
   }
   const adapter = createEntityAdapter<Entity>()


### PR DESCRIPTION
This came up this morning in the chat with Shrugsy: entityType is never fixed to whatever is actually returned by the `selectId` function.

This **would** do that. But at the added type complexity, I guess it won't be worth it. Nonetheless, I gave it a try.

I guess this is one of those "I'll make a PR to document that we tried it and it didn't work out" PRs that we can point to in the future if someone asks for it.

Unless you see it differently and want to get it in @markerikson ? It **has** some use, it's just questionable if that is worth the overhead.