### PR TITLE
Clarify mutation loading / fetching lack of distinction

### DIFF
--- a/docs/rtk-query/usage/mutations.mdx
+++ b/docs/rtk-query/usage/mutations.mdx
@@ -112,7 +112,7 @@ Below are some of the most frequently used properties on the "mutation result" o
 
 :::note
 
-With RTK Query, a mutation does contain a semantic distinction between 'loading' and 'fetching' in the way that a [query does](./queries.mdx#frequently-used-query-hook-return-values). For a mutation, subsequent calls are not assumed to be necessarily related, so a mutation is either 'loading' or 'not loading', with no concept of 're-fetching'.
+With RTK Query, a mutation does not contain a semantic distinction between 'loading' and 'fetching' in the way that a [query does](./queries.mdx#frequently-used-query-hook-return-values). For a mutation, subsequent calls are not assumed to be necessarily related, so a mutation is either 'loading' or 'not loading', with no concept of 're-fetching'.
 
 :::
 


### PR DESCRIPTION
My assumption is that this sentence should say that there is no distinction
between loading and fetching considering that only `isLoading` is exposed
(unlike `useQuery` which exposes `isFetching` as well)