### PR TITLE
Removed unnecessary sort in sorted_state_adapter.ts#merge()

### DIFF
--- a/src/entities/sorted_state_adapter.ts
+++ b/src/entities/sorted_state_adapter.ts
@@ -117,8 +117,6 @@ export function createSortedStateAdapter<T>(
   }
 
   function merge(models: T[], state: R): void {
-    models.sort(sort)
-
     // Insert/overwrite all new/updated
     models.forEach(model => {
       state.entities[selectId(model)] = model


### PR DESCRIPTION
Hi Redux Toolkit maintainers,

While perusing the code, discovered the following:

https://github.com/reduxjs/redux-toolkit/blob/61ec24c3a7c06f08e9b1bcdead63c01fc43cf3b6/src/entities/sorted_state_adapter.ts#L120 

Forked the repo, removed the sort, ran the tests with `npm test` and found no issues.

Since allEntities are sorted just after merging into state, seems like it would improve performance without the pre-sort.

Is a reason for the pre-sort I'm not seeing, that the tests are not capturing? If so I would really like to know why.

Thanks for your time!