### PR TITLE
remove `Id` to force lazy evaluation of Api type

### DIFF
--- a/src/query/apiTypes.ts
+++ b/src/query/apiTypes.ts
@@ -4,7 +4,7 @@ import type {
   EndpointDefinition,
   ReplaceTagTypes,
 } from './endpointDefinitions'
-import type { UnionToIntersection, Id, NoInfer } from './tsHelpers'
+import type { UnionToIntersection, NoInfer } from './tsHelpers'
 import type { CoreModule } from './core/module'
 import type { CreateApiOptions } from './createApi'
 import type { BaseQueryFn } from './baseQueryTypes'
@@ -54,48 +54,44 @@ export type Api<
   ReducerPath extends string,
   TagTypes extends string,
   Enhancers extends ModuleName = CoreModule
-> = Id<
-  Id<
-    UnionToIntersection<
-      ApiModules<BaseQuery, Definitions, ReducerPath, TagTypes>[Enhancers]
-    >
-  > & {
-    /**
-     * A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
-     */
-    injectEndpoints<NewDefinitions extends EndpointDefinitions>(_: {
-      endpoints: (
-        build: EndpointBuilder<BaseQuery, TagTypes, ReducerPath>
-      ) => NewDefinitions
-      overrideExisting?: boolean
-    }): Api<
-      BaseQuery,
-      Definitions & NewDefinitions,
-      ReducerPath,
-      TagTypes,
-      Enhancers
-    >
-    /**
-     *A function to enhance a generated API with additional information. Useful with code-generation.
-     */
-    enhanceEndpoints<NewTagTypes extends string = never>(_: {
-      addTagTypes?: readonly NewTagTypes[]
-      endpoints?: ReplaceTagTypes<
-        Definitions,
-        TagTypes | NoInfer<NewTagTypes>
-      > extends infer NewDefinitions
-        ? {
-            [K in keyof NewDefinitions]?:
-              | Partial<NewDefinitions[K]>
-              | ((definition: NewDefinitions[K]) => void)
-          }
-        : never
-    }): Api<
-      BaseQuery,
-      ReplaceTagTypes<Definitions, TagTypes | NewTagTypes>,
-      ReducerPath,
-      TagTypes | NewTagTypes,
-      Enhancers
-    >
-  }
->
+> = UnionToIntersection<
+  ApiModules<BaseQuery, Definitions, ReducerPath, TagTypes>[Enhancers]
+> & {
+  /**
+   * A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
+   */
+  injectEndpoints<NewDefinitions extends EndpointDefinitions>(_: {
+    endpoints: (
+      build: EndpointBuilder<BaseQuery, TagTypes, ReducerPath>
+    ) => NewDefinitions
+    overrideExisting?: boolean
+  }): Api<
+    BaseQuery,
+    Definitions & NewDefinitions,
+    ReducerPath,
+    TagTypes,
+    Enhancers
+  >
+  /**
+   *A function to enhance a generated API with additional information. Useful with code-generation.
+   */
+  enhanceEndpoints<NewTagTypes extends string = never>(_: {
+    addTagTypes?: readonly NewTagTypes[]
+    endpoints?: ReplaceTagTypes<
+      Definitions,
+      TagTypes | NoInfer<NewTagTypes>
+    > extends infer NewDefinitions
+      ? {
+          [K in keyof NewDefinitions]?:
+            | Partial<NewDefinitions[K]>
+            | ((definition: NewDefinitions[K]) => void)
+        }
+      : never
+  }): Api<
+    BaseQuery,
+    ReplaceTagTypes<Definitions, TagTypes | NewTagTypes>,
+    ReducerPath,
+    TagTypes | NewTagTypes,
+    Enhancers
+  >
+}

--- a/src/query/core/module.ts
+++ b/src/query/core/module.ts
@@ -27,7 +27,6 @@ import { buildSlice } from './buildSlice'
 import { buildMiddleware } from './buildMiddleware'
 import { buildSelectors } from './buildSelectors'
 import { buildInitiate } from './buildInitiate'
-import type { Id } from '../tsHelpers'
 import { assertCast, safeAssign } from '../tsHelpers'
 import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type { SliceActions } from './buildSlice'
@@ -180,9 +179,9 @@ declare module '../apiTypes' {
           any,
           any
         >
-          ? Id<ApiEndpointQuery<Definitions[K], Definitions>>
+          ? ApiEndpointQuery<Definitions[K], Definitions>
           : Definitions[K] extends MutationDefinition<any, any, any, any, any>
-          ? Id<ApiEndpointMutation<Definitions[K], Definitions>>
+          ? ApiEndpointMutation<Definitions[K], Definitions>
           : never
       }
     }


### PR DESCRIPTION
This should fix https://github.com/reduxjs/redux-toolkit/issues/1090
@colemars could you please give the codesandbox build a try?