### PR TITLE
Update extraReducers syntax and add RTKQ info boxes

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -39,12 +39,12 @@ const usersSlice = createSlice({
   reducers: {
     // standard reducer logic, with auto-generated action types per reducer
   },
-  extraReducers: {
+  extraReducers: (builder) => {
     // Add reducers for additional action types here, and handle loading state as needed
-    [fetchUserById.fulfilled]: (state, action) => {
+    builder.addCase(fetchUserById.fulfilled, (state, action) => {
       // Add user to the state array
       state.entities.push(action.payload)
-    },
+    })
   },
 })
 
@@ -467,29 +467,36 @@ const usersSlice = createSlice({
     error: null,
   },
   reducers: {},
-  extraReducers: {
-    [fetchUserById.pending]: (state, action) => {
-      if (state.loading === 'idle') {
-        state.loading = 'pending'
-        state.currentRequestId = action.meta.requestId
-      }
-    },
-    [fetchUserById.fulfilled]: (state, action) => {
-      const { requestId } = action.meta
-      if (state.loading === 'pending' && state.currentRequestId === requestId) {
-        state.loading = 'idle'
-        state.entities.push(action.payload)
-        state.currentRequestId = undefined
-      }
-    },
-    [fetchUserById.rejected]: (state, action) => {
-      const { requestId } = action.meta
-      if (state.loading === 'pending' && state.currentRequestId === requestId) {
-        state.loading = 'idle'
-        state.error = action.error
-        state.currentRequestId = undefined
-      }
-    },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchUserById.pending, (state, action) => {
+        if (state.loading === 'idle') {
+          state.loading = 'pending'
+          state.currentRequestId = action.meta.requestId
+        }
+      })
+      .addCase(fetchUserById.fulfilled, (state, action) => {
+        const { requestId } = action.meta
+        if (
+          state.loading === 'pending' &&
+          state.currentRequestId === requestId
+        ) {
+          state.loading = 'idle'
+          state.entities.push(action.payload)
+          state.currentRequestId = undefined
+        }
+      })
+      .addCase(fetchUserById.rejected, (state, action) => {
+        const { requestId } = action.meta
+        if (
+          state.loading === 'pending' &&
+          state.currentRequestId === requestId
+        ) {
+          state.loading = 'idle'
+          state.error = action.error
+          state.currentRequestId = undefined
+        }
+      })
   },
 })
 

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -17,6 +17,12 @@ This abstracts the standard recommended approach for handling async request life
 
 It does not generate any reducer functions, since it does not know what data you're fetching, how you want to track loading state, or how the data you return needs to be processed. You should write your own reducer logic that handles these actions, with whatever loading state and processing logic is appropriate for your own app.
 
+:::tip
+
+Redux Toolkit's [**RTK Query data fetching API**](../rtk-query/overview.md) is a purpose built data fetching and caching solution for Redux apps, and can **eliminate the need to write _any_ thunks or reducers to manage data fetching**. We encourage you to try it out and see if it can help simplify the data fetching code in your own apps!
+
+:::
+
 Sample usage:
 
 ```js {5-11,22-25,30}

--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -182,8 +182,11 @@ createSlice({
 })
 ```
 
-> **Note**: If you are using TypeScript, we recommend using the `builder callback` API that is shown above. If you do not use the `builder callback` and are using TypeScript, you will need to use `actionCreator.type` or `actionCreator.toString()`
-> to force the TS compiler to accept the computed property. Please see [Usage With TypeScript](./../usage/usage-with-typescript.md#type-safety-with-extraReducers) for further details.
+:::tip
+
+We recommend using the `builder callback` API as the default, especially if you are using TypeScript. If you do not use the `builder callback` and are using TypeScript, you will need to use `actionCreator.type` or `actionCreator.toString()` to force the TS compiler to accept the computed property. Please see [Usage With TypeScript](./../usage/usage-with-typescript.md#type-safety-with-extraReducers) for further details.
+
+:::
 
 ## Return Value
 

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -546,7 +546,13 @@ There are many kinds of async middleware for Redux, and each lets you write your
 
 [Each of these libraries has different use cases and tradeoffs](https://redux.js.org/faq/actions#what-async-middleware-should-i-use-how-do-you-decide-between-thunks-sagas-observables-or-something-else).
 
-**We recommend [using the Redux Thunk middleware as the standard approach](https://github.com/reduxjs/redux-thunk)**, as it is sufficient for most typical use cases (such as basic AJAX data fetching). In addition, use of the `async/await` syntax in thunks makes them easier to read.
+:::tip
+
+Redux Toolkit's [**RTK Query data fetching API**](../rtk-query/overview.md) is a purpose built data fetching and caching solution for Redux apps, and can **eliminate the need to write _any_ thunks or reducers to manage data fetching**. We encourage you to try it out and see if it can help simplify the data fetching code in your own apps!
+
+:::
+
+If you do need to write data fetching logic yourself, we recommend [using the Redux Thunk middleware as the standard approach](https://github.com/reduxjs/redux-thunk), as it is sufficient for most typical use cases (such as basic AJAX data fetching). In addition, use of the `async/await` syntax in thunks makes them easier to read.
 
 **The Redux Toolkit `configureStore` function [automatically sets up the thunk middleware by default](../api/getDefaultMiddleware.mdx)**, so you can immediately start writing thunks as part of your application code.
 

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -666,12 +666,12 @@ const usersSlice = createSlice({
   reducers: {
     // standard reducer logic, with auto-generated action types per reducer
   },
-  extraReducers: {
+  extraReducers: (builder) => {
     // Add reducers for additional action types here, and handle loading state as needed
-    [fetchUserById.fulfilled]: (state, action) => {
+    builder.addCase(fetchUserById.fulfilled, (state, action) => {
       // Add user to the state array
       state.entities.push(action.payload)
-    },
+    })
   },
 })
 
@@ -872,11 +872,11 @@ export const slice = createSlice({
   name: 'articles',
   initialState: articlesAdapter.getInitialState(),
   reducers: {},
-  extraReducers: {
-    [fetchArticle.fulfilled]: (state, action) => {
+  extraReducers: (builder) => {
+    builder.addCase(fetchArticle.fulfilled, (state, action) => {
       // Handle the fetch result by inserting the articles here
       articlesAdapter.upsertMany(state, action.payload.articles)
-    },
+    })
   },
 })
 
@@ -916,11 +916,11 @@ export const slice = createSlice({
   name: 'comments',
   initialState: commentsAdapter.getInitialState(),
   reducers: {},
-  extraReducers: {
-    [fetchArticle.fulfilled]: (state, action) => {
+  extraReducers: (builder) => {
+    builder.addCase(fetchArticle.fulfilled, (state, action) => {
       // Same for the comments
       commentsAdapter.upsertMany(state, action.payload.comments)
-    },
+    })
   },
 })
 


### PR DESCRIPTION
This PR:

- Updates all uses of `extraReducers` to show the "builder" syntax instead of the "object" syntax, except for examples that are specifically meant to show the object form
- Adds a couple info boxes to the `createAsyncThunk` API ref and the Usage Guide to point folks to RTKQ for data fetching