### PR TITLE
Docs - Add explanation for removeAll method for createEntityAdapter's CRUD functions

### DIFF
--- a/docs/api/createEntityAdapter.mdx
+++ b/docs/api/createEntityAdapter.mdx
@@ -206,12 +206,13 @@ The primary content of an entity adapter is a set of generated reducer functions
 - `setAll`: accepts an array of entities or an object in the shape of `Record<EntityId, T>`, and replaces the existing entity contents with the values in the array.
 - `removeOne`: accepts a single entity ID value, and removes the entity with that ID if it exists.
 - `removeMany`: accepts an array of entity ID values, and removes each entity with those IDs if they exist.
+- `removeAll`: removes all entities from the entity state object.
 - `updateOne`: accepts an "update object" containing an entity ID and an object containing one or more new field values to update inside a `changes` field, and performs a shallow update on the corresponding entity.
 - `updateMany`: accepts an array of update objects, and performs shallow updates on all corresponding entities.
 - `upsertOne`: accepts a single entity. If an entity with that ID exists, it will perform a shallow update and the specified fields will be merged into the existing entity, with any matching fields overwriting the existing values. If the entity does not exist, it will be added.
 - `upsertMany`: accepts an array of entities or an object in the shape of `Record<EntityId, T>` that will be shallowly upserted.
 
-Each method has a signature that looks like:
+Each method (except `removeAll`) has a signature that looks like:
 
 ```ts no-transpile
 (state: EntityState<T>, argument: TypeOrPayloadAction<Argument<T>>) => EntityState<T>

--- a/docs/api/createEntityAdapter.mdx
+++ b/docs/api/createEntityAdapter.mdx
@@ -212,7 +212,7 @@ The primary content of an entity adapter is a set of generated reducer functions
 - `upsertOne`: accepts a single entity. If an entity with that ID exists, it will perform a shallow update and the specified fields will be merged into the existing entity, with any matching fields overwriting the existing values. If the entity does not exist, it will be added.
 - `upsertMany`: accepts an array of entities or an object in the shape of `Record<EntityId, T>` that will be shallowly upserted.
 
-Each method (except `removeAll`) has a signature that looks like:
+Each method has a signature that looks like:
 
 ```ts no-transpile
 (state: EntityState<T>, argument: TypeOrPayloadAction<Argument<T>>) => EntityState<T>


### PR DESCRIPTION
Hi, thanks for the awesome library and documentation!

I was looking for a method that removes all entities in state objects created by `createEntityAdapter`. I thought this was not available as the current documentation does not explain the method as [seen here](https://redux-toolkit.js.org/api/createEntityAdapter#crud-functions).

Turns out I was wrong as there _is_ a `removeAll` method described in the [types](https://redux-toolkit.js.org/api/createEntityAdapter#return-value) section above.

I'm adding a line to explain the `removeAll` method to improve clarity for beginners like me that gloss over the docs and assume no such method exists.

Thanks again!