### PR TITLE
remove `originalArgs` from the mutation slice

### DIFF
--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -175,7 +175,6 @@ export type QuerySubState<D extends BaseEndpointDefinition<any, any, any>> = Id<
 >
 
 type BaseMutationSubState<D extends BaseEndpointDefinition<any, any, any>> = {
-  originalArgs?: QueryArgFrom<D>
   data?: ResultTypeFrom<D>
   error?:
     | SerializedError
@@ -202,7 +201,6 @@ export type MutationSubState<D extends BaseEndpointDefinition<any, any, any>> =
     } & WithRequiredProp<BaseMutationSubState<D>, 'error'>)
   | {
       status: QueryStatus.uninitialized
-      originalArgs?: undefined
       data?: undefined
       error?: undefined
       endpointName?: string

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -190,7 +190,6 @@ export function buildSlice({
 
             draft[requestId] = {
               status: QueryStatus.pending,
-              originalArgs: arg.originalArgs,
               endpointName: arg.endpointName,
               startedTimeStamp,
             }

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -363,9 +363,11 @@ export type UseMutationStateOptions<
 }
 
 export type UseMutationStateResult<
-  _ extends MutationDefinition<any, any, any, any>,
+  D extends MutationDefinition<any, any, any, any>,
   R
-> = NoInfer<R>
+> = NoInfer<R> & {
+  originalArgs?: QueryArgFrom<D>
+}
 
 /**
  * A React hook that lets you trigger an update request for a given endpoint, and subscribes the component to read the request status from the Redux store. The component will re-render as the loading status changes.
@@ -740,11 +742,19 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       )
 
       const currentState = useSelector(mutationSelector, shallowEqual)
+      const originalArgs = promiseRef.current?.arg.originalArgs
+      const finalState = useMemo(
+        () => ({
+          ...currentState,
+          originalArgs,
+        }),
+        [currentState, originalArgs]
+      )
 
-      return useMemo(() => [triggerMutation, currentState], [
-        triggerMutation,
-        currentState,
-      ])
+      return useMemo(
+        () => [triggerMutation, finalState],
+        [triggerMutation, finalState]
+      )
     }
   }
 }

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -198,11 +198,8 @@ describe('hooks tests', () => {
         const [value, setValue] = React.useState(0)
         getRenderCount = useRenderCounter()
 
-        const {
-          isLoading,
-          isFetching,
-          refetch,
-        } = api.endpoints.getUser.useQuery(22, { skip: value < 1 })
+        const { isLoading, isFetching, refetch } =
+          api.endpoints.getUser.useQuery(22, { skip: value < 1 })
         refetchMe = refetch
         return (
           <div>
@@ -259,13 +256,10 @@ describe('hooks tests', () => {
     test('useQuery hook respects refetchOnMountOrArgChange: true', async () => {
       let data, isLoading, isFetching
       function User() {
-        ;({
-          data,
-          isLoading,
-          isFetching,
-        } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-          refetchOnMountOrArgChange: true,
-        }))
+        ;({ data, isLoading, isFetching } =
+          api.endpoints.getIncrementedAmount.useQuery(undefined, {
+            refetchOnMountOrArgChange: true,
+          }))
         return (
           <div>
             <div data-testid="isLoading">{String(isLoading)}</div>
@@ -308,13 +302,10 @@ describe('hooks tests', () => {
     test('useQuery does not refetch when refetchOnMountOrArgChange: NUMBER condition is not met', async () => {
       let data, isLoading, isFetching
       function User() {
-        ;({
-          data,
-          isLoading,
-          isFetching,
-        } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-          refetchOnMountOrArgChange: 10,
-        }))
+        ;({ data, isLoading, isFetching } =
+          api.endpoints.getIncrementedAmount.useQuery(undefined, {
+            refetchOnMountOrArgChange: 10,
+          }))
         return (
           <div>
             <div data-testid="isLoading">{String(isLoading)}</div>
@@ -351,13 +342,10 @@ describe('hooks tests', () => {
     test('useQuery refetches when refetchOnMountOrArgChange: NUMBER condition is met', async () => {
       let data, isLoading, isFetching
       function User() {
-        ;({
-          data,
-          isLoading,
-          isFetching,
-        } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-          refetchOnMountOrArgChange: 0.5,
-        }))
+        ;({ data, isLoading, isFetching } =
+          api.endpoints.getIncrementedAmount.useQuery(undefined, {
+            refetchOnMountOrArgChange: 0.5,
+          }))
         return (
           <div>
             <div data-testid="isLoading">{String(isLoading)}</div>
@@ -403,14 +391,11 @@ describe('hooks tests', () => {
       let data, isLoading, isFetching
       function User() {
         const [skip, setSkip] = React.useState(true)
-        ;({
-          data,
-          isLoading,
-          isFetching,
-        } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-          refetchOnMountOrArgChange: 0.5,
-          skip,
-        }))
+        ;({ data, isLoading, isFetching } =
+          api.endpoints.getIncrementedAmount.useQuery(undefined, {
+            refetchOnMountOrArgChange: 0.5,
+            skip,
+          }))
 
         return (
           <div>
@@ -452,14 +437,11 @@ describe('hooks tests', () => {
       let data, isLoading, isFetching
       function User() {
         const [skip, setSkip] = React.useState(true)
-        ;({
-          data,
-          isLoading,
-          isFetching,
-        } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-          skip,
-          refetchOnMountOrArgChange: 0.5,
-        }))
+        ;({ data, isLoading, isFetching } =
+          api.endpoints.getIncrementedAmount.useQuery(undefined, {
+            skip,
+            refetchOnMountOrArgChange: 0.5,
+          }))
 
         return (
           <div>
@@ -540,10 +522,8 @@ describe('hooks tests', () => {
     let getRenderCount: () => number = () => 0
     test('useLazyQuery does not automatically fetch when mounted and has undefined data', async () => {
       function User() {
-        const [
-          fetchUser,
-          { data: hookData, isFetching, isUninitialized },
-        ] = api.endpoints.getUser.useLazyQuery()
+        const [fetchUser, { data: hookData, isFetching, isUninitialized }] =
+          api.endpoints.getUser.useLazyQuery()
         getRenderCount = useRenderCounter()
 
         data = hookData
@@ -592,10 +572,8 @@ describe('hooks tests', () => {
       let interval = 1000
       function User() {
         const [options, setOptions] = React.useState<SubscriptionOptions>()
-        const [
-          fetchUser,
-          { data: hookData, isFetching, isUninitialized },
-        ] = api.endpoints.getUser.useLazyQuery(options)
+        const [fetchUser, { data: hookData, isFetching, isUninitialized }] =
+          api.endpoints.getUser.useLazyQuery(options)
         getRenderCount = useRenderCounter()
 
         data = hookData
@@ -676,10 +654,8 @@ describe('hooks tests', () => {
 
     test('useLazyQuery accepts updated args and unsubscribes the original query', async () => {
       function User() {
-        const [
-          fetchUser,
-          { data: hookData, isFetching, isUninitialized },
-        ] = api.endpoints.getUser.useLazyQuery()
+        const [fetchUser, { data: hookData, isFetching, isUninitialized }] =
+          api.endpoints.getUser.useLazyQuery()
 
         data = hookData
 
@@ -766,10 +742,8 @@ describe('hooks tests', () => {
   describe('useMutation', () => {
     test('useMutation hook sets and unsets the isLoading flag when running', async () => {
       function User() {
-        const [
-          updateUser,
-          { isLoading },
-        ] = api.endpoints.updateUser.useMutation()
+        const [updateUser, { isLoading }] =
+          api.endpoints.updateUser.useMutation()
 
         return (
           <div>
@@ -847,7 +821,6 @@ describe('hooks tests', () => {
 
           expectType<{
             endpointName: string
-            originalArgs: { name: string }
             track?: boolean
           }>(res.arg)
           expectType<string>(res.requestId)
@@ -1217,10 +1190,8 @@ describe('hooks tests', () => {
       let data, isLoading, isError
       function User() {
         ;({ data, isError, isLoading } = api.endpoints.checkSession.useQuery())
-        const [
-          login,
-          { isLoading: loginLoading },
-        ] = api.endpoints.login.useMutation()
+        const [login, { isLoading: loginLoading }] =
+          api.endpoints.login.useMutation()
 
         return (
           <div>
@@ -1310,10 +1281,8 @@ describe('hooks with createApi defaults set', () => {
     let data, isLoading, isFetching
 
     function User() {
-      ;({
-        data,
-        isLoading,
-      } = defaultApi.endpoints.getIncrementedAmount.useQuery())
+      ;({ data, isLoading } =
+        defaultApi.endpoints.getIncrementedAmount.useQuery())
       return (
         <div>
           <div data-testid="isLoading">{String(isLoading)}</div>
@@ -1338,12 +1307,10 @@ describe('hooks with createApi defaults set', () => {
     unmount()
 
     function OtherUser() {
-      ;({
-        data,
-        isFetching,
-      } = defaultApi.endpoints.getIncrementedAmount.useQuery(undefined, {
-        refetchOnMountOrArgChange: true,
-      }))
+      ;({ data, isFetching } =
+        defaultApi.endpoints.getIncrementedAmount.useQuery(undefined, {
+          refetchOnMountOrArgChange: true,
+        }))
       return (
         <div>
           <div data-testid="isFetching">{String(isFetching)}</div>
@@ -1370,10 +1337,8 @@ describe('hooks with createApi defaults set', () => {
     let data, isLoading, isFetching
 
     function User() {
-      ;({
-        data,
-        isLoading,
-      } = defaultApi.endpoints.getIncrementedAmount.useQuery())
+      ;({ data, isLoading } =
+        defaultApi.endpoints.getIncrementedAmount.useQuery())
       return (
         <div>
           <div data-testid="isLoading">{String(isLoading)}</div>
@@ -1398,12 +1363,10 @@ describe('hooks with createApi defaults set', () => {
     unmount()
 
     function OtherUser() {
-      ;({
-        data,
-        isFetching,
-      } = defaultApi.endpoints.getIncrementedAmount.useQuery(undefined, {
-        refetchOnMountOrArgChange: false,
-      }))
+      ;({ data, isFetching } =
+        defaultApi.endpoints.getIncrementedAmount.useQuery(undefined, {
+          refetchOnMountOrArgChange: false,
+        }))
       return (
         <div>
           <div data-testid="isFetching">{String(isFetching)}</div>

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -821,6 +821,7 @@ describe('hooks tests', () => {
 
           expectType<{
             endpointName: string
+            originalArgs: { name: string }
             track?: boolean
           }>(res.arg)
           expectType<string>(res.requestId)
@@ -1926,6 +1927,19 @@ describe('hooks with createApi defaults set', () => {
         expect(screen.getByTestId('status').textContent).toBe('fulfilled')
       )
       expect(getRenderCount()).toBe(5)
+    })
+
+    test('useMutation return value contains originalArgs', async () => {
+      const { result } = renderHook(api.endpoints.increment.useMutation, {
+        wrapper: storeRef.wrapper,
+      })
+
+      const firstRenderResult = result.current
+      expect(firstRenderResult[1].originalArgs).toBe(undefined)
+      firstRenderResult[0](5)
+      const secondRenderResult = result.current
+      expect(firstRenderResult[1].originalArgs).toBe(undefined)
+      expect(secondRenderResult[1].originalArgs).toBe(5)
     })
 
     it('useMutation with selectFromResult option has a type error if the result is not an object', async () => {

--- a/packages/toolkit/src/query/tests/cacheLifecycle.test.ts
+++ b/packages/toolkit/src/query/tests/cacheLifecycle.test.ts
@@ -417,7 +417,6 @@ test(`mutation: getCacheEntry`, async () => {
     isLoading: true,
     isSuccess: false,
     isUninitialized: false,
-    originalArgs: 'arg',
     startedTimeStamp: expect.any(Number),
     status: 'pending',
   })
@@ -431,7 +430,6 @@ test(`mutation: getCacheEntry`, async () => {
     isLoading: false,
     isSuccess: true,
     isUninitialized: false,
-    originalArgs: 'arg',
     startedTimeStamp: expect.any(Number),
     status: 'fulfilled',
   })

--- a/packages/toolkit/src/query/tests/queryLifecycle.test.tsx
+++ b/packages/toolkit/src/query/tests/queryLifecycle.test.tsx
@@ -274,7 +274,6 @@ test('mutation: getCacheEntry (success)', async () => {
     isLoading: true,
     isSuccess: false,
     isUninitialized: false,
-    originalArgs: 'arg',
     startedTimeStamp: expect.any(Number),
     status: 'pending',
   })
@@ -288,7 +287,6 @@ test('mutation: getCacheEntry (success)', async () => {
     isLoading: false,
     isSuccess: true,
     isUninitialized: false,
-    originalArgs: 'arg',
     startedTimeStamp: expect.any(Number),
     status: 'fulfilled',
   })
@@ -332,7 +330,6 @@ test('mutation: getCacheEntry (error)', async () => {
     isLoading: true,
     isSuccess: false,
     isUninitialized: false,
-    originalArgs: 'arg',
     startedTimeStamp: expect.any(Number),
     status: 'pending',
   })
@@ -347,7 +344,6 @@ test('mutation: getCacheEntry (error)', async () => {
     isLoading: false,
     isSuccess: false,
     isUninitialized: false,
-    originalArgs: 'arg',
     startedTimeStamp: expect.any(Number),
     status: 'rejected',
   })


### PR DESCRIPTION
Fixes #1209 #1315

This needs a few more tests and we should generally discuss how we communicate it:

Technically, it is a breaking change (removes a store property what would have been returned by a selector), but it is a necessary bugfix.

Generally, the information removed is still available as
* property on the promise returned by `dispatch`
* part of the thunk action meta
* return value of the thunk (I could keep that using the promise approach described above)

so it has very little impact.

Are we okay putting this out as a patch release @markerikson?