### PR TITLE
improve typing for unbound functions

### DIFF
--- a/packages/toolkit/src/createAction.ts
+++ b/packages/toolkit/src/createAction.ts
@@ -83,7 +83,7 @@ export type _ActionCreatorWithPreparedPayload<
  */
 interface BaseActionCreator<P, T extends string, M = never, E = never> {
   type: T
-  match(action: Action<unknown>): action is PayloadAction<P, T, M, E>
+  match: (action: Action<unknown>) => action is PayloadAction<P, T, M, E>
 }
 
 /**

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -235,10 +235,10 @@ export type AsyncThunkAction<
   | ReturnType<AsyncThunkFulfilledActionCreator<Returned, ThunkArg>>
   | ReturnType<AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig>>
 > & {
-  abort(reason?: string): void
+  abort: (reason?: string) => void
   requestId: string
   arg: ThunkArg
-  unwrap(): Promise<Returned>
+  unwrap: () => Promise<Returned>
 }
 
 type AsyncThunkActionCreator<

--- a/packages/toolkit/src/matchers.ts
+++ b/packages/toolkit/src/matchers.ts
@@ -359,9 +359,9 @@ export type UnknownAsyncThunkAction =
   | UnknownAsyncThunkFulfilledAction
 
 export type AnyAsyncThunk = {
-  pending: { match(action: any): action is any }
-  fulfilled: { match(action: any): action is any }
-  rejected: { match(action: any): action is any }
+  pending: { match: (action: any) => action is any }
+  fulfilled: { match: (action: any) => action is any }
+  rejected: { match: (action: any) => action is any }
 }
 
 export type ActionsFromAsyncThunk<T extends AnyAsyncThunk> =

--- a/packages/toolkit/src/tsHelpers.ts
+++ b/packages/toolkit/src/tsHelpers.ts
@@ -102,7 +102,7 @@ export type NoInfer<T> = [T][T extends any ? 0 : never]
 export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>
 
 export interface HasMatchFunction<T> {
-  match(v: any): v is T
+  match: (v: any) => v is T
 }
 
 export const hasMatchFunction = <T>(


### PR DESCRIPTION
This updates the creator APIs to more accurately express types for the returned function objects. For example, `match():` would be treated as a bound function relying on 'this', but it is now updated to `match: () =>`. This will not trigger the `@typescript-eslint/unbound-method` rule when passing `actions.act
ionName.match`.