### PR TITLE
Add check for undefined middleware in configureStore

### DIFF
--- a/src/configureStore.test.ts
+++ b/src/configureStore.test.ts
@@ -98,6 +98,23 @@ describe('configureStore', () => {
     })
   })
 
+  describe('given a middleware creation function that returns an array with non-functions', () => {
+    it('throws an error', () => {
+      const invalidBuilder = jest.fn(getDefaultMiddleware => [true] as any)
+      expect(() =>
+        configureStore({ middleware: invalidBuilder, reducer })
+      ).toThrow('each middleware provided to configureStore must be a function')
+    })
+  })
+
+  describe('given custom middleware that contains non-functions', () => {
+    it('throws an error', () => {
+      expect(() =>
+        configureStore({ middleware: [true] as any, reducer })
+      ).toThrow('each middleware provided to configureStore must be a function')
+    })
+  })
+
   describe('given custom middleware', () => {
     it('calls createStore with custom middleware and without default middleware', () => {
       const thank: redux.Middleware = _store => next => action => next(action)

--- a/src/configureStore.test.ts
+++ b/src/configureStore.test.ts
@@ -68,6 +68,36 @@ describe('configureStore', () => {
     })
   })
 
+  describe('given undefined middleware', () => {
+    it('calls createStore with default middleware', () => {
+      expect(configureStore({ middleware: undefined, reducer })).toBeInstanceOf(
+        Object
+      )
+      expect(redux.applyMiddleware).toHaveBeenCalledWith(
+        expect.any(Function), // thunk
+        expect.any(Function), // immutableCheck
+        expect.any(Function) // serializableCheck
+      )
+      expect(devtools.composeWithDevTools).toHaveBeenCalled()
+      expect(redux.createStore).toHaveBeenCalledWith(
+        reducer,
+        undefined,
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('given a middleware creation function that returns undefined', () => {
+    it('throws an error', () => {
+      const invalidBuilder = jest.fn(getDefaultMiddleware => undefined as any)
+      expect(() =>
+        configureStore({ middleware: invalidBuilder, reducer })
+      ).toThrow(
+        'when using a middleware builder function, an array of middleware must be returned'
+      )
+    })
+  })
+
   describe('given custom middleware', () => {
     it('calls createStore with custom middleware and without default middleware', () => {
       const thank: redux.Middleware = _store => next => action => next(action)

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -153,11 +153,17 @@ export function configureStore<
     )
   }
 
-  const middlewareEnhancer = applyMiddleware(
-    ...(typeof middleware === 'function'
-      ? middleware(curriedGetDefaultMiddleware)
-      : middleware)
-  )
+  let finalMiddleware = middleware
+  if (typeof finalMiddleware === 'function') {
+    finalMiddleware = finalMiddleware(curriedGetDefaultMiddleware)
+    if (!Array.isArray(finalMiddleware)) {
+      throw new Error(
+        'when using a middleware builder function, an array of middleware must be returned'
+      )
+    }
+  }
+
+  const middlewareEnhancer = applyMiddleware(...finalMiddleware)
 
   let finalCompose = compose
 

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -156,9 +156,19 @@ export function configureStore<
   let finalMiddleware = middleware
   if (typeof finalMiddleware === 'function') {
     finalMiddleware = finalMiddleware(curriedGetDefaultMiddleware)
-    if (!Array.isArray(finalMiddleware)) {
+
+    if (!IS_PRODUCTION) {
+      if (!Array.isArray(finalMiddleware)) {
+        throw new Error(
+          'when using a middleware builder function, an array of middleware must be returned'
+        )
+      }
+    }
+  }
+  if (!IS_PRODUCTION) {
+    if (finalMiddleware.some(item => typeof item !== 'function')) {
       throw new Error(
-        'when using a middleware builder function, an array of middleware must be returned'
+        'each middleware provided to configureStore must be a function'
       )
     }
   }

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -157,20 +157,19 @@ export function configureStore<
   if (typeof finalMiddleware === 'function') {
     finalMiddleware = finalMiddleware(curriedGetDefaultMiddleware)
 
-    if (!IS_PRODUCTION) {
-      if (!Array.isArray(finalMiddleware)) {
-        throw new Error(
-          'when using a middleware builder function, an array of middleware must be returned'
-        )
-      }
-    }
-  }
-  if (!IS_PRODUCTION) {
-    if (finalMiddleware.some(item => typeof item !== 'function')) {
+    if (!IS_PRODUCTION && !Array.isArray(finalMiddleware)) {
       throw new Error(
-        'each middleware provided to configureStore must be a function'
+        'when using a middleware builder function, an array of middleware must be returned'
       )
     }
+  }
+  if (
+    !IS_PRODUCTION &&
+    finalMiddleware.some(item => typeof item !== 'function')
+  ) {
+    throw new Error(
+      'each middleware provided to configureStore must be a function'
+    )
   }
 
   const middlewareEnhancer = applyMiddleware(...finalMiddleware)


### PR DESCRIPTION
Closes #937 

As per commit message:
```
* Throw an error when a middleware creation callback
  is provided to configureStore that does not return
  an array of middleware
```

Two new tests are added:
- explicitly passing `middleware: undefined` should use default middleware (same as excluding the option)
- passing `middleware: () => undefined` should be considered a user error and throw an error

Note: While issue #937 arose due to a middleware creation function that returns `undefined`, I've considered `"returning anything besides an array"` as a user error in this context.