### PR TITLE
add baseQueryMeta to thunks, meta to lifecycle results

### DIFF
--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -366,7 +366,9 @@ export type AsyncThunkRejectedActionCreator<
     aborted: boolean
     condition: boolean
   } & (
-    | { rejectedWithValue: false }
+    | ({ rejectedWithValue: false } & {
+        [K in keyof GetRejectedMeta<ThunkApiConfig>]?: undefined
+      })
     | ({ rejectedWithValue: true } & GetRejectedMeta<ThunkApiConfig>)
   )
 >

--- a/src/query/baseQueryTypes.ts
+++ b/src/query/baseQueryTypes.ts
@@ -59,7 +59,7 @@ export type BaseQueryMeta<BaseQuery extends BaseQueryFn> = UnwrapPromise<
 
 export type BaseQueryError<BaseQuery extends BaseQueryFn> = Exclude<
   UnwrapPromise<ReturnType<BaseQuery>>,
-  { error: undefined }
+  { error?: undefined }
 >['error']
 
 export type BaseQueryArg<

--- a/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -219,7 +219,7 @@ export const build: SubMiddlewareBuilder = ({
       } else if (isFullfilledThunk(action)) {
         const lifecycle = lifecycleMap[cacheKey]
         if (lifecycle?.valueResolved) {
-          lifecycle.valueResolved({ data: action.payload.result })
+          lifecycle.valueResolved({ data: action.payload })
           delete lifecycle.valueResolved
         }
       } else if (

--- a/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -219,7 +219,12 @@ export const build: SubMiddlewareBuilder = ({
       } else if (isFullfilledThunk(action)) {
         const lifecycle = lifecycleMap[cacheKey]
         if (lifecycle?.valueResolved) {
-          lifecycle.valueResolved({ data: action.payload })
+          lifecycle.valueResolved(
+            {
+              data: action.payload,
+              meta: action.meta.baseQueryMeta,
+            } as any /* TODO typings */
+          )
           delete lifecycle.valueResolved
         }
       } else if (

--- a/src/query/core/buildMiddleware/index.ts
+++ b/src/query/core/buildMiddleware/index.ts
@@ -79,7 +79,6 @@ export function buildMiddleware<
       originalArgs: querySubState.originalArgs,
       subscribe: false,
       forceRefetch: true,
-      startedTimeStamp: Date.now(),
       queryCacheKey: queryCacheKey as any,
       ...override,
     })

--- a/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -169,7 +169,7 @@ export const build: SubMiddlewareBuilder = ({
         }
       } else if (isFullfilledThunk(action)) {
         const { requestId } = action.meta
-        lifecycleMap[requestId]?.resolve({ data: action.payload.result })
+        lifecycleMap[requestId]?.resolve({ data: action.payload })
         delete lifecycleMap[requestId]
       } else if (isRejectedThunk(action)) {
         const { requestId, rejectedWithValue } = action.meta

--- a/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -168,15 +168,23 @@ export const build: SubMiddlewareBuilder = ({
           onQueryStarted(originalArgs, lifecycleApi)
         }
       } else if (isFullfilledThunk(action)) {
-        const { requestId } = action.meta
-        lifecycleMap[requestId]?.resolve({ data: action.payload })
+        const { requestId, baseQueryMeta } = action.meta
+        lifecycleMap[requestId]?.resolve(
+          {
+            data: action.payload,
+            meta: baseQueryMeta,
+          } as any /* TODO typings for this */
+        )
         delete lifecycleMap[requestId]
       } else if (isRejectedThunk(action)) {
-        const { requestId, rejectedWithValue } = action.meta
-        lifecycleMap[requestId]?.reject({
-          error: action.payload ?? action.error,
-          isUnhandledError: !rejectedWithValue,
-        })
+        const { requestId, rejectedWithValue, baseQueryMeta } = action.meta
+        lifecycleMap[requestId]?.reject(
+          {
+            error: action.payload ?? action.error,
+            isUnhandledError: !rejectedWithValue,
+            meta: baseQueryMeta,
+          } as any /* TODO typings for this */
+        )
         delete lifecycleMap[requestId]
       }
 

--- a/src/query/core/buildMiddleware/types.ts
+++ b/src/query/core/buildMiddleware/types.ts
@@ -8,9 +8,17 @@ import type {
 } from '@reduxjs/toolkit'
 
 import type { Api, ApiContext } from '../../apiTypes'
-import type { AssertTagTypes, EndpointDefinitions } from '../../endpointDefinitions'
+import type {
+  AssertTagTypes,
+  EndpointDefinitions,
+} from '../../endpointDefinitions'
 import type { QueryStatus, QuerySubState, RootState } from '../apiState'
-import type { MutationThunkArg, QueryThunkArg, ThunkResult } from '../buildThunks'
+import type {
+  MutationThunk,
+  QueryThunk,
+  QueryThunkArg,
+  ThunkResult,
+} from '../buildThunks'
 
 export type QueryStateMeta<T> = Record<string, undefined | T>
 export type TimeoutId = ReturnType<typeof setTimeout>
@@ -22,8 +30,8 @@ export interface BuildMiddlewareInput<
 > {
   reducerPath: ReducerPath
   context: ApiContext<Definitions>
-  queryThunk: AsyncThunk<ThunkResult, QueryThunkArg, {}>
-  mutationThunk: AsyncThunk<ThunkResult, MutationThunkArg, {}>
+  queryThunk: QueryThunk
+  mutationThunk: MutationThunk
   api: Api<any, Definitions, ReducerPath, TagTypes>
   assertTagType: AssertTagTypes
 }

--- a/src/query/core/buildSlice.ts
+++ b/src/query/core/buildSlice.ts
@@ -29,7 +29,9 @@ import type {
 } from './apiState'
 import { QueryStatus } from './apiState'
 import type {
+  MutationThunk,
   MutationThunkArg,
+  QueryThunk,
   QueryThunkArg,
   ThunkResult,
 } from './buildThunks'
@@ -81,22 +83,8 @@ export function buildSlice({
   config,
 }: {
   reducerPath: string
-  queryThunk: AsyncThunk<
-    ThunkResult,
-    QueryThunkArg,
-    {
-      pendingMeta: { startedTimeStamp: number }
-      fulfilledMeta: { fulfilledTimeStamp: number }
-    }
-  >
-  mutationThunk: AsyncThunk<
-    ThunkResult,
-    MutationThunkArg,
-    {
-      pendingMeta: { startedTimeStamp: number }
-      fulfilledMeta: { fulfilledTimeStamp: number }
-    }
-  >
+  queryThunk: QueryThunk
+  mutationThunk: MutationThunk
   context: ApiContext<EndpointDefinitions>
   assertTagType: AssertTagTypes
   config: Omit<

--- a/src/query/core/buildSlice.ts
+++ b/src/query/core/buildSlice.ts
@@ -81,8 +81,22 @@ export function buildSlice({
   config,
 }: {
   reducerPath: string
-  queryThunk: AsyncThunk<ThunkResult, QueryThunkArg, {}>
-  mutationThunk: AsyncThunk<ThunkResult, MutationThunkArg, {}>
+  queryThunk: AsyncThunk<
+    ThunkResult,
+    QueryThunkArg,
+    {
+      pendingMeta: { startedTimeStamp: number }
+      fulfilledMeta: { fulfilledTimeStamp: number }
+    }
+  >
+  mutationThunk: AsyncThunk<
+    ThunkResult,
+    MutationThunkArg,
+    {
+      pendingMeta: { startedTimeStamp: number }
+      fulfilledMeta: { fulfilledTimeStamp: number }
+    }
+  >
   context: ApiContext<EndpointDefinitions>
   assertTagType: AssertTagTypes
   config: Omit<
@@ -114,7 +128,7 @@ export function buildSlice({
     },
     extraReducers(builder) {
       builder
-        .addCase(queryThunk.pending, (draft, { meta: { arg, requestId } }) => {
+        .addCase(queryThunk.pending, (draft, { meta, meta: { arg } }) => {
           if (arg.subscribe) {
             // only initialize substate if we want to subscribe to it
             draft[arg.queryCacheKey] ??= {
@@ -125,9 +139,9 @@ export function buildSlice({
 
           updateQuerySubstateIfExists(draft, arg.queryCacheKey, (substate) => {
             substate.status = QueryStatus.pending
-            substate.requestId = requestId
+            substate.requestId = meta.requestId
             substate.originalArgs = arg.originalArgs
-            substate.startedTimeStamp = arg.startedTimeStamp
+            substate.startedTimeStamp = meta.startedTimeStamp
           })
         })
         .addCase(queryThunk.fulfilled, (draft, { meta, payload }) => {
@@ -137,12 +151,9 @@ export function buildSlice({
             (substate) => {
               if (substate.requestId !== meta.requestId) return
               substate.status = QueryStatus.fulfilled
-              substate.data = copyWithStructuralSharing(
-                substate.data,
-                payload.result
-              )
+              substate.data = copyWithStructuralSharing(substate.data, payload)
               delete substate.error
-              substate.fulfilledTimeStamp = payload.fulfilledTimeStamp
+              substate.fulfilledTimeStamp = meta.fulfilledTimeStamp
             }
           )
         })
@@ -184,26 +195,26 @@ export function buildSlice({
       builder
         .addCase(
           mutationThunk.pending,
-          (draft, { meta: { arg, requestId } }) => {
+          (draft, { meta: { arg, requestId, startedTimeStamp } }) => {
             if (!arg.track) return
 
             draft[requestId] = {
               status: QueryStatus.pending,
               originalArgs: arg.originalArgs,
               endpointName: arg.endpointName,
-              startedTimeStamp: arg.startedTimeStamp,
+              startedTimeStamp,
             }
           }
         )
         .addCase(
           mutationThunk.fulfilled,
-          (draft, { payload, meta: { requestId, arg } }) => {
-            if (!arg.track) return
+          (draft, { payload, meta, meta: { requestId } }) => {
+            if (!meta.arg.track) return
 
             updateMutationSubstateIfExists(draft, { requestId }, (substate) => {
               substate.status = QueryStatus.fulfilled
-              substate.data = payload.result
-              substate.fulfilledTimeStamp = payload.fulfilledTimeStamp
+              substate.data = payload
+              substate.fulfilledTimeStamp = meta.fulfilledTimeStamp
             })
           }
         )

--- a/src/query/core/buildThunks.ts
+++ b/src/query/core/buildThunks.ts
@@ -129,7 +129,13 @@ export type ThunkResult = unknown
 
 export type ThunkApiMetaConfig = {
   pendingMeta: { startedTimeStamp: number }
-  fulfilledMeta: { fulfilledTimeStamp: number }
+  fulfilledMeta: {
+    fulfilledTimeStamp: number
+    baseQueryMeta: unknown
+  }
+  rejectedMeta: {
+    baseQueryMeta: unknown
+  }
 }
 export type QueryThunk = AsyncThunk<
   ThunkResult,
@@ -312,11 +318,12 @@ export function buildThunks<
         await transformResponse(result.data, result.meta),
         {
           fulfilledTimeStamp: Date.now(),
+          baseQueryMeta: result.meta,
         }
       )
     } catch (error) {
       if (error instanceof HandledError) {
-        return rejectWithValue(error.value)
+        return rejectWithValue(error.value, { baseQueryMeta: error.meta })
       }
       throw error
     }

--- a/src/query/endpointDefinitions.ts
+++ b/src/query/endpointDefinitions.ts
@@ -33,7 +33,7 @@ interface EndpointDefinitionWithQuery<
    *
    * ```ts
    * // codeblock-meta title="query example"
-   * 
+   *
    * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
    * interface Post {
    *   id: number
@@ -75,7 +75,7 @@ interface EndpointDefinitionWithQueryFn<
    * @example
    * ```ts
    * // codeblock-meta title="Basic queryFn example"
-   * 
+   *
    * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
    * interface Post {
    *   id: number
@@ -203,7 +203,7 @@ export interface QueryExtraOptions<
    *
    * ```ts
    * // codeblock-meta title="providesTags example"
-   * 
+   *
    * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
    * interface Post {
    *   id: number
@@ -362,14 +362,14 @@ export interface MutationExtraOptions<
     arg: QueryArg,
     mutationApi: MutationApi<ReducerPath, any>,
     error: unknown,
-    meta: undefined
+    meta: BaseQueryMeta<BaseQuery>
   ): void
   /** @deprecated please use `onQueryStarted` instead */
   onSuccess?(
     arg: QueryArg,
     mutationApi: MutationApi<ReducerPath, any>,
     result: ResultType,
-    meta: undefined
+    meta: BaseQueryMeta<BaseQuery>
   ): void
 }
 

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,9 +1,5 @@
 export { QueryStatus } from './core/apiState'
-export type {
-  Api,
-  Module,
-  ApiModules,
-} from './apiTypes'
+export type { Api, Module, ApiModules } from './apiTypes'
 export type { BaseQueryEnhancer, BaseQueryFn } from './baseQueryTypes'
 export type {
   EndpointDefinitions,
@@ -12,7 +8,11 @@ export type {
   MutationDefinition,
 } from './endpointDefinitions'
 export { fetchBaseQuery } from './fetchBaseQuery'
-export type { FetchBaseQueryError, FetchArgs } from './fetchBaseQuery'
+export type {
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+  FetchArgs,
+} from './fetchBaseQuery'
 export { retry } from './retry'
 export { setupListeners } from './core/setupListeners'
 export { skipSelector, skipToken, SkipToken } from './core/buildSelectors'

--- a/src/query/tests/buildHooks.test.tsx
+++ b/src/query/tests/buildHooks.test.tsx
@@ -849,7 +849,6 @@ describe('hooks tests', () => {
             endpointName: string
             originalArgs: { name: string }
             track?: boolean
-            startedTimeStamp: number
           }>(res.arg)
           expectType<string>(res.requestId)
           expectType<() => void>(res.abort)

--- a/src/query/tests/cacheCollection.test.ts
+++ b/src/query/tests/cacheCollection.test.ts
@@ -1,6 +1,5 @@
-import { createApi } from '@reduxjs/toolkit/query'
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
 import { configureStore } from '@reduxjs/toolkit'
-import { fetchBaseQuery } from '../fetchBaseQuery'
 import { waitMs } from './helpers'
 import type { Middleware, Reducer } from 'redux'
 

--- a/src/query/tests/cacheLifecycle.test.ts
+++ b/src/query/tests/cacheLifecycle.test.ts
@@ -108,7 +108,13 @@ describe.each([['query'], ['mutation']] as const)(
       await fakeTimerWaitFor(() => {
         expect(gotFirstValue).toHaveBeenCalled()
       })
-      expect(gotFirstValue).toHaveBeenCalledWith({ data: { value: 'success' } })
+      expect(gotFirstValue).toHaveBeenCalledWith({
+        data: { value: 'success' },
+        meta: {
+          request: expect.any(Request),
+          response: expect.any(Object), // Response is not available in jest env
+        },
+      })
       expect(onCleanup).not.toHaveBeenCalled()
 
       promise.unsubscribe(), await waitMs()

--- a/src/query/tests/cacheLifecycle.test.ts
+++ b/src/query/tests/cacheLifecycle.test.ts
@@ -1,6 +1,7 @@
 import { createApi } from '@reduxjs/toolkit/query'
-import { fetchBaseQuery } from '../fetchBaseQuery'
-import { fakeTimerWaitFor, setupApiStore, waitMs } from './helpers'
+import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query'
+import { fetchBaseQuery } from '@reduxjs/toolkit/query'
+import { expectType, fakeTimerWaitFor, setupApiStore, waitMs } from './helpers'
 
 beforeAll(() => {
   jest.useFakeTimers()
@@ -81,7 +82,7 @@ describe.each([['query'], ['mutation']] as const)(
       const extended = api.injectEndpoints({
         overrideExisting: true,
         endpoints: (build) => ({
-          injected: build[type as 'mutation']<unknown, string>({
+          injected: build[type as 'mutation']<number, string>({
             query: () => '/success',
             async onCacheEntryAdded(
               arg,
@@ -89,6 +90,9 @@ describe.each([['query'], ['mutation']] as const)(
             ) {
               onNewCacheEntry(arg)
               const firstValue = await cacheDataLoaded
+              expectType<{ data: number; meta?: FetchBaseQueryMeta }>(
+                firstValue
+              )
               gotFirstValue(firstValue)
               await cacheEntryRemoved
               onCleanup()

--- a/src/query/tests/createApi.test.ts
+++ b/src/query/tests/createApi.test.ts
@@ -2,11 +2,9 @@ import { configureStore, createAction, createReducer } from '@reduxjs/toolkit'
 import type {
   Api,
   MutationDefinition,
-  QueryDefinition} from '@reduxjs/toolkit/query';
-import {
-  createApi,
-  fetchBaseQuery
+  QueryDefinition,
 } from '@reduxjs/toolkit/query'
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
 import {
   ANY,
   expectType,
@@ -19,8 +17,8 @@ import { server } from './mocks/server'
 import { rest } from 'msw'
 
 const originalEnv = process.env.NODE_ENV
-beforeAll(() => void (process.env.NODE_ENV = 'development'))
-afterAll(() => void (process.env.NODE_ENV = originalEnv))
+beforeAll(() => void ((process.env as any).NODE_ENV = 'development'))
+afterAll(() => void ((process.env as any).NODE_ENV = originalEnv))
 
 let spy: jest.SpyInstance
 beforeAll(() => {

--- a/src/query/tests/devWarnings.test.tsx
+++ b/src/query/tests/devWarnings.test.tsx
@@ -12,11 +12,11 @@ let nodeEnv: string
 beforeEach(() => {
   restore = mockConsole(createConsole())
   nodeEnv = process.env.NODE_ENV!
-  process.env.NODE_ENV = 'development'
+  ;(process.env as any).NODE_ENV = 'development'
 })
 
 afterEach(() => {
-  process.env.NODE_ENV = nodeEnv
+  ;(process.env as any).NODE_ENV = nodeEnv
   restore()
 })
 
@@ -49,7 +49,7 @@ describe('missing middleware', () => {
     ['development', true],
     ['production', false],
   ])('%s warns if middleware is missing: %s', ([env, shouldWarn]) => {
-    process.env.NODE_ENV = env
+    ;(process.env as any).NODE_ENV = env
     const store = configureStore({ reducer: { api1: api1.reducer } })
     store.dispatch(api1.endpoints.q1.initiate(undefined))
     expect(getLog().log).toBe(
@@ -97,7 +97,7 @@ describe('missing reducer', () => {
     ['development', true],
     ['production', false],
   ])('%s warns if reducer is missing: %s', ([env, shouldWarn]) => {
-    process.env.NODE_ENV = env
+    ;(process.env as any).NODE_ENV = env
     test('middleware not crashing if reducer is missing', async () => {
       const store = configureStore({
         reducer: { x: () => 0 },

--- a/src/query/tests/matchers.test.tsx
+++ b/src/query/tests/matchers.test.tsx
@@ -231,8 +231,8 @@ test('inferred types', () => {
         .addMatcher(
           api.endpoints.querySuccess.matchFulfilled,
           (state, action) => {
-            expectExactType({} as ResultType)(action.payload.result)
-            expectExactType(0 as number)(action.payload.fulfilledTimeStamp)
+            expectExactType({} as ResultType)(action.payload)
+            expectExactType(0 as number)(action.meta.fulfilledTimeStamp)
             // @ts-expect-error
             console.log(action.error)
             expectExactType({} as ArgType)(action.meta.arg.originalArgs)

--- a/src/query/tests/queryLifecycle.test.tsx
+++ b/src/query/tests/queryLifecycle.test.tsx
@@ -59,7 +59,13 @@ describe.each([['query'], ['mutation']] as const)(
       storeRef.store.dispatch(extended.endpoints.injected.initiate('arg'))
       expect(onStart).toHaveBeenCalledWith('arg')
       await waitFor(() => {
-        expect(onSuccess).toHaveBeenCalledWith({ data: { value: 'success' } })
+        expect(onSuccess).toHaveBeenCalledWith({
+          data: { value: 'success' },
+          meta: {
+            request: expect.any(Request),
+            response: expect.any(Object), // Response is not available in jest env
+          },
+        })
       })
     })
 
@@ -90,6 +96,10 @@ describe.each([['query'], ['mutation']] as const)(
             data: { value: 'error' },
           },
           isUnhandledError: false,
+          meta: {
+            request: expect.any(Request),
+            response: expect.any(Object), // Response is not available in jest env
+          },
         })
       })
       expect(onSuccess).not.toHaveBeenCalled()

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -156,7 +156,7 @@ export function createSerializableStateInvariantMiddleware(
     isSerializable = isPlain,
     getEntries,
     ignoredActions = [],
-    ignoredActionPaths = ['meta.arg'],
+    ignoredActionPaths = ['meta.arg', 'meta.baseQueryMeta'],
     ignoredPaths = [],
     warnAfter = 32,
     ignoreState = false,

--- a/src/tests/createAsyncThunk.test.ts
+++ b/src/tests/createAsyncThunk.test.ts
@@ -1,5 +1,4 @@
-import type {
-  AnyAction} from '@reduxjs/toolkit';
+import type { AnyAction } from '@reduxjs/toolkit'
 import {
   createAsyncThunk,
   unwrapResult,
@@ -494,11 +493,11 @@ describe('createAsyncThunk with abortController', () => {
       freshlyLoadedModule = require('../createAsyncThunk')
       restore = mockConsole(createConsole())
       nodeEnv = process.env.NODE_ENV!
-      process.env.NODE_ENV = 'development'
+      ;(process.env as any).NODE_ENV = 'development'
     })
 
     afterEach(() => {
-      process.env.NODE_ENV = nodeEnv
+      ;(process.env as any).NODE_ENV = nodeEnv
       restore()
       window.AbortController = keepAbortController
       jest.resetModules()


### PR DESCRIPTION
This contains #1083 and is a definite WIP, just want to see if it works for #1080

@TamasSzigeti could you give the CodeSandbox build of this a spin? Types are still missing, but `meta` is *on* there, so you might have to do an `any`-cast to get it out there atm. if working with TS

Install instructions at https://ci.codesandbox.io/status/reduxjs/redux-toolkit/pr/1084/