### PR TITLE
🐛 Fix bad type for prefetch thunk action creator

### DIFF
--- a/src/query/core/buildThunks.ts
+++ b/src/query/core/buildThunks.ts
@@ -193,7 +193,7 @@ export function buildThunks<
   reducerPath: ReducerPath
   context: ApiContext<Definitions>
   serializeQueryArgs: InternalSerializeQueryArgs
-  api: Api<BaseQuery, EndpointDefinitions, ReducerPath, any>
+  api: Api<BaseQuery, Definitions, ReducerPath, any>
 }) {
   type State = RootState<any, string, ReducerPath>
 
@@ -357,7 +357,7 @@ export function buildThunks<
     options: any
   ): options is { ifOlderThan: false | number } => 'ifOlderThan' in options
 
-  const prefetch = <EndpointName extends QueryKeys<EndpointDefinitions>>(
+  const prefetch = <EndpointName extends QueryKeys<Definitions>>(
     endpointName: EndpointName,
     arg: any,
     options: PrefetchOptions

--- a/src/query/core/module.ts
+++ b/src/query/core/module.ts
@@ -128,7 +128,7 @@ declare module '../apiTypes' {
         /**
          * TODO
          */
-        prefetch<EndpointName extends QueryKeys<EndpointDefinitions>>(
+        prefetch<EndpointName extends QueryKeys<Definitions>>(
           endpointName: EndpointName,
           arg: QueryArgFrom<Definitions[EndpointName]>,
           options: PrefetchOptions

--- a/src/query/tests/buildMiddleware.test.tsx
+++ b/src/query/tests/buildMiddleware.test.tsx
@@ -12,6 +12,12 @@ const api = createApi({
       },
       providesTags: ['Banana'],
     }),
+    getBananas: build.query<unknown, void>({
+      query() {
+        return { url: 'bananas' }
+      },
+      providesTags: ['Banana']
+    }),
     getBread: build.query<unknown, number>({
       query(id) {
         return { url: `bread/${id}` }
@@ -82,5 +88,31 @@ describe.skip('TS only tests', () => {
   it('should error when using non-existing TagTypes in the full format', () => {
     // @ts-expect-error
     api.util.invalidateTags([{ type: 'Missing' }])
+  })
+  it('should allow pre-fetching for an endpoint that takes an arg', () => {
+    api.util.prefetch('getBanana', 5, { force: true })
+    api.util.prefetch('getBanana', 5, { force: false })
+    api.util.prefetch('getBanana', 5, { ifOlderThan: false })
+    api.util.prefetch('getBanana', 5, { ifOlderThan: 30 })
+    api.util.prefetch('getBanana', 5, {})
+  })
+  it('should error when pre-fetching with the incorrect arg type', () => {
+    // @ts-expect-error arg should be number, not string
+    api.util.prefetch('getBanana', '5', { force: true })
+  })
+  it('should allow pre-fetching for an endpoint with a void arg', () => {
+    api.util.prefetch('getBananas', undefined, { force: true })
+    api.util.prefetch('getBananas', undefined, { force: false })
+    api.util.prefetch('getBananas', undefined, { ifOlderThan: false })
+    api.util.prefetch('getBananas', undefined, { ifOlderThan: 30 })
+    api.util.prefetch('getBananas', undefined, {})
+  })
+  it('should error when pre-fetching with a defined arg when expecting void', () => {
+    // @ts-expect-error arg should be void, not number
+    api.util.prefetch('getBananas', 5, { force: true })
+  })
+  it('should error when pre-fetching for an incorrect endpoint name', () => {
+    // @ts-expect-error endpoint name does not exist
+    api.util.prefetch('getPomegranates', undefined, { force: true })
   })
 })


### PR DESCRIPTION
- Fixes the `endpointName` arg being typed as `never`

### Bug details
#### Description

When using the `prefetch` thunk action creator manually (not the generated `usePrefetch` hook), the first argument `endpointName` is typed as `never`.

#### Expected behaviour

The type for `endpointName` should allow one of the `queryKeys` based on the endpoints defined on the corresponding api.

#### Version

1.6.0-beta.0

#### Reproduction example

https://codesandbox.io/s/rtkq-apiutilprefetch-type-bug-ksc27?file=/src/api.ts:460-519

```
Argument of type 'string' is not assignable to parameter of type 'never'.ts(2345)
```