### PR TITLE
[DRAFT] Experiment: Add "indices" to entity adapter

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -144,10 +144,7 @@ export function createAsyncThunk<Returned, ThunkArg = void, ThunkApiConfig exten
 export const createDraftSafeSelector: typeof createSelector;
 
 // @public (undocumented)
-export function createEntityAdapter<T>(options?: {
-    selectId?: IdSelector<T>;
-    sortComparer?: false | Comparer<T>;
-}): EntityAdapter<T>;
+export function createEntityAdapter<T>(options?: EntityDefinition<T>): EntityAdapter<T>;
 
 // @public
 export function createImmutableStateInvariantMiddleware(options?: ImmutableStateInvariantMiddlewareOptions): Middleware;
@@ -230,6 +227,8 @@ export interface EntityState<T> {
     entities: Dictionary<T>;
     // (undocumented)
     ids: EntityId[];
+    // (undocumented)
+    indices: Indices<T, IndexComparers<T>>;
 }
 
 // @public (undocumented)

--- a/src/entities/create_adapter.ts
+++ b/src/entities/create_adapter.ts
@@ -1,7 +1,6 @@
 import {
   EntityDefinition,
   Comparer,
-  IdSelector,
   EntityAdapter,
   IndexComparers
 } from './models'
@@ -16,11 +15,11 @@ import { createUnsortedStateAdapter } from './unsorted_state_adapter'
  *
  * @public
  */
-export function createEntityAdapter<
-  T,
-  IC extends IndexComparers<T> = IndexComparers<unknown>
->(options?: EntityDefinition<T, IC>): EntityAdapter<T> {
-  const { selectId, sortComparer, indices = {} as IC } = {
+
+export function createEntityAdapter<T>(
+  options?: EntityDefinition<T>
+): EntityAdapter<T> {
+  const { selectId, sortComparer, indices = {} as IndexComparers<T> } = {
     sortComparer: false as const,
     selectId: (instance: any) => instance.id,
     ...options

--- a/src/entities/create_adapter.ts
+++ b/src/entities/create_adapter.ts
@@ -1,4 +1,10 @@
-import { EntityDefinition, Comparer, IdSelector, EntityAdapter } from './models'
+import {
+  EntityDefinition,
+  Comparer,
+  IdSelector,
+  EntityAdapter,
+  IndexComparers
+} from './models'
 import { createInitialStateFactory } from './entity_state'
 import { createSelectorsFactory } from './state_selectors'
 import { createSortedStateAdapter } from './sorted_state_adapter'
@@ -10,22 +16,20 @@ import { createUnsortedStateAdapter } from './unsorted_state_adapter'
  *
  * @public
  */
-export function createEntityAdapter<T>(
-  options: {
-    selectId?: IdSelector<T>
-    sortComparer?: false | Comparer<T>
-  } = {}
-): EntityAdapter<T> {
-  const { selectId, sortComparer }: EntityDefinition<T> = {
-    sortComparer: false,
+export function createEntityAdapter<
+  T,
+  IC extends IndexComparers<T> = IndexComparers<unknown>
+>(options?: EntityDefinition<T, IC>): EntityAdapter<T> {
+  const { selectId, sortComparer, indices = {} as IC } = {
+    sortComparer: false as const,
     selectId: (instance: any) => instance.id,
     ...options
   }
 
-  const stateFactory = createInitialStateFactory<T>()
+  const stateFactory = createInitialStateFactory<T, IndexComparers<T>>(indices)
   const selectorsFactory = createSelectorsFactory<T>()
   const stateAdapter = sortComparer
-    ? createSortedStateAdapter(selectId, sortComparer)
+    ? createSortedStateAdapter(selectId, sortComparer as Comparer<T>)
     : createUnsortedStateAdapter(selectId)
 
   return {

--- a/src/entities/entity_state.test.ts
+++ b/src/entities/entity_state.test.ts
@@ -6,6 +6,18 @@ import { BookModel } from './fixtures/book'
 describe('Entity State', () => {
   let adapter: EntityAdapter<BookModel>
 
+  const adapter2 = createEntityAdapter<BookModel>({
+    selectId: (book: BookModel) => book.id,
+    indices: {
+      // TODO These should be BookModel, not unknown
+      id: (a, b) => a.id.localeCompare(b.id)
+    }
+  })
+
+  const tempState = adapter2.getInitialState()
+  // TODO should be an empty array
+  console.log(tempState.indices.id)
+
   beforeEach(() => {
     adapter = createEntityAdapter({
       selectId: (book: BookModel) => book.id
@@ -17,7 +29,8 @@ describe('Entity State', () => {
 
     expect(initialState).toEqual({
       ids: [],
-      entities: {}
+      entities: {},
+      indices: {}
     })
   })
 
@@ -29,7 +42,8 @@ describe('Entity State', () => {
     expect(initialState).toEqual({
       ...additionalProperties,
       ids: [],
-      entities: {}
+      entities: {},
+      indices: {}
     })
   })
 

--- a/src/entities/entity_state.ts
+++ b/src/entities/entity_state.ts
@@ -1,19 +1,33 @@
-import { EntityState } from './models'
+import { EntityState, IndexComparers, BasicObject, Indices } from './models'
 
-export function getInitialEntityState<V>(): EntityState<V> {
+export function getInitialEntityState<V, IC extends IndexComparers<V>>(
+  indexComparers: IC
+): EntityState<V, IC> {
+  const indices = {} as Indices<V, IC>
+
+  for (let key in indexComparers) {
+    indices[key] = []
+  }
+
   return {
     ids: [],
-    entities: {}
+    entities: {},
+    indices
   }
 }
 
-export function createInitialStateFactory<V>() {
+export function createInitialStateFactory<V, IC extends IndexComparers<V>>(
+  indexComparers: IC
+) {
   function getInitialState(): EntityState<V>
   function getInitialState<S extends object>(
     additionalState: S
   ): EntityState<V> & S
   function getInitialState(additionalState: any = {}): any {
-    return Object.assign(getInitialEntityState(), additionalState)
+    return Object.assign(
+      getInitialEntityState(indexComparers as any),
+      additionalState
+    )
   }
 
   return { getInitialState }

--- a/src/entities/entity_state.ts
+++ b/src/entities/entity_state.ts
@@ -1,8 +1,8 @@
-import { EntityState, IndexComparers, BasicObject, Indices } from './models'
+import { EntityState, IndexComparers, Indices } from './models'
 
 export function getInitialEntityState<V, IC extends IndexComparers<V>>(
   indexComparers: IC
-): EntityState<V, IC> {
+): EntityState<V> {
   const indices = {} as Indices<V, IC>
 
   for (let key in indexComparers) {

--- a/src/entities/indexers.test.ts
+++ b/src/entities/indexers.test.ts
@@ -1,0 +1,552 @@
+import { bisect, numberCmp, Index, Indexer, Keyer } from './indexers'
+
+declare function require(m: string): any
+var assert = require('assert')
+
+function attributeKeyer<O>(...k: (keyof O)[]): Keyer<O> {
+  return function(o: O) {
+    return k.map(a => o[a])
+  }
+}
+
+interface Cup {
+  size: number
+  color: string
+  id: number
+}
+
+type CupIndexes = {
+  byColorAndSize: Index<Cup>
+  bySize: Index<Cup>
+  byId: Index<Cup>
+  bySizeOfColorBiggest: Index<Cup>
+}
+
+let indexer = new Indexer<Cup, CupIndexes>('byId')
+indexer.addIndex('byId', attributeKeyer<Cup>('id'))
+indexer.addIndex('byColorAndSize', attributeKeyer<Cup>('color', 'size'))
+indexer.addIndex('bySize', attributeKeyer<Cup>('size'))
+indexer.addGroupedIndex(
+  'bySizeOfColorBiggest',
+  attributeKeyer<Cup>('size'),
+  'byColorAndSize',
+  attributeKeyer<Cup>('color'),
+  (iter, reverseIter) => {
+    return reverseIter()
+  }
+)
+
+let lastCupId = 0
+const firstCup = { size: 0, color: 'a', id: lastCupId } as Cup
+
+function largeCupThan(cup: Cup) {
+  return { ...cup, id: ++lastCupId, size: cup.size + 1 }
+}
+
+function shrinkCup(cup: Cup) {
+  return { ...cup, size: cup.size - 1 }
+}
+
+function shareColorWith(cup: Cup, cup2: Cup) {
+  return { ...cup, color: cup2.color }
+}
+
+function smallerCupThan(cup: Cup) {
+  return { ...cup, id: ++lastCupId, size: cup.size - 1 }
+}
+
+function differentColorThan(cup: Cup) {
+  return { ...cup, id: ++lastCupId, color: cup.color + 'a' }
+}
+
+function similarCup(cup: Cup) {
+  return { ...cup, id: ++lastCupId }
+}
+
+function accumulate(index: Index<Cup>) {
+  let result = [] as Cup[]
+  let iterator = Indexer.iterator(index)
+  for (let v = iterator(); v; v = iterator()) {
+    result.push(v)
+  }
+  return result
+}
+
+function reverseAccumulate(
+  index: Index<Cup>,
+  startKey?: any[],
+  endKey?: any[]
+): Cup[] {
+  let result = [] as Cup[]
+  let iterator = Indexer.reverseIter(index, startKey, endKey)
+  for (let v = iterator(); v; v = iterator()) {
+    result.push(v)
+  }
+  return result
+}
+
+let indexes: CupIndexes
+let previousIndexes: CupIndexes | undefined
+
+function assertReferenceChanges(newIndexes: CupIndexes) {
+  assert.notStrictEqual(newIndexes, indexes, 'reference should change')
+  previousIndexes = indexes
+  indexes = newIndexes
+  return indexes
+}
+
+function assertReferenceDoesNotChange(newStore: CupIndexes) {
+  assert.strictEqual(newStore, indexes, 'reference should not change')
+  return indexes
+}
+
+describe('Indexers', () => {
+  beforeEach(() => {
+    indexes = indexer.empty()
+    previousIndexes = undefined
+  })
+
+  test('bisect finds the correct insert index', () => {
+    const ids = [1, 4, 9, 12, 27]
+
+    function subject(targetNumber: number) {
+      return bisect(ids, targetNumber, numberCmp)
+    }
+
+    assert.equal(subject(11), 3)
+    assert.equal(subject(3), 1)
+    assert.equal(subject(-1), 0)
+    assert.equal(subject(100), 5)
+  })
+
+  test('add / remove', () => {
+    assertReferenceDoesNotChange(indexer.removeByPk(indexes, [12]))
+
+    const cup1 = firstCup
+    const cup2 = differentColorThan(largeCupThan(cup1))
+    const cup3 = smallerCupThan(similarCup(cup2))
+    const cup4 = largeCupThan(largeCupThan(cup1))
+    const cup5 = largeCupThan(largeCupThan(cup3))
+    const overwrittenCup3 = { ...cup3 }
+    overwrittenCup3.size = 5000
+
+    assertReferenceChanges(indexer.update(indexes, [cup2]))
+    assert.notStrictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.update(indexes, [cup1]))
+    assert.notStrictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.update(indexes, [cup4]))
+    assert.notStrictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.update(indexes, [overwrittenCup3, cup3]))
+    assert.strictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    let loaded = indexes
+
+    assertReferenceDoesNotChange(indexer.removeByPk(indexes, [cup5.id]))
+
+    assert.deepEqual(
+      accumulate(indexes.byId),
+      [cup1, cup2, cup3, cup4],
+      'keeps cups organized by id'
+    )
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [cup1, cup4, cup3, cup2],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [cup1, cup3, cup2, cup4],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [cup2, cup4],
+      'keeps cups organized by size of per color biggest'
+    )
+
+    assert.strictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.removeByPk(indexes, [cup2.id]))
+    assert.deepEqual(
+      accumulate(indexes.byId),
+      [cup1, cup3, cup4],
+      'keeps cups organize by id'
+    )
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [cup1, cup4, cup3],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [cup1, cup3, cup4],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [cup3, cup4],
+      'keeps cups organized by size of per color biggest'
+    )
+    assert.notStrictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.removeByPk(indexes, [cup1.id]))
+    assert.deepEqual(
+      accumulate(indexes.byId),
+      [cup3, cup4],
+      'keeps cups organized by id'
+    )
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [cup4, cup3],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [cup3, cup4],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [cup3, cup4],
+      'keeps cups organized by size of per color biggest'
+    )
+    assert.strictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceDoesNotChange(indexer.removeByPk(indexes, [cup1.id]))
+    assert.deepEqual(
+      accumulate(indexes.byId),
+      [cup3, cup4],
+      'keeps cups organized by id'
+    )
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [cup4, cup3],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [cup3, cup4],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [cup3, cup4],
+      'keeps cups organized by size of per color biggest'
+    )
+    assert.strictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.removeByPk(indexes, [cup3.id]))
+    assert.deepEqual(
+      accumulate(indexes.byId),
+      [cup4],
+      'keeps cups organized by id'
+    )
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [cup4],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [cup4],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [cup4],
+      'keeps cups organized by size of per color biggest'
+    )
+    assert.notStrictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    assertReferenceChanges(indexer.removeByPk(indexes, [cup4.id]))
+    assert.deepEqual(accumulate(indexes.byId), [], 'keeps cups organized by id')
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [],
+      'keeps cups organized by size of per color biggest'
+    )
+    assert.notStrictEqual(
+      indexes.bySizeOfColorBiggest,
+      previousIndexes!.bySizeOfColorBiggest
+    )
+
+    indexes = loaded
+    assertReferenceChanges(
+      indexer.removeAll(indexes, [cup5, cup1, cup2, cup1, cup2])
+    )
+    assert.deepEqual(
+      accumulate(indexes.byId),
+      [cup3, cup4],
+      'keeps cups organized by id'
+    )
+    assert.deepEqual(
+      accumulate(indexes.byColorAndSize),
+      [cup4, cup3],
+      'keeps cups organized by color and size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySize),
+      [cup3, cup4],
+      'keeps cups organized by size'
+    )
+    assert.deepEqual(
+      accumulate(indexes.bySizeOfColorBiggest),
+      [cup3, cup4],
+      'keeps cups organized by size of per color biggest'
+    )
+  })
+
+  test('update managing indexes', () => {
+    let cup1 = firstCup
+    let cup2 = differentColorThan(cup1)
+    let cup3 = differentColorThan(cup1)
+
+    let cup4 = largeCupThan(cup1)
+    let cup5 = smallerCupThan(cup2)
+    let cup6 = largeCupThan(cup3)
+    let cup7 = largeCupThan(cup6)
+
+    let unusedCup2 = shrinkCup(cup2)
+    let unusedCup22 = shrinkCup(unusedCup2)
+    let unusedCup5 = { ...cup5 }
+    unusedCup5.size = 9999
+
+    assertReferenceChanges(
+      indexer.update(indexes, [
+        unusedCup2,
+        cup6,
+        unusedCup22,
+        cup4,
+        cup2,
+        cup3,
+        cup5,
+        unusedCup5,
+        cup5,
+        cup7,
+        cup3,
+        cup1
+      ])
+    )
+
+    assert.deepEqual(accumulate(indexes.byId), [
+      cup1,
+      cup2,
+      cup3,
+      cup4,
+      cup5,
+      cup6,
+      cup7
+    ])
+    assert.deepEqual(accumulate(indexes.byColorAndSize), [
+      cup1,
+      cup4,
+      cup5,
+      cup2,
+      cup3,
+      cup6,
+      cup7
+    ])
+    assert.deepEqual(accumulate(indexes.bySize), [
+      cup5,
+      cup1,
+      cup2,
+      cup3,
+      cup4,
+      cup6,
+      cup7
+    ])
+
+    let oldCup4 = cup4
+    cup4 = shrinkCup(shrinkCup(cup4))
+    assertReferenceChanges(indexer.update(indexes, [oldCup4, cup4]))
+    assert.deepEqual(accumulate(indexes.byId), [
+      cup1,
+      cup2,
+      cup3,
+      cup4,
+      cup5,
+      cup6,
+      cup7
+    ])
+    assert.deepEqual(accumulate(indexes.byColorAndSize), [
+      cup4,
+      cup1,
+      cup5,
+      cup2,
+      cup3,
+      cup6,
+      cup7
+    ])
+    assert.deepEqual(accumulate(indexes.bySize), [
+      cup4,
+      cup5,
+      cup1,
+      cup2,
+      cup3,
+      cup6,
+      cup7
+    ])
+
+    cup7 = shareColorWith(cup7, cup4)
+    assertReferenceChanges(indexer.update(indexes, [cup2, cup7, cup7]))
+    assert.deepEqual(accumulate(indexes.byId), [
+      cup1,
+      cup2,
+      cup3,
+      cup4,
+      cup5,
+      cup6,
+      cup7
+    ])
+    assert.deepEqual(accumulate(indexes.byColorAndSize), [
+      cup4,
+      cup1,
+      cup7,
+      cup5,
+      cup2,
+      cup3,
+      cup6
+    ])
+    assert.deepEqual(accumulate(indexes.bySize), [
+      cup4,
+      cup5,
+      cup1,
+      cup2,
+      cup3,
+      cup6,
+      cup7
+    ])
+  })
+
+  test('reverseIter', () => {
+    let cup1 = firstCup
+    let cup2 = smallerCupThan(cup1)
+    let cup3 = smallerCupThan(cup2)
+    let cup4 = smallerCupThan(cup3)
+    let cup5 = smallerCupThan(cup4)
+
+    assertReferenceChanges(indexer.update(indexes, [cup2, cup1, cup3]))
+    assertReferenceChanges(indexer.update(indexes, [cup5, cup4]))
+
+    assert.deepEqual(
+      reverseAccumulate(
+        indexes.bySize,
+        [cup2.size, Infinity],
+        [cup4.size, cup4.id, 'a']
+      ),
+      [cup2, cup3]
+    )
+    assert.deepEqual(
+      reverseAccumulate(
+        indexes.bySize,
+        [cup2.size, Infinity],
+        [cup4.size, cup4.id]
+      ),
+      [cup2, cup3]
+    )
+    assert.deepEqual(
+      reverseAccumulate(
+        indexes.bySize,
+        [cup2.size, Infinity],
+        [cup4.size - 0.1]
+      ),
+      [cup2, cup3, cup4]
+    )
+    assert.deepEqual(
+      reverseAccumulate(
+        indexes.bySize,
+        [cup2.size, Infinity],
+        [cup2.size, Infinity]
+      ),
+      []
+    )
+    assert.deepEqual(reverseAccumulate(indexes.bySize, [cup3.size, Infinity]), [
+      cup3,
+      cup4,
+      cup5
+    ])
+    assert.deepEqual(reverseAccumulate(indexes.bySize), [
+      cup1,
+      cup2,
+      cup3,
+      cup4,
+      cup5
+    ])
+  })
+
+  test('performance', () => {
+    let cups = [] as Cup[]
+
+    function randomColor() {
+      let v = Math.random()
+
+      if (v < 0.1) return 'red'
+      if (v < 0.25) return 'orange'
+      if (v < 0.45) return 'blue'
+      if (v < 0.6) return 'green'
+      if (v < 9) return 'yellow'
+      return 'purple'
+    }
+
+    for (let i = 0; i < 2500; ++i) {
+      cups.push({
+        id: ++lastCupId,
+        color: randomColor(),
+        size: Math.floor(Math.random() * 74832)
+      })
+    }
+
+    let start = Date.now()
+    cups.forEach(cup => {
+      indexes = indexer.update(indexes, [cup])
+    })
+
+    cups.forEach(cup => {
+      indexes = indexer.removeByPk(indexes, [cup.id])
+    })
+
+    let time = Date.now() - start
+
+    console.log('Permonace: 2500 inserts and removals in', time, 'ms')
+  })
+})

--- a/src/entities/indexers.test.ts
+++ b/src/entities/indexers.test.ts
@@ -31,7 +31,7 @@ indexer.addGroupedIndex(
   attributeKeyer<Cup>('size'),
   'byColorAndSize',
   attributeKeyer<Cup>('color'),
-  (iter, reverseIter) => {
+  (_iter, reverseIter) => {
     return reverseIter()
   }
 )

--- a/src/entities/indexers.test.ts
+++ b/src/entities/indexers.test.ts
@@ -514,7 +514,7 @@ describe('Indexers', () => {
     ])
   })
 
-  test('performance', () => {
+  test.skip('performance', () => {
     let cups = [] as Cup[]
 
     function randomColor() {

--- a/src/entities/indexers.ts
+++ b/src/entities/indexers.ts
@@ -1,0 +1,352 @@
+export function bisect<T, E>(
+  array: T[],
+  e: E,
+  cmp: (a: E, b: T) => number,
+  l = 0,
+  r = array.length
+) {
+  let mid: number
+  let c: number
+
+  while (l < r) {
+    mid = (l + r) >>> 1
+    c = cmp(e, array[mid])
+    if (c > 0) {
+      l = mid + 1
+    } else {
+      r = mid
+    }
+  }
+
+  return l
+}
+
+export function arrayCmp(a: any[], b: any[]): number {
+  for (let i = 0; i < a.length && i < b.length; ++i) {
+    let aVal = a[i]
+    let bVal = b[i]
+
+    if (aVal === bVal) continue
+
+    if (bVal === Infinity) return -1
+    if (aVal === Infinity) return 1
+    if (aVal == null) return -1
+    if (bVal == null) return 1
+    if (aVal < bVal) return -1
+    return 1
+  }
+
+  if (a.length === b.length) return 0
+  if (a.length > b.length) return 1
+  return -1
+}
+
+export function numberCmp(a: number, b: number) {
+  return a - b
+}
+
+export type Entry<V> = [any[], V]
+export type Index<V> = Entry<V>[]
+export type IndexStore<V> = { [k: string]: Index<V> }
+export type Keyer<V> = (v: V) => any[]
+export type IndexIterator<V> = () => V | void
+export type GroupReducer<V> = (
+  iter: IndexIterator<V>,
+  reverseIter: IndexIterator<V>
+) => V | void
+
+function cmpKeyToEntry(a: any[], b: Entry<any>) {
+  return arrayCmp(a, b[0])
+}
+
+export class Indexer<V, I extends IndexStore<V>> {
+  private indexKeyers = {} as Record<keyof I, Keyer<V>> // { [k: keyof I]: Keyer<V> }
+  private indexDependentGroup = {} as Record<keyof I, string> // { [k: string]: string }
+  private indexGroupKeyers = {} as Record<keyof I, Keyer<V>> // { [k: string]: Keyer<V> }
+  private indexReducers = {} as Record<keyof I, GroupReducer<V>> // { [k: string]: GroupReducer<V> }
+  private indexes = [] as (keyof I)[]
+
+  constructor(private mainIndexName: keyof I) {}
+
+  addIndex(attr: keyof I, keyer: Keyer<V>) {
+    if (attr in this.indexKeyers) {
+      throw new Error('duplicate definition for index ' + attr)
+    }
+    this.indexKeyers[attr] = keyer
+    this.indexes.push(attr)
+  }
+
+  addGroupedIndex(
+    attr: keyof I,
+    keyer: Keyer<V>,
+    groupAttr: keyof I,
+    groupKeyer: Keyer<V>,
+    reducer: GroupReducer<V>
+  ) {
+    if (!this.indexKeyers[groupAttr]) {
+      throw new Error(
+        'Dependent index ' + groupAttr + ' should be defined before ' + attr
+      )
+    }
+    this.addIndex(attr, keyer)
+
+    // @ts-ignore TODO Fix this
+    this.indexDependentGroup[attr] = groupAttr
+    this.indexGroupKeyers[attr] = groupKeyer
+    this.indexReducers[attr] = reducer
+  }
+
+  // @ts-ignore TODO Fix this
+  private _empty: I
+
+  matchesInitialState(initialState: I) {
+    return this._empty === initialState
+  }
+
+  empty(): I {
+    if (this._empty) return this._empty
+
+    let result = (this._empty = {} as I)
+    for (let k in this.indexKeyers) {
+      // @ts-ignore TODO Fix this
+      result[k] = []
+    }
+
+    return result
+  }
+
+  removeAll(indexes: I, values: V[]) {
+    return this.splice(indexes, values, [])
+  }
+
+  removeByPk(indexes: I, primaryKey: any[]): I {
+    return this.removeAll(
+      indexes,
+      Indexer.getAllMatching(indexes[this.mainIndexName], primaryKey)
+    )
+  }
+
+  update(indexes: I, values: V[]): I {
+    let oldValues = [] as V[]
+    let newValues = [] as V[]
+
+    let uniqueValues = uniqueIndex(this.indexKeyers[this.mainIndexName], values)
+    uniqueValues.forEach(v => {
+      let existing = Indexer.getFirstMatching(indexes[this.mainIndexName], v[0])
+      if (existing) oldValues.push(existing)
+      newValues.push(v[1])
+    })
+
+    return this.splice(indexes, oldValues, newValues)
+  }
+
+  static iterator<V>(
+    index: Index<V>,
+    startKey?: any[],
+    endKey?: any[]
+  ): IndexIterator<V> {
+    let { startIdx, endIdx } = Indexer.getRangeFrom(index, startKey, endKey)
+    let idx = startIdx
+
+    return () => {
+      if (idx < endIdx) {
+        return index[idx++][1]
+      }
+    }
+  }
+
+  static reverseIter<V>(
+    index: Index<V>,
+    startKey?: any[],
+    endKey?: any[]
+  ): IndexIterator<V> {
+    if (startKey) startKey = startKey.concat([undefined])
+    if (endKey) endKey = endKey.concat([undefined])
+
+    let { startIdx, endIdx } = Indexer.getRangeFrom(index, endKey, startKey)
+    let idx = endIdx
+
+    return () => {
+      if (idx > startIdx) {
+        return index[--idx][1]
+      }
+    }
+  }
+
+  static getAllMatching<V>(index: Index<V>, key: any[]): V[] {
+    let { startIdx, endIdx } = Indexer.getRangeFrom(
+      index,
+      key,
+      key.concat([Infinity])
+    )
+    return index.slice(startIdx, endIdx).map(([_, value]) => value)
+  }
+
+  static getAllUniqueMatchingAnyOf<V>(index: Index<V>, keys: any[][]): V[] {
+    let result = [] as V[]
+    let retrievedIdxs = new Int8Array(index.length)
+
+    for (let key of keys) {
+      let { startIdx, endIdx } = Indexer.getRangeFrom(
+        index,
+        key,
+        key.concat([Infinity])
+      )
+      for (; startIdx < endIdx; ++startIdx) {
+        if (retrievedIdxs[startIdx]) continue
+        retrievedIdxs[startIdx] = 1
+        result.push(index[startIdx][1])
+      }
+    }
+
+    return result
+  }
+
+  static getRangeFrom(index: Index<any>, startKey?: any[], endKey?: any[]) {
+    let startIdx: number
+    let endIdx: number
+
+    if (startKey == null) {
+      startIdx = 0
+    } else {
+      startIdx = bisect<Entry<any>, any[]>(index, startKey, cmpKeyToEntry)
+    }
+
+    if (endKey == null) {
+      endIdx = index.length
+    } else {
+      endIdx = bisect<Entry<any>, any[]>(index, endKey, cmpKeyToEntry)
+    }
+
+    return { startIdx, endIdx }
+  }
+
+  static getFirstMatching<V>(index: Index<V>, key: any[]): V | void {
+    let iter = Indexer.iterator(index, key, key.concat([Infinity]))
+    return iter()
+  }
+
+  private splice(indexes: I, removeValues: V[], addValues: V[]) {
+    let oldIndexes = indexes
+    if (!removeValues.length && !addValues.length) {
+      return indexes
+    }
+
+    indexes = { ...(indexes as any) }
+
+    for (let indexName of this.indexes) {
+      let index = indexes[indexName]
+      let valuesToRemove = removeValues
+      let valuesToAdd = addValues
+
+      const groupIndexName = this.indexDependentGroup[indexName]
+      if (groupIndexName) {
+        let groupKeyer = this.indexGroupKeyers[indexName]
+        let reducer = this.indexReducers[indexName]
+
+        let updateGroups = uniqueIndex(
+          groupKeyer,
+          valuesToRemove.concat(valuesToAdd)
+        )
+        valuesToRemove = []
+        valuesToAdd = []
+
+        for (let updateGroup of updateGroups) {
+          let updateGroupKey = updateGroup[0]
+          const prevGroupIndex = oldIndexes[groupIndexName]
+          let iter = Indexer.iterator(
+            prevGroupIndex,
+            updateGroupKey,
+            updateGroupKey.concat([Infinity])
+          )
+          let reverseIter = Indexer.reverseIter(
+            prevGroupIndex,
+            updateGroupKey.concat([Infinity]),
+            updateGroupKey
+          )
+          let remove = reducer(iter, reverseIter)
+
+          const curGroupIndex = indexes[groupIndexName]
+          iter = Indexer.iterator(
+            curGroupIndex,
+            updateGroupKey,
+            updateGroupKey.concat([Infinity])
+          )
+          reverseIter = Indexer.reverseIter(
+            curGroupIndex,
+            updateGroupKey.concat([Infinity]),
+            updateGroupKey
+          )
+          let add = reducer(iter, reverseIter)
+
+          if (remove === add) continue
+          if (remove) valuesToRemove.push(remove)
+          if (add) valuesToAdd.push(add)
+        }
+      }
+
+      if (!valuesToAdd.length && !valuesToRemove.length) {
+        continue
+      }
+
+      // @ts-ignore TODO Fix this
+      index = indexes[indexName] = indexes[indexName].slice()
+
+      for (let value of valuesToRemove) {
+        this.removeFromIndex(index, indexName, value)
+      }
+
+      for (let value of valuesToAdd) {
+        this.addToIndex(index, indexName, value)
+      }
+    }
+
+    return indexes
+  }
+
+  private strictValueKeyOf(indexName: keyof I, value: V): any[] {
+    let pk = this.indexKeyers[this.mainIndexName](value)
+
+    if (indexName === this.mainIndexName) {
+      return pk
+    }
+
+    const indexKey = this.indexKeyers[indexName](value)
+    Array.prototype.push.apply(indexKey, pk)
+    return indexKey
+  }
+
+  private addToIndex(index: Index<V>, indexName: keyof I, v: V) {
+    let key = this.strictValueKeyOf(indexName, v)
+    let { startIdx } = Indexer.getRangeFrom(index, key)
+    index.splice(startIdx, 0, [key, v])
+  }
+
+  private removeFromIndex(index: Index<any>, indexName: keyof I, v: V) {
+    let key = this.strictValueKeyOf(indexName, v)
+    let { startIdx, endIdx } = Indexer.getRangeFrom(
+      index,
+      key,
+      key.concat([null])
+    )
+    index.splice(startIdx, endIdx - startIdx)
+  }
+}
+
+function uniqueIndex<V>(
+  keyer: Keyer<V>,
+  values: V[],
+  index = [] as Index<V>
+): Index<V> {
+  for (let value of values) {
+    let key = keyer(value)
+    let { startIdx, endIdx } = Indexer.getRangeFrom(
+      index,
+      key,
+      key.concat([null])
+    )
+    index.splice(startIdx, endIdx - startIdx, [key, value])
+  }
+
+  return index
+}

--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -35,10 +35,9 @@ export interface Dictionary<T> extends DictionaryNum<T> {
  */
 export type Update<T> = { id: EntityId; changes: Partial<T> }
 
-export interface BasicObject {
-  [key: string]: any
-}
-
+/**
+ * @public
+ */
 export type Indices<T, IC extends IndexComparers<T>> = {
   [key in keyof IC]: EntityId[]
 }
@@ -51,6 +50,9 @@ export interface EntityState<T> {
   indices: Indices<T, IndexComparers<T>>
 }
 
+/**
+ * @public
+ */
 export type IndexComparers<T> = {
   [key: string]: Comparer<T>
 }

--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -35,20 +35,36 @@ export interface Dictionary<T> extends DictionaryNum<T> {
  */
 export type Update<T> = { id: EntityId; changes: Partial<T> }
 
+export interface BasicObject {
+  [key: string]: any
+}
+
+export type Indices<T, IC extends IndexComparers<T>> = {
+  [key in keyof IC]: EntityId[]
+}
 /**
  * @public
  */
-export interface EntityState<T> {
+export interface EntityState<
+  T,
+  IC extends IndexComparers<T> = IndexComparers<unknown>
+> {
   ids: EntityId[]
   entities: Dictionary<T>
+  indices: Indices<T, IC>
+}
+
+export type IndexComparers<T> = {
+  [key: string]: Comparer<T>
 }
 
 /**
  * @public
  */
-export interface EntityDefinition<T> {
-  selectId: IdSelector<T>
-  sortComparer: false | Comparer<T>
+export interface EntityDefinition<T, IC extends IndexComparers<T>> {
+  selectId?: IdSelector<T>
+  sortComparer?: false | Comparer<T>
+  indices?: IC
 }
 
 export type PreventAny<S, T> = IsAny<S, EntityState<T>, S>

--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -45,13 +45,10 @@ export type Indices<T, IC extends IndexComparers<T>> = {
 /**
  * @public
  */
-export interface EntityState<
-  T,
-  IC extends IndexComparers<T> = IndexComparers<unknown>
-> {
+export interface EntityState<T> {
   ids: EntityId[]
   entities: Dictionary<T>
-  indices: Indices<T, IC>
+  indices: Indices<T, IndexComparers<T>>
 }
 
 export type IndexComparers<T> = {
@@ -61,10 +58,10 @@ export type IndexComparers<T> = {
 /**
  * @public
  */
-export interface EntityDefinition<T, IC extends IndexComparers<T>> {
+export interface EntityDefinition<T> {
   selectId?: IdSelector<T>
   sortComparer?: false | Comparer<T>
-  indices?: IC
+  indices?: IndexComparers<T>
 }
 
 export type PreventAny<S, T> = IsAny<S, EntityState<T>, S>

--- a/src/entities/sorted_state_adapter.test.ts
+++ b/src/entities/sorted_state_adapter.test.ts
@@ -34,7 +34,7 @@ describe('Sorted State Adapter', () => {
       }
     })
 
-    state = { ids: [], entities: {} }
+    state = { ids: [], entities: {}, indices: {} }
   })
 
   it('should let you add one entity to the state', () => {
@@ -44,7 +44,8 @@ describe('Sorted State Adapter', () => {
       ids: [TheGreatGatsby.id],
       entities: {
         [TheGreatGatsby.id]: TheGreatGatsby
-      }
+      },
+      indices: {}
     })
   })
 
@@ -56,7 +57,8 @@ describe('Sorted State Adapter', () => {
       ids: [TheGreatGatsby.id],
       entities: {
         [TheGreatGatsby.id]: TheGreatGatsby
-      }
+      },
+      indices: {}
     })
   })
 
@@ -82,7 +84,8 @@ describe('Sorted State Adapter', () => {
         [TheGreatGatsby.id]: TheGreatGatsby,
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -100,7 +103,8 @@ describe('Sorted State Adapter', () => {
         [TheGreatGatsby.id]: TheGreatGatsby,
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -117,7 +121,8 @@ describe('Sorted State Adapter', () => {
       entities: {
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -134,7 +139,8 @@ describe('Sorted State Adapter', () => {
       entities: {
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -151,7 +157,8 @@ describe('Sorted State Adapter', () => {
       entities: {
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -162,7 +169,8 @@ describe('Sorted State Adapter', () => {
 
     expect(withoutOne).toEqual({
       ids: [],
-      entities: {}
+      entities: {},
+      indices: {}
     })
   })
 
@@ -182,7 +190,8 @@ describe('Sorted State Adapter', () => {
       ids: [AnimalFarm.id],
       entities: {
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -197,7 +206,8 @@ describe('Sorted State Adapter', () => {
 
     expect(withoutAll).toEqual({
       ids: [],
-      entities: {}
+      entities: {},
+      indices: {}
     })
   })
 
@@ -217,7 +227,8 @@ describe('Sorted State Adapter', () => {
           ...TheGreatGatsby,
           ...changes
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -286,7 +297,8 @@ describe('Sorted State Adapter', () => {
           ...TheGreatGatsby,
           ...changes
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -312,7 +324,8 @@ describe('Sorted State Adapter', () => {
           ...changes
         },
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -338,7 +351,8 @@ describe('Sorted State Adapter', () => {
           ...changes
         },
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -363,7 +377,8 @@ describe('Sorted State Adapter', () => {
           ...AClockworkOrange,
           ...secondChange
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -373,7 +388,8 @@ describe('Sorted State Adapter', () => {
       ids: [TheGreatGatsby.id],
       entities: {
         [TheGreatGatsby.id]: TheGreatGatsby
-      }
+      },
+      indices: {}
     })
   })
 
@@ -392,7 +408,8 @@ describe('Sorted State Adapter', () => {
           ...TheGreatGatsby,
           ...changes
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -413,7 +430,8 @@ describe('Sorted State Adapter', () => {
           ...firstChange
         },
         [AClockworkOrange.id]: AClockworkOrange
-      }
+      },
+      indices: {}
     })
   })
 
@@ -426,7 +444,8 @@ describe('Sorted State Adapter', () => {
       ids: [TheGreatGatsby.id],
       entities: {
         [TheGreatGatsby.id]: TheGreatGatsby
-      }
+      },
+      indices: {}
     })
   })
 
@@ -460,7 +479,8 @@ describe('Sorted State Adapter', () => {
           ...firstChange
         },
         [AClockworkOrange.id]: AClockworkOrange
-      }
+      },
+      indices: {}
     })
   })
 
@@ -474,6 +494,7 @@ describe('Sorted State Adapter', () => {
         Object {
           "entities": Object {},
           "ids": Array [],
+          "indices": Object {},
         }
       `)
     })
@@ -494,6 +515,7 @@ describe('Sorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -519,6 +541,7 @@ describe('Sorted State Adapter', () => {
             "af",
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -544,6 +567,7 @@ describe('Sorted State Adapter', () => {
             "af",
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -569,6 +593,7 @@ describe('Sorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -601,6 +626,7 @@ describe('Sorted State Adapter', () => {
             "tgg",
             "aco",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -620,6 +646,7 @@ describe('Sorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -643,6 +670,7 @@ describe('Sorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -674,6 +702,7 @@ describe('Sorted State Adapter', () => {
             "tgg",
             "af",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -694,6 +723,7 @@ describe('Sorted State Adapter', () => {
           "ids": Array [
             "af",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -718,6 +748,7 @@ describe('Sorted State Adapter', () => {
           "ids": Array [
             "aco",
           ],
+          "indices": Object {},
         }
       `)
     })

--- a/src/entities/unsorted_state_adapter.test.ts
+++ b/src/entities/unsorted_state_adapter.test.ts
@@ -31,7 +31,7 @@ describe('Unsorted State Adapter', () => {
       selectId: (book: BookModel) => book.id
     })
 
-    state = { ids: [], entities: {} }
+    state = { ids: [], entities: {}, indices: {} }
   })
 
   it('should let you add one entity to the state', () => {
@@ -41,7 +41,8 @@ describe('Unsorted State Adapter', () => {
       ids: [TheGreatGatsby.id],
       entities: {
         [TheGreatGatsby.id]: TheGreatGatsby
-      }
+      },
+      indices: {}
     })
   })
 
@@ -67,7 +68,8 @@ describe('Unsorted State Adapter', () => {
         [TheGreatGatsby.id]: TheGreatGatsby,
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -85,7 +87,8 @@ describe('Unsorted State Adapter', () => {
         [TheGreatGatsby.id]: TheGreatGatsby,
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -102,7 +105,8 @@ describe('Unsorted State Adapter', () => {
       entities: {
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -119,7 +123,8 @@ describe('Unsorted State Adapter', () => {
       entities: {
         [AClockworkOrange.id]: AClockworkOrange,
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -130,7 +135,8 @@ describe('Unsorted State Adapter', () => {
 
     expect(withoutOne).toEqual({
       ids: [],
-      entities: {}
+      entities: {},
+      indices: {}
     })
   })
 
@@ -150,7 +156,8 @@ describe('Unsorted State Adapter', () => {
       ids: [AnimalFarm.id],
       entities: {
         [AnimalFarm.id]: AnimalFarm
-      }
+      },
+      indices: {}
     })
   })
 
@@ -165,7 +172,8 @@ describe('Unsorted State Adapter', () => {
 
     expect(withoutAll).toEqual({
       ids: [],
-      entities: {}
+      entities: {},
+      indices: {}
     })
   })
 
@@ -185,7 +193,8 @@ describe('Unsorted State Adapter', () => {
           ...TheGreatGatsby,
           ...changes
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -226,7 +235,8 @@ describe('Unsorted State Adapter', () => {
           ...TheGreatGatsby,
           ...changes
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -251,7 +261,8 @@ describe('Unsorted State Adapter', () => {
           ...AClockworkOrange,
           ...secondChange
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -290,7 +301,8 @@ describe('Unsorted State Adapter', () => {
       ids: [TheGreatGatsby.id],
       entities: {
         [TheGreatGatsby.id]: TheGreatGatsby
-      }
+      },
+      indices: {}
     })
   })
 
@@ -309,7 +321,8 @@ describe('Unsorted State Adapter', () => {
           ...TheGreatGatsby,
           ...changes
         }
-      }
+      },
+      indices: {}
     })
   })
 
@@ -330,7 +343,8 @@ describe('Unsorted State Adapter', () => {
           ...firstChange
         },
         [AClockworkOrange.id]: AClockworkOrange
-      }
+      },
+      indices: {}
     })
   })
 
@@ -351,7 +365,8 @@ describe('Unsorted State Adapter', () => {
           ...firstChange
         },
         [AClockworkOrange.id]: AClockworkOrange
-      }
+      },
+      indices: {}
     })
   })
 
@@ -365,6 +380,7 @@ describe('Unsorted State Adapter', () => {
         Object {
           "entities": Object {},
           "ids": Array [],
+          "indices": Object {},
         }
       `)
     })
@@ -385,6 +401,7 @@ describe('Unsorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -410,6 +427,7 @@ describe('Unsorted State Adapter', () => {
             "tgg",
             "af",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -435,6 +453,7 @@ describe('Unsorted State Adapter', () => {
             "tgg",
             "af",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -460,6 +479,7 @@ describe('Unsorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -506,6 +526,7 @@ describe('Unsorted State Adapter', () => {
             "aco",
             "th",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -525,6 +546,7 @@ describe('Unsorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -548,6 +570,7 @@ describe('Unsorted State Adapter', () => {
           "ids": Array [
             "tgg",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -579,6 +602,7 @@ describe('Unsorted State Adapter', () => {
             "tgg",
             "af",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -599,6 +623,7 @@ describe('Unsorted State Adapter', () => {
           "ids": Array [
             "af",
           ],
+          "indices": Object {},
         }
       `)
     })
@@ -623,6 +648,7 @@ describe('Unsorted State Adapter', () => {
           "ids": Array [
             "aco",
           ],
+          "indices": Object {},
         }
       `)
     })

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -118,7 +118,9 @@ export function createUnsortedStateAdapter<T>(
           // Spreads ignore falsy values, so this works even if there isn't
           // an existing update already at this key
           changes: {
-            ...updatesPerEntity[update.id]?.changes,
+            ...(updatesPerEntity[update.id]
+              ? updatesPerEntity[update.id].changes
+              : null),
             ...update.changes
           }
         }

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -9,7 +9,11 @@ import {
   createStateOperator,
   createSingleArgumentStateOperator
 } from './state_adapter'
-import { selectIdValue } from './utils'
+import {
+  selectIdValue,
+  ensureEntitiesArray,
+  splitAddedUpdatedEntities
+} from './utils'
 
 export function createUnsortedStateAdapter<T>(
   selectId: IdSelector<T>
@@ -27,25 +31,27 @@ export function createUnsortedStateAdapter<T>(
     state.entities[key] = entity
   }
 
-  function addManyMutably(entities: T[] | Record<EntityId, T>, state: R): void {
-    if (!Array.isArray(entities)) {
-      entities = Object.values(entities)
-    }
+  function addManyMutably(
+    newEntities: T[] | Record<EntityId, T>,
+    state: R
+  ): void {
+    newEntities = ensureEntitiesArray(newEntities)
 
-    for (const entity of entities) {
+    for (const entity of newEntities) {
       addOneMutably(entity, state)
     }
   }
 
-  function setAllMutably(entities: T[] | Record<EntityId, T>, state: R): void {
-    if (!Array.isArray(entities)) {
-      entities = Object.values(entities)
-    }
+  function setAllMutably(
+    newEntities: T[] | Record<EntityId, T>,
+    state: R
+  ): void {
+    newEntities = ensureEntitiesArray(newEntities)
 
     state.ids = []
     state.entities = {}
 
-    addManyMutably(entities, state)
+    addManyMutably(newEntities, state)
   }
 
   function removeOneMutably(key: EntityId, state: R): void {
@@ -112,9 +118,7 @@ export function createUnsortedStateAdapter<T>(
           // Spreads ignore falsy values, so this works even if there isn't
           // an existing update already at this key
           changes: {
-            ...(updatesPerEntity[update.id]
-              ? updatesPerEntity[update.id].changes
-              : null),
+            ...updatesPerEntity[update.id]?.changes,
             ...update.changes
           }
         }
@@ -140,24 +144,14 @@ export function createUnsortedStateAdapter<T>(
   }
 
   function upsertManyMutably(
-    entities: T[] | Record<EntityId, T>,
+    newEntities: T[] | Record<EntityId, T>,
     state: R
   ): void {
-    if (!Array.isArray(entities)) {
-      entities = Object.values(entities)
-    }
-
-    const added: T[] = []
-    const updated: Update<T>[] = []
-
-    for (const entity of entities) {
-      const id = selectIdValue(entity, selectId)
-      if (id in state.entities) {
-        updated.push({ id, changes: entity })
-      } else {
-        added.push(entity)
-      }
-    }
+    const { added, updated } = splitAddedUpdatedEntities<T>(
+      newEntities,
+      selectId,
+      state
+    )
 
     updateManyMutably(updated, state)
     addManyMutably(added, state)

--- a/src/entities/utils.ts
+++ b/src/entities/utils.ts
@@ -1,4 +1,10 @@
-import { IdSelector } from './models'
+import {
+  EntityState,
+  EntityStateAdapter,
+  IdSelector,
+  Update,
+  EntityId
+} from './models'
 
 export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
   const key = selectId(entity)
@@ -15,4 +21,35 @@ export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
   }
 
   return key
+}
+
+export function ensureEntitiesArray<T>(
+  entities: T[] | Record<EntityId, T>
+): T[] {
+  if (!Array.isArray(entities)) {
+    entities = Object.values(entities)
+  }
+
+  return entities
+}
+
+export function splitAddedUpdatedEntities<T>(
+  newEntities: T[] | Record<EntityId, T>,
+  selectId: IdSelector<T>,
+  state: EntityState<T>
+) {
+  newEntities = ensureEntitiesArray(newEntities)
+
+  const added: T[] = []
+  const updated: Update<T>[] = []
+
+  for (const entity of newEntities) {
+    const id = selectIdValue(entity, selectId)
+    if (id in state.entities) {
+      updated.push({ id, changes: entity })
+    } else {
+      added.push(entity)
+    }
+  }
+  return { added, updated }
 }

--- a/src/entities/utils.ts
+++ b/src/entities/utils.ts
@@ -1,10 +1,4 @@
-import {
-  EntityState,
-  EntityStateAdapter,
-  IdSelector,
-  Update,
-  EntityId
-} from './models'
+import { EntityState, IdSelector, Update, EntityId } from './models'
 
 export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
   const key = selectId(entity)


### PR DESCRIPTION
Inspired by #799 , I'm trying to add some "indices" to `createEntityAdapter`. The idea is that you could define secondary sorting options beyond the standard sorting for `state.ids`, and the entity adapter will automatically keep those updated.

I initially was looking at `redux-indexers`, but decided that it wasn't quite a good fit.

I'm now playing with the idea of having the sorting get done inside of the `merge()` function in `sorted_state_adapter`.

Was having trouble getting the fields of the `indices` option to carry through, but @msutkowski just got that working in #946 .

Still got a lot of experimenting left to do.