### PR TITLE
Fix spelling errors

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -9,7 +9,7 @@ hide_title: true
 
 Redux Toolkit is written in TypeScript, and its API is designed to enable great integration with TypeScript applications.
 
-This page is intended to give an overview of all common usecases and the most probable pitfalls you might encounter when using RTK with TypeScript.
+This page is intended to give an overview of all common use cases and the most probable pitfalls you might encounter when using RTK with TypeScript.
 
 **If you encounter any problems with the types that are not described on this page, please open an issue for discussion.**
 

--- a/src/isPlainObject.ts
+++ b/src/isPlainObject.ts
@@ -1,6 +1,6 @@
 /**
  * Returns true if the passed value is "plain" object, i.e. an object whose
- * protoype is the root `Object.prototype`. This includes objects created
+ * prototype is the root `Object.prototype`. This includes objects created
  * using object literals, but not for instance for class instances.
  *
  * @param {any} value The value to inspect.


### PR DESCRIPTION
Hi there! 👋 

Fixed the following spelling mistakes:

- [x] `"usecases"` to `"use cases"`
- [x] `"protoype"` to `"prototype"`

Awesome library! 🎉 