### PR TITLE
Examples: Query/Authentication - Change authentication to authorization headers

### DIFF
--- a/examples/query/react/authentication-with-extrareducers/src/app/services/auth.ts
+++ b/examples/query/react/authentication-with-extrareducers/src/app/services/auth.ts
@@ -23,7 +23,7 @@ export const api = createApi({
       // By default, if we have a token in the store, let's use that for authenticated requests
       const token = (getState() as RootState).auth.token
       if (token) {
-        headers.set('authentication', `Bearer ${token}`)
+        headers.set('authorization', `Bearer ${token}`)
       }
       return headers
     },

--- a/examples/query/react/authentication-with-extrareducers/src/mocks/handlers.ts
+++ b/examples/query/react/authentication-with-extrareducers/src/mocks/handlers.ts
@@ -6,7 +6,7 @@ const token = nanoid()
 export const handlers = [
   rest.get('/protected', (req, res, ctx) => {
     const headers = req.headers.all()
-    if (headers.authentication !== `Bearer ${token}`) {
+    if (headers.authorization !== `Bearer ${token}`) {
       return res(
         ctx.json({
           message: 'You shall not pass. Please login first.',

--- a/examples/query/react/authentication/src/app/services/auth.ts
+++ b/examples/query/react/authentication/src/app/services/auth.ts
@@ -23,7 +23,7 @@ export const api = createApi({
       // By default, if we have a token in the store, let's use that for authenticated requests
       const token = (getState() as RootState).auth.token
       if (token) {
-        headers.set('authentication', `Bearer ${token}`)
+        headers.set('authorization', `Bearer ${token}`)
       }
       return headers
     },

--- a/examples/query/react/authentication/src/mocks/handlers.ts
+++ b/examples/query/react/authentication/src/mocks/handlers.ts
@@ -6,7 +6,7 @@ const token = nanoid()
 export const handlers = [
   rest.get('/protected', (req, res, ctx) => {
     const headers = req.headers.all()
-    if (headers.authentication !== `Bearer ${token}`) {
+    if (headers.authorization !== `Bearer ${token}`) {
       return res(
         ctx.json({
           message: 'You shall not pass. Please login first.',


### PR DESCRIPTION
- Changes `authentication` to `authorization` to prevent confusion