### PR TITLE
👷 Remove defunct strictOptionalProperties refs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,10 +110,6 @@ jobs:
         if: ${{ matrix.ts < 4.1 }}
         run: sed -i -e 's/@pre41-ts-ignore/@ts-ignore/' -e  '/pre41-remove-start/,/pre41-remove-end/d' ./src/tests/*.* ./src/query/tests/*.ts*
 
-      - name: 'disable strictOptionalProperties'
-        if: ${{ matrix.ts == 'next' }}
-        run: sed -i -e 's|//\(.*strictOptionalProperties.*\)$|\1|' tsconfig.base.json
-
       - name: Test types
         run: |
           ./node_modules/.bin/tsc --version

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,6 @@
     "rootDir": "./src",
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
-    // "strictOptionalProperties": false, // disable strictOptionalProperties for now to also build with 4.4
     // linter checks for common issues
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Should allow the `ts-next` task to pass again.

On TS-next, `strictOptionalProperties` has been renamed, and is now opt-in. As a result, the allowances previously made to account for it are no longer necessary, and currently cause an error due to the now non-existent property.

See https://github.com/microsoft/TypeScript/pull/44626