### PR TITLE
Fix bad transpilation of set iteration breaking invalidation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,3 +11,4 @@ jobs:
       - uses: preactjs/compressed-size-action@v1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          pattern: './dist/**/*.js'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: preactjs/compressed-size-action@v1
+      - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          pattern: './dist/**/*.js'

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.log
 node_modules
 # Dist and query are both build output folders
-dist
+dist*/
 !query/
 # But don't ignore the RTK Query source
 !src/query/

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -116,6 +116,8 @@ const entryPoints: EntryPointOptions[] = [
 ]
 
 const esVersionMappings = {
+  // Don't output ES2015 - have TS convert to ES5 instead
+  es2015: ts.ScriptTarget.ES5,
   es2017: ts.ScriptTarget.ES2017,
   es2018: ts.ScriptTarget.ES2018,
   es2019: ts.ScriptTarget.ES2019,
@@ -130,7 +132,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     folder = '',
     prefix = 'redux-toolkit',
     name,
-    target,
+    target = 'es2015',
     entryPoint,
   } = options
 
@@ -142,7 +144,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     entryPoints: [entryPoint],
     outfile: outputFilePath,
     write: false,
-    target: 'esnext',
+    target: target,
     sourcemap: 'inline',
     bundle: true,
     format: format === 'umd' ? 'esm' : format,
@@ -232,7 +234,11 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
       mapping = transformResult.map as RawSourceMap
     }
 
-    console.log('Build artifact:', chunk.path)
+    const relativePath = path.relative(process.cwd(), chunk.path)
+    console.log(`Build artifact: ${relativePath}, settings: `, {
+      target,
+      output: ts.ScriptTarget[esVersion],
+    })
     await fs.writeFile(chunk.path, code)
     await fs.writeJSON(chunk.path + '.map', mapping)
   }

--- a/src/query/core/buildMiddleware.ts
+++ b/src/query/core/buildMiddleware.ts
@@ -242,7 +242,8 @@ export function buildMiddleware<
     }
 
     context.batch(() => {
-      for (const queryCacheKey of toInvalidate.values()) {
+      const valuesArray = Array.from(toInvalidate.values())
+      for (const queryCacheKey of valuesArray) {
         const querySubState = state.queries[queryCacheKey]
         const subscriptionSubState = state.subscriptions[queryCacheKey]
         if (querySubState && subscriptionSubState) {


### PR DESCRIPTION
TS seems to be transpiling a `for..of` Set iteration the wrong way - it's producing a `for(let i` loop over `_values.length`, which doesn't exist.

Working around this by creating an Array from the Set values and looping over that.

Also tweaked the build setup to try having ESBuild do most of the transpilation instead of TS. (Doesn't fix the problem here, because ESBuild only goes down to ES2015, and it's an ES2015->ES5 step that's breaking.)