### PR TITLE
Add "Quick Start" tutorial pages

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -1,11 +1,11 @@
 ---
-id: quick-start
-title: Quick Start
-sidebar_label: Quick Start
+id: getting-started
+title: Getting Started
+sidebar_label: Getting Started
 hide_title: true
 ---
 
-# Quick Start
+# Getting Started with Redux
 
 ## Purpose
 

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -5,11 +5,11 @@ sidebar_label: Getting Started
 hide_title: true
 ---
 
-# Getting Started with Redux
+# Getting Started with Redux Toolkit
 
 ## Purpose
 
-The **Redux Toolkit** package is intended to be the standard way to write Redux logic. It was originally created to help address three common concerns about Redux:
+The **Redux Toolkit** package is intended to be the standard way to write [Redux](https://redux.js.org) logic. It was originally created to help address three common concerns about Redux:
 
 - "Configuring a Redux store is too complicated"
 - "I have to add a lot of packages to get Redux to do anything useful"
@@ -17,23 +17,9 @@ The **Redux Toolkit** package is intended to be the standard way to write Redux 
 
 We can't solve every use case, but in the spirit of [`create-react-app`](https://github.com/facebook/create-react-app) and [`apollo-boost`](https://dev-blog.apollodata.com/zero-config-graphql-state-management-27b1f1b3c2c3), we can try to provide some tools that abstract over the setup process and handle the most common use cases, as well as include some useful utilities that will let the user simplify their application code.
 
-Because of that, this package is deliberately limited in scope. It does _not_ address concepts like "reusable encapsulated Redux modules", data caching, folder or file structures, managing entity relationships in the store, and so on.
-
-That said, **these tools should be beneficial to all Redux users**. Whether you're a brand new Redux user setting up your
+**These tools should be beneficial to all Redux users**. Whether you're a brand new Redux user setting up your
 first project, or an experienced user who wants to simplify an existing application, **Redux Toolkit** can help
 you make your Redux code better.
-
-## What's Included
-
-Redux Toolkit includes these APIs:
-
-- [`configureStore()`](../api/configureStore.mdx): wraps `createStore` to provide simplified configuration options and good defaults. It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
-- [`createReducer()`](../api/createReducer.mdx): that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements. In addition, it automatically uses the [`immer` library](https://github.com/immerjs/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
-- [`createAction()`](../api/createAction.mdx): generates an action creator function for the given action type string. The function itself has `toString()` defined, so that it can be used in place of the type constant.
-- [`createSlice()`](../api/createSlice.mdx): accepts an object of reducer functions, a slice name, and an initial state value, and automatically generates a slice reducer with corresponding action creators and action types.
-- [`createAsyncThunk`](../api/createAsyncThunk.mdx): accepts an action type string and a function that returns a promise, and generates a thunk that dispatches `pending/fulfilled/rejected` action types based on that promise
-- [`createEntityAdapter`](../api/createEntityAdapter.mdx): generates a set of reusable reducers and selectors to manage normalized data in the store
-- The [`createSelector` utility](../api/createSelector.mdx) from the [Reselect](https://github.com/reduxjs/reselect) library, re-exported for ease of use.
 
 ## Installation
 
@@ -43,6 +29,12 @@ The recommended way to start new apps with React and Redux Toolkit is by using t
 
 ```sh
 npx create-react-app my-app --template redux
+```
+
+We also have [a Redux+TS template for CRA as well](https://github.com/reduxjs/cra-template-redux-typescript):
+
+```sh
+npx create-react-app my-app --template redux-typescript
 ```
 
 ### An Existing App
@@ -59,6 +51,18 @@ yarn add @reduxjs/toolkit
 
 It is also available as a precompiled UMD package that defines a `window.RTK` global variable.
 The UMD package can be used as a [`<script>` tag](https://unpkg.com/@reduxjs/toolkit/dist/redux-toolkit.umd.js) directly.
+
+## What's Included
+
+Redux Toolkit includes these APIs:
+
+- [`configureStore()`](../api/configureStore.mdx): wraps `createStore` to provide simplified configuration options and good defaults. It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
+- [`createReducer()`](../api/createReducer.mdx): that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements. In addition, it automatically uses the [`immer` library](https://github.com/immerjs/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
+- [`createAction()`](../api/createAction.mdx): generates an action creator function for the given action type string. The function itself has `toString()` defined, so that it can be used in place of the type constant.
+- [`createSlice()`](../api/createSlice.mdx): accepts an object of reducer functions, a slice name, and an initial state value, and automatically generates a slice reducer with corresponding action creators and action types.
+- [`createAsyncThunk`](../api/createAsyncThunk.mdx): accepts an action type string and a function that returns a promise, and generates a thunk that dispatches `pending/fulfilled/rejected` action types based on that promise
+- [`createEntityAdapter`](../api/createEntityAdapter.mdx): generates a set of reusable reducers and selectors to manage normalized data in the store
+- The [`createSelector` utility](../api/createSelector.mdx) from the [Reselect](https://github.com/reduxjs/reselect) library, re-exported for ease of use.
 
 ## Help and Discussion
 

--- a/docs/tutorials/overview.md
+++ b/docs/tutorials/overview.md
@@ -12,11 +12,17 @@ hide_title: true
 
 :::tip
 
-To avoid duplicating explanations between the Redux core and Redux Toolkit documentation, we've focused on making the Redux core docs tutorials comprehensive, and point to them instead of having additional tutorials here in the Redux Toolkit docs.
+To avoid duplicating explanations between the Redux core and Redux Toolkit documentation, we've focused on making the Redux core docs tutorials comprehensive, and point to them instead of having extended tutorials here in the Redux Toolkit docs.
 
 :::
 
 See these linked tutorials to learn how to use Redux Toolkit effectively.
+
+## Redux Toolkit Quick Start
+
+The [**Redux Toolkit Quick Start tutorial**](./quick-start.md) briefly shows how to add and use Redux Toolkit in a React application.
+
+**If you just want the fastest way to get a basic example running, read the Quick Start tutorial.**
 
 ## Redux Essentials: A Real-World Example
 

--- a/docs/tutorials/overview.md
+++ b/docs/tutorials/overview.md
@@ -18,11 +18,13 @@ To avoid duplicating explanations between the Redux core and Redux Toolkit docum
 
 See these linked tutorials to learn how to use Redux Toolkit effectively.
 
-## Redux Toolkit Quick Start
+## Redux Toolkit Quick Starts
 
 The [**Redux Toolkit Quick Start tutorial**](./quick-start.md) briefly shows how to add and use Redux Toolkit in a React application.
 
 **If you just want the fastest way to get a basic example running, read the Quick Start tutorial.**
+
+We also have a [**TypeScript Quick Start tutorial**](./typescript.md) that briefly shows how to set up and use TypeScript with Redux Toolkit and React-Redux.
 
 ## Redux Essentials: A Real-World Example
 

--- a/docs/tutorials/overview.md
+++ b/docs/tutorials/overview.md
@@ -47,3 +47,11 @@ If you already know Redux and just want to know how to migrate an existing appli
 The RTK docs page on [**Usage with TypeScript**](../usage/usage-with-typescript.md) shows the basic pattern for setting up Redux Toolkit with TypeScript and React, and documents specific TS patterns for each of the RTK APIs.
 
 In addition, the [Redux + TS template for Create-React-App](https://github.com/reduxjs/cra-template-redux-typescript) comes with RTK already configured to use those TS patterns, and serves as a good example of how this should work.
+
+## Legacy Redux Toolkit Tutorials
+
+We previously had a set of "Basic/Intermediate/Advanced" tutorials directly in the Redux Toolkit docs. They were helpful, but we've removed them in favor of pointing to the "Essentials" and "Fundamentals" tutorials in the Redux core docs.
+
+If you'd like to browse the the old tutorials, you can see the content files in our repo's history:
+
+[Redux Toolkit repo: legacy "Basic/Intermediate/Advanced" tutorial files](https://github.com/reduxjs/redux-toolkit/tree/e85eb17b39/docs/tutorials)

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -9,7 +9,7 @@ hide_title: true
 
 :::tip What You'll Learn
 
-- How to set up and use Redux Toolkit
+- How to set up and use Redux Toolkit with React-Redux
 
 :::
 
@@ -30,6 +30,8 @@ Welcome to the Redux Toolkit Quick Start tutorial! **This tutorial will briefly 
 This page will focus on just how to set up a Redux application with Redux Toolkit and the main APIs you'll use. For explanations of what Redux is, how it works, and full examples of how to use Redux Toolkit, [see the tutorials linked in the "Tutorials Overview" page](./overview.md).
 
 For this tutorial, we assume that you're using Redux Toolkit with React, but you can also use it with other UI layers as well. The examples are based on [a typical Create-React-App folder structure](https://create-react-app.dev/docs/folder-structure) where all the application code is in a `src`, but the patterns can be adapted to whatever project or folder setup you're using.
+
+The [Redux+JS template for Create-React-App](https://github.com/reduxjs/cra-template-redux) comes with this same project setup already configured.
 
 ## Usage Summary
 
@@ -145,7 +147,7 @@ import { decrement, increment } from './counterSlice'
 import styles from './Counter.module.css'
 
 export function Counter() {
-  const count = useSelector(state => state.counter)
+  const count = useSelector(state => state.counter.value)
   const dispatch = useDispatch()
 
   return (
@@ -199,6 +201,8 @@ That was a brief overview of how to set up and use Redux Toolkit with React. Rec
 :::
 
 ### Full Counter App Example
+
+The counter example app shown here is also the
 
 Here's the complete counter application as a running CodeSandbox:
 

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -1,8 +1,215 @@
 ---
 id: quick-start
-title: Quick start
+title: Quick Start
 sidebar_label: Quick Start
 hide_title: true
 ---
 
 # Quick Start
+
+:::tip What You'll Learn
+
+- How to set up and use Redux Toolkit
+
+:::
+
+:::info Prerequisites
+
+- Familiarity with [ES6 syntax and features](https://www.taniarascia.com/es6-syntax-and-feature-overview/)
+- Knowledge of React terminology: [JSX](https://reactjs.org/docs/introducing-jsx.html), [State](https://reactjs.org/docs/state-and-lifecycle.html), [Function Components, Props](https://reactjs.org/docs/components-and-props.html), and [Hooks](https://reactjs.org/docs/hooks-intro.html)
+- Understanding of [Redux terms and concepts](https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow)
+
+:::
+
+## Introduction
+
+Welcome to the Redux Toolkit Quick Start tutorial! **This tutorial will briefly introduce you to Redux Toolkit and teach you how to start using it correctly**.
+
+### How to Read This Tutorial
+
+This page will focus on just how to set up a Redux application with Redux Toolkit and the main APIs you'll use. For explanations of what Redux is, how it works, and full examples of how to use Redux Toolkit, [see the tutorials linked in the "Tutorials Overview" page](./overview.md).
+
+For this tutorial, we assume that you're using Redux Toolkit with React, but you can also use it with other UI layers as well. The examples are based on [a typical Create-React-App folder structure](https://create-react-app.dev/docs/folder-structure) where all the application code is in a `src`, but the patterns can be adapted to whatever project or folder setup you're using.
+
+## Usage Summary
+
+### Install Redux Toolkit and React-Redux
+
+Add the Redux Toolkit and React-Redux packages to your project:
+
+```sh
+npm install @reduxjs/toolkit react-redux
+```
+
+### Create a Redux Store
+
+Create a file named `src/app/store.js`. Import the `configureStore` API from Redux Toolkit. We'll start by creating an empty Redux store, and exporting it:
+
+```js title="app/store.js"
+import { configureStore } from '@reduxjs/toolkit'
+
+export default configureStore({
+  reducer: {}
+})
+```
+
+This creates a Redux store, and also automatically configure the Redux DevTools extension so that you can inspect the store while developing.
+
+### Provide the Redux Store to React
+
+Once the store is created, we can make it available to our React components by putting a React-Redux `<Provider>` around our application in `src/index.js`. Import the Redux store we just created, put a `<Provider>` around your `<App>`, and pass the store as a prop:
+
+```js title="index.js"
+import React from 'react'
+import ReactDOM from 'react-dom'
+import './index.css'
+import App from './App'
+// highlight-start
+import store from './app/store'
+import { Provider } from 'react-redux'
+// highlight-end
+
+ReactDOM.render(
+  // highlight-next-line
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById('root')
+)
+```
+
+### Create a Redux State Slice
+
+Add a new file named `src/features/counter/counterSlice.js`. In that file, import the `createSlice` API from Redux Toolkit.
+
+Creating a slice requires a string name to identify the slice, an initial state value, and one or more reducer functions to define how the state can be updated. Once a slice is created, we can export the generated Redux action creators and the reducer function for the whole slice.
+
+Redux requires that [we write all state updates immutably, by making copies of data and updating the copies](https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow#immutability). However, Redux Toolkit's `createSlice` and `createReducer` APIs use [Immer](https://immerjs.github.io/immer/docs/introduction) inside to allow us to [write "mutating" update logic that becomes correct immutable updates](https://redux.js.org/tutorials/fundamentals/part-8-modern-redux#immutable-updates-with-immer).
+
+```js title="features/counter/counterSlice.js"
+import { createSlice } from '@reduxjs/toolkit'
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  initialState: {
+    value: 0
+  },
+  reducers: {
+    increment: state => {
+      // Redux Toolkit allows us to write "mutating" logic in reducers. It
+      // doesn't actually mutate the state because it uses the Immer library,
+      // which detects changes to a "draft state" and produces a brand new
+      // immutable state based off those changes
+      state.value += 1
+    },
+    decrement: state => {
+      state.value -= 1
+    },
+    incrementByAmount: (state, action) => {
+      state.value += action.payload
+    }
+  }
+})
+
+// Action creators are generated for eache case reducer function
+export const { increment, decrement, incrementByAmount } = counterSlice.actions
+
+export default counterSlice.reducer
+```
+
+### Add Slice Reducers to the Store
+
+Next, we need to import the reducer function from the counter slice and add it to our store. By defining a field inside the `reducers` parameter, we tell the store to use this slice reducer function to handle all updates to that state.
+
+```js title="app/store.js"
+import { configureStore } from '@reduxjs/toolkit'
+// highlight-next-line
+import counterReducer from '../features/counter/counterSlice'
+
+export default configureStore({
+  reducer: {
+    // highlight-next-line
+    counter: counterReducer
+  }
+})
+```
+
+### Use Redux State and Actions in React Components
+
+Now we can use the React-Redux hooks to let React components interact with the Redux store. We can read data from the store with `useSelector`, and dispatch actions using `useDispatch`. Create a `src/features/counter/Counter.js` file with a `<Counter>` component inside, then import that component into `App.js` and render it inside of `<App>`.
+
+```jsx title="features/counter/Counter.js"
+import React, { useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { decrement, increment } from './counterSlice'
+import styles from './Counter.module.css'
+
+export function Counter() {
+  const count = useSelector(state => state.counter)
+  const dispatch = useDispatch()
+
+  return (
+    <div>
+      <div>
+        <button
+          aria-label="Increment value"
+          onClick={() => dispatch(increment())}
+        >
+          Increment
+        </button>
+        <span>{count}</span>
+        <button
+          aria-label="Decrement value"
+          onClick={() => dispatch(decrement())}
+        >
+          Decrement
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+Now, any time you click the "Increment" and "Decrement buttons:
+
+- The corresponding Redux action will be dispatched to the store
+- The counter slice reducer will see the actions and update its state
+- The `<Counter>` component will see the new state value from the store and re-render itself with the new data
+
+## What You've Learned
+
+That was a brief overview of how to set up and use Redux Toolkit with React. Recapping the details:
+
+:::tip Summary
+
+- **Create a Redux store with `configureStore`**
+  - `configureStore` accepts a `reducer` function as a named argument
+  - `configureStore` automatically sets up the store with good default settings
+- **Provide the Redux store to the React application components**
+  - Put a React-Redux `<Provider>` component around your `<App />`
+  - Pass the Redux store as `<Provider store={store}>`
+- **Create a Redux "slice" reducer with `createSlice`**
+  - Call `createSlice` with a string name, an initial state, and named reducer functions
+  - Reducer functions may "mutate" the state using Immer
+  - Export the generated slice reducer and action creators
+- **Use the React-Redux `useSelector/useDispatch` hooks in React components**
+  - Read data from the store with the `useSelector` hook
+  - Get the `dispatch` function with the `useDispatch` hook, and dispatch actions as needed
+
+:::
+
+### Full Counter App Example
+
+Here's the complete counter application as a running CodeSandbox:
+
+<iframe
+  class="codesandbox"
+  src="https://codesandbox.io/embed/github/reduxjs/redux-essentials-counter-example/tree/master/?fontsize=14&hidenavigation=1&module=%2Fsrc%2Ffeatures%2Fcounter%2FcounterSlice.js&theme=dark&runonclick=1"
+  title="redux-essentials-example"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+## What's Next?
+
+We recommend going through [**the "Redux Essentials" and "Redux Fundamentals" tutorials in the Redux core docs**](https://redux.js.org/tutorials/index), which will give you a complete understanding of how Redux works, what Redux Toolkit does, and how to use it correctly.

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -1,0 +1,8 @@
+---
+id: quick-start
+title: Quick start
+sidebar_label: Quick Start
+hide_title: true
+---
+
+# Quick Start

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -5,7 +5,7 @@ sidebar_label: Quick Start
 hide_title: true
 ---
 
-# Quick Start
+# Redux Toolkit Quick Start
 
 :::tip What You'll Learn
 

--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -1,0 +1,152 @@
+---
+id: typescript
+title: TypeScript Quick Start
+sidebar_label: TypeScript Quick Start
+hide_title: true
+---
+
+# Redux Toolkit TypeScript Quick Start
+
+:::tip What You'll Learn
+
+- How to set up and use Redux Toolkit and React-Redux with TypeScript
+
+:::
+
+:::info Prerequisites
+
+- Knowledge of React [Hooks](https://reactjs.org/docs/hooks-intro.html)
+- Understanding of [Redux terms and concepts](https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow)
+- Understanding of TypeScript syntax and concepts
+
+:::
+
+## Introduction
+
+Welcome to the Redux Toolkit TypeScript Quick Start tutorial! **This tutorial will briefly show how to use TypeScript with Redux Toolkit**.
+
+This page focuses on just how to set up the TypeScript aspects . For explanations of what Redux is, how it works, and full examples of how to use Redux Toolkit, [see the tutorials linked in the "Tutorials Overview" page](./overview.md).
+
+The [Redux+TS template for Create-React-App](https://github.com/reduxjs/cra-template-redux-typescript) comes with a working example of these patterns already configured.
+
+## Project Setup
+
+### Define Root State and Dispatch Types
+
+Using [configureStore](../api/configureStore.mdx) should not need any additional typings. You will, however, want to extract the `RootState` type and the `Dispatch` type so that they can be referenced as needed. Inferring these types from the store itself means that they correctly update as you add more state slices or modify middleware settings.
+
+Since those are types, it's safe to export them directly from your store setup file such as `app/store.ts` and import them directly into other files.
+
+```ts title="app/store.ts"
+import { configureStore } from '@reduxjs/toolkit'
+// ...
+
+const store = configureStore({
+  reducer: {
+    one: oneSlice.reducer,
+    two: twoSlice.reducer
+  }
+})
+
+// highlight-start
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+// highlight-end
+```
+
+### Define Typed Hooks
+
+While it's possible to import the `RootState` and `AppDispatch` types into each component, it's better to create typed versions of the `useDispatch` and `useSelector` hooks for usage in your application. Since these are actual variables, not types, it's important to define them in a separate file such as `app/hooks.ts`, not the store setup file. This allows you to import them into any component file that needs to use the hooks, and avoids potential circular import dependency issues.
+
+```ts title="app/hooks.ts"
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import { RootState, AppDispatch } from './store'
+
+// highlight-start
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+// highlight-end
+```
+
+## Application Usage
+
+### Define Slice State and Action Types
+
+Each slice file should define a type for its initial state value, so that `createSlice` can correctly infer the type of `state` in each case reducer.
+
+All generated actions should be defined using the `PayloadAction<T>` type from Redux Toolkit, which takes the type of the `action.payload` field as its generic argument.
+
+You can safely import the `RootState` type from the store file here. It's a circular import, but the TypeScript compiler can correctly handle that for types. This may be needed for use cases like writing selector functions.
+
+```ts title="features/counter/counterSlice.ts"
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from '../../app/store'
+
+// highlight-start
+// Define a type for the slice state
+interface CounterState {
+  value: number
+}
+
+// Define the initial state using that type
+const initialState: CounterState = {
+  value: 0
+}
+// highlight-end
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  // `createSlice` will infer the state type from the `initialState` argument
+  initialState,
+  reducers: {
+    increment: state => {
+      state.value += 1
+    },
+    decrement: state => {
+      state.value -= 1
+    },
+    // highlight-start
+    // Use the PayloadAction type to declare the contents of `action.payload`
+    incrementByAmount: (state, action: PayloadAction<number>) => {
+      // highlight-end
+      state.value += action.payload
+    }
+  }
+})
+
+export const { increment, decrement, incrementByAmount } = counterSlice.actions
+
+// Other code such as selectors can use the imported `RootState` type
+export const selectCount = (state: RootState) => state.counter.value
+
+export default counterSlice.reducer
+```
+
+### Use Typed Hooks in Components
+
+In component files, import the pre-typed hooks instead of the standard hooks from React-Redux.
+
+```tsx title="features/counter/Counter.tsx"
+import React, { useState } from 'react'
+
+// highlight-next-line
+import { useAppSelector, useAppDispatch } from 'app/hooks'
+
+import { decrement, increment } from './counterSlice'
+
+export function Counter() {
+  // highlight-start
+  // The `state` arg is correctly typed as `RootState` already
+  const count = useAppSelector(state => state.counter.value)
+  const dispatch = useAppDispatch()
+  // highlight-end
+
+  // omit rendering logic
+}
+```
+
+## What's Next?
+
+See [the "Usage with TypeScript" page](../usage/usage-with-typescript.md) for extended details on how to use Redux Toolkit's APIs with TypeScript.

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -11,7 +11,7 @@ The Redux core library is deliberately unopinionated. It lets you decide how you
 
 This is good in some cases, because it gives you flexibility, but that flexibility isn't always needed. Sometimes we just want the simplest possible way to get started, with some good default behavior out of the box. Or, maybe you're writing a larger application and finding yourself writing some similar code, and you'd like to cut down on how much of that code you have to write by hand.
 
-As described in the [Quick Start](../introduction/quick-start.md) page, the goal of Redux Toolkit is to help simplify common Redux use cases. It is not intended to be a complete solution for everything you might want to do with Redux, but it should make a lot of the Redux-related code you need to write a lot simpler (or in some cases, eliminate some of the hand-written code entirely).
+As described in the [Quick Start](../introduction/getting-started.md) page, the goal of Redux Toolkit is to help simplify common Redux use cases. It is not intended to be a complete solution for everything you might want to do with Redux, but it should make a lot of the Redux-related code you need to write a lot simpler (or in some cases, eliminate some of the hand-written code entirely).
 
 Redux Toolkit exports several individual functions that you can use in your application, and adds dependencies on some other packages that are commonly used with Redux. This lets you decide how to use these in your own application, whether it be a brand new project or updating a large existing app.
 

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -7,73 +7,29 @@ hide_title: true
 
 # Usage With TypeScript
 
+:::tip What You'll Learn
+
+- Details on how to use each Redux Toolkit API with TypeScript
+
+:::
+
+## Introduction
+
 Redux Toolkit is written in TypeScript, and its API is designed to enable great integration with TypeScript applications.
 
-The first part of this page is intended to give you an overview over how to do a basic setup that every application requires. The second part goes into the specifics of the different APIs included in Redux Toolkit and how to type them correctly.
+This page provides specific details for each of the different APIs included in Redux Toolkit and how to type them correctly with TypeScript.
 
-**If you encounter any problems with the types that are not described on this page, please open an issue for discussion.**
+**See the [TypeScript Quick Start tutorial page](../tutorials/typescript.md) for a brief overview of how to set up and use Redux Toolkit and React-Redux to work with TypeScript**.
 
-## Basic Project Setup
+:::info
 
-Using [configureStore](../api/configureStore.mdx) should not need any additional typings. You will, however, want to extract the `RootState` type and the `Dispatch` type so that they can be referenced as needed. Inferring these types from the store itself means that they correctly update as you add more state slices or modify middleware settings.
+If you encounter any problems with the types that are not described on this page, please [open an issue](https://github.com/reduxjs/redux-toolkit/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) for discussion.
 
-Since those are types, it's safe to export them directly from your store setup file such as `app/store.ts` and import them directly into other files.
+:::
 
-Also, you will want to create typed versions of the `useDispatch` and `useSelector` hooks for usage in your application. Since these are actual variables, not types, it's important to define them in a separate file such as `app/hooks.ts`, not the store setup file. This allows you to import them into any component file that needs to use the hooks, and avoids potential circular import dependency issues.
+## `configureStore`
 
-The basic setup looks like this:
-
-```ts title="app/store.ts"
-import { configureStore } from '@reduxjs/toolkit'
-// ...
-
-const store = configureStore({
-  reducer: {
-    one: oneSlice.reducer,
-    two: twoSlice.reducer
-  }
-})
-
-// highlight-start
-// Infer the `RootState` and `AppDispatch` types from the store itself
-export type RootState = ReturnType<typeof store.getState>
-export type AppDispatch = typeof store.dispatch
-// highlight-end
-```
-
-```ts title="app/hooks.ts"
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
-import { RootState, AppDispatch } from './store'
-
-// highlight-start
-// Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>()
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
-// highlight-end
-```
-
-Then, in component files, import the pre-typed hooks instead of the default hooks from React-Redux:
-
-```ts title="features/todos/TodoListItem"
-// highlight-next-line
-import {useAppSelector, useAppDispatch} from 'app/hooks';
-
-import {selectTodoById} from './todosSlice'
-
-export const TodoListItem = ({id}) => {
-  // highlight-start
-  // Don't have to declare `(state: RootState)` - already typed correctly
-  const todo = = useAppSelector(state => selectTodoById(state, id))
-  const dispatch = useAppDispatch()
-  // highlight-end
-
-  // rendering logic here
-}
-```
-
-## Using `configureStore` with TypeScript
-
-The basics of using `configureStore` are already shown in the last section. Here are some additional details that you might find useful.
+The basics of using `configureStore` are shown in [TypeScript Quick Start tutorial page](../tutorials/typescript.md). Here are some additional details that you might find useful.
 
 ### Getting the `State` type
 

--- a/website/_redirects
+++ b/website/_redirects
@@ -1,7 +1,10 @@
 
 /docs/*          /:splat
 
-
+# Deleted old tutorials
 /tutorials/basic-tutorial           /tutorials/overview
 /tutorials/intermediate-tutorial    /tutorials/overview
 /tutorials/advanced-tutorial        /tutorials/overview
+
+# Renamed start page
+/introduction/quick-start           /introduction/getting-started

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -87,8 +87,8 @@ module.exports = {
       },
       items: [
         {
-          to: 'introduction/quick-start',
-          label: 'Quick Start',
+          to: 'introduction/getting-started',
+          label: 'Getting Started',
           position: 'right'
         },
         { to: 'tutorials/overview', label: 'Tutorials', position: 'right' },
@@ -112,8 +112,8 @@ module.exports = {
           title: 'Docs',
           items: [
             {
-              label: 'Quick Start',
-              to: 'introduction/quick-start'
+              label: 'Getting Started',
+              to: 'introduction/getting-started'
             },
             {
               label: 'Tutorials',

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -12,7 +12,8 @@
       "collapsed": false,
       "items": [
         "tutorials/tutorials-overview",
-        "tutorials/quick-start"
+        "tutorials/quick-start",
+        "tutorials/typescript"
       ]
     },
     {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
       "label": "Tutorials",
       "collapsed": false,
       "items": [
-        "tutorials/tutorials-overview"
+        "tutorials/tutorials-overview",
+        "tutorials/quick-start"
       ]
     },
     {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,7 +4,7 @@
       "type": "category",
       "label": "Introduction",
       "collapsed": false,
-      "items": ["introduction/quick-start"]
+      "items": ["introduction/getting-started"]
     },
     {
       "type": "category",

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -147,7 +147,7 @@ function Home() {
                 'button button--secondary button--lg',
                 styles.getStarted,
               )}
-              to={useBaseUrl('introduction/quick-start')}
+              to={useBaseUrl('introduction/getting-started')}
             >
               Get Started
             </Link>


### PR DESCRIPTION
This PR:

- Renames the existing "Intro > Quick Start" page to "Intro > Getting Started"
- Adds a new "Quick Start" tutorial page that really is just the basics of using RTK
- Adds a new "TS Quick Start" tutorial page that just shows project setup, slices, and hooks
- Removes the "Project Setup" content that was just added to the "Usage with TS" page