### PR TITLE
Fixes typo in usage documentation

### DIFF
--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -938,7 +938,7 @@ You can [view the full code of this example `normalizr` usage on CodeSandbox](ht
 
 ### Using selectors with `createEntityAdapter`
 
-The entity adapter providers a selector factory that generates the most common selectors for you. Taking the examples above, we can add selectors to our `usersSlice` like this:
+The entity adapter provides a selector factory that generates the most common selectors for you. Taking the examples above, we can add selectors to our `usersSlice` like this:
 
 ```js
 // Rename the exports for readability in component usage


### PR DESCRIPTION
Saw that small typo and didn't want to forget about it so here it is.

_Note that it's a really small change and the typo itself wasn't hurting the message that much, so feel free to close this PR and include this minuscule change within any other changes. Sorry for the noise!_ 😅 