### PR TITLE
prevent badly typed `Middleware<any>` from casting `dispatch` to `any`

### DIFF
--- a/src/tests/configureStore.typetest.ts
+++ b/src/tests/configureStore.typetest.ts
@@ -13,7 +13,7 @@ import {
   getDefaultMiddleware,
 } from '@reduxjs/toolkit'
 import thunk, { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
-import { expectType } from './helpers'
+import { expectNotAny, expectType } from './helpers'
 
 const _anyMiddleware: any = () => () => () => {}
 
@@ -396,5 +396,18 @@ const _anyMiddleware: any = () => () => () => {}
     const result1: 'A' = store.dispatch('a')
     // @ts-expect-error
     store.dispatch(thunkA())
+  }
+
+  /**
+   * Test: badly typed middleware won't make `dispatch` `any`
+   */
+  {
+    const store = configureStore({
+      reducer: reducerA,
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware().concat(_anyMiddleware as Middleware<any>),
+    })
+
+    expectNotAny(store.dispatch)
   }
 }

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -74,7 +74,7 @@ export type DispatchForMiddlewares<M> = M extends ReadonlyArray<any>
       M[number] extends infer MiddlewareValues
         ? MiddlewareValues extends Middleware<infer DispatchExt, any, any>
           ? DispatchExt extends Function
-            ? DispatchExt
+            ? IsAny<DispatchExt, never, DispatchExt>
             : never
           : never
         : never


### PR DESCRIPTION
Happened to myself: had a cast to `Middleware<any>` somewhere in the tests and suddenly all our `dispatch` were `any`, too. We should catch that.