### PR TITLE
Freeze initial state by passing through Immer

### DIFF
--- a/src/createReducer.test.ts
+++ b/src/createReducer.test.ts
@@ -90,6 +90,16 @@ describe('createReducer', () => {
         'Cannot add property text, object is not extensible'
       )
     })
+
+    test('Freezes initial state', () => {
+      const initialState = [{ text: 'Buy milk' }]
+      const todosReducer = createReducer(initialState, {})
+
+      const mutateStateOutsideReducer = () => (initialState[0].text = 'edited')
+      expect(mutateStateOutsideReducer).toThrowError(
+        /Cannot assign to read only property/
+      )
+    })
   })
 
   describe('given pure reducers with immutable updates', () => {

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -199,7 +199,7 @@ export function createReducer<S>(
       ? executeReducerBuilderCallback(mapOrBuilderCallback)
       : [mapOrBuilderCallback, actionMatchers, defaultCaseReducer]
 
-  const frozenInitialState = createNextState(initialState, draft => {})
+  const frozenInitialState = createNextState(initialState, () => {})
 
   return function(state = frozenInitialState, action): S {
     let caseReducers = [

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -199,7 +199,9 @@ export function createReducer<S>(
       ? executeReducerBuilderCallback(mapOrBuilderCallback)
       : [mapOrBuilderCallback, actionMatchers, defaultCaseReducer]
 
-  return function(state = initialState, action): S {
+  const frozenInitialState = createNextState(initialState, draft => {})
+
+  return function(state = frozenInitialState, action): S {
     let caseReducers = [
       actionsMap[action.type],
       ...finalActionMatchers


### PR DESCRIPTION
This PR:

- Updates `createReducer` to freeze the initial state by running it through Immer

Fixes #939 