### PR TITLE
Docs - add 'Migrating to RTK Query' page

### DIFF
--- a/docs/usage/rtk-query/migrating-from-thunks.mdx
+++ b/docs/usage/rtk-query/migrating-from-thunks.mdx
@@ -1,0 +1,312 @@
+---
+id: migrating-from-thunks
+title: Migrating from thunks
+sidebar_label: Migrating from thunks
+hide_title: true
+---
+
+# Migrating from thunks
+
+While RTK Query is not intended to be a replacement for thunks, it _is_ expected to cover a lot of overlapping behaviour that users may have previously used `createAsyncThunk` for, including caching purposes, and request lifecycle managment (e.g. `isUninitialized`, `isLoading`, `isError` states).
+
+In order to migrate from standalone thunks + reducers to RTK Query, the appropriate endpoints should be added to an RTK Query api, and the existing thunks & reducers deleted. This generally will not include much common code kept between the two, as they work differently and one will replace the other.
+
+## Examples
+
+The examples below demonstrate two methods of achieving a similar purpose: caching data from a request while also providing `isUninitialized`, `isLoading` & `isError` states associated with the request. The first method uses thunks & manually written reducers, while the second uses an api defined with RTK Query.
+
+:::note
+RTK Query provides a lot more than the features created with the thunk example shown below. The example is only intended to demonstrate how the common features below could be replaced with RTK Query.
+:::
+
+### Using thunks & manually written reducers
+
+1. Create the appropriate thunk, add the appropriate reducers to your slice, and create selectors for the data and request statuses:
+
+   ```ts title="src/services/pokemonSlice.ts"
+   // file: src/services/types.ts noEmit
+   export interface Pokemon {}
+
+   // file: src/store.ts noEmit
+   import { configureStore } from '@reduxjs/toolkit'
+   import { pokemonSlice } from './services/pokemonSlice'
+
+   export const store = configureStore({
+     reducer: {
+       pokemon: pokemonSlice.reducer,
+     },
+   })
+
+   export type RootState = ReturnType<typeof store.getState>
+
+   // file: src/services/pokemonSlice.ts
+   import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+   import { Pokemon } from './types'
+   import { RootState } from '../store'
+
+   // highlight-start
+   type RequestState = 'pending' | 'fulfilled' | 'rejected'
+   // highlight-end
+
+   // highlight-start
+   const fetchPokemonByName = createAsyncThunk<Pokemon, string>(
+     'pokemon/fetchByName',
+     async (name, { rejectWithValue }) => {
+       const response = await fetch(
+         `https://pokeapi.co/api/v2/pokemon/${name}`
+       ).then((res) => res.json())
+       if (response.status < 200 || response.status >= 300) {
+         return rejectWithValue(response)
+       }
+       return response
+     }
+   )
+   // highlight-end
+
+   export const pokemonSlice = createSlice({
+     name: 'pokemon',
+     initialState: {
+       // highlight-start
+       dataByName: {} as Record<string, Pokemon | undefined>,
+       statusByName: {} as Record<string, RequestState | undefined>,
+       // highlight-end
+     },
+     reducers: {},
+     extraReducers: (builder) => {
+       // highlight-start
+       builder.addCase(fetchPokemonByName.pending, (state, action) => {
+         state.statusByName[action.meta.arg] = 'pending'
+       })
+       builder.addCase(fetchPokemonByName.fulfilled, (state, action) => {
+         state.statusByName[action.meta.arg] = 'fulfilled'
+         state.dataByName[action.meta.arg] = action.payload
+       })
+       builder.addCase(fetchPokemonByName.rejected, (state, action) => {
+         state.statusByName[action.meta.arg] = 'rejected'
+       })
+       // highlight-end
+     },
+   })
+
+   // highlight-start
+   export const selectStatusByName = (state: RootState, name: string) =>
+     state.pokemon.statusByName[name]
+   export const selectDataByName = (state: RootState, name: string) =>
+     state.pokemon.dataByName[name]
+   // highlight-end
+   ```
+
+1. If not done previously, add the reducer to your store setup:
+
+   ```ts title="src/services/store.ts"
+   // file: src/services/pokemonSlice.ts noEmit
+   import { Reducer } from '@reduxjs/toolkit'
+   declare const reducer: Reducer<{}>
+   export const pokemonSlice = {
+     reducer,
+   }
+
+   // file: src/store.ts
+   import { configureStore } from '@reduxjs/toolkit'
+   import { pokemonSlice } from './services/pokemonSlice'
+
+   export const store = configureStore({
+     reducer: {
+       // highlight-start
+       pokemon: pokemonSlice.reducer,
+       // highlight-end
+     },
+   })
+
+   export type RootState = ReturnType<typeof store.getState>
+   ```
+
+   Create a hook to manage accessing the appropriate data & request status:
+
+   ```ts title="src/hooks.ts"
+   // file: src/services/pokemonSlice.ts noEmit
+   import { AsyncThunkAction } from '@reduxjs/toolkit'
+   import { RootState } from '../store'
+   interface Pokemon {}
+   export declare const fetchPokemonByName: (
+     arg: string
+   ) => AsyncThunkAction<Pokemon, string, {}>
+
+   export const selectStatusByName = (state: RootState, name: string) =>
+     state.pokemon.statusByName[name]
+   export const selectDataByName = (state: RootState, name: string) =>
+     state.pokemon.dataByName[name]
+
+   // file: src/store.ts noEmit
+   interface Pokemon {}
+   type RequestState = 'pending' | 'fulfilled' | 'rejected'
+
+   const initialPokemonSlice = {
+     dataByName: {} as Record<string, Pokemon | undefined>,
+     statusByName: {} as Record<string, RequestState | undefined>,
+   }
+   export type RootState = {
+     pokemon: typeof initialPokemonSlice
+   }
+
+   // file: src/hooks.ts
+   import { useEffect } from 'react'
+   import { useDispatch, useSelector } from 'react-redux'
+   import { RootState } from './store'
+   import {
+     fetchPokemonByName,
+     selectStatusByName,
+     selectDataByName,
+   } from './services/pokemonSlice'
+
+   // highlight-start
+   export function useGetPokemonByName(name: string) {
+     const dispatch = useDispatch()
+     const statusByName = useSelector((state: RootState) =>
+       selectStatusByName(state, name)
+     )
+     const data = useSelector((state: RootState) =>
+       selectStatusByName(state, name)
+     )
+     useEffect(() => {
+       // upon mount or name change, if status is uninitialized, send a request
+       // for the pokemon name
+       if (statusByName === undefined) {
+         dispatch(fetchPokemonByName(name))
+       }
+     }, [statusByName, dispatch, name])
+
+     const isUninitialized = statusByName === undefined
+     const isLoading = statusByName === 'pending'
+     const isError = statusByName === 'rejected'
+     const isSuccess = statusByName === 'fulfilled'
+
+     return { data, isUninitialized, isLoading, isError, isSuccess }
+   }
+   // highlight-end
+   ```
+
+1. Use the manually created hook:
+
+   ```tsx title="Usage in a react component"
+   // highlight-start
+   import * as React from 'react'
+   import { useGetPokemonByName } from './hooks'
+   // highlight-end
+
+   export default function App() {
+     // highlight-start
+     const { data, isError, isLoading } = useGetPokemonByName('bulbasaur')
+     // highlight-end
+
+     return (
+       <div className="App">
+         {isError ? (
+           <>Oh no, there was an error</>
+         ) : isLoading ? (
+           <>Loading...</>
+         ) : data ? (
+           <>
+             <h3>{data.species.name}</h3>
+             <img src={data.sprites.front_shiny} alt={data.species.name} />
+           </>
+         ) : null}
+       </div>
+     )
+   }
+   ```
+
+### Using RTK Query
+
+1. Add the appropriate endpoint to your api:
+
+   ```ts title="src/services/api.ts"
+   // file: types.ts noEmit
+   interface Pokemon {}
+
+   // file: api.ts
+   import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+   export const api = createApi({
+     baseQuery: fetchBaseQuery({ baseUrl: 'https://pokeapi.co/api/v2/' }),
+     endpoints: (build) => ({
+       // highlight-start
+       getPokemonByName: build.query<Pokemon, string>({
+         query: (name) => `pokemon/${name}`,
+       }),
+       // highlight-end
+     }),
+   })
+
+   export const { useGetPokemonByNameQuery } = api
+   ```
+
+1. If not done previously, add the reducer & middleware to your store setup, and optionally [set up listeners](../../api/rtk-query/setupListeners) for additional behaviour:
+
+   ```ts title="src/store.ts"
+   // file: src/services/api.ts noEmit
+   import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+   interface Pokemon {}
+
+   export const api = createApi({
+     baseQuery: fetchBaseQuery({ baseUrl: 'https://pokeapi.co/api/v2/' }),
+     endpoints: (builder) => ({
+       getPokemonByName: builder.query<Pokemon, string>({
+         query: (name) => `pokemon/${name}`,
+       }),
+     }),
+   })
+
+   // file: src/store.ts
+   import { configureStore } from '@reduxjs/toolkit'
+   // highlight-start
+   import { setupListeners } from '@reduxjs/toolkit/query'
+   import { api } from './services/api'
+   // highlight-end
+
+   export const store = configureStore({
+     reducer: {
+       // highlight-start
+       [api.reducerPath]: api.reducer,
+       // highlight-end
+     },
+     // highlight-start
+     middleware: (gDM) => gDM().concat(api.middleware),
+     // highlight-end
+   })
+
+   // highlight-start
+   setupListeners(store.dispatch)
+   // highlight-end
+   ```
+
+1. Use the automatically created hook:
+
+   ```tsx title="Usage in a react component"
+   // highlight-start
+   import * as React from 'react'
+   import { useGetPokemonByNameQuery } from './services/api'
+   // highlight-end
+
+   export default function App() {
+     // highlight-start
+     // Using a query hook automatically fetches data and returns query values
+     const { data, error, isLoading } = useGetPokemonByNameQuery('bulbasaur')
+     // highlight-end
+
+     return (
+       <div className="App">
+         {error ? (
+           <>Oh no, there was an error</>
+         ) : isLoading ? (
+           <>Loading...</>
+         ) : data ? (
+           <>
+             <h3>{data.species.name}</h3>
+             <img src={data.sprites.front_shiny} alt={data.species.name} />
+           </>
+         ) : null}
+       </div>
+     )
+   }
+   ```

--- a/docs/usage/rtk-query/migrating-from-thunks.mdx
+++ b/docs/usage/rtk-query/migrating-from-thunks.mdx
@@ -218,7 +218,7 @@ RTK Query provides a lot more than the features created with the thunk example s
 
 ### Using RTK Query
 
-1. Add the appropriate endpoint to your api:
+1. Add the appropriate endpoint to your api and export the automatically created hook:
 
    ```ts title="src/services/api.ts"
    // file: types.ts noEmit
@@ -238,7 +238,9 @@ RTK Query provides a lot more than the features created with the thunk example s
      }),
    })
 
+   // highlight-start
    export const { useGetPokemonByNameQuery } = api
+   // highlight-end
    ```
 
 1. If not done previously, add the reducer & middleware to your store setup, and optionally [set up listeners](../../api/rtk-query/setupListeners) for additional behaviour:

--- a/docs/usage/rtk-query/migrating-to-rtk-query.mdx
+++ b/docs/usage/rtk-query/migrating-to-rtk-query.mdx
@@ -349,7 +349,7 @@ export const { useGetPokemonByNameQuery } = api
 
 #### Connecting our Api to the store
 
-Now that we have our api definition created, we need to hook it up to our store. In order to do that, we will need to use the [`reducerPath`](../../api/rtk-query/redux-integration.mdx#reducerpath) and [`middleware`](../../api/rtk-query/redux-integration.mdx#middleware) properties from our created `api`. This will allow the store to process the internal actions that the generated hook uses, allows the generated API logic to find the state correctly, and adds the logic for managing caching, invalidation, subscriptions, polling, and more.
+Now that we have our api definition created, we need to hook it up to our store. In order to do that, we will need to use the [`reducerPath`](../../api/rtk-query/created-api/redux-integration.mdx#reducerpath) and [`middleware`](../../api/rtk-query/created-api/redux-integration.mdx#middleware) properties from our created `api`. This will allow the store to process the internal actions that the generated hook uses, allows the generated API logic to find the state correctly, and adds the logic for managing caching, invalidation, subscriptions, polling, and more.
 
 ```ts title="src/store.ts"
 // file: src/services/pokemonSlice.ts noEmit

--- a/docs/usage/rtk-query/migrating-to-rtk-query.mdx
+++ b/docs/usage/rtk-query/migrating-to-rtk-query.mdx
@@ -63,13 +63,12 @@ import { RootState } from '../store'
 export const fetchPokemonByName = createAsyncThunk<Pokemon, string>(
   'pokemon/fetchByName',
   async (name, { rejectWithValue }) => {
-    const response = await fetch(
-      `https://pokeapi.co/api/v2/pokemon/${name}`
-    ).then((res) => res.json())
+    const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${name}`)
+    const data = await response.json()
     if (response.status < 200 || response.status >= 300) {
-      return rejectWithValue(response)
+      return rejectWithValue(data)
     }
-    return response
+    return data
   }
 )
 // highlight-end
@@ -450,7 +449,7 @@ Given that we're no longer using that slice any longer, we can remove the import
 We can also remove the _entire slice and hook files_ completely!
 
 ```diff
-- src/services/pokemonSlice.ts (-52 lines)
+- src/services/pokemonSlice.ts (-51 lines)
 - src/hooks.ts (-34 lines)
 ```
 

--- a/docs/usage/rtk-query/migrating-to-rtk-query.mdx
+++ b/docs/usage/rtk-query/migrating-to-rtk-query.mdx
@@ -1,15 +1,19 @@
 ---
-id: migrating-from-thunks
-title: Migrating from thunks
-sidebar_label: Migrating from thunks
+id: migrating-to-rtk-query
+title: Migrating to RTK Query
+sidebar_label: Migrating to RTK Query
 hide_title: true
 ---
 
-# Migrating from thunks
+# Migrating to RTK Query
 
-While RTK Query is not intended to be a replacement for thunks, it _is_ expected to cover a lot of overlapping behaviour that users may have previously used `createAsyncThunk` for, including caching purposes, and request lifecycle managment (e.g. `isUninitialized`, `isLoading`, `isError` states).
+The most common use case for side effects in Redux apps is fetching data. Redux apps typically use a tool like thunks, sagas, or observables to make an AJAX request, and [dispatch actions based on the results of the request](https://redux.js.org/tutorials/fundamentals/part-7-standard-patterns#async-request-status). Reducers then listen for those actions to manage loading state and cache the fetched data.
 
-In order to migrate from standalone thunks + reducers to RTK Query, the appropriate endpoints should be added to an RTK Query api, and the existing thunks & reducers deleted. This generally will not include much common code kept between the two, as they work differently and one will replace the other.
+RTK Query is purpose-built to solve the use case of data fetching. While it can't replace all of the situations where you'd use thunks or other side effects approaches, using RTK Query should eliminate the need for most of that hand-written side effects logic.
+
+RTK Query is expected to cover a lot of overlapping behaviour that users may have previously used `createAsyncThunk` for, including caching purposes, and request lifecycle management (e.g. `isUninitialized`, `isLoading`, `isError` states).
+
+In order to migrate data-fetching features from existing Redux tools to RTK Query, the appropriate endpoints should be added to an RTK Query api, and the previous feature code deleted. This generally will not include much common code kept between the two, as the tools work differently and one will replace the other.
 
 ## Examples
 

--- a/docs/usage/rtk-query/migrating-to-rtk-query.mdx
+++ b/docs/usage/rtk-query/migrating-to-rtk-query.mdx
@@ -7,6 +7,8 @@ hide_title: true
 
 # Migrating to RTK Query
 
+## Overview
+
 The most common use case for side effects in Redux apps is fetching data. Redux apps typically use a tool like thunks, sagas, or observables to make an AJAX request, and [dispatch actions based on the results of the request](https://redux.js.org/tutorials/fundamentals/part-7-standard-patterns#async-request-status). Reducers then listen for those actions to manage loading state and cache the fetched data.
 
 RTK Query is purpose-built to solve the use case of data fetching. While it can't replace all of the situations where you'd use thunks or other side effects approaches, using RTK Query should eliminate the need for most of that hand-written side effects logic.
@@ -15,304 +17,457 @@ RTK Query is expected to cover a lot of overlapping behaviour that users may hav
 
 In order to migrate data-fetching features from existing Redux tools to RTK Query, the appropriate endpoints should be added to an RTK Query api, and the previous feature code deleted. This generally will not include much common code kept between the two, as the tools work differently and one will replace the other.
 
-## Examples
+If you're looking to get started with RTK Query from scratch, you may also wish to see [`RTK Query Quick Start`](../../tutorials/rtk-query.mdx).
 
-The examples below demonstrate two methods of achieving a similar purpose: caching data from a request while also providing `isUninitialized`, `isLoading` & `isError` states associated with the request. The first method uses thunks & manually written reducers, while the second uses an api defined with RTK Query.
+## Example - Migrating data-fetching logic from Redux Toolkit to RTK Query
 
-:::note
-RTK Query provides a lot more than the features created with the thunk example shown below. The example is only intended to demonstrate how the common features below could be replaced with RTK Query.
+:::tip What You'll Learn
+
+- How to convert conventional data-fetching logic implemented with `Redux Toolkit` + `createAsyncThunk` to use `Redux Toolkit Query`
+
 :::
 
-### Using thunks & manually written reducers
+A common method used to implement simple, cached, data-fetching logic with Redux is to set up a slice using `createSlice`, with state containing the associated `data` and `status` for a query, using `createAsyncThunk` to handle the asynchronous request lifecycles. Below we will explore an example of such an implementation, and how we can later go about migrating that code to use RTK Query instead.
 
-1. Create the appropriate thunk, add the appropriate reducers to your slice, and create selectors for the data and request statuses:
+:::note
+RTK Query also provides many more features than what is created with the thunk example shown below. The example is only intended to demonstrate how the particular implementation could be replaced with RTK Query.
+:::
 
-   ```ts title="src/services/pokemonSlice.ts"
-   // file: src/services/types.ts noEmit
-   export interface Pokemon {}
+### Design specifications
 
-   // file: src/store.ts noEmit
-   import { configureStore } from '@reduxjs/toolkit'
-   import { pokemonSlice } from './services/pokemonSlice'
+For our example, the design specifications required for the tool are as follows:
 
-   export const store = configureStore({
-     reducer: {
-       pokemon: pokemonSlice.reducer,
-     },
-   })
+- Provide a hook to fetch data for a `pokemon` using the api: https://pokeapi.co/api/v2/pokemon/bulbasaur, where bulbasaur can be any pokemon name
+- A request for any given name should only be sent if it hasn't already done so for the session
+- The hook should provide us with the current status of the request for the supplied pokemon name; whether it is in an 'uninitialized', 'pending', 'fulfilled', or 'rejected' state
+- The hook should provide us with the current data for the supplied pokemon name
 
-   export type RootState = ReturnType<typeof store.getState>
+With the above specifications in mind, lets first look at an overview of how this could be implemented traditionally using `createAsyncThunk` combined with `createSlice`.
 
-   // file: src/services/pokemonSlice.ts
-   import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-   import { Pokemon } from './types'
-   import { RootState } from '../store'
+### Implementation using `createSlice` & `createAsyncThunk`
 
-   // highlight-start
-   type RequestState = 'pending' | 'fulfilled' | 'rejected'
-   // highlight-end
+#### Slice file
 
-   // highlight-start
-   const fetchPokemonByName = createAsyncThunk<Pokemon, string>(
-     'pokemon/fetchByName',
-     async (name, { rejectWithValue }) => {
-       const response = await fetch(
-         `https://pokeapi.co/api/v2/pokemon/${name}`
-       ).then((res) => res.json())
-       if (response.status < 200 || response.status >= 300) {
-         return rejectWithValue(response)
-       }
-       return response
-     }
-   )
-   // highlight-end
+The three snippets below make up our slice file. This file is concerned with managing our asynchronous request lifecycles, as well as storing our data & request statuses for a given pokemon name.
 
-   export const pokemonSlice = createSlice({
-     name: 'pokemon',
-     initialState: {
-       // highlight-start
-       dataByName: {} as Record<string, Pokemon | undefined>,
-       statusByName: {} as Record<string, RequestState | undefined>,
-       // highlight-end
-     },
-     reducers: {},
-     extraReducers: (builder) => {
-       // highlight-start
-       builder.addCase(fetchPokemonByName.pending, (state, action) => {
-         state.statusByName[action.meta.arg] = 'pending'
-       })
-       builder.addCase(fetchPokemonByName.fulfilled, (state, action) => {
-         state.statusByName[action.meta.arg] = 'fulfilled'
-         state.dataByName[action.meta.arg] = action.payload
-       })
-       builder.addCase(fetchPokemonByName.rejected, (state, action) => {
-         state.statusByName[action.meta.arg] = 'rejected'
-       })
-       // highlight-end
-     },
-   })
+##### Thunk action creator
 
-   // highlight-start
-   export const selectStatusByName = (state: RootState, name: string) =>
-     state.pokemon.statusByName[name]
-   export const selectDataByName = (state: RootState, name: string) =>
-     state.pokemon.dataByName[name]
-   // highlight-end
-   ```
+Below we create a thunk action creator using [`createAsyncThunk`](../../api/createAsyncThunk.mdx) in order to manage asynchronous request lifecycles. This will be accessible within components & hooks to be dispatched, in order to fire off a request for some pokemon data. `createAsyncThunk` itself will handle dispatching lifecycle methods for our request: `pending`, `fulfilled`, and `rejected`, which we will handle within our slice.
 
-1. If not done previously, add the reducer to your store setup:
+```ts title="src/services/pokemonSlice.ts - Thunk Action Creator" no-transpile
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { Pokemon } from './types'
+import { RootState } from '../store'
 
-   ```ts title="src/services/store.ts"
-   // file: src/services/pokemonSlice.ts noEmit
-   import { Reducer } from '@reduxjs/toolkit'
-   declare const reducer: Reducer<{}>
-   export const pokemonSlice = {
-     reducer,
-   }
+// highlight-start
+export const fetchPokemonByName = createAsyncThunk<Pokemon, string>(
+  'pokemon/fetchByName',
+  async (name, { rejectWithValue }) => {
+    const response = await fetch(
+      `https://pokeapi.co/api/v2/pokemon/${name}`
+    ).then((res) => res.json())
+    if (response.status < 200 || response.status >= 300) {
+      return rejectWithValue(response)
+    }
+    return response
+  }
+)
+// highlight-end
 
-   // file: src/store.ts
-   import { configureStore } from '@reduxjs/toolkit'
-   import { pokemonSlice } from './services/pokemonSlice'
+// slice & selectors omitted
+```
 
-   export const store = configureStore({
-     reducer: {
-       // highlight-start
-       pokemon: pokemonSlice.reducer,
-       // highlight-end
-     },
-   })
+##### Slice
 
-   export type RootState = ReturnType<typeof store.getState>
-   ```
+Below we have our `slice` created with [`createSlice`](../../api/createSlice.mdx). We have our reducers containing our request handling logic defined here, storing the appropriate 'status' and 'data' in our state based on the name we search with.
 
-   Create a hook to manage accessing the appropriate data & request status:
+```ts title="src/services/pokemonSlice.ts - slice logic" no-transpile
+// imports & thunk action creator omitted
 
-   ```ts title="src/hooks.ts"
-   // file: src/services/pokemonSlice.ts noEmit
-   import { AsyncThunkAction } from '@reduxjs/toolkit'
-   import { RootState } from '../store'
-   interface Pokemon {}
-   export declare const fetchPokemonByName: (
-     arg: string
-   ) => AsyncThunkAction<Pokemon, string, {}>
+// highlight-start
+type RequestState = 'pending' | 'fulfilled' | 'rejected'
+// highlight-end
 
-   export const selectStatusByName = (state: RootState, name: string) =>
-     state.pokemon.statusByName[name]
-   export const selectDataByName = (state: RootState, name: string) =>
-     state.pokemon.dataByName[name]
+export const pokemonSlice = createSlice({
+  name: 'pokemon',
+  initialState: {
+    // highlight-start
+    dataByName: {} as Record<string, Pokemon | undefined>,
+    statusByName: {} as Record<string, RequestState | undefined>,
+    // highlight-end
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    // highlight-start
+    // When our request is pending:
+    // - store the 'pending' state as the status for the corresponding pokemon name
+    builder.addCase(fetchPokemonByName.pending, (state, action) => {
+      state.statusByName[action.meta.arg] = 'pending'
+    })
+    // When our request is fulfilled:
+    // - store the 'fulfilled' state as the status for the corresponding pokemon name
+    // - and store the received payload as the data for the corresponding pokemon name
+    builder.addCase(fetchPokemonByName.fulfilled, (state, action) => {
+      state.statusByName[action.meta.arg] = 'fulfilled'
+      state.dataByName[action.meta.arg] = action.payload
+    })
+    // When our request is rejected:
+    // - store the 'rejected' state as the status for the corresponding pokemon name
+    builder.addCase(fetchPokemonByName.rejected, (state, action) => {
+      state.statusByName[action.meta.arg] = 'rejected'
+    })
+    // highlight-end
+  },
+})
 
-   // file: src/store.ts noEmit
-   interface Pokemon {}
-   type RequestState = 'pending' | 'fulfilled' | 'rejected'
+// selectors omitted
+```
 
-   const initialPokemonSlice = {
-     dataByName: {} as Record<string, Pokemon | undefined>,
-     statusByName: {} as Record<string, RequestState | undefined>,
-   }
-   export type RootState = {
-     pokemon: typeof initialPokemonSlice
-   }
+##### Selectors
 
-   // file: src/hooks.ts
-   import { useEffect } from 'react'
-   import { useDispatch, useSelector } from 'react-redux'
-   import { RootState } from './store'
-   import {
-     fetchPokemonByName,
-     selectStatusByName,
-     selectDataByName,
-   } from './services/pokemonSlice'
+Below we have our selectors defined, allowing us to later access the appropriate status & data for any given pokemon name.
 
-   // highlight-start
-   export function useGetPokemonByName(name: string) {
-     const dispatch = useDispatch()
-     const statusByName = useSelector((state: RootState) =>
-       selectStatusByName(state, name)
-     )
-     const data = useSelector((state: RootState) =>
-       selectStatusByName(state, name)
-     )
-     useEffect(() => {
-       // upon mount or name change, if status is uninitialized, send a request
-       // for the pokemon name
-       if (statusByName === undefined) {
-         dispatch(fetchPokemonByName(name))
-       }
-     }, [statusByName, dispatch, name])
+```ts title="src/services/pokemonSlice.ts - selectors" no-transpile
+// imports, thunk action creator & slice omitted
 
-     const isUninitialized = statusByName === undefined
-     const isLoading = statusByName === 'pending'
-     const isError = statusByName === 'rejected'
-     const isSuccess = statusByName === 'fulfilled'
+// highlight-start
+export const selectStatusByName = (state: RootState, name: string) =>
+  state.pokemon.statusByName[name]
+export const selectDataByName = (state: RootState, name: string) =>
+  state.pokemon.dataByName[name]
+// highlight-end
+```
 
-     return { data, isUninitialized, isLoading, isError, isSuccess }
-   }
-   // highlight-end
-   ```
+#### Store
 
-1. Use the manually created hook:
+In our `store` for our app, we include the corresponding reducer from our slice under the `pokemon` branch in our state tree. This lets our store handle the appropriate actions for our requests we will dispatch when running the app, using the logic defined previously.
 
-   ```tsx title="Usage in a react component"
-   // highlight-start
-   import * as React from 'react'
-   import { useGetPokemonByName } from './hooks'
-   // highlight-end
+```ts title="src/services/store.ts"
+// file: src/services/pokemonSlice.ts noEmit
+import { Reducer } from '@reduxjs/toolkit'
+declare const reducer: Reducer<{}>
+export const pokemonSlice = {
+  reducer,
+}
 
-   export default function App() {
-     // highlight-start
-     const { data, isError, isLoading } = useGetPokemonByName('bulbasaur')
-     // highlight-end
+// file: src/store.ts
+import { configureStore } from '@reduxjs/toolkit'
+import { pokemonSlice } from './services/pokemonSlice'
 
-     return (
-       <div className="App">
-         {isError ? (
-           <>Oh no, there was an error</>
-         ) : isLoading ? (
-           <>Loading...</>
-         ) : data ? (
-           <>
-             <h3>{data.species.name}</h3>
-             <img src={data.sprites.front_shiny} alt={data.species.name} />
-           </>
-         ) : null}
-       </div>
-     )
-   }
-   ```
+export const store = configureStore({
+  reducer: {
+    // highlight-start
+    pokemon: pokemonSlice.reducer,
+    // highlight-end
+  },
+})
 
-### Using RTK Query
+export type RootState = ReturnType<typeof store.getState>
+```
 
-1. Add the appropriate endpoint to your api and export the automatically created hook:
+In order to have the store accessible within our app, we will wrap our `App` component with a [`Provider`](https://react-redux.js.org/api/provider) component from `react-redux`.
 
-   ```ts title="src/services/api.ts"
-   // file: types.ts noEmit
-   interface Pokemon {}
+```tsx title="src/index.ts"
+import { render } from 'react-dom'
+// highlight-start
+import { Provider } from 'react-redux'
+// highlight-end
 
-   // file: api.ts
-   import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import App from './App'
+// highlight-start
+import { store } from './store'
+// highlight-end
 
-   export const api = createApi({
-     baseQuery: fetchBaseQuery({ baseUrl: 'https://pokeapi.co/api/v2/' }),
-     endpoints: (build) => ({
-       // highlight-start
-       getPokemonByName: build.query<Pokemon, string>({
-         query: (name) => `pokemon/${name}`,
-       }),
-       // highlight-end
-     }),
-   })
+const rootElement = document.getElementById('root')
+render(
+  // highlight-start
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  // highlight-end
+  rootElement
+)
+```
 
-   // highlight-start
-   export const { useGetPokemonByNameQuery } = api
-   // highlight-end
-   ```
+#### Custom hook
 
-1. If not done previously, add the reducer & middleware to your store setup, and optionally [set up listeners](../../api/rtk-query/setupListeners) for additional behaviour:
+Below we create a hook to manage sending our request at the appropriate time, as well as obtaining the appropriate data & status from the store. [`useDispatch`](https://react-redux.js.org/api/hooks#usedispatch) and [`useSelector`](https://react-redux.js.org/api/hooks#useselector) are used from [`react-redux`](https://react-redux.js.org/introduction/getting-started) in order to communicate with the Redux store. At the end of our hook, we return the information in a neat, packaged object to be accessed in components.
 
-   ```ts title="src/store.ts"
-   // file: src/services/api.ts noEmit
-   import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-   interface Pokemon {}
+```ts title="src/hooks.ts"
+// file: src/services/pokemonSlice.ts noEmit
+import { AsyncThunkAction } from '@reduxjs/toolkit'
+import { RootState } from '../store'
+interface Pokemon {}
+export declare const fetchPokemonByName: (
+  arg: string
+) => AsyncThunkAction<Pokemon, string, {}>
 
-   export const api = createApi({
-     baseQuery: fetchBaseQuery({ baseUrl: 'https://pokeapi.co/api/v2/' }),
-     endpoints: (builder) => ({
-       getPokemonByName: builder.query<Pokemon, string>({
-         query: (name) => `pokemon/${name}`,
-       }),
-     }),
-   })
+export const selectStatusByName = (state: RootState, name: string) =>
+  state.pokemon.statusByName[name]
+export const selectDataByName = (state: RootState, name: string) =>
+  state.pokemon.dataByName[name]
 
-   // file: src/store.ts
-   import { configureStore } from '@reduxjs/toolkit'
-   // highlight-start
-   import { setupListeners } from '@reduxjs/toolkit/query'
-   import { api } from './services/api'
-   // highlight-end
+// file: src/store.ts noEmit
+interface Pokemon {}
+type RequestState = 'pending' | 'fulfilled' | 'rejected'
 
-   export const store = configureStore({
-     reducer: {
-       // highlight-start
-       [api.reducerPath]: api.reducer,
-       // highlight-end
-     },
-     // highlight-start
-     middleware: (gDM) => gDM().concat(api.middleware),
-     // highlight-end
-   })
+const initialPokemonSlice = {
+  dataByName: {} as Record<string, Pokemon | undefined>,
+  statusByName: {} as Record<string, RequestState | undefined>,
+}
+export type RootState = {
+  pokemon: typeof initialPokemonSlice
+}
 
-   // highlight-start
-   setupListeners(store.dispatch)
-   // highlight-end
-   ```
+// file: src/hooks.ts
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from './store'
+import {
+  fetchPokemonByName,
+  selectStatusByName,
+  selectDataByName,
+} from './services/pokemonSlice'
 
-1. Use the automatically created hook:
+// highlight-start
+export function useGetPokemonByNameQuery(name: string) {
+  const dispatch = useDispatch()
+  // select the current status from the store state for the provided name
+  const status = useSelector((state: RootState) =>
+    selectStatusByName(state, name)
+  )
+  // select the current data from the store state for the provided name
+  const data = useSelector((state: RootState) => selectDataByName(state, name))
+  useEffect(() => {
+    // upon mount or name change, if status is uninitialized, send a request
+    // for the pokemon name
+    if (status === undefined) {
+      dispatch(fetchPokemonByName(name))
+    }
+  }, [status, name, dispatch])
 
-   ```tsx title="Usage in a react component"
-   // highlight-start
-   import * as React from 'react'
-   import { useGetPokemonByNameQuery } from './services/api'
-   // highlight-end
+  // derive status booleans for ease of use
+  const isUninitialized = status === undefined
+  const isLoading = status === 'pending' || status === undefined
+  const isError = status === 'rejected'
+  const isSuccess = status === 'fulfilled'
 
-   export default function App() {
-     // highlight-start
-     // Using a query hook automatically fetches data and returns query values
-     const { data, error, isLoading } = useGetPokemonByNameQuery('bulbasaur')
-     // highlight-end
+  // return the import data for the caller of the hook to use
+  return { data, isUninitialized, isLoading, isError, isSuccess }
+}
+// highlight-end
+```
 
-     return (
-       <div className="App">
-         {error ? (
-           <>Oh no, there was an error</>
-         ) : isLoading ? (
-           <>Loading...</>
-         ) : data ? (
-           <>
-             <h3>{data.species.name}</h3>
-             <img src={data.sprites.front_shiny} alt={data.species.name} />
-           </>
-         ) : null}
-       </div>
-     )
-   }
-   ```
+#### Using the custom hook
+
+Our code above meets all of the design specifications, so let's use it! Below we can see how the hook can be called in a component, and return the relevant data & status booleans.
+
+Our implementation below provides the following behaviour in the component:
+
+- When our component is mounted, if a request for the provided pokemon name has not already been sent for the session, send the request off
+- The hook always provides the latest received `data` when available, as well as the request status booleans `isUninitialized`, `isPending`, `isFulfilled` & `isRejected` in order to determine the current UI at any given moment as a function of our state.
+
+```tsx title="src/App.tsx"
+import * as React from 'react'
+// highlight-start
+import { useGetPokemonByNameQuery } from './hooks'
+// highlight-end
+
+export default function App() {
+  // highlight-start
+  const { data, isError, isLoading } = useGetPokemonByNameQuery('bulbasaur')
+  // highlight-end
+
+  return (
+    <div className="App">
+      {isError ? (
+        <>Oh no, there was an error</>
+      ) : isLoading ? (
+        <>Loading...</>
+      ) : data ? (
+        <>
+          <h3>{data.species.name}</h3>
+          <img src={data.sprites.front_shiny} alt={data.species.name} />
+        </>
+      ) : null}
+    </div>
+  )
+}
+```
+
+A runnable example of the above code can be seen below:
+
+<iframe
+  src="https://codesandbox.io/s/data-fetchingcaching-example-rtk-with-thunks-5kf80?fontsize=12&hidenavigation=1&module=%2Fsrc%2Fservices/pokemonSlice.ts&theme=dark&view=preview"
+  style={{
+    width: '100%',
+    height: '800px',
+    border: 0,
+    borderRadius: '4px',
+    overflow: 'hidden',
+  }}
+  title="Data Fetching Example - RTK with Thunks"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+### Converting to RTK Query
+
+Our implementation above _does_ work perfectly fine for the requirements specified, however, extending the code to include further endpoints could involve a lot of repetition. It also has some certain limitations that may not be immediately obvious. For example, multiple components rendering simultaneously calling our hook would each send off a request for bulbasaur at the same time!
+
+Below we will walk through how a lot of the boilerplate can be avoided by migrating the above code to use RTK Query instead. RTK Query will also handle many other situations for us, including de-duping requests on a more granular level to prevent sending unnecessary duplicate requests like that brought up above.
+
+#### Api file
+
+Our code below is for our `api definition`, acting as our network API interface layer, created using [`createApi`](../../api/rtk-query/createApi.mdx). This file will contain our endpoint definition, and `createApi` will provide us with an auto-generated hook which manages firing our request only when necessary, as well as providing us with request status lifecycle booleans.
+
+This will completely cover our logic implemented above for the entire slice file, including the thunk, slice definition, selectors, _and_ our custom hook!
+
+```ts title="src/services/api.ts"
+// file: types.ts noEmit
+export interface Pokemon {}
+
+// file: api.ts
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { Pokemon } from './types'
+
+export const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://pokeapi.co/api/v2/' }),
+  endpoints: (build) => ({
+    // highlight-start
+    getPokemonByName: build.query<Pokemon, string>({
+      query: (name) => `pokemon/${name}`,
+    }),
+    // highlight-end
+  }),
+})
+
+// highlight-start
+export const { useGetPokemonByNameQuery } = api
+// highlight-end
+```
+
+#### Connecting our Api to the store
+
+Now that we have our api definition created, we need to hook it up to our store. In order to do that, we will need to use the [`reducerPath`](../../api/rtk-query/redux-integration.mdx#reducerpath) and [`middleware`](../../api/rtk-query/redux-integration.mdx#middleware) properties from our created `api`. This will allow the store to process the internal actions that the generated hook uses, allows the generated API logic to find the state correctly, and adds the logic for managing caching, invalidation, subscriptions, polling, and more.
+
+```ts title="src/store.ts"
+// file: src/services/pokemonSlice.ts noEmit
+import { Reducer } from '@reduxjs/toolkit'
+declare const reducer: Reducer<{}>
+export const pokemonSlice = {
+  reducer,
+}
+
+// file: src/services/api.ts noEmit
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+interface Pokemon {}
+
+export const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://pokeapi.co/api/v2/' }),
+  endpoints: (builder) => ({
+    getPokemonByName: builder.query<Pokemon, string>({
+      query: (name) => `pokemon/${name}`,
+    }),
+  }),
+})
+
+// file: src/store.ts
+import { configureStore } from '@reduxjs/toolkit'
+import { pokemonSlice } from './services/pokemonSlice'
+// highlight-start
+import { api } from './services/api'
+// highlight-end
+
+export const store = configureStore({
+  reducer: {
+    pokemon: pokemonSlice.reducer,
+    // highlight-start
+    [api.reducerPath]: api.reducer,
+    // highlight-end
+  },
+  // highlight-start
+  middleware: (gDM) => gDM().concat(api.middleware),
+  // highlight-end
+})
+
+export type RootState = ReturnType<typeof store.getState>
+```
+
+#### Using our auto-generated hook
+
+At this basic level, the usage of the auto-generated hook is identical to our custom hook! All we need to do is change our import path and we're good to go!
+
+```diff title="src/App.tsx"
+  import * as React from 'react'
+- import { useGetPokemonByNameQuery } from './hooks'
++ import { useGetPokemonByNameQuery } from './services/api'
+
+  export default function App() {
+    const { data, isError, isLoading } = useGetPokemonByNameQuery('bulbasaur')
+
+
+    return (
+      <div className="App">
+        {isError ? (
+          <>Oh no, there was an error</>
+        ) : isLoading ? (
+          <>Loading...</>
+        ) : data ? (
+          <>
+            <h3>{data.species.name}</h3>
+            <img src={data.sprites.front_shiny} alt={data.species.name} />
+          </>
+        ) : null}
+      </div>
+    )
+  }
+```
+
+#### Cleaning up unused code
+
+As mentioned previously, our `api` definition has replaced all of the logic that we implemented previously using `createAsyncThunk`, `createSlice`, and our custom hook definition.
+
+Given that we're no longer using that slice any longer, we can remove the import and reducer from our store:
+
+```diff title="src/store.ts"
+  import { configureStore } from '@reduxjs/toolkit'
+- import { pokemonSlice } from './services/pokemonSlice'
+  import { api } from './services/api'
+
+
+  export const store = configureStore({
+    reducer: {
+-     pokemon: pokemonSlice.reducer,
+      [api.reducerPath]: api.reducer,
+    },
+    middleware: (gDM) => gDM().concat(api.middleware),
+  })
+
+  export type RootState = ReturnType<typeof store.getState>
+```
+
+We can also remove the _entire slice and hook files_ completely!
+
+```diff
+- src/services/pokemonSlice.ts (-52 lines)
+- src/hooks.ts (-34 lines)
+```
+
+We've now re-implemented the full set of design specifications (and more!) in less than 20 lines of code, with room to easily expand by adding additional endpoints onto our api definition.
+
+A runnable example of our re-factored implementation using RTK Query can be seen below:
+
+<iframe
+  src="https://codesandbox.io/s/data-fetchingcaching-example-rtk-query-ndmwo?fontsize=12&hidenavigation=1&module=%2Fsrc%2Fservices/api.ts&theme=dark&view=preview"
+  style={{
+    width: '100%',
+    height: '800px',
+    border: 0,
+    borderRadius: '4px',
+    overflow: 'hidden',
+  }}
+  title="Data Fetching Example - RTK with Thunks"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -44,7 +44,7 @@
             "usage/rtk-query/code-generation",
             "usage/rtk-query/customizing-create-api",
             "usage/rtk-query/customizing-queries",
-            "usage/rtk-query/migrating-from-thunks",
+            "usage/rtk-query/migrating-to-rtk-query",
             "usage/rtk-query/examples"
           ]
         }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -44,6 +44,7 @@
             "usage/rtk-query/code-generation",
             "usage/rtk-query/customizing-create-api",
             "usage/rtk-query/customizing-queries",
+            "usage/rtk-query/migrating-from-thunks",
             "usage/rtk-query/examples"
           ]
         }


### PR DESCRIPTION
Related to #964 

- Adds a ~~'Migrating from thunks'~~ 'Migrating to RTK Query' page

Note that realistically it is more like 'How to delete your thunk code and re-write it shorter with RTK Query'