### PR TITLE
Minor docs tweaks

### DIFF
--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -93,6 +93,8 @@ export default store
 You can also pass an object full of ["slice reducers"](https://redux.js.org/recipes/structuring-reducers/splitting-reducer-logic), and `configureStore` will call [`combineReducers`](https://redux.js.org/api/combinereducers) for you:
 
 ```js
+import { configureStore } from '@reduxjs/toolkit'
+// highlight-start
 import usersReducer from './usersReducer'
 import postsReducer from './postsReducer'
 
@@ -102,6 +104,9 @@ const store = configureStore({
     posts: postsReducer,
   },
 })
+// highlight-end
+
+export default store
 ```
 
 Note that this only works for one level of reducers. If you want to nest reducers, you'll need to call `combineReducers` yourself to handle the nesting.

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -36,10 +36,12 @@ The basics of using `configureStore` are shown in [TypeScript Quick Start tutori
 The easiest way of getting the `State` type is to define the root reducer in advance and extract its `ReturnType`.  
 It is recommend to give the type a different name like `RootState` to prevent confusion, as the type name `State` is usually overused.
 
-```typescript {3}
+```typescript
 import { combineReducers } from '@reduxjs/toolkit'
 const rootReducer = combineReducers({})
+// highlight-start
 export type RootState = ReturnType<typeof rootReducer>
+// highlight-end
 ```
 
 Alternatively, if you choose to not create a `rootReducer` yourself and instead pass the slice reducers directly to `configureStore()`, you need to slightly modify the typing to correctly infer the root reducer:
@@ -54,13 +56,15 @@ const store = configureStore({
   },
 })
 export type RootState = ReturnType<typeof store.getState>
+
+export default store
 ```
 
 ### Getting the `Dispatch` type
 
 If you want to get the `Dispatch` type from your store, you can extract it after creating the store. It is recommended to give the type a different name like `AppDispatch` to prevent confusion, as the type name `Dispatch` is usually overused. You may also find it to be more convenient to export a hook like `useAppDispatch` shown below, then using it wherever you'd call `useDispatch`.
 
-```typescript {6}
+```typescript
 import { configureStore } from '@reduxjs/toolkit'
 import { useDispatch } from 'react-redux'
 import rootReducer from './rootReducer'
@@ -69,8 +73,12 @@ const store = configureStore({
   reducer: rootReducer,
 })
 
+// highlight-start
 export type AppDispatch = typeof store.dispatch
 export const useAppDispatch = () => useDispatch<AppDispatch>() // Export a hook that can be reused to resolve types
+// highlight-end
+
+export default store
 ```
 
 ### Correct typings for the `Dispatch` type
@@ -81,7 +89,7 @@ As TypeScript often widens array types when combining arrays using the spread op
 
 Also, we suggest using the callback notation for the `middleware` option to get a correctly pre-typed version of `getDefaultMiddleware` that does not require you to specify any generics by hand.
 
-```ts {10-20}
+```ts
 import { configureStore } from '@reduxjs/toolkit'
 import additionalMiddleware from 'additional-middleware'
 import logger from 'redux-logger'
@@ -89,9 +97,10 @@ import logger from 'redux-logger'
 import untypedMiddleware from 'untyped-middleware'
 import rootReducer from './rootReducer'
 
-type RootState = ReturnType<typeof rootReducer>
+export type RootState = ReturnType<typeof rootReducer>
 const store = configureStore({
   reducer: rootReducer,
+  // highlight-start
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware()
       .prepend(
@@ -105,9 +114,12 @@ const store = configureStore({
       )
       // prepend and concat calls can be chained
       .concat(logger),
+  // highlight-end
 })
 
-type AppDispatch = typeof store.dispatch
+export type AppDispatch = typeof store.dispatch
+
+export default store
 ```
 
 #### Using `MiddlewareArray` without `getDefaultMiddleware`


### PR DESCRIPTION
Further expands on #991 by showing the store exported in other snippets that might be mimicked closely. Also tries to fix a couple of instances identified where the snippet highlighting did not appear to match up with the code being discussed.

Changes:
```
    - Show `store` as exported in relevant snippets
    - Fix incorrect highlighted section in docs regarding
      middleware usage with typescript
    - Convert majority of snippet highlighting methods to explicitly wrap
      lines as opposed to specifying line numbers
```