### PR TITLE
Add inferred action creator types

### DIFF
--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -129,7 +129,7 @@ export interface EnhancedStore<
 export function configureStore<
   S = any,
   A extends Action = AnyAction,
-  M extends Middlewares<S> = [ThunkMiddlewareFor<S>]
+  M extends Middlewares<S> = [ThunkMiddlewareFor<S, {}, A>]
 >(options: ConfigureStoreOptions<S, A, M>): EnhancedStore<S, A, M> {
   const curriedGetDefaultMiddleware = curryGetDefaultMiddleware<S>()
 

--- a/src/getDefaultMiddleware.ts
+++ b/src/getDefaultMiddleware.ts
@@ -29,16 +29,17 @@ interface GetDefaultMiddlewareOptions {
 
 export type ThunkMiddlewareFor<
   S,
-  O extends GetDefaultMiddlewareOptions = {}
+  O extends GetDefaultMiddlewareOptions = {},
+  A extends AnyAction = AnyAction
 > = O extends {
   thunk: false
 }
   ? never
   : O extends { thunk: { extraArgument: infer E } }
-  ? ThunkMiddleware<S, AnyAction, E>
+  ? ThunkMiddleware<S, A, E>
   :
-      | ThunkMiddleware<S, AnyAction, null> //The ThunkMiddleware with a `null` ExtraArgument is here to provide backwards-compatibility.
-      | ThunkMiddleware<S, AnyAction>
+      | ThunkMiddleware<S, A, null> //The ThunkMiddleware with a `null` ExtraArgument is here to provide backwards-compatibility.
+      | ThunkMiddleware<S, A>
 
 export type CurriedGetDefaultMiddleware<S = any> = <
   O extends Partial<GetDefaultMiddlewareOptions> = {


### PR DESCRIPTION
Hey, guys. I want to share some ideas about safety infer the action types. This is just a draft of the idea because I am using the [template literal types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html) of TS 4.1 and I know have such a version dependency would be problematic for people using old versions of TS. I didn't work into caseReducers and other things, because like I said, I just want to share the idea and see if this will make sense to be part of redux-toolkit in the future or someone know some way to use template literal types and keep support for old versions of TS.

The idea is to infer the `slice.actions` and `slice.reducer` to make totally safety the usage of the `type` property of the action.

![Screenshot from 2021-04-01 23-59-51](https://user-images.githubusercontent.com/8618687/113376146-6ae0a380-9347-11eb-834d-94cafb15a95c.png)

```ts
const slice = createSlice({
  name: 'counter',
  initialState: 0,
  reducers: {
    increment: (state: number, action) => state + action.payload,
    decrement: (state: number, action) => state - action.payload
  },
  extraReducers: {
    [firstAction.type]: (state: number, action) =>
      state + action.payload.count
  }
})

/* Reducer */

type InferredTypeActions = 'counter/increment' | 'counter/decrement'

const reducer: Reducer<number, PayloadAction<void, InferredTypeActions>> = slice.reducer
```