### PR TITLE
run prepare everywhere except CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "build-ci": "rimraf dist && tsc && node scripts/cli.js",
+    "build-ci": "rimraf dist && tsc && node scripts/cli.js --skipExtraction ",
     "build-prepare": "npm run build-ci",
     "build": "rimraf dist && tsc && node scripts/cli.js --local",
     "build-only": "rimraf dist && tsc && node scripts/cli.js --skipExtraction",
@@ -90,7 +90,7 @@
     "lint": "eslint src examples",
     "test": "jest --runInBand",
     "type-tests": "yarn tsc -p src/tests && yarn tsc -p src/query/tests",
-    "prepare": "node -e 'process.exit(process.env.CI?0:1)' || npm run build-prepare"
+    "prepack": "npm run build-prepare"
   },
   "files": [
     "dist/**/*.js",

--- a/package.json
+++ b/package.json
@@ -82,13 +82,15 @@
   },
   "scripts": {
     "build-ci": "rimraf dist && tsc && node scripts/cli.js",
+    "build-prepare": "npm run build-ci",
     "build": "rimraf dist && tsc && node scripts/cli.js --local",
     "build-only": "rimraf dist && tsc && node scripts/cli.js --skipExtraction",
     "format": "prettier --write \"(src|examples)/**/*.{ts,tsx}\" \"**/*.md\"",
     "format:check": "prettier --list-different \"(src|examples)/**/*.{ts,tsx}\" \"docs/*/**.md\"",
     "lint": "eslint src examples",
     "test": "jest --runInBand",
-    "type-tests": "yarn tsc -p src/tests && yarn tsc -p src/query/tests"
+    "type-tests": "yarn tsc -p src/tests && yarn tsc -p src/query/tests",
+    "prepare": "node -e 'process.exit(process.env.CI?0:1)' || npm run build-prepare"
   },
   "files": [
     "dist/**/*.js",


### PR DESCRIPTION
This should make `prepare` run locally again, but still skip it in CI.

@markerikson can you please validate that on your local machine? I think this should work on Windows.

Should get triggered by `npm pack`.