### PR TITLE
Add `idGenerator` option to `createAsyncThunk` (#743)

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -89,7 +89,7 @@ An object with the following optional fields:
 
 - `condition`: a callback that can be used to skip execution of the payload creator and all action dispatches, if desired. See [Canceling Before Execution](#canceling-before-execution) for a complete description.
 - `dispatchConditionRejection`: if `condition()` returns `false`, the default behavior is that no actions will be dispatched at all. If you still want a "rejected" action to be dispatched when the thunk was canceled, set this flag to `true`.
-- `idGenerator`: a function to use when generating the `requestId` for the request sequence. Defaults to use [nanoid](https://www.npmjs.com/package/nanoid).
+- `idGenerator`: a function to use when generating the `requestId` for the request sequence. Defaults to use [nanoid](./otherExports.mdx/#nanoid).
 
 ## Return Value
 

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -89,6 +89,7 @@ An object with the following optional fields:
 
 - `condition`: a callback that can be used to skip execution of the payload creator and all action dispatches, if desired. See [Canceling Before Execution](#canceling-before-execution) for a complete description.
 - `dispatchConditionRejection`: if `condition()` returns `false`, the default behavior is that no actions will be dispatched at all. If you still want a "rejected" action to be dispatched when the thunk was canceled, set this flag to `true`.
+- `idGenerator`: a function to use when generating a 'request ID' per request instance. Defaults to use [nanoid](https://www.npmjs.com/package/nanoid).
 
 ## Return Value
 

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -89,7 +89,7 @@ An object with the following optional fields:
 
 - `condition`: a callback that can be used to skip execution of the payload creator and all action dispatches, if desired. See [Canceling Before Execution](#canceling-before-execution) for a complete description.
 - `dispatchConditionRejection`: if `condition()` returns `false`, the default behavior is that no actions will be dispatched at all. If you still want a "rejected" action to be dispatched when the thunk was canceled, set this flag to `true`.
-- `idGenerator`: a function to use when generating a 'request ID' per request instance. Defaults to use [nanoid](https://www.npmjs.com/package/nanoid).
+- `idGenerator`: a function to use when generating the `requestId` for the request sequence. Defaults to use [nanoid](https://www.npmjs.com/package/nanoid).
 
 ## Return Value
 

--- a/docs/api/otherExports.mdx
+++ b/docs/api/otherExports.mdx
@@ -11,7 +11,7 @@ Redux Toolkit exports some of its internal utilities, and re-exports additional 
 
 ### `nanoid`
 
-An inlined copy of [`nanoid/nonsecure`](https://github.com/ai/nanoid). Generates a non-cryptographically-secure random ID string. `createAsyncThunk` uses this by default for request IDs, but may also be useful for other cases as well.
+An inlined copy of [`nanoid/nonsecure`](https://github.com/ai/nanoid). Generates a non-cryptographically-secure random ID string. `createAsyncThunk` uses this by default for request IDs. May also be useful for other cases as well.
 
 ```ts
 import { nanoid } from '@reduxjs/toolkit'

--- a/docs/api/otherExports.mdx
+++ b/docs/api/otherExports.mdx
@@ -11,7 +11,7 @@ Redux Toolkit exports some of its internal utilities, and re-exports additional 
 
 ### `nanoid`
 
-An inlined copy of [`nanoid/nonsecure`](https://github.com/ai/nanoid). Generates a non-cryptographically-secure random ID string. Automatically used by `createAsyncThunk` for request IDs, but may also be useful for other cases as well.
+An inlined copy of [`nanoid/nonsecure`](https://github.com/ai/nanoid). Generates a non-cryptographically-secure random ID string. `createAsyncThunk` uses this by default for request IDs, but may also be useful for other cases as well.
 
 ```ts
 import { nanoid } from '@reduxjs/toolkit'

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -92,6 +92,7 @@ export type AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig extends AsyncThu
 export interface AsyncThunkOptions<ThunkArg = void, ThunkApiConfig extends AsyncThunkConfig = {}> {
     condition?(arg: ThunkArg, api: Pick<GetThunkAPI<ThunkApiConfig>, 'getState' | 'extra'>): boolean | undefined;
     dispatchConditionRejection?: boolean;
+    idGenerator?: () => string;
     // (undocumented)
     serializeError?: (x: unknown) => GetSerializedErrorType<ThunkApiConfig>;
 }

--- a/src/createAsyncThunk.test.ts
+++ b/src/createAsyncThunk.test.ts
@@ -643,7 +643,7 @@ describe('conditional skipping of asyncThunks', () => {
     const idGenerator = makeFakeIdGenerator()
     const asyncThunk = createAsyncThunk(
       'test',
-      async (args: undefined, { requestId }) => {
+      async (args: void, { requestId }) => {
         generatedRequestId = requestId
       },
       { idGenerator }
@@ -668,7 +668,7 @@ describe('conditional skipping of asyncThunks', () => {
     generatedRequestId = ''
     const defaultAsyncThunk = createAsyncThunk(
       'test',
-      async (args: undefined, { requestId }) => {
+      async (args: void, { requestId }) => {
         generatedRequestId = requestId
       }
     )

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -225,7 +225,9 @@ export interface AsyncThunkOptions<
   serializeError?: (x: unknown) => GetSerializedErrorType<ThunkApiConfig>
 
   /**
-   * A function to use when generating a 'request ID' per request instance. Defaults to use nanoid.
+   * A function to use when generating the `requestId` for the request sequence.
+   *
+   * @default `nanoid`
    */
   idGenerator?: () => string
 }

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -223,6 +223,11 @@ export interface AsyncThunkOptions<
   dispatchConditionRejection?: boolean
 
   serializeError?: (x: unknown) => GetSerializedErrorType<ThunkApiConfig>
+
+  /**
+   * A function to use when generating a 'request ID' per request instance. Defaults to use nanoid.
+   */
+  idGenerator?: () => string
 }
 
 export type AsyncThunkPendingActionCreator<
@@ -392,7 +397,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
     arg: ThunkArg
   ): AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> {
     return (dispatch, getState, extra) => {
-      const requestId = nanoid()
+      const requestId = (options?.idGenerator || nanoid)()
 
       const abortController = new AC()
       let abortReason: string | undefined

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -399,7 +399,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
     arg: ThunkArg
   ): AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> {
     return (dispatch, getState, extra) => {
-      const requestId = (options?.idGenerator || nanoid)()
+      const requestId = (options?.idGenerator ?? nanoid)()
 
       const abortController = new AC()
       let abortReason: string | undefined

--- a/type-tests/files/createAsyncThunk.typetest.ts
+++ b/type-tests/files/createAsyncThunk.typetest.ts
@@ -393,3 +393,27 @@ const anyAction = { type: 'foo' } as AnyAction
     expectType<Funky>(anyAction.error)
   }
 }
+
+/**
+ * `idGenerator` option takes no arguments, and returns a string
+ */
+{
+  const returnsNumWithArgs = (foo: any) => 100
+  // has to stay on one line or type tests fail in older TS versions
+  // prettier-ignore
+  // @ts-expect-error
+  const shouldFailNumWithArgs = createAsyncThunk('foo', () => {}, { idGenerator: returnsNumWithArgs })
+
+  const returnsNumWithoutArgs = () => 100
+  // prettier-ignore
+  // @ts-expect-error
+  const shouldFailNumWithoutArgs = createAsyncThunk('foo', () => {}, { idGenerator: returnsNumWithoutArgs })
+
+  const returnsStrWithArgs = (foo: any) => 'foo'
+  // prettier-ignore
+  // @ts-expect-error
+  const shouldFailStrArgs = createAsyncThunk('foo', () => {}, { idGenerator: returnsStrWithArgs })
+
+  const returnsStrWithoutArgs = () => 'foo'
+  const shouldSucceed = createAsyncThunk('foo', () => {}, { idGenerator: returnsStrWithoutArgs })
+}


### PR DESCRIPTION
Closes #743 

This PR adds an optional `idGenerator` option to the `createAsyncThunk` options to allow specifying how request IDs are generated rather than using nanoid.