### PR TITLE
Extract common utils from both adapter files

### DIFF
--- a/src/entities/sorted_state_adapter.ts
+++ b/src/entities/sorted_state_adapter.ts
@@ -92,7 +92,7 @@ export function createSortedStateAdapter<T>(
     newEntities: T[] | Record<EntityId, T>,
     state: R
   ): void {
-    const { added, updated } = splitAddedUpdatedEntities<T>(
+    const [added, updated] = splitAddedUpdatedEntities<T>(
       newEntities,
       selectId,
       state

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -149,7 +149,7 @@ export function createUnsortedStateAdapter<T>(
     newEntities: T[] | Record<EntityId, T>,
     state: R
   ): void {
-    const { added, updated } = splitAddedUpdatedEntities<T>(
+    const [added, updated] = splitAddedUpdatedEntities<T>(
       newEntities,
       selectId,
       state

--- a/src/entities/unsorted_state_adapter.ts
+++ b/src/entities/unsorted_state_adapter.ts
@@ -9,7 +9,11 @@ import {
   createStateOperator,
   createSingleArgumentStateOperator
 } from './state_adapter'
-import { selectIdValue } from './utils'
+import {
+  selectIdValue,
+  ensureEntitiesArray,
+  splitAddedUpdatedEntities
+} from './utils'
 
 export function createUnsortedStateAdapter<T>(
   selectId: IdSelector<T>
@@ -27,25 +31,27 @@ export function createUnsortedStateAdapter<T>(
     state.entities[key] = entity
   }
 
-  function addManyMutably(entities: T[] | Record<EntityId, T>, state: R): void {
-    if (!Array.isArray(entities)) {
-      entities = Object.values(entities)
-    }
+  function addManyMutably(
+    newEntities: T[] | Record<EntityId, T>,
+    state: R
+  ): void {
+    newEntities = ensureEntitiesArray(newEntities)
 
-    for (const entity of entities) {
+    for (const entity of newEntities) {
       addOneMutably(entity, state)
     }
   }
 
-  function setAllMutably(entities: T[] | Record<EntityId, T>, state: R): void {
-    if (!Array.isArray(entities)) {
-      entities = Object.values(entities)
-    }
+  function setAllMutably(
+    newEntities: T[] | Record<EntityId, T>,
+    state: R
+  ): void {
+    newEntities = ensureEntitiesArray(newEntities)
 
     state.ids = []
     state.entities = {}
 
-    addManyMutably(entities, state)
+    addManyMutably(newEntities, state)
   }
 
   function removeOneMutably(key: EntityId, state: R): void {
@@ -140,24 +146,14 @@ export function createUnsortedStateAdapter<T>(
   }
 
   function upsertManyMutably(
-    entities: T[] | Record<EntityId, T>,
+    newEntities: T[] | Record<EntityId, T>,
     state: R
   ): void {
-    if (!Array.isArray(entities)) {
-      entities = Object.values(entities)
-    }
-
-    const added: T[] = []
-    const updated: Update<T>[] = []
-
-    for (const entity of entities) {
-      const id = selectIdValue(entity, selectId)
-      if (id in state.entities) {
-        updated.push({ id, changes: entity })
-      } else {
-        added.push(entity)
-      }
-    }
+    const { added, updated } = splitAddedUpdatedEntities<T>(
+      newEntities,
+      selectId,
+      state
+    )
 
     updateManyMutably(updated, state)
     addManyMutably(added, state)

--- a/src/entities/utils.ts
+++ b/src/entities/utils.ts
@@ -1,4 +1,10 @@
-import { IdSelector } from './models'
+import {
+  EntityState,
+  EntityStateAdapter,
+  IdSelector,
+  Update,
+  EntityId
+} from './models'
 
 export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
   const key = selectId(entity)
@@ -15,4 +21,35 @@ export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
   }
 
   return key
+}
+
+export function ensureEntitiesArray<T>(
+  entities: T[] | Record<EntityId, T>
+): T[] {
+  if (!Array.isArray(entities)) {
+    entities = Object.values(entities)
+  }
+
+  return entities
+}
+
+export function splitAddedUpdatedEntities<T>(
+  newEntities: T[] | Record<EntityId, T>,
+  selectId: IdSelector<T>,
+  state: EntityState<T>
+) {
+  newEntities = ensureEntitiesArray(newEntities)
+
+  const added: T[] = []
+  const updated: Update<T>[] = []
+
+  for (const entity of newEntities) {
+    const id = selectIdValue(entity, selectId)
+    if (id in state.entities) {
+      updated.push({ id, changes: entity })
+    } else {
+      added.push(entity)
+    }
+  }
+  return { added, updated }
 }

--- a/src/entities/utils.ts
+++ b/src/entities/utils.ts
@@ -31,7 +31,7 @@ export function splitAddedUpdatedEntities<T>(
   newEntities: T[] | Record<EntityId, T>,
   selectId: IdSelector<T>,
   state: EntityState<T>
-) {
+): [T[], Update<T>[]] {
   newEntities = ensureEntitiesArray(newEntities)
 
   const added: T[] = []
@@ -45,5 +45,5 @@ export function splitAddedUpdatedEntities<T>(
       added.push(entity)
     }
   }
-  return { added, updated }
+  return [added, updated]
 }

--- a/src/entities/utils.ts
+++ b/src/entities/utils.ts
@@ -1,10 +1,4 @@
-import {
-  EntityState,
-  EntityStateAdapter,
-  IdSelector,
-  Update,
-  EntityId
-} from './models'
+import { EntityState, IdSelector, Update, EntityId } from './models'
 
 export function selectIdValue<T>(entity: T, selectId: IdSelector<T>) {
   const key = selectId(entity)

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -57,7 +57,7 @@ export function findNonSerializableValue(
   const hasIgnoredPaths = ignoredPaths.length > 0
 
   for (const [key, nestedValue] of entries) {
-    const nestedPath = path ? path + '.' + key : key // path.concat(property)
+    const nestedPath = path ? path + '.' + key : key
 
     if (hasIgnoredPaths && ignoredPaths.indexOf(nestedPath) >= 0) {
       continue


### PR DESCRIPTION
This PR:

- Dedupes some of the logic in the `unsorted_state_adapter` / `sorted_state_adapter` files by extracting some common utils
- Fixes a leftover stray bit of commented out code in the serializability middleware