### PR TITLE
Docs - extend customizing queries content

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -71,6 +71,12 @@
         "redux": "^4.0.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "axios": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
@@ -78,6 +84,24 @@
       "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
       }
     },
     "csstype": {
@@ -92,11 +116,34 @@
       "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
       "dev": true
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "formik": {
       "version": "2.1.5",
@@ -112,6 +159,17 @@
         "scheduler": "^0.18.0",
         "tiny-warning": "^1.0.2",
         "tslib": "^1.10.0"
+      }
+    },
+    "graphql-request": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.4.0.tgz",
+      "integrity": "sha512-acrTzidSlwAj8wBNO7Q/UQHS8T+z5qRGquCQRv9J1InwR01BBWV9ObnoE+JS5nCCEj8wSGS0yrDXVDoRiKZuOg==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
       }
     },
     "hoist-non-react-statics": {
@@ -155,6 +213,27 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.47.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "@types/redux-logger": "^3.0.8",
     "axios": "^0.20.0",
     "formik": "^2.1.5",
+    "graphql-request": "^3.4.0",
     "immutable": "^3.8.2",
     "rxjs": "^6.6.2"
   }

--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -391,73 +391,10 @@ _(optional, not applicable with `queryFn`)_
 
 In some cases, you may want to manipulate the data returned from a query before you put it in the cache. In this instance, you can take advantage of `transformResponse`.
 
-By default, the payload from the server is returned directly.
-
-```ts
-function defaultTransformResponse(baseQueryReturnValue: unknown) {
-  return baseQueryReturnValue
-}
-```
-
-To change it, provide a function that looks like:
+See also [Customizing query responses with `transformResponse`](../usage/customizing-queries.mdx#customizing-query-responses-with-transformresponse)
 
 ```ts title="Unpack a deeply nested collection" no-transpile
 transformResponse: (response) => response.some.deeply.nested.collection
-```
-
-#### Example - Normalizing response data
-
-```ts title="Normalize the response data" no-transpile
-transformResponse: (response) =>
-  response.reduce((acc, curr) => {
-    acc[curr.id] = curr
-    return acc
-  }, {})
-```
-
-#### Example - Unpacking deeply nested data
-
-```ts title="GraphQL transformation example"
-// file: graphqlBaseQuery.ts noEmit
-import { BaseQueryFn } from '@reduxjs/toolkit/query'
-declare const graphqlBaseQuery: (args: { baseUrl: string }) => BaseQueryFn
-declare const gql: (literals: TemplateStringsArray) => void
-export { graphqlBaseQuery, gql }
-
-// file: graphqlApi.ts
-import { createApi } from '@reduxjs/toolkit/query'
-import { graphqlBaseQuery, gql } from './graphqlBaseQuery'
-
-interface Post {
-  id: number
-  title: string
-}
-
-export const api = createApi({
-  baseQuery: graphqlBaseQuery({
-    baseUrl: '/graphql',
-  }),
-  endpoints: (builder) => ({
-    getPosts: builder.query<Post[], void>({
-      query: () => ({
-        body: gql`
-          query {
-            posts {
-              data {
-                id
-                title
-              }
-            }
-          }
-        `,
-      }),
-      // highlight-start
-      transformResponse: (response: { posts: { data: Post[] } }) =>
-        response.posts.data,
-      // highlight-end
-    }),
-  }),
-})
 ```
 
 ### `extraOptions`

--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -58,6 +58,49 @@ export const { useGetPokemonByNameQuery } = pokemonApi
 
 [summary](docblock://query/createApi.ts?token=CreateApiOptions.baseQuery)
 
+#### baseQuery function arguments
+
+- `args` - The return value of the `query` function for a given endpoint
+- `api` - The `BaseQueryApi` object, containing `signal`, `dispatch` and `getState` properties
+  - `signal` - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object that may be used to abort DOM requests and/or read whether the request is aborted.
+  - `dispatch` - The `store.dispatch` method for the corresponding Redux store
+  - `getState` - A function that may be called to access the current store state
+- `extraOptions` - The value of the optional `extraOptions` property provided for a given endpoint
+
+#### baseQuery function signature
+
+```ts title="Base Query signature" no-transpile
+export type BaseQueryFn<
+  Args = any,
+  Result = unknown,
+  Error = unknown,
+  DefinitionExtraOptions = {},
+  Meta = {}
+> = (
+  args: Args,
+  api: BaseQueryApi,
+  extraOptions: DefinitionExtraOptions
+) => MaybePromise<QueryReturnValue<Result, Error, Meta>>
+
+export interface BaseQueryApi {
+  signal: AbortSignal
+  dispatch: ThunkDispatch<any, any, any>
+  getState: () => unknown
+}
+
+export type QueryReturnValue<T = unknown, E = unknown, M = unknown> =
+  | {
+      error: E
+      data?: undefined
+      meta?: M
+    }
+  | {
+      error?: undefined
+      data: T
+      meta?: M
+    }
+```
+
 [examples](docblock://query/createApi.ts?token=CreateApiOptions.baseQuery)
 
 ### `endpoints`
@@ -300,11 +343,49 @@ _(required if no `query` provided)_
 
 [summary](docblock://query/endpointDefinitions.ts?token=EndpointDefinitionWithQueryFn.queryFn)
 
+Called with the same arguments as `baseQuery`, as well as the provided `baseQuery` function itself. It is expected to return an object with either a `data` or `error` property, or a promise that resolves to return such an object.
+
+See also [Customizing queries with queryFn](../usage/customizing-queries.mdx#customizing-queries-with-queryfn).
+
+```ts title="queryFn signature" no-transpile
+queryFn(
+  arg: QueryArg,
+  api: BaseQueryApi,
+  extraOptions: BaseQueryExtraOptions<BaseQuery>,
+  baseQuery: (arg: Parameters<BaseQuery>[0]) => ReturnType<BaseQuery>
+): MaybePromise<
+| {
+    error: BaseQueryError<BaseQuery>
+    data?: undefined
+  }
+| {
+    error?: undefined
+    data: ResultType
+  }
+>
+
+export interface BaseQueryApi {
+  signal: AbortSignal
+  dispatch: ThunkDispatch<any, any, any>
+  getState: () => unknown
+}
+```
+
+#### queryFn function arguments
+
+- `args` - The argument provided when the query itself is called
+- `api` - The `BaseQueryApi` object, containing `signal`, `dispatch` and `getState` properties
+  - `signal` - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object that may be used to abort DOM requests and/or read whether the request is aborted.
+  - `dispatch` - The `store.dispatch` method for the corresponding Redux store
+  - `getState` - A function that may be called to access the current store state
+- `extraOptions` - The value of the optional `extraOptions` property provided for the endpoint
+- `baseQuery` - The `baseQuery` function provided to the api itself
+
 [examples](docblock://query/endpointDefinitions.ts?token=EndpointDefinitionWithQueryFn.queryFn)
 
 ### `transformResponse`
 
-_(optional, can't be used with `queryFn`)_
+_(optional, not applicable with `queryFn`)_
 
 [summary](docblock://query/endpointDefinitions.ts?token=EndpointDefinitionWithQuery.transformResponse)
 

--- a/docs/rtk-query/usage/cached-data.mdx
+++ b/docs/rtk-query/usage/cached-data.mdx
@@ -1010,8 +1010,8 @@ The Redux docs have always recommended [keeping data in a normalized lookup tabl
 
 There are a couple additional points that can help here:
 
-- The generated query hooks have [a `selectFromResult` option](../api/created-api/hooks.mdx) that allow components to read individual pieces of data from a query result. As an example, a `<TodoList>` component might call `useTodosQuery()`, and each individual `<TodoListItem>` could use the same query hook but select from the result to get the right todo object.
-- You can use the [`transformResponse` endpoint option](../api/createApi.mdx) to modify the fetched data so that it's stored in a different shape, such as using `createEntityAdapter` to normalize the data _for this one response_ before it's inserted into the cache.
+- The generated query hooks have [a `selectFromResult` option](../api/created-api/hooks.mdx#selectfromresult) that allow components to read individual pieces of data from a query result. As an example, a `<TodoList>` component might call `useTodosQuery()`, and each individual `<TodoListItem>` could use the same query hook but select from the result to get the right todo object.
+- You can use the [`transformResponse` endpoint option](../api/createApi.mdx#transformresponse) to modify the fetched data so that it's [stored in a different shape](./customizing-queries.mdx#customizing-query-responses-with-transformresponse), such as using `createEntityAdapter` to normalize the data _for this one response_ before it's inserted into the cache.
 
 ## Further information
 

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -7,20 +7,23 @@ hide_title: true
 
 # Customizing queries
 
-RTK Query is agnostic as to how your requests resolve. You can use any library you like to handle requests, or no library at all. By default, RTK Query ships with [`fetchBaseQuery`](../api/fetchBaseQuery), which is a lightweight [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) wrapper that automatically handles request headers and response parsing in a manner similar to common libraries like `axios`. If `fetchBaseQuery` alone does not meet your needs, you can customize it's behaviour with a wrapper function, or create your own [`baseQuery`](../api/createApi#basequery) function from scratch for [`createApi`](../api/createApi) to use.
+RTK Query is agnostic as to how your requests resolve. You can use any library you like to handle requests, or no library at all. RTK Query provides reasonable defaults expected to cover the majority of use cases, while also allowing room for customization to alter query handling to fit specific needs.
 
-## Implementing a custom baseQuery
+## Customizing queries with baseQuery
+
+The default method to handle queries is via the [`baseQuery`](../api/createApi#basequery) option on [`createApi`](../api/createApi), in combination with the [`query`](../api/createApi.mdx#query) option on an endpoint definition.
+
+To process queries, endpoints are defined with a [`query`](../api/createApi.mdx#query) option, which passes it's return value to a common [`baseQuery`](../api/createApi#basequery) function used for the API.
+
+By default, RTK Query ships with [`fetchBaseQuery`](../api/fetchBaseQuery), which is a lightweight [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) wrapper that automatically handles request headers and response parsing in a manner similar to common libraries like `axios`. If `fetchBaseQuery` alone does not meet your needs, you can customize it's behaviour with a wrapper function, or create your own [`baseQuery`](../api/createApi.mdx#basequery) function from scratch for [`createApi`](../api/createApi) to use.
+
+See also [`baseQuery API Reference`](../api/createApi.mdx#basequery).
+
+### Implementing a custom baseQuery
 
 RTK Query expects a `baseQuery` function to be called with three arguments: `args`, `api`, and `extraOptions`. It is expected to return an object with either a `data` or `error` property, or a promise that resolves to return such an object.
 
-### baseQuery function arguments
-
-- `args` - The return value of the `query` function for a given endpoint
-- `api` - The `BaseQueryApi` object, containing `signal`, `dispatch` and `getState` properties
-  - `signal` - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object that may be used to abort DOM requests and/or read whether the request is aborted.
-  - `dispatch` - The `store.dispatch` method for the corresponding Redux store
-  - `getState` - A function that may be called to access the current store state
-- `extraOptions` - The value of the optional `extraOptions` property provided for a given endpoint
+#### baseQuery function arguments
 
 ```ts title="baseQuery example arguments" no-transpile
 const customBaseQuery = (
@@ -34,7 +37,7 @@ const customBaseQuery = (
 }
 ```
 
-### baseQuery function return value
+#### baseQuery function return value
 
 1.  ```ts title="Expected success result format" no-transpile
     return { data: YourData }
@@ -56,51 +59,17 @@ const customBaseQuery = (
 }
 ```
 
+<!-- TODO: move this to a 'usage with typescript' page instead (and cover in more detail)-->
+
 The type for `data` is dictated based on the types specified per endpoint (both queries & mutations), while the type for `error` is dictated by the `baseQuery` function used.
 
 :::note
 This format is required so that RTK Query can infer the return types for your responses.
 :::
 
-### baseQuery function signature
+At it's core, a `baseQuery` function only needs to have the minimum return value to be valid; an object with a `data` or `error` property. It is up to the user to determine how they wish to use the provided arguments, and how requests are handled within the function itself.
 
-The signature of a `baseQuery` function is as follows:
-
-```ts title="Base Query signature" no-transpile
-export type BaseQueryFn<
-  Args = any,
-  Result = unknown,
-  Error = unknown,
-  DefinitionExtraOptions = {},
-  Meta = {}
-> = (
-  args: Args,
-  api: BaseQueryApi,
-  extraOptions: DefinitionExtraOptions
-) => MaybePromise<QueryReturnValue<Result, Error, Meta>>
-
-export interface BaseQueryApi {
-  signal: AbortSignal
-  dispatch: ThunkDispatch<any, any, any>
-  getState: () => unknown
-}
-
-export type QueryReturnValue<T = unknown, E = unknown, M = unknown> =
-  | {
-      error: E
-      data?: undefined
-      meta?: M
-    }
-  | {
-      error?: undefined
-      data: T
-      meta?: M
-    }
-```
-
-A custom `baseQuery` need only follow the `BaseQueryFn` signature above in order to be used. The [examples](#examples) further on demonstrate multiple implementations of `baseQuery` functions to meet different requirements.
-
-### fetchBaseQuery defaults
+#### fetchBaseQuery defaults
 
 For [`fetchBaseQuery`](../api/fetchBaseQuery) specifically, the return type is as follows:
 
@@ -126,9 +95,66 @@ Promise<{
     return { error: { status: number, data: YourErrorData } }
     ```
 
-## Examples
+## Customizing queries with queryFn
 
-### Axios Base Query
+Individual endpoints on [`createApi`](../api/createApi) accept a [`queryFn`](../api/createApi#queryfn) property which allows a given endpoint to ignore `baseQuery` for that endpoint by providing an inline function determining how that query resolves.
+
+This can be useful for scenarios where you want to have particularly different behaviour for a single endpoint, or where the query itself is not relevant. Such situations may include:
+
+- One-off queries that use a different base URL
+- One-off queries that use different request handling, such as automatic re-tries
+- One-off queries that use different error handling behaviour
+- Performing multiple requests with a single query ([example](#performing-multiple-requests-with-a-single-query))
+- Leveraging invalidation behaviour with no relevant query ([example](#no-op-queryfn))
+- Using [Streaming Updates](./streaming-updates) with no relevant initial request ([example](#streaming-data-with-no-initial-request))
+
+See also [`queryFn API Reference`](../api/createApi.mdx#queryfn) for the type signature and available options.
+
+### Implementing a `queryFn`
+
+In order to use `queryFn`, it can be treated as an inline `baseQuery`. It will be called with the same arguments as `baseQuery`, as well as the provided `baseQuery` function itself (`arg`, `api`, `extraOptions`, and `baseQuery`). Similarly to `baseQuery`, it is expected to return an object with either a `data` or `error` property, or a promise that resolves to return such an object.
+
+#### queryFn function arguments
+
+```ts title="queryFn example arguments" no-transpile
+const queryFn = (
+  // highlight-start
+  args,
+  { signal, dispatch, getState },
+  extraOptions,
+  baseQuery
+  // highlight-end
+) => {
+  // omitted
+}
+```
+
+#### queryFn function return value
+
+1.  ```ts title="Expected success result format" no-transpile
+    return { data: YourData }
+    ```
+2.  ```ts title="Expected error result format" no-transpile
+    return { error: YourError }
+    ```
+
+```ts title="queryFn example return value" no-transpile
+const queryFn = (
+  args,
+  { signal, dispatch, getState },
+  extraOptions,
+  baseQuery
+) => {
+  // highlight-start
+  if (Math.random() > 0.5) return { error: 'Too high!' }
+  return { data: 'All good!' }
+  // highlight-end
+}
+```
+
+## Examples - baseQuery
+
+### Axios baseQuery
 
 This example implements a very basic axios-based `baseQuery` utility.
 
@@ -172,6 +198,72 @@ const api = createApi({
       }),
     }
   },
+})
+```
+
+### GraphQL baseQuery
+
+This example implements a very basic GraphQL-based `baseQuery`.
+
+```ts title="Basic GraphQL baseQuery"
+import { createApi } from '@reduxjs/toolkit/query'
+import { request, gql, ClientError } from 'graphql-request'
+
+// highlight-start
+const graphqlBaseQuery = ({ baseUrl }: { baseUrl: string }) => async ({
+  body,
+}: {
+  body: string
+}) => {
+  try {
+    const result = await request(baseUrl, body)
+    return { data: result }
+  } catch (error) {
+    if (error instanceof ClientError) {
+      return { error: { status: error.response.status, data: error } }
+    }
+    return { error: { status: 500, data: error } }
+  }
+}
+// highlight-end
+
+export const api = createApi({
+  // highlight-start
+  baseQuery: graphqlBaseQuery({
+    baseUrl: 'https://graphqlzero.almansi.me/api',
+  }),
+  // highlight-end
+  endpoints: (builder) => ({
+    getPosts: builder.query({
+      query: () => ({
+        body: gql`
+          query {
+            posts {
+              data {
+                id
+                title
+              }
+            }
+          }
+        `,
+      }),
+      transformResponse: (response) => response.posts.data,
+    }),
+    getPost: builder.query({
+      query: (id) => ({
+        body: gql`
+        query {
+          post(id: ${id}) {
+            id
+            title
+            body
+          }
+        }
+        `,
+      }),
+      transformResponse: (response) => response.post,
+    }),
+  }),
 })
 ```
 
@@ -284,128 +376,6 @@ export const api = createApi({
 export const { useGetPostsQuery, useGetPostQuery } = api
 ```
 
-### Excluding baseQuery with queryFn
-
-Individual endpoints on [`createApi`](../api/createApi) accept a [`queryFn`](../api/createApi#queryfn) property which allows a given endpoint to ignore `baseQuery` for that endpoint by providing an inline function determining how that query resolves.
-
-This can be useful for scenarios where you want to have particularly different behaviour for a single endpoint, or where the query itself is not relevant. Such situations may include:
-
-- One-off queries that use a different base URL
-- One-off queries that use different handling, such as automatic re-tries
-- One off queries that use different error handling behaviour
-- Leveraging invalidation behaviour with no relevant query
-- Using [Streaming Updates](./streaming-updates) with no relevant initial query
-
-```ts title="Excluding baseQuery for a single endpoint"
-// file: types.ts noEmit
-export interface Post {
-  id: number
-  name: string
-}
-export interface User {
-  id: number
-  name: string
-}
-export interface Message {
-  id: number
-  channel: 'general' | 'redux'
-  userName: string
-  text: string
-}
-
-// file: api.ts
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
-import { Post, User, Message } from './types'
-
-const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  tagTypes: ['Post', 'User', 'Message'],
-  endpoints: (build) => ({
-    getPosts: build.query<Post[], void>({
-      query: () => 'posts',
-      providesTags: ['Post'],
-    }),
-
-    getUsers: build.query<User[], void>({
-      query: () => 'users',
-      providesTags: ['User'],
-    }),
-
-    // highlight-start
-    refetchPostsAndUsers: build.mutation<null, void>({
-      // The query is not relevant here, so a `null` returning `queryFn` is used
-      queryFn: () => ({ data: null }),
-      // This mutation takes advantage of tag invalidation behaviour to trigger
-      // any queries that provide the 'Post' or 'User' tags to re-fetch if the queries
-      // are currently subscribed to the cached data
-      invalidatesTags: ['Post', 'User'],
-    }),
-    // highlight-end
-
-    // highlight-start
-    streamMessages: build.query<Message[], void>({
-      // The query it not relevant here as the data will be provided via streaming updates.
-      // A queryFn returning an empty array is used, with contents being populated via
-      // streaming updates below as they are received.
-      queryFn: () => ({ data: [] }),
-      async onCacheEntryAdded(arg, { updateCachedData, cacheEntryRemoved }) {
-        const ws = new WebSocket('ws://localhost:8080')
-        // populate the array with messages as they are received from the websocket
-        ws.addEventListener('message', (event) => {
-          updateCachedData((draft) => {
-            draft.push(JSON.parse(event.data))
-          })
-        })
-        await cacheEntryRemoved
-        ws.close()
-      },
-    }),
-    // highlight-end
-  }),
-})
-```
-
-For typescript users, the error type that `queryFn` must return is dictated by the provided `baseQuery` function. For users who wish to _only_ use `queryFn` for each endpoint and not include a `baseQuery` at all, RTK Query provides a `fakeBaseQuery` function that can be used to easily specify the error type each `queryFn` should return.
-
-```ts title="Excluding baseQuery for all endpoints"
-import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query'
-
-type CustomErrorType = { type: 'too cold' | 'too hot' }
-
-const api = createApi({
-  // highlight-start
-  baseQuery: fakeBaseQuery<CustomErrorType>(),
-  // highlight-end
-  endpoints: (build) => ({
-    eatPorridge: build.query<'just right', 1 | 2 | 3>({
-      queryFn(seat) {
-        if (seat === 1) {
-          return { error: { type: 'too cold' } }
-        }
-
-        if (seat === 2) {
-          return { error: { type: 'too hot' } }
-        }
-
-        return { data: 'just right' }
-      },
-    }),
-    microwaveHotPocket: build.query<'delicious!', number>({
-      queryFn(duration) {
-        if (duration < 110) {
-          return { error: { type: 'too cold' } }
-        }
-        if (duration > 140) {
-          return { error: { type: 'too hot' } }
-        }
-
-        return { data: 'delicious!' }
-      },
-    }),
-  }),
-})
-```
-
 ### Adding Meta information to queries
 
 A `baseQuery` can also include a `meta` property in it's return value. This can be beneficial in cases where you may wish to include additional information associated with the request such as a request ID or timestamp.
@@ -492,6 +462,190 @@ const api = createApi({
         return returnValue.filter(
           (post) => post.timestamp >= meta.timestamp - DAY_MS
         )
+      },
+      // highlight-end
+    }),
+  }),
+})
+```
+
+## Examples - queryFn
+
+### Using a no-op queryFn
+
+In certain scenarios, you may wish to have a `query` or `mutation` where sending a request or returning data is not relevant for the situation. Such a scenario would be to leverage the `invalidatesTags` property to force re-fetch specific `tags` that have been provided to the cache.
+
+See also [`providing errors to the cache`](./cached-data.mdx#providing-data-to-the-cache) to see additional detail and an example for such a scenario to 'refetch errored queries'.
+
+```ts title="Using a no-op queryFn"
+// file: types.ts noEmit
+export interface Post {
+  id: number
+  name: string
+}
+export interface User {
+  id: number
+  name: string
+}
+
+// file: api.ts
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
+import { Post, User } from './types'
+
+const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+  tagTypes: ['Post', 'User'],
+  endpoints: (build) => ({
+    getPosts: build.query<Post[], void>({
+      query: () => 'posts',
+      providesTags: ['Post'],
+    }),
+
+    getUsers: build.query<User[], void>({
+      query: () => 'users',
+      providesTags: ['User'],
+    }),
+
+    // highlight-start
+    refetchPostsAndUsers: build.mutation<null, void>({
+      // The query is not relevant here, so a `null` returning `queryFn` is used
+      queryFn: () => ({ data: null }),
+      // This mutation takes advantage of tag invalidation behaviour to trigger
+      // any queries that provide the 'Post' or 'User' tags to re-fetch if the queries
+      // are currently subscribed to the cached data
+      invalidatesTags: ['Post', 'User'],
+    }),
+    // highlight-end
+  }),
+})
+```
+
+### Streaming data with no initial request
+
+RTK Query provides the ability for an endpoint to send an initial request for data, followed up with recurring [streaming updates](./streaming-updates.mdx) that perform further updates to the cached data as the updates occur. However, the initial request is optional, and you may wish to use streaming updates without any initial request fired off.
+
+In the example below, a `queryFn` is used to populate the cache data with an empty array, with no initial request sent. The array is later populated using streaming updates via the [`onCacheEntryAdded`](../api/createApi.mdx#oncacheentryadded) endpoint option, updating the cached data as it is received.
+
+```ts title="Streaming data with no initial request"
+// file: types.ts noEmit
+export interface Message {
+  id: number
+  channel: 'general' | 'redux'
+  userName: string
+  text: string
+}
+
+// file: api.ts
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
+import { Message } from './types'
+
+const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+  tagTypes: ['Message'],
+  endpoints: (build) => ({
+    // highlight-start
+    streamMessages: build.query<Message[], void>({
+      // The query is not relevant here as the data will be provided via streaming updates.
+      // A queryFn returning an empty array is used, with contents being populated via
+      // streaming updates below as they are received.
+      queryFn: () => ({ data: [] }),
+      async onCacheEntryAdded(arg, { updateCachedData, cacheEntryRemoved }) {
+        const ws = new WebSocket('ws://localhost:8080')
+        // populate the array with messages as they are received from the websocket
+        ws.addEventListener('message', (event) => {
+          updateCachedData((draft) => {
+            draft.push(JSON.parse(event.data))
+          })
+        })
+        await cacheEntryRemoved
+        ws.close()
+      },
+    }),
+    // highlight-end
+  }),
+})
+```
+
+### Performing multiple requests with a single query
+
+In the example below, a query is written to fetch all posts for a random user. This is done using a first request for a random user, followed by getting all posts for that user. Using `queryFn` allows the two requests to be included within a single query, avoiding having to chain that logic within component code.
+
+```ts title="Performing multiple requests with a single query"
+// file: types.ts noEmit
+export interface Post {}
+export interface User {
+  id: number
+}
+
+// file: api.ts
+import {
+  createApi,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+} from '@reduxjs/toolkit/query'
+import { Post, User } from './types'
+
+const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: '/ ' }),
+  endpoints: (build) => ({
+    getRandomUserPosts: build.query<Post, void>({
+      async queryFn(_arg, _queryApi, _extraOptions, fetchWithBQ) {
+        // get a random user
+        const randomResult = await fetchWithBQ('users/random')
+        if (randomResult.error) throw randomResult.error
+        const user = randomResult.data as User
+        const result = await fetchWithBQ(`user/${user.id}/posts`)
+        return result.data
+          ? { data: result.data as Post }
+          : { error: result.error as FetchBaseQueryError }
+      },
+    }),
+  }),
+})
+```
+
+### Excluding baseQuery for all endpoints
+
+<!-- TODO: move this to a 'usage with typescript' page instead-->
+
+For typescript users, the error type that `queryFn` must return is dictated by the provided `baseQuery` function. For users who wish to _only_ use `queryFn` for each endpoint and not include a `baseQuery` at all, RTK Query provides a `fakeBaseQuery` function that can be used to easily specify the error type each `queryFn` should return.
+
+```ts title="Excluding baseQuery for all endpoints"
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query'
+
+type CustomErrorType = { type: 'too cold' | 'too hot' }
+
+const api = createApi({
+  // highlight-start
+  baseQuery: fakeBaseQuery<CustomErrorType>(),
+  // highlight-end
+  endpoints: (build) => ({
+    eatPorridge: build.query<'just right', 1 | 2 | 3>({
+      // highlight-start
+      queryFn(seat) {
+        if (seat === 1) {
+          return { error: { type: 'too cold' } }
+        }
+
+        if (seat === 2) {
+          return { error: { type: 'too hot' } }
+        }
+
+        return { data: 'just right' }
+      },
+      // highlight-end
+    }),
+    microwaveHotPocket: build.query<'delicious!', number>({
+      // highlight-start
+      queryFn(duration) {
+        if (duration < 110) {
+          return { error: { type: 'too cold' } }
+        }
+        if (duration > 140) {
+          return { error: { type: 'too hot' } }
+        }
+
+        return { data: 'delicious!' }
       },
       // highlight-end
     }),

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -9,7 +9,7 @@ hide_title: true
 
 RTK Query is agnostic as to how your requests resolve. You can use any library you like to handle requests, or no library at all. RTK Query provides reasonable defaults expected to cover the majority of use cases, while also allowing room for customization to alter query handling to fit specific needs.
 
-## Customizing queries with baseQuery
+## Customizing queries with `baseQuery`
 
 The default method to handle queries is via the [`baseQuery`](../api/createApi#basequery) option on [`createApi`](../api/createApi), in combination with the [`query`](../api/createApi.mdx#query) option on an endpoint definition.
 
@@ -19,7 +19,7 @@ By default, RTK Query ships with [`fetchBaseQuery`](../api/fetchBaseQuery), whic
 
 See also [`baseQuery API Reference`](../api/createApi.mdx#basequery).
 
-### Implementing a custom baseQuery
+### Implementing a custom `baseQuery`
 
 RTK Query expects a `baseQuery` function to be called with three arguments: `args`, `api`, and `extraOptions`. It is expected to return an object with either a `data` or `error` property, or a promise that resolves to return such an object.
 
@@ -95,9 +95,70 @@ Promise<{
     return { error: { status: number, data: YourErrorData } }
     ```
 
-## Customizing queries with queryFn
+## Customizing query responses with `transformResponse`
 
-Individual endpoints on [`createApi`](../api/createApi) accept a [`queryFn`](../api/createApi#queryfn) property which allows a given endpoint to ignore `baseQuery` for that endpoint by providing an inline function determining how that query resolves.
+Individual endpoints on [`createApi`](../api/createApi.mdx) accept a [`transformResponse`](../api/createApi.mdx) property which allows manipulation of the data returned by a query or mutation before it hits the cache.
+
+`transformResponse` is called with the data that a successful `baseQuery` returns for the corresponding endpoint, and the return value of `transformResponse` is used as the cached data associated with that endpoint call.
+
+By default, the payload from the server is returned directly.
+
+```ts
+function defaultTransformResponse(baseQueryReturnValue: unknown) {
+  return baseQueryReturnValue
+}
+```
+
+To change it, provide a function that looks like:
+
+```ts title="Unpack a deeply nested collection" no-transpile
+transformResponse: (response) => response.some.deeply.nested.collection
+```
+
+`transformResponse` is also called with the `meta` property returned from the `baseQuery`, which can be used while determining the transformed response. The value for `meta` is dependent on the `baseQuery` used.
+
+```ts title="transformResponse meta example" no-transpile
+transformResponse: (response: { sideA: Tracks; sideB: Tracks }, meta) => {
+  if (meta?.coinFlip === 'heads') {
+    return response.sideA
+  }
+  return response.sideB
+}
+```
+
+While there is less need to store the response in a [normalized lookup table](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape) with RTK Query managing caching data, `transformResponse` can be leveraged to do so if desired.
+
+```ts title="Normalize the response data" no-transpile
+transformResponse: (response) =>
+  response.reduce((acc, curr) => {
+    acc[curr.id] = curr
+    return acc
+  }, {})
+
+/*
+  will convert:
+  [
+    {id: 1, name: 'Harry'},
+    {id: 2, name: 'Ron'},
+    {id: 3, name: 'Hermione'},
+  ]
+
+  to:
+  {
+    1: { id: 1, name: "Harry" },
+    2: { id: 2, name: "Ron" },
+    3: { id: 3, name: "Hermione" },
+  }
+*/
+```
+
+[`createEntityAdapter`](../../api/createEntityAdapter.mdx) can also be used with `transformResponse` to normalize data, while also taking advantage of other features provided by `createEntityAdapter`, including providing an `ids` array, using [`sortComparer`](../../api/createEntityAdapter.mdx#sortcomparer) to maintain a consistently sorted list, as well as maintaining strong TypeScript support.
+
+See also [Websocket Chat API with a transformed response shape](./streaming-updates.mdx#websocket-chat-api-with-a-transformed-response-shape) for an example of `transformResponse` normalizing response data in combination with `createEntityAdapter`, while also updating further data using [`streaming updates`](./streaming-updates.mdx).
+
+## Customizing queries with `queryFn`
+
+Individual endpoints on [`createApi`](../api/createApi.mdx) accept a [`queryFn`](../api/createApi.mdx#queryfn) property which allows a given endpoint to ignore `baseQuery` for that endpoint by providing an inline function determining how that query resolves.
 
 This can be useful for scenarios where you want to have particularly different behaviour for a single endpoint, or where the query itself is not relevant. Such situations may include:
 
@@ -152,7 +213,7 @@ const queryFn = (
 }
 ```
 
-## Examples - baseQuery
+## Examples - `baseQuery`
 
 ### Axios baseQuery
 
@@ -469,7 +530,114 @@ const api = createApi({
 })
 ```
 
-## Examples - queryFn
+## Examples - `transformResponse`
+
+### Unpacking deeply nested GraphQL data
+
+```ts title="GraphQL transformation example"
+// file: graphqlBaseQuery.ts noEmit
+import { BaseQueryFn } from '@reduxjs/toolkit/query'
+declare const graphqlBaseQuery: (args: { baseUrl: string }) => BaseQueryFn
+declare const gql: (literals: TemplateStringsArray) => void
+export { graphqlBaseQuery, gql }
+
+// file: graphqlApi.ts
+import { createApi } from '@reduxjs/toolkit/query'
+import { graphqlBaseQuery, gql } from './graphqlBaseQuery'
+
+interface Post {
+  id: number
+  title: string
+}
+
+export const api = createApi({
+  baseQuery: graphqlBaseQuery({
+    baseUrl: '/graphql',
+  }),
+  endpoints: (builder) => ({
+    getPosts: builder.query<Post[], void>({
+      query: () => ({
+        body: gql`
+          query {
+            posts {
+              data {
+                id
+                title
+              }
+            }
+          }
+        `,
+      }),
+      // highlight-start
+      transformResponse: (response: { posts: { data: Post[] } }) =>
+        response.posts.data,
+      // highlight-end
+    }),
+  }),
+})
+```
+
+### Normalizing data with `createEntityAdapter`
+
+In the example below, `transformResponse` is used in conjunction with [`createEntityAdapter`](../../api/createEntityAdapter.mdx) to normalize the data before storing it in the cache.
+
+For a response such as:
+
+<!-- prettier-ignore -->
+```ts no-transpile
+[
+  { id: 1, name: 'Harry' },
+  { id: 2, name: 'Ron' },
+  { id: 3, name: 'Hermione' },
+]
+```
+
+The normalized cache data will be stored as:
+
+```ts no-transpile
+{
+  ids: [1, 3, 2],
+  entities: {
+    1: { id: 1, name: "Harry" },
+    2: { id: 2, name: "Ron" },
+    3: { id: 3, name: "Hermione" },
+  }
+}
+```
+
+```ts
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { createEntityAdapter, EntityState } from '@reduxjs/toolkit'
+
+export interface Post {
+  id: number
+  name: string
+}
+
+// highlight-start
+const postsAdapter = createEntityAdapter<Post>({
+  sortComparer: (a, b) => a.name.localeCompare(b.name),
+})
+// highlight-end
+
+export const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+  endpoints: (build) => ({
+    getPosts: build.query<EntityState<Post>, void>({
+      query: () => `posts`,
+      // highlight-start
+      transformResponse(response: Post[]) {
+        return postsAdapter.addMany(postsAdapter.getInitialState(), response)
+      },
+      // highlight-end
+    }),
+  }),
+})
+
+export const { useGetPostsQuery } = api
+```
+
+## Examples - `queryFn`
 
 ### Using a no-op queryFn
 

--- a/src/query/endpointDefinitions.ts
+++ b/src/query/endpointDefinitions.ts
@@ -74,7 +74,7 @@ interface EndpointDefinitionWithQueryFn<
    *
    * @example
    * ```ts
-   * // codeblock-meta title="queryFn example"
+   * // codeblock-meta title="Basic queryFn example"
    * 
    * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
    * interface Post {
@@ -91,7 +91,7 @@ interface EndpointDefinitionWithQueryFn<
    *     }),
    *     flipCoin: build.query<'heads' | 'tails', void>({
    *       // highlight-start
-   *       queryFn() {
+   *       queryFn(arg, queryApi, extraOptions, baseQuery) {
    *         const randomVal = Math.random()
    *         if (randomVal < 0.45) {
    *           return { data: 'heads' }


### PR DESCRIPTION
Related to #964 

This PR extends the 'Customizing Queries' content. It aims to split the focus on 'customizing queries' between `baseQuery`, `transformResponse` and `queryFn`, including adding meaningful descriptions for `transformResponse` & `queryFn`, as well as adding additional examples. 