### PR TITLE
[website] text color always white on darkness BG

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -76,6 +76,7 @@
   --ifm-hero-background-color: #593d88;
   --ifm-hero-text-color: #ffffff;
 }
+
 blockquote {
   color: var(--blockquote-text-color);
   background-color: var(--ifm-blockquote-color);
@@ -95,6 +96,14 @@ blockquote {
 }
 div[class*='codeBlockTitle'] {
   padding: 0.15rem var(--ifm-pre-padding);
+}
+
+:root[data-theme='dark'] .admonition code {
+  color: var(--ifm-blockquote-color);
+}
+
+:root[data-theme='dark'] blockquote code {
+  color: var(--ifm-blockquote-color);
 }
 
 code {


### PR DESCRIPTION
I fixed `<code>` text color in a `<blockquote>` as same as other places.  

## Before PR

<img width="967" alt="Screen Shot 2021-06-21 at 0 27 47" src="https://user-images.githubusercontent.com/5501268/122748449-2a9a1d00-d2c7-11eb-9f29-04711030818e.png">


## After PR

<img width="1005" alt="Screen Shot 2021-06-21 at 16 15 57" src="https://user-images.githubusercontent.com/5501268/122748955-bb70f880-d2c7-11eb-85df-c1d236d315bc.png">
g…]()


Thank you for review it 😀
