### PR TITLE
[docs:query] add useQuery() manual call example at overview pt2

### DIFF
--- a/docs/tutorials/rtk-query.mdx
+++ b/docs/tutorials/rtk-query.mdx
@@ -188,6 +188,8 @@ export default function App() {
   // highlight-start
   // Using a query hook automatically fetches data and returns query values
   const { data, error, isLoading } = useGetPokemonByNameQuery('bulbasaur')
+  // Individual hooks are also accessible under the generated endpoints:
+  // const { data, error, isLoading } = pokemonApi.endpoints.getPokemonByName.useQuery('bulbasaur')
   // highlight-end
 
   return (


### PR DESCRIPTION
I do exact same change to https://github.com/reduxjs/redux-toolkit/pull/1257.
Actually same code example used to in 2 different pages, I illustrate each page link.

<img width="1033" alt="Screen Shot 2021-07-09 at 15 18 43" src="https://user-images.githubusercontent.com/5501268/125060213-176cb700-e0e7-11eb-9c51-76339d3fd343.png">

Thank you for your review!


