### PR TITLE
Fix the example code in "Quick start" tutorial

### DIFF
--- a/docs/tutorials/quick-start.mdx
+++ b/docs/tutorials/quick-start.mdx
@@ -112,7 +112,7 @@ Redux requires that [we write all state updates immutably, by making copies of d
 ```ts title="features/counter/counterSlice.js"
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-interface CounterState {
+export interface CounterState {
   value: number
 }
 


### PR DESCRIPTION
VSCode shows the error in the `store.js` file
```
Exported variable 'store' has or is using name 'CounterState' from external module ".../src/client/features/counter/counterSlice" but cannot be named.
ts(4023)
```

Managed to fix this by exporting the CounterState in the `features/counter/counterSlice.js`.