### PR TITLE
Docs: fix invalid typescript expression

### DIFF
--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -291,7 +291,7 @@ The standard approach is to declare an interface or type for your state, create 
 type SliceState = { state: 'loading' } | { state: 'finished'; data: string }
 
 // First approach: define the initial state using that type
-const initialState = { state: 'loading' }: SliceState
+const initialState: SliceState = { state: 'loading' }
 
 createSlice({
   name: 'test1',


### PR DESCRIPTION
Hey,

Just a fix for invalid ts expression in docs. 

[(playground)](https://www.typescriptlang.org/play?#code/C4TwDgpgBAygNgSwMYRsAhsaBeKBvKAZwywC4oByOAe3QBMEA7AcwqgF8oAffIkichQBmTBIQAWEOhQDcUOpnTliAJybMOAKE0B6HVABiCFcSjowYFbSTjydCCMbRgkqKOAJ0cPpmgBXQnUoF0xg8AhNJGpGU3dPODRfKFwCYl9BGnp1NnZyeGRUfk0gA)