### PR TITLE
undo adding `statusText` since it is empty in HTTP/2

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -66,7 +66,6 @@ export type FetchBaseQueryError =
        */
       status: number
       data: unknown
-      statusText: string
     }
   | {
       /**
@@ -86,8 +85,16 @@ export type FetchBaseQueryError =
        **/
       status: 'PARSING_ERROR'
       originalStatus: number
-      statusText: string
       data: string
+      error: string
+    }
+  | {
+      /**
+       * * `"CUSTOM_ERROR"`:
+       *   A custom error type that you can return from your `fetchFn` where another error might not make sense.
+       **/
+      status: 'CUSTOM_ERROR'
+      data?: unknown
       error: string
     }
 
@@ -237,7 +244,6 @@ export function fetchBaseQuery({
         error: {
           status: 'PARSING_ERROR',
           originalStatus: response.status,
-          statusText: response.statusText,
           data: await responseClone.clone().text(),
           error: String(e),
         },
@@ -254,7 +260,6 @@ export function fetchBaseQuery({
           error: {
             status: response.status,
             data: resultData,
-            statusText: response.statusText,
           },
           meta,
         }

--- a/packages/toolkit/src/query/tests/errorHandling.test.tsx
+++ b/packages/toolkit/src/query/tests/errorHandling.test.tsx
@@ -67,7 +67,6 @@ describe('fetchBaseQuery', () => {
     ).resolves.toEqual({
       error: {
         data: { value: 'error' },
-        statusText: 'Internal Server Error',
         status: 500,
       },
       meta: {
@@ -118,7 +117,6 @@ describe('query error handling', () => {
         isSuccess: false,
         error: {
           status: 500,
-          statusText: 'Internal Server Error',
           data: { value: 'error' },
         },
       })
@@ -161,7 +159,6 @@ describe('query error handling', () => {
         isSuccess: false,
         error: {
           status: 500,
-          statusText: 'Internal Server Error',
           data: { value: 'error' },
         },
         // last data will stay available
@@ -193,7 +190,6 @@ describe('query error handling', () => {
         isSuccess: false,
         error: {
           status: 500,
-          statusText: 'Internal Server Error',
           data: { value: 'error' },
         },
       })
@@ -261,7 +257,6 @@ describe('mutation error handling', () => {
         isSuccess: false,
         error: {
           status: 500,
-          statusText: 'Internal Server Error',
           data: { value: 'error' },
         },
       })
@@ -313,7 +308,6 @@ describe('mutation error handling', () => {
           isSuccess: false,
           error: {
             status: 500,
-            statusText: 'Internal Server Error',
             data: { value: 'error' },
           },
         })
@@ -351,7 +345,6 @@ describe('mutation error handling', () => {
           isSuccess: false,
           error: {
             status: 500,
-            statusText: 'Internal Server Error',
             data: { value: 'error' },
           },
         })
@@ -587,7 +580,6 @@ describe('error handling in a component', () => {
       expect(result).toMatchObject({
         error: {
           status: 500,
-          statusText: 'Internal Server Error',
           data: { value: 'error' },
         },
       })
@@ -625,7 +617,6 @@ describe('error handling in a component', () => {
       const unwrappedPromise = mutationqueryFulfilled!.unwrap()
       expect(unwrappedPromise).rejects.toMatchObject({
         status: 500,
-        statusText: 'Internal Server Error',
         data: { value: 'error' },
       })
     })

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -123,7 +123,6 @@ describe('fetchBaseQuery', () => {
       expect(res.meta?.response).toBeInstanceOf(Object)
       expect(res.error).toEqual({
         status: 500,
-        statusText: 'Internal Server Error',
         data: { value: 'error' },
       })
     })
@@ -202,7 +201,6 @@ describe('fetchBaseQuery', () => {
         status: 'PARSING_ERROR',
         error: 'SyntaxError: Unexpected token h in JSON at position 1',
         originalStatus: 200,
-        statusText: 'OK',
         data: `this is not json!`,
       })
     })
@@ -230,7 +228,6 @@ describe('fetchBaseQuery', () => {
       expect(res.meta?.response).toBeInstanceOf(Object)
       expect(res.error).toEqual({
         status: 500,
-        statusText: 'Internal Server Error',
         data: `this is not json!`,
       })
     })
@@ -260,7 +257,6 @@ describe('fetchBaseQuery', () => {
         status: 'PARSING_ERROR',
         error: 'SyntaxError: Unexpected token h in JSON at position 1',
         originalStatus: 500,
-        statusText: 'Internal Server Error',
         data: `this is not json!`,
       })
     })
@@ -458,7 +454,6 @@ describe('fetchBaseQuery', () => {
 
       expect(res.error).toEqual({
         status: 200,
-        statusText: 'OK',
         data: {
           success: false,
           message: 'This returns a 200 but is really an error',
@@ -692,11 +687,11 @@ describe('fetchFn', () => {
       ok: true,
       status: 200,
       text: async () => `{ "url": "mock-return-url" }`,
-      clone: () => fakeResponse
+      clone: () => fakeResponse,
     }
 
-    const spiedFetch = jest.spyOn(window, 'fetch');
-    spiedFetch.mockResolvedValueOnce(fakeResponse as any);
+    const spiedFetch = jest.spyOn(window, 'fetch')
+    spiedFetch.mockResolvedValueOnce(fakeResponse as any)
 
     const { data } = await baseQuery(
       { url: '/echo' },
@@ -707,9 +702,9 @@ describe('fetchFn', () => {
       },
       {}
     )
-    expect(data).toEqual({url: 'mock-return-url'})
+    expect(data).toEqual({ url: 'mock-return-url' })
 
-    spiedFetch.mockClear();
+    spiedFetch.mockClear()
   })
 })
 

--- a/packages/toolkit/src/query/tests/queryLifecycle.test.tsx
+++ b/packages/toolkit/src/query/tests/queryLifecycle.test.tsx
@@ -98,7 +98,6 @@ describe.each([['query'], ['mutation']] as const)(
         expect(onError).toHaveBeenCalledWith({
           error: {
             status: 500,
-            statusText: 'Internal Server Error',
             data: { value: 'error' },
           },
           isUnhandledError: false,
@@ -221,7 +220,6 @@ test('query: getCacheEntry (error)', async () => {
     error: {
       data: { value: 'error' },
       status: 500,
-      statusText: 'Internal Server Error',
     },
     endpointName: 'injected',
     isError: true,
@@ -340,7 +338,6 @@ test('mutation: getCacheEntry (error)', async () => {
     error: {
       data: { value: 'error' },
       status: 500,
-      statusText: 'Internal Server Error',
     },
     endpointName: 'injected',
     isError: true,


### PR DESCRIPTION
I wasn't aware of this, but HTTP/2 does not send a `statusText`, so it would be an empty string, depending on host configuration. Better leave it out before it confuses users - also, no sense in keeping it in when it is going away in the long run.

https://github.com/whatwg/fetch/issues/599