### PR TITLE
Update doc to reflect that default middleware is not replaced when using "getDefaultMiddleware"

### DIFF
--- a/docs/api/immutabilityMiddleware.mdx
+++ b/docs/api/immutabilityMiddleware.mdx
@@ -120,7 +120,7 @@ import exampleSliceReducer from './exampleSlice'
 
 const store = configureStore({
   reducer: exampleSliceReducer,
-  // Note that this will replace all default middleware
+  // Note that this will NOT replace all default middleware
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       immutableCheck: {

--- a/docs/api/immutabilityMiddleware.mdx
+++ b/docs/api/immutabilityMiddleware.mdx
@@ -120,7 +120,7 @@ import exampleSliceReducer from './exampleSlice'
 
 const store = configureStore({
   reducer: exampleSliceReducer,
-  // Note that this will NOT replace all default middleware
+  // This replaces the original default middleware with the customized versions
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       immutableCheck: {


### PR DESCRIPTION
Seen in the final example in this section: https://redux-toolkit.js.org/api/immutabilityMiddleware#createimmutablestateinvariantmiddleware

I think this line may have just been pasted from the prior example in the section, but isn't true when using `getDefaultMiddleware`

This whole line can also be removed. Whichever seems best to you all.