### PR TITLE
Add note that hooks need to be reset separately

### DIFF
--- a/docs/rtk-query/api/created-api/cache-management-utils.mdx
+++ b/docs/rtk-query/api/created-api/cache-management-utils.mdx
@@ -190,6 +190,8 @@ const resetApiState = () => ({
 
 A Redux action creator that can be dispatched to manually reset the api state completely. This will immediately remove all existing cache entries, and all queries will be considered 'uninitialized'.
 
+Note that [hooks](./hooks.mdx) have their own state that is not affected by `resetApiState`
+
 #### Example
 
 ```ts no-transpile

--- a/docs/rtk-query/api/created-api/cache-management-utils.mdx
+++ b/docs/rtk-query/api/created-api/cache-management-utils.mdx
@@ -190,7 +190,7 @@ const resetApiState = () => ({
 
 A Redux action creator that can be dispatched to manually reset the api state completely. This will immediately remove all existing cache entries, and all queries will be considered 'uninitialized'.
 
-Note that [hooks](./hooks.mdx) have their own state that is not affected by `resetApiState`
+Note that [hooks](./hooks.mdx) also track state in local component state and might not fully be reset by `resetApiState`.
 
 #### Example
 


### PR DESCRIPTION
Keeping around a mounted component with live hooks means that the page will not be fully reset even if `resetApiState` is called. Although this makes sense if you think about it, it's probably best to mention in the documentation since if people run into this issue, this is the first place they will look to figure out what could have gone wrong.