### PR TITLE
add "Basic Project Setup" section to TS docs, move TS docs to top level

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -20,9 +20,8 @@ Also, you will want to create typed versions of the `useDispatch` and `useSelect
 
 That said, a basic setup would look like this:
 
-```ts
+```ts title="store.ts"
 import { configureStore } from '@reduxjs/toolkit'
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 // ...
 
 const store = configureStore({
@@ -34,6 +33,11 @@ const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
+```
+
+```ts title="hooks.ts"
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import { RootState, AppDispatch } from './store'
 
 // for use throughout your application instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>()

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -9,18 +9,21 @@ hide_title: true
 
 Redux Toolkit is written in TypeScript, and its API is designed to enable great integration with TypeScript applications.
 
-The first part of this page is intended to give you an overview over how to do a basic setup that every application requires. The second part goes into the specifics of the different APIs
+The first part of this page is intended to give you an overview over how to do a basic setup that every application requires. The second part goes into the specifics of the different APIs included in Redux Toolkit and how to type them correctly.
 
 **If you encounter any problems with the types that are not described on this page, please open an issue for discussion.**
 
 ## Basic Project Setup
 
-Using [configureStore](../api/configureStore.mdx) should not need any additional typings. You will, however, want to extract the `RootState` type and the `Dispatch` type.
-Also, you will want to create typed versions of the `useDispatch` and `useSelector` hooks for usage in your application.
+Using [configureStore](../api/configureStore.mdx) should not need any additional typings. You will, however, want to extract the `RootState` type and the `Dispatch` type so that they can be referenced as needed. Inferring these types from the store itself means that they correctly update as you add more state slices or modify middleware settings.
 
-That said, a basic setup would look like this:
+Since those are types, it's safe to export them directly from your store setup file such as `app/store.ts` and import them directly into other files.
 
-```ts title="store.ts"
+Also, you will want to create typed versions of the `useDispatch` and `useSelector` hooks for usage in your application. Since these are actual variables, not types, it's important to define them in a separate file such as `app/hooks.ts`, not the store setup file. This allows you to import them into any component file that needs to use the hooks, and avoids potential circular import dependency issues.
+
+The basic setup looks like this:
+
+```ts title="app/store.ts"
 import { configureStore } from '@reduxjs/toolkit'
 // ...
 
@@ -31,17 +34,41 @@ const store = configureStore({
   }
 })
 
+// highlight-start
+// Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
+// highlight-end
 ```
 
-```ts title="hooks.ts"
+```ts title="app/hooks.ts"
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import { RootState, AppDispatch } from './store'
 
-// for use throughout your application instead of plain `useDispatch` and `useSelector`
+// highlight-start
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>()
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+// highlight-end
+```
+
+Then, in component files, import the pre-typed hooks instead of the default hooks from React-Redux:
+
+```ts title="features/todos/TodoListItem"
+// highlight-next-line
+import {useAppSelector, useAppDispatch} from 'app/hooks';
+
+import {selectTodoById} from './todosSlice'
+
+export const TodoListItem = ({id}) => {
+  // highlight-start
+  // Don't have to declare `(state: RootState)` - already typed correctly
+  const todo = = useAppSelector(state => selectTodoById(state, id))
+  const dispatch = useAppDispatch()
+  // highlight-end
+
+  // rendering logic here
+}
 ```
 
 ## Using `configureStore` with TypeScript

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -9,13 +9,40 @@ hide_title: true
 
 Redux Toolkit is written in TypeScript, and its API is designed to enable great integration with TypeScript applications.
 
-This page is intended to give an overview of all common usecases and the most probable pitfalls you might encounter when using RTK with TypeScript.
+The first part of this page is intended to give you an overview over how to do a basic setup that every application requires. The second part goes into the specifics of the different APIs.
 
 **If you encounter any problems with the types that are not described on this page, please open an issue for discussion.**
 
+## Basic Project Setup
+
+Using [configureStore](../api/configureStore.mdx) should not need any additional typings. You will, however, want to extract the `RootState` type and the `Dispatch` type.
+Also, you will want to create typed versions of the `useDispatch` and `useSelector` hooks for usage in your application.
+
+That said, a basic setup would look like this:
+
+```ts
+import { configureStore } from '@reduxjs/toolkit'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+// ...
+
+const store = configureStore({
+  reducer: {
+    one: oneSlice.reducer,
+    two: twoSlice.reducer
+  }
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+
+// for use throughout your application instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+```
+
 ## Using `configureStore` with TypeScript
 
-Using [configureStore](../api/configureStore.mdx) should not need any additional typings. You might, however, want to extract the `RootState` type and the `Dispatch` type.
+The basics of using `configureStore` are already shown in the last section. Here are some additional details that you might find useful.
 
 ### Getting the `State` type
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,10 @@
 {
   "docs": [
-    "introduction/quick-start",
+    {
+      "type": "category",
+      "label": "Introduction",
+      "items": ["introduction/quick-start"]
+    },
     {
       "type": "category",
       "label": "Tutorials",
@@ -10,12 +14,15 @@
         "tutorials/advanced-tutorial"
       ]
     },
-    "usage/usage-guide",
-    "usage/usage-with-typescript",
+    {
+      "type": "category",
+      "label": "Using Redux Toolkit",
+      "collapsed": false,
+      "items": ["usage/usage-guide", "usage/usage-with-typescript"]
+    },
     {
       "type": "category",
       "label": "API Reference",
-      "collapsed": false,
       "items": [
         {
           "type": "category",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,46 +1,56 @@
 {
-  "docs": {
-    "Introduction": ["introduction/quick-start"],
-    "Tutorials": [
-      "tutorials/basic-tutorial",
-      "tutorials/intermediate-tutorial",
-      "tutorials/advanced-tutorial"
-    ],
-    "Using Redux Toolkit": ["usage/usage-guide", "usage/usage-with-typescript"],
-    "API Reference": [
-      {
-        "type": "category",
-        "label": "Store Setup",
-        "collapsed": false,
-        "items": [
-          "api/configureStore",
-          "api/getDefaultMiddleware",
-          "api/immutabilityMiddleware",
-          "api/serializabilityMiddleware"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "Reducers and Actions",
-        "collapsed": false,
-        "items": [
-          "api/createReducer",
-          "api/createAction",
-          "api/createSlice",
-          "api/createAsyncThunk",
-          "api/createEntityAdapter"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "Other",
-        "collapsed": false,
-        "items": [
-          "api/createSelector",
-          "api/matching-utilities",
-          "api/other-exports"
-        ]
-      }
-    ]
-  }
+  "docs": [
+    "introduction/quick-start",
+    {
+      "type": "category",
+      "label": "Tutorials",
+      "items": [
+        "tutorials/basic-tutorial",
+        "tutorials/intermediate-tutorial",
+        "tutorials/advanced-tutorial"
+      ]
+    },
+    "usage/usage-guide",
+    "usage/usage-with-typescript",
+    {
+      "type": "category",
+      "label": "API Reference",
+      "collapsed": false,
+      "items": [
+        {
+          "type": "category",
+          "label": "Store Setup",
+          "collapsed": false,
+          "items": [
+            "api/configureStore",
+            "api/getDefaultMiddleware",
+            "api/immutabilityMiddleware",
+            "api/serializabilityMiddleware"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Reducers and Actions",
+          "collapsed": false,
+          "items": [
+            "api/createReducer",
+            "api/createAction",
+            "api/createSlice",
+            "api/createAsyncThunk",
+            "api/createEntityAdapter"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Other",
+          "collapsed": false,
+          "items": [
+            "api/createSelector",
+            "api/matching-utilities",
+            "api/other-exports"
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This adds a "Basic Project Setup" section to the TS docs and also moves the quick start guide, TS docs & usage guide to the top level of the navigation.
The only two categories are now "Tutorials" and "API reference" while I directly uncollapsed the API reference part. What do you think @markerikson ?