### PR TITLE
experiment: additional arguments into `selectState`

### DIFF
--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -222,17 +222,17 @@ export interface EntityAdapter<T> extends EntityStateAdapter<T> {
 export type EntityId = number | string;
 
 // @public (undocumented)
-export interface EntitySelectors<T, V> {
+export interface EntitySelectors<T, V, ExtraArgs extends any[] = []> {
     // (undocumented)
-    selectAll: (state: V) => T[];
+    selectAll: (state: V, ...args: ExtraArgs) => T[];
     // (undocumented)
-    selectById: (state: V, id: EntityId) => T | undefined;
+    selectById: (state: V, id: EntityId, ...args: ExtraArgs) => T | undefined;
     // (undocumented)
-    selectEntities: (state: V) => Dictionary<T>;
+    selectEntities: (state: V, ...args: ExtraArgs) => Dictionary<T>;
     // (undocumented)
-    selectIds: (state: V) => EntityId[];
+    selectIds: (state: V, ...args: ExtraArgs) => EntityId[];
     // (undocumented)
-    selectTotal: (state: V) => number;
+    selectTotal: (state: V, ...args: ExtraArgs) => number;
 }
 
 // @public (undocumented)

--- a/src/entities/models.ts
+++ b/src/entities/models.ts
@@ -148,12 +148,12 @@ export interface EntityStateAdapter<T> {
 /**
  * @public
  */
-export interface EntitySelectors<T, V> {
-  selectIds: (state: V) => EntityId[]
-  selectEntities: (state: V) => Dictionary<T>
-  selectAll: (state: V) => T[]
-  selectTotal: (state: V) => number
-  selectById: (state: V, id: EntityId) => T | undefined
+export interface EntitySelectors<T, V, ExtraArgs extends any[] = []> {
+  selectIds: (state: V, ...args: ExtraArgs) => EntityId[]
+  selectEntities: (state: V, ...args: ExtraArgs) => Dictionary<T>
+  selectAll: (state: V, ...args: ExtraArgs) => T[]
+  selectTotal: (state: V, ...args: ExtraArgs) => number
+  selectById: (state: V, id: EntityId, ...args: ExtraArgs) => T | undefined
 }
 
 /**

--- a/src/entities/state_selectors.ts
+++ b/src/entities/state_selectors.ts
@@ -3,11 +3,11 @@ import { EntityState, EntitySelectors, Dictionary, EntityId } from './models'
 
 export function createSelectorsFactory<T>() {
   function getSelectors(): EntitySelectors<T, EntityState<T>>
-  function getSelectors<V>(
-    selectState: (state: V) => EntityState<T>
-  ): EntitySelectors<T, V>
+  function getSelectors<V, ExtraArgs extends any[]>(
+    selectState: (state: V, ...args: ExtraArgs) => EntityState<T>
+  ): EntitySelectors<T, V, ExtraArgs>
   function getSelectors(
-    selectState?: (state: any) => EntityState<T>
+    selectState?: (state: any, ...args: any[]) => EntityState<T>
   ): EntitySelectors<T, any> {
     const selectIds = (state: any) => state.ids
 
@@ -40,10 +40,9 @@ export function createSelectorsFactory<T>() {
       }
     }
 
-    const selectGlobalizedEntities = createDraftSafeSelector(
-      selectState,
-      selectEntities
-    )
+    const selectGlobalizedEntities: (
+      ...args: any[]
+    ) => Dictionary<T> = createDraftSafeSelector(selectState, selectEntities)
 
     return {
       selectIds: createDraftSafeSelector(selectState, selectIds),
@@ -51,7 +50,7 @@ export function createSelectorsFactory<T>() {
       selectAll: createDraftSafeSelector(selectState, selectAll),
       selectTotal: createDraftSafeSelector(selectState, selectTotal),
       selectById: createDraftSafeSelector(
-        selectGlobalizedEntities,
+        (state, _, ...args) => selectGlobalizedEntities(state, ...args),
         selectId,
         selectById
       ),


### PR DESCRIPTION
As requested by Daniel in chat.

It's not a lot of code, so it could be discussion-worthy.

Essentially, the idea is to be able to pass additional args into the selectors created by the entityAdapter.
Actually, this is currently already possible for everything except `selectById` due to how reselect works - but not supported by the types.

Example:

```ts
import { createEntityAdapter } from "@reduxjs/toolkit";

const adapter = createEntityAdapter();

export const { selectAll: getComponents } = adapter.getSelectors(
  // @ts-ignore
  (state, containerId) => state.page.containers[containerId].components
);

let components = adapter.getInitialState();
components = adapter.addOne(components, { id: 1, foo: "bar" });

const state = {
    page: {
      containers: [undefined, undefined, { components }]
    }
  };

//@ts-ignore
const x = getComponents(state, 2);

```