### PR TITLE
Remove unnecessary condition

### DIFF
--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -259,9 +259,7 @@ export function createSlice<
     actionMatchers = [],
     defaultCaseReducer = undefined
   ] =
-    typeof options.extraReducers === 'undefined'
-      ? []
-      : typeof options.extraReducers === 'function'
+    typeof options.extraReducers === 'function'
       ? executeReducerBuilderCallback(options.extraReducers)
       : [options.extraReducers]
 


### PR DESCRIPTION
For `extraReducers`, when it is a function it will not be `undefined`, when it is `undefined` we defined a default value for it. Therefore, the judment of `undefined` is redundant :)

https://github.com/reduxjs/redux-toolkit/blob/d5f1b65541c8b2a7b99b7e7ba5d34c6c3e2ac896/src/createSlice.ts#L257-L266