### PR TITLE
[website] remove duplicated line docusaurus.config.js

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -155,7 +155,6 @@ module.exports = {
       ],
       copyright: `Copyright © 2015–${new Date().getFullYear()} Dan Abramov and the Redux documentation authors.`,
     },
-    image: 'img/redux-logo-landscape.png',
     algolia: {
       apiKey: '82d838443b672336bf63cab4772d9eb4',
       indexName: 'redux-starter-kit',


### PR DESCRIPTION
It's subtle, I find out duplicated completely same key/values on same layer 'image: 'img/redux-logo-landscape.png','
Just remove it.