### PR TITLE
Remove ApiWithInjectedEndpoints references

### DIFF
--- a/docs/rtk-query/usage/code-splitting.mdx
+++ b/docs/rtk-query/usage/code-splitting.mdx
@@ -24,7 +24,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 // initialize an empty api service that we'll inject endpoints into later as needed
 export const emptySplitApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  endpoints: () => ({}),
+  endpoints: () => ({})
 })
 ```
 
@@ -36,19 +36,19 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
 export const emptySplitApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  endpoints: () => ({}),
+  endpoints: () => ({})
 })
 
 // file: extendedApi.ts
 import { emptySplitApi } from './emptySplitApi'
 
 const extendedApi = emptySplitApi.injectEndpoints({
-  endpoints: (build) => ({
+  endpoints: build => ({
     example: build.query({
-      query: () => 'test',
-    }),
+      query: () => 'test'
+    })
   }),
-  overrideExisting: false,
+  overrideExisting: false
 })
 
 export const { useExampleQuery } = extendedApi
@@ -57,91 +57,3 @@ export const { useExampleQuery } = extendedApi
 :::tip
 You will get a warning if you inject an endpoint that already exists in development mode when you don't explicitly specify `overrideExisting: true`. You **will not see this in production** and the existing endpoint will just be overriden, so make sure to account for this in your tests.
 :::
-
-## Typing a "completely injected" API using `ApiWithInjectedEndpoints`
-
-However, doing this, you will never end up with one "big api definition" that has correct types for all endpoints. Under certain circumstances, that might be useful though. So you can use the `ApiWithInjectedEndpoints` to construct this "full api definition" yourself:
-
-```ts title="Declaring an API using ApiWithInjectedEndpoints"
-// file: posts.ts noEmit
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-export const apiWithPosts = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  endpoints: () => ({}),
-})
-// file: post.ts noEmit
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-export const apiWithPost = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  endpoints: () => ({}),
-})
-
-// file: splitApi.ts
-import {
-  createApi,
-  fetchBaseQuery,
-  ApiWithInjectedEndpoints,
-} from '@reduxjs/toolkit/query'
-
-// initialize an empty api service that we'll inject endpoints into later as needed
-export const emptySplitApi = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  endpoints: () => ({}),
-})
-
-// highlight-start
-export const splitApi = emptySplitApi as ApiWithInjectedEndpoints<
-  typeof emptySplitApi,
-  [
-    // These are only type imports, not runtime imports, meaning they're not included in the initial bundle
-    typeof import('./posts').apiWithPosts,
-    typeof import('./post').apiWithPost
-  ]
->
-// highlight-end
-```
-
-Note however, that all endpoints added with `ApiWithInjectedEndpoints` are _optional_ on that definition, meaning that you have to check if they are `undefined` before using them.
-
-A good strategy using this would be to do a check for `undefined` with an _asserting_ function, so you don't have your hooks in a conditional, which would violate the rules of hooks.
-
-```tsx title="Using a type assertion"
-function assert(condition: any, msg = 'Generic Assertion'): asserts condition {
-  if (!condition) {
-    throw new Error(`Assertion failed: ${msg}`)
-  }
-}
-
-const Post = ({ id }: { id: number }) => {
-  // highlight-start
-  assert(
-    splitApi.endpoints.getPost?.useQuery,
-    'Endpoint `getPost` not loaded! Did you forget to import it in your current bundle?'
-  )
-  const { data, error } = splitApi.endpoints.getPost.useQuery(id)
-  // highlight-end
-  return error ? (
-    <>there was an error</>
-  ) : !data ? (
-    <>loading</>
-  ) : (
-    <h1>{data.name}</h1>
-  )
-}
-```
-
-## Example
-
-<iframe
-  src="https://codesandbox.io/embed/concepts-code-splitting-9cll0?fontsize=12&hidenavigation=1&theme=dark&module=%2Fsrc%2Ffeatures%2Fposts%2FPostsManager.tsx"
-  style={{
-    width: '100%',
-    height: '600px',
-    border: 0,
-    borderRadius: '4px',
-    overflow: 'hidden',
-  }}
-  title="Concepts Code Splitting"
-  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
-  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
-></iframe>

--- a/etc/redux-toolkit.api.md
+++ b/etc/redux-toolkit.api.md
@@ -4,31 +4,31 @@
 
 ```ts
 
-import { Action } from 'redux';
-import { ActionCreator } from 'redux';
-import { AnyAction } from 'redux';
-import { CombinedState } from 'redux';
+import type { Action } from 'redux';
+import type { ActionCreator } from 'redux';
+import type { AnyAction } from 'redux';
+import type { CombinedState } from 'redux';
 import { default as createNextState } from 'immer';
 import { createSelector } from 'reselect';
 import { current } from 'immer';
-import { Dispatch } from 'redux';
+import type { Dispatch } from 'redux';
 import { Draft } from 'immer';
 import { freeze } from 'immer';
 import { isDraft } from 'immer';
-import { Middleware } from 'redux';
+import type { Middleware } from 'redux';
 import { original } from 'immer';
 import { OutputParametricSelector } from 'reselect';
 import { OutputSelector } from 'reselect';
 import { ParametricSelector } from 'reselect';
-import { PreloadedState } from 'redux';
-import { Reducer } from 'redux';
-import { ReducersMapObject } from 'redux';
+import type { PreloadedState } from 'redux';
+import type { Reducer } from 'redux';
+import type { ReducersMapObject } from 'redux';
 import { Selector } from 'reselect';
-import { Store } from 'redux';
-import { StoreEnhancer } from 'redux';
+import type { Store } from 'redux';
+import type { StoreEnhancer } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import { ThunkDispatch } from 'redux-thunk';
-import { ThunkMiddleware } from 'redux-thunk';
+import type { ThunkMiddleware } from 'redux-thunk';
 
 // @public
 export interface ActionCreatorWithNonInferrablePayload<T extends string = string> extends BaseActionCreator<unknown, T> {

--- a/etc/rtk-query.api.md
+++ b/etc/rtk-query.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import { ActionCreatorWithoutPayload } from '@reduxjs/toolkit';
-import { ThunkDispatch } from '@reduxjs/toolkit';
+import type { ActionCreatorWithoutPayload } from '@reduxjs/toolkit';
+import type { ThunkDispatch } from '@reduxjs/toolkit';
 
 // @public (undocumented)
 export type Api<BaseQuery extends BaseQueryFn, Definitions extends EndpointDefinitions, ReducerPath extends string, TagTypes extends string, Enhancers extends ModuleName = CoreModule> = Id<Id<UnionToIntersection<ApiModules<BaseQuery, Definitions, ReducerPath, TagTypes>[Enhancers]>> & {
@@ -14,7 +14,6 @@ export type Api<BaseQuery extends BaseQueryFn, Definitions extends EndpointDefin
         overrideExisting?: boolean;
     }): Api<BaseQuery, Definitions & NewDefinitions, ReducerPath, TagTypes, Enhancers>;
     enhanceEndpoints<NewTagTypes extends string = never>(_: {
-        addEntityTypes?: readonly NewTagTypes[];
         addTagTypes?: readonly NewTagTypes[];
         endpoints?: ReplaceTagTypes<Definitions, TagTypes | NoInfer<NewTagTypes>> extends infer NewDefinitions ? {
             [K in keyof NewDefinitions]?: Partial<NewDefinitions[K]> | ((definition: NewDefinitions[K]) => void);
@@ -25,11 +24,6 @@ export type Api<BaseQuery extends BaseQueryFn, Definitions extends EndpointDefin
 // @public (undocumented)
 export interface ApiModules<BaseQuery extends BaseQueryFn, Definitions extends EndpointDefinitions, ReducerPath extends string, TagTypes extends string> {
 }
-
-// @public (undocumented)
-export type ApiWithInjectedEndpoints<ApiDefinition extends Api<any, any, any, any>, Injections extends ApiDefinition extends Api<infer B, any, infer R, infer E> ? [Api<B, any, R, E>, ...Api<B, any, R, E>[]] : never> = Omit<ApiDefinition, 'endpoints'> & Omit<Injections, 'endpoints'> & {
-    endpoints: ApiDefinition['endpoints'] & Partial<UnionToIntersection<Injections[number]['endpoints']>>;
-};
 
 // @public (undocumented)
 export type BaseQueryEnhancer<AdditionalArgs = unknown, AdditionalDefinitionExtraOptions = unknown, Config = void> = <BaseQuery extends BaseQueryFn>(baseQuery: BaseQuery, config: Config) => BaseQueryFn<BaseQueryArg<BaseQuery> & AdditionalArgs, BaseQueryResult<BaseQuery>, BaseQueryError<BaseQuery>, BaseQueryExtraOptions<BaseQuery> & AdditionalDefinitionExtraOptions>;
@@ -140,8 +134,14 @@ export function setupListeners(dispatch: ThunkDispatch<any, any, any>, customHan
     onOffline: typeof onOffline;
 }) => () => void): () => void;
 
+// @public @deprecated (undocumented)
+export const skipSelector: symbol;
+
 // @public (undocumented)
-export const skipSelector: unique symbol;
+export type SkipToken = typeof skipToken;
+
+// @public
+export const skipToken: unique symbol;
 
 
 // (No @packageDocumentation comment for this package)

--- a/src/query/apiTypes.ts
+++ b/src/query/apiTypes.ts
@@ -99,14 +99,3 @@ export type Api<
     >
   }
 >
-
-export type ApiWithInjectedEndpoints<
-  ApiDefinition extends Api<any, any, any, any>,
-  Injections extends ApiDefinition extends Api<infer B, any, infer R, infer E>
-    ? [Api<B, any, R, E>, ...Api<B, any, R, E>[]]
-    : never
-> = Omit<ApiDefinition, 'endpoints'> &
-  Omit<Injections, 'endpoints'> & {
-    endpoints: ApiDefinition['endpoints'] &
-      Partial<UnionToIntersection<Injections[number]['endpoints']>>
-  }

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,7 +1,6 @@
 export { QueryStatus } from './core/apiState'
 export type {
   Api,
-  ApiWithInjectedEndpoints,
   Module,
   ApiModules,
 } from './apiTypes'


### PR DESCRIPTION
- Drops `ApiWithInjectedEndpoints` references
- Includes updated API extractor outputs