### PR TITLE
split up yarn and npm install instructions for easier copying

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -44,7 +44,10 @@ Redux Toolkit is available as a package on NPM for use with a module bundler or 
 ```bash
 # NPM
 npm install @reduxjs/toolkit
+```
+or
 
+```bash
 # Yarn
 yarn add @reduxjs/toolkit
 ```

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -45,6 +45,7 @@ Redux Toolkit is available as a package on NPM for use with a module bundler or 
 # NPM
 npm install @reduxjs/toolkit
 ```
+
 or
 
 ```bash


### PR DESCRIPTION
it is annoying to copy ( left top ) two commands instead of one command `npm install ...` or `yarn add ...` 
please have look at https://redux-toolkit.js.org/introduction/getting-started#an-existing-app and try yourself a copy at the left top you will get two commands instead of one command