### PR TITLE
Optimize dev check middleware performance

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -274,7 +274,7 @@ export interface EntityStateAdapter<T> {
 }
 
 // @public (undocumented)
-export function findNonSerializableValue(value: unknown, path?: ReadonlyArray<string>, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][], ignoredPaths?: string[]): NonSerializableValue | false;
+export function findNonSerializableValue(value: unknown, path?: string, isSerializable?: (value: unknown) => boolean, getEntries?: (value: unknown) => [string, any][], ignoredPaths?: string[]): NonSerializableValue | false;
 
 export { freeze }
 
@@ -419,6 +419,7 @@ export interface SerializableStateInvariantMiddlewareOptions {
     ignoredActionPaths?: string[];
     ignoredActions?: string[];
     ignoredPaths?: string[];
+    ignoreState?: boolean;
     isSerializable?: (value: any) => boolean;
     warnAfter?: number;
 }

--- a/src/immutablePerfBenchmarks.ts
+++ b/src/immutablePerfBenchmarks.ts
@@ -1,0 +1,256 @@
+// import Benchmark from 'benchmark'
+import { Store, MiddlewareAPI, Dispatch } from 'redux'
+import faker from 'faker'
+
+import { configureStore } from './configureStore'
+import { createSlice } from './createSlice'
+
+import {
+  createImmutableStateInvariantMiddleware,
+  tm2,
+  ImmutableStateInvariantMiddlewareOptions
+} from './immutableStateInvariantMiddleware'
+
+export class TaskInfo {
+  private _taskName: string
+  private _percentage: string | undefined
+  private _timeMillis: number
+
+  constructor(taskName: string, timeMillis: number) {
+    this._taskName = taskName
+    this._timeMillis = timeMillis
+  }
+
+  get taskName(): string {
+    return this._taskName
+  }
+
+  get timeMills(): number {
+    return this._timeMillis
+  }
+
+  get percentage(): string | undefined {
+    return this._percentage
+  }
+
+  calculatePercentage(totalTimeMillis: number): string {
+    this._percentage = ((this._timeMillis * 100) / totalTimeMillis).toFixed(2)
+    return this._percentage
+  }
+}
+
+export class StopWatch {
+  public static NoTaskMessage = 'No task info kept'
+
+  private id: string
+  private currentTaskName: string | null = null
+  private startTimeMillis = 0
+  private totalTimeMillis = 0
+  private taskList: Array<TaskInfo> = []
+
+  constructor(id = '') {
+    this.id = id
+  }
+
+  /**
+   * start a task
+   */
+  start(taskName = ''): void {
+    this.currentTaskName !== null &&
+      this.throwError("Can't start StopWatch: it's already running")
+    this.currentTaskName = taskName
+    this.startTimeMillis = Date.now()
+  }
+
+  /**
+   * stop the current task
+   */
+  stop(): void {
+    this.currentTaskName === null &&
+      this.throwError("Can't stop StopWatch: it's not running")
+    const lastTime: number = Date.now() - this.startTimeMillis
+    this.totalTimeMillis += lastTime
+    const lastTaskInfo = new TaskInfo(this.currentTaskName!, lastTime)
+    this.taskList.push(lastTaskInfo)
+    this.currentTaskName = null
+  }
+
+  /**
+   * Return a string with a table describing all tasks performed.
+   */
+  prettyPrint(): string {
+    const output: Array<string> = [this.shortSummary()]
+    if (this.taskList.length) {
+      output.push('------------------------------------------')
+      output.push('ms \t\t % \t\t Task name')
+      output.push('------------------------------------------')
+      this.taskList.forEach((task: TaskInfo) => {
+        let percentage = '0'
+        try {
+          percentage = task.calculatePercentage(this.totalTimeMillis)
+        } catch (e) {}
+        output.push(
+          `${task.timeMills} \t\t ${percentage} \t\t ${task.taskName}`
+        )
+      })
+    } else {
+      output.push(StopWatch.NoTaskMessage)
+    }
+    const outputString = output.join('\n')
+
+    console.info(outputString)
+    return outputString
+  }
+
+  /**
+   * Return a task matching the given name
+   */
+  getTask(taskName: string): TaskInfo | undefined {
+    const task = this.taskList.find(task => task.taskName === taskName)
+    if (task) {
+      task.calculatePercentage(this.totalTimeMillis)
+    }
+
+    return task
+  }
+
+  /**
+   * Return the total running time in milliseconds
+   */
+  getTotalTime(): number {
+    return this.totalTimeMillis
+  }
+
+  /**
+   * Return a short description of the total running time.
+   */
+  shortSummary(): string {
+    return `StopWatch '${this.id}' running time (millis) = ${this.totalTimeMillis}`
+  }
+
+  /**
+   * Return whether the stop watch is currently running
+   */
+  isRunning(): boolean {
+    return this.currentTaskName !== null
+  }
+
+  /**
+   * Return the number of tasks timed.
+   */
+  getTaskCount(): number {
+    return this.taskList.length
+  }
+
+  private throwError(msg: string): never {
+    throw new Error(msg)
+  }
+}
+
+/*
+let state: any
+const getState: Store['getState'] = () => state
+
+function middleware(options: ImmutableStateInvariantMiddlewareOptions = {}) {
+  return createImmutableStateInvariantMiddleware(options)({
+    getState
+  } as MiddlewareAPI)
+}
+
+const next: Dispatch = action => action
+*/
+
+function createSliceData() {
+  const people = Array.from({ length: 10000 }).map(
+    () => faker.helpers.userCard() as any
+  )
+  people.forEach(person => {
+    person.vehicles = Array.from({ length: 2 }).map(() =>
+      faker.vehicle.vehicle()
+    )
+  })
+
+  return people
+}
+
+const state: any = {
+  a: createSliceData(),
+  b: createSliceData(),
+  c: createSliceData()
+}
+
+// debugger
+// let q = 42
+
+const dummySlice = createSlice({
+  name: 'dummy',
+  initialState: state,
+  reducers: {}
+})
+
+const originalStore = configureStore({
+  reducer: dummySlice.reducer,
+  middleware: gdm =>
+    gdm({
+      // serializableCheck: false
+    })
+})
+
+function runOriginal() {
+  // const dispatch = middleware()(next)
+  // dispatch({ type: 'SOME_ACTION' })
+  originalStore.dispatch({ type: 'SOME_ACTION' })
+}
+
+const queuedStore = configureStore({
+  reducer: dummySlice.reducer,
+  middleware: gdm =>
+    gdm({
+      // serializableCheck: false,
+      immutableCheck: {
+        trackFunction: tm2
+      }
+    })
+})
+
+function runQueued() {
+  queuedStore.dispatch({ type: 'SOME_ACTION' })
+}
+/*
+const suite = new Benchmark.Suite('abcd', {
+  setup() {
+    state = {
+      a: createSliceData(),
+      b: createSliceData(),
+      c: createSliceData()
+    }
+  }
+})
+
+suite
+  .add('Original', )
+  .add('Queued', )
+  .on('cycle', function(event: any) {
+    console.log(String(event.target))
+  })
+  .on('complete', function(this: any) {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({})
+*/
+
+const stopwatch = new StopWatch()
+
+stopwatch.start('Original')
+runOriginal()
+stopwatch.stop()
+
+stopwatch.start('Queued')
+runQueued()
+stopwatch.stop()
+
+// debugger
+
+stopwatch.prettyPrint()
+
+// let z = q

--- a/src/immutableStateInvariantMiddleware.test.ts
+++ b/src/immutableStateInvariantMiddleware.test.ts
@@ -184,7 +184,7 @@ describe('trackForMutations', () => {
 
       expect(tracker.detectMutations()).toEqual({
         wasMutated: true,
-        path: spec.path
+        path: spec.path.join('.')
       })
     })
   }

--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -443,6 +443,21 @@ describe('serializableStateInvariantMiddleware', () => {
     `)
   })
 
+  it('allows ignoring state entirely', () => {
+    const badValue = new Map()
+    const reducer = () => badValue
+    configureStore({
+      reducer,
+      middleware: [
+        createSerializableStateInvariantMiddleware({
+          ignoreState: true
+        })
+      ]
+    }).dispatch({ type: 'test' })
+
+    expect(getLog().log).toMatchInlineSnapshot(`""`)
+  })
+
   it('Should print a warning if execution takes too long', () => {
     const reducer: Reducer = (state = 42, action) => {
       return state

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -12,12 +12,13 @@ import { getTimeMeasureUtils } from './utils'
  * @public
  */
 export function isPlain(val: any) {
+  const type = typeof val
   return (
-    typeof val === 'undefined' ||
+    type === 'undefined' ||
     val === null ||
-    typeof val === 'string' ||
-    typeof val === 'boolean' ||
-    typeof val === 'number' ||
+    type === 'string' ||
+    type === 'boolean' ||
+    type === 'number' ||
     Array.isArray(val) ||
     isPlainObject(val)
   )
@@ -33,7 +34,7 @@ interface NonSerializableValue {
  */
 export function findNonSerializableValue(
   value: unknown,
-  path: ReadonlyArray<string> = [],
+  path: string = '',
   isSerializable: (value: unknown) => boolean = isPlain,
   getEntries?: (value: unknown) => [string, any][],
   ignoredPaths: string[] = []
@@ -42,7 +43,7 @@ export function findNonSerializableValue(
 
   if (!isSerializable(value)) {
     return {
-      keyPath: path.join('.') || '<root>',
+      keyPath: path || '<root>',
       value: value
     }
   }
@@ -55,16 +56,16 @@ export function findNonSerializableValue(
 
   const hasIgnoredPaths = ignoredPaths.length > 0
 
-  for (const [property, nestedValue] of entries) {
-    const nestedPath = path.concat(property)
+  for (const [key, nestedValue] of entries) {
+    const nestedPath = path ? path + '.' + key : key // path.concat(property)
 
-    if (hasIgnoredPaths && ignoredPaths.indexOf(nestedPath.join('.')) >= 0) {
+    if (hasIgnoredPaths && ignoredPaths.indexOf(nestedPath) >= 0) {
       continue
     }
 
     if (!isSerializable(nestedValue)) {
       return {
-        keyPath: nestedPath.join('.'),
+        keyPath: nestedPath,
         value: nestedValue
       }
     }
@@ -167,7 +168,7 @@ export function createSerializableStateInvariantMiddleware(
     measureUtils.measureTime(() => {
       const foundActionNonSerializableValue = findNonSerializableValue(
         action,
-        [],
+        '',
         isSerializable,
         getEntries,
         ignoredActionPaths
@@ -194,7 +195,7 @@ export function createSerializableStateInvariantMiddleware(
 
       const foundStateNonSerializableValue = findNonSerializableValue(
         state,
-        [],
+        '',
         isSerializable,
         getEntries,
         ignoredPaths

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -214,11 +214,10 @@ export function createSerializableStateInvariantMiddleware(
           console.error(
             `A non-serializable value was detected in the state, in the path: \`${keyPath}\`. Value:`,
             value,
-          `
+            `
 Take a look at the reducer(s) handling this action type: ${action.type}.
 (See https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state)`
-        
-)
+          )
         }
       })
 

--- a/tsconfig.perf.json
+++ b/tsconfig.perf.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "outDir": "dist",
+    "strict": true,
+    "target": "es2018",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/*.test.ts"]
+}


### PR DESCRIPTION
This PR:

- Optimizes the immutability middleware by:
    - assuming that frozen objects are immutable, which lets us bail out immediately in most cases with Immer
    - replacing array keypaths with strings
    - Tweaking a couple loops
- Optimizes the serializability middleware by:
    - replacing array keypaths with strings
- Adds a new `ignoreState` option to the serializability middleware that skips checking state entirely

Fixes #885 and fixes #926 .