### PR TITLE
Docs: fixed typo in rtk-query docs

### DIFF
--- a/docs/rtk-query/api/created-api/redux-integration.mdx
+++ b/docs/rtk-query/api/created-api/redux-integration.mdx
@@ -11,7 +11,7 @@ hide_title: true
 
 Internally, `createApi` will call [the Redux Toolkit `createSlice` API](https://redux-toolkit.js.org/api/createSlice) to generate a slice reducer and corresponding action creators with the appropriate logic for caching fetched data. It also automatically generates a custom Redux middleware that manages subscription counts and cache lifetimes.
 
-The generated slice reducer and the middleware both need to be added to your Redux store setup in `configureStore` in order to work correctly: test
+The generated slice reducer and the middleware both need to be added to your Redux store setup in `configureStore` in order to work correctly:
 
 ```ts title="src/store.ts"
 // file: src/services/pokemon.ts noEmit


### PR DESCRIPTION
There's a `test` in the rtk-query docs, stumbled into it while looking for "test" in the docs search