### PR TITLE
Rename algoliaOptions to searchParameters per docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -159,7 +159,7 @@ module.exports = {
     algolia: {
       apiKey: '82d838443b672336bf63cab4772d9eb4',
       indexName: 'redux-starter-kit',
-      algoliaOptions: {},
+      searchParameters: {},
     },
     googleAnalytics: {
       trackingID: 'UA-130598673-3',


### PR DESCRIPTION
This should remain `{}`, but wanted to make sure we tracked specifically against the docs. - https://docusaurus.io/docs/search#connecting-algolia