### PR TITLE
Update `immer` to v9.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5725,9 +5725,9 @@
       "dev": true
     },
     "immer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
-      "integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.1.tgz",
+      "integrity": "sha512-7CCw1DSgr8kKYXTYOI1qMM/f5qxT5vIVMeGLDCDX8CSxsggr1Sjdoha4OhsP0AZ1UvWbyZlILHvLjaynuu02Mg=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "query"
   ],
   "dependencies": {
-    "immer": "^8.0.1",
+    "immer": "^9.0.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0"


### PR DESCRIPTION
Closes #931 

As far as I can tell, nothing in RTK is affected by the immer upgrade.