### PR TITLE
Export `miniSerializeError`

### DIFF
--- a/docs/api/otherExports.mdx
+++ b/docs/api/otherExports.mdx
@@ -20,6 +20,24 @@ console.log(nanoid())
 // 'dgPXxUz_6fWIQBD8XmiSy'
 ```
 
+### `miniSerializeError`
+
+A re-worked, inlined copy of [`serialize-error`](https://github.com/sindresorhus/serialize-error). Serializes an error into a plain object. `createAsyncThunk` uses this by default for rejected cases. May also be useful other other cases as well.  
+
+Returns a plain object with optional `name`, `message`, `stack` and `code` properties.
+
+```ts
+import { miniSerializeError } from '@reduxjs/toolkit'
+
+const serializedError = miniSerializeError(new Error('Something has gone wrong'))
+console.log(serializedError.name)
+// "Error"
+console.log(serializedError.message)
+// "Something has gone wrong"
+console.log(serializedError.stack)
+// "Error: Something has gone wrong↵    at <anonymous>:24:34"
+```
+
 ## Exports from Other Libraries
 
 ### `createNextState`

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -394,6 +394,9 @@ export class MiddlewareArray<Middlewares extends Middleware<any, any>> extends A
     prepend<AdditionalMiddlewares extends ReadonlyArray<Middleware<any, any>>>(...items: AdditionalMiddlewares): MiddlewareArray<AdditionalMiddlewares[number] | Middlewares>;
 }
 
+// @public
+export const miniSerializeError: (value: any) => SerializedError;
+
 // @public (undocumented)
 export let nanoid: (size?: number) => string;
 

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -48,7 +48,12 @@ class RejectWithValue<RejectValue> {
   constructor(public readonly payload: RejectValue) {}
 }
 
-// Reworked from https://github.com/sindresorhus/serialize-error
+/**
+ * Serializes an error into a plain object.
+ * Reworked from https://github.com/sindresorhus/serialize-error
+ *
+ * @public
+ */
 export const miniSerializeError = (value: any): SerializedError => {
   if (typeof value === 'object' && value !== null) {
     const simpleError: SerializedError = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,11 @@ export type {
   Comparer,
 } from './entities/models'
 
-export { createAsyncThunk, unwrapResult } from './createAsyncThunk'
+export {
+  createAsyncThunk,
+  unwrapResult,
+  miniSerializeError,
+} from './createAsyncThunk'
 export type {
   AsyncThunk,
   AsyncThunkOptions,


### PR DESCRIPTION
Closes #902 

As per title: exports `miniSerializeError`. Also adds a short entry to the `otherExports` docs page describing the purpose of `miniSerializeError`.

I was on the fence about moving `miniSerializeError` out of `createAsyncThunk.ts` into it's own file, but ended up leaving it there.