### PR TITLE
Fix RTKQ migration doc syntax

### DIFF
--- a/docs/rtk-query/usage/migrating-to-rtk-query.mdx
+++ b/docs/rtk-query/usage/migrating-to-rtk-query.mdx
@@ -12,7 +12,7 @@ description: 'RTK Query > Usage > Migrating to RTKQ: how to convert logic to RTK
 
 :::tip What You'll Learn
 
-- How to convert conventional data-fetching logic implemented with Redux Toolkit`+ `createAsyncThunk`to use`Redux Toolkit Query`
+- How to convert conventional data-fetching logic implemented with Redux Toolkit + `createAsyncThunk` to use Redux Toolkit Query
 
 :::
 


### PR DESCRIPTION
The hanging code tick was causing formatting issues. Also unticked the names
of the project as it doesn't appear they are ticked in other places in the
docs.