### PR TITLE
[docs:query] add useQuery() manual call example at overview

### DIFF
--- a/docs/rtk-query/overview.md
+++ b/docs/rtk-query/overview.md
@@ -152,7 +152,7 @@ import { useGetPokemonByNameQuery } from './services/pokemon'
 export default function App() {
   // Using a query hook automatically fetches data and returns query values
   const { data, error, isLoading } = useGetPokemonByNameQuery('bulbasaur')
-  // You can also perform with raw endpoints name and useQuery() API
+  // Individual hooks are also accessible under the generated endpoints:
   // const { data, error, isLoading } = pokemonApi.endpoints.getPokemonByName.useQuery('bulbasaur')
   
   // render UI based on data and loading state

--- a/docs/rtk-query/overview.md
+++ b/docs/rtk-query/overview.md
@@ -152,7 +152,9 @@ import { useGetPokemonByNameQuery } from './services/pokemon'
 export default function App() {
   // Using a query hook automatically fetches data and returns query values
   const { data, error, isLoading } = useGetPokemonByNameQuery('bulbasaur')
-
+  // You can also perform with raw endpoints name and useQuery() API
+  // const { data, error, isLoading } = pokemonApi.endpoints.getPokemonByName.useQuery('bulbasaur')
+  
   // render UI based on data and loading state
 }
 ```


### PR DESCRIPTION
I'm living fan time with RTK Query thank you so much for making so cool library 🤗

At the RTK overview I thought some person has feeling like "black box" about a auto generated naming query/mutation even they understood that's really convenient.

So putting manual object access version at the same point might be remove anxiety about where does it come?

Thank you for review it!