### PR TITLE
Docs: fix createAsyncThunk args typo

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -113,7 +113,7 @@ When dispatched, the thunk will:
 
 ## Promise Lifecycle Actions
 
-`createAsyncThunk` will generate three Redux action creators using [`createAction`](./createAction.mdx): `pending`, `fulfilled`, and `rejected`. Each lifecycle action creator will be attached to the returned thunk action creator so that your reducer logic can reference the action types and respond to the actions when dispatched. Each action object will contain the current unique `requestId` and `args` values under `action.meta`.
+`createAsyncThunk` will generate three Redux action creators using [`createAction`](./createAction.mdx): `pending`, `fulfilled`, and `rejected`. Each lifecycle action creator will be attached to the returned thunk action creator so that your reducer logic can reference the action types and respond to the actions when dispatched. Each action object will contain the current unique `requestId` and `arg` values under `action.meta`.
 
 The action creators will have these signatures:
 


### PR DESCRIPTION
Correct `action.meta` value from `args` to `arg`.

This small typo always throws me off when I reference the docs since it comes before the formal model types 😛 .