### PR TITLE
use `Symbol.for` for skipToken

### DIFF
--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -39,7 +39,7 @@ export type SkipToken = typeof skipToken
  * If passed directly into a query or mutation selector, that selector will always
  * return an uninitialized state.
  */
-export const skipToken = /* @__PURE__ */ Symbol('skip selector')
+export const skipToken = /* @__PURE__ */ Symbol.for('RTKQ/skipToken')
 /** @deprecated renamed to `skipToken` */
 export const skipSelector = skipToken
 


### PR DESCRIPTION
This would use `Symbol.for` instead of `Symbol` for `skipToken`, meaning that alternating import paths would not lead to two separate symbols, but that they would return the same reference.

Fixes #1308