### PR TITLE
No need for await return

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -374,7 +374,7 @@ const fetchUserById = createAsyncThunk(
     const response = await fetch(`https://reqres.in/api/users/${userId}`, {
       signal: thunkAPI.signal
     })
-    return await response.json()
+    return response.json()
   }
 )
 ```


### PR DESCRIPTION
When using an `async` function await automatically runs on return see: eslint rule https://eslint.org/docs/rules/no-return-await