### PR TITLE
fix: `createAsyncThunk` union return values fall back to allowing only single member

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -177,7 +177,7 @@ type GetSerializedErrorType<ThunkApiConfig> = ThunkApiConfig extends {
   ? GetSerializedErrorType
   : SerializedError
 
-type MaybePromise<T> = T | Promise<T>
+type MaybePromise<T> = T | Promise<T> | (T extends any ? Promise<T> : never)
 
 /**
  * A type describing the return value of the `payloadCreator` argument to `createAsyncThunk`.

--- a/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
@@ -137,6 +137,16 @@ const anyAction = { type: 'foo' } as AnyAction
   expectType<RejectValue>(unwrapResult(returned))
 })()
 
+/**
+ * regression #1156: union return values fall back to allowing only single member
+ */
+;(async () => {
+  const fn = createAsyncThunk('session/isAdmin', async () => {
+    const response: boolean = false
+    return response
+  })
+})()
+
 {
   interface Item {
     name: string


### PR DESCRIPTION
This should fix #1156