### PR TITLE
Expose `useLazyQuerySubscription` for individual endpoints

### DIFF
--- a/src/query/react/module.ts
+++ b/src/query/react/module.ts
@@ -130,12 +130,14 @@ export const reactHooksModule = ({
           const {
             useQuery,
             useLazyQuery,
+            useLazyQuerySubscription,
             useQueryState,
             useQuerySubscription,
           } = buildQueryHooks(endpointName)
           safeAssign(anyApi.endpoints[endpointName], {
             useQuery,
             useLazyQuery,
+            useLazyQuerySubscription,
             useQueryState,
             useQuerySubscription,
           })


### PR DESCRIPTION
The typing for `QueryHooks` claimed to include `useLazyQuerySubscription`, which *appeared* to expose the hook for individual endpoints. However in the react module, it was never used, so something like `api.endpoints.getPosts.useLazyQuerySubscription` would show the corresponding type, but would actually be `undefined`.

This PR makes the react modules attach `useLazyQuerySubscription` to query endpoints, in line with the types.