### PR TITLE
fix lint 'consistent-type-imports' rules

### DIFF
--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -6,13 +6,11 @@ import rollup from 'rollup'
 import path from 'path'
 import fs from 'fs-extra'
 import ts from 'typescript'
-import { RawSourceMap, SourceMapConsumer } from 'source-map'
+import type { RawSourceMap } from 'source-map'
+import { SourceMapConsumer } from 'source-map'
 import merge from 'merge-source-map'
-import {
-  Extractor,
-  ExtractorConfig,
-  ExtractorResult,
-} from '@microsoft/api-extractor'
+import type { ExtractorResult } from '@microsoft/api-extractor'
+import { Extractor, ExtractorConfig } from '@microsoft/api-extractor'
 import yargs from 'yargs/yargs'
 
 import { extractInlineSourcemap, removeInlineSourceMap } from './sourcemap'
@@ -180,7 +178,8 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
               return
             }
             const source = await fs.readFile(args.path, 'utf-8')
-            const defaultPattern = /\/\* PROD_START_REMOVE_UMD[\s\S]*?\/\* PROD_STOP_REMOVE_UMD \*\//g
+            const defaultPattern =
+              /\/\* PROD_START_REMOVE_UMD[\s\S]*?\/\* PROD_STOP_REMOVE_UMD \*\//g
             const code = source.replace(defaultPattern, '')
             return {
               contents: code,
@@ -330,9 +329,8 @@ async function main({ skipExtraction = false, local = false }: BuildArgs) {
     for (let entryPoint of entryPoints) {
       try {
         // Load and parse the api-extractor.json file
-        const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(
-          entryPoint.extractionConfig
-        )
+        const extractorConfig: ExtractorConfig =
+          ExtractorConfig.loadFileAndPrepare(entryPoint.extractionConfig)
 
         console.log('Extracting API types for entry point: ', entryPoint.prefix)
         // Invoke API Extractor

--- a/packages/toolkit/scripts/moduld.d.ts
+++ b/packages/toolkit/scripts/moduld.d.ts
@@ -1,5 +1,5 @@
 declare module 'merge-source-map' {
-  import { RawSourceMap } from 'source-map'
+  import type { RawSourceMap } from 'source-map'
   export default function merge(
     map1: string | RawSourceMap,
     map2: string | RawSourceMap

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -465,7 +465,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   api,
   moduleOptions: { batch, useDispatch, useSelector, useStore },
 }: {
-  api: Api<any, Definitions, any, any, CoreModule>
+  api: Api<any, Definitions, any, any>
   moduleOptions: Required<ReactHooksModuleOptions>
 }) {
   return { buildQueryHooks, buildMutationHook, usePrefetch }

--- a/packages/toolkit/src/tests/mapBuilders.typetest.ts
+++ b/packages/toolkit/src/tests/mapBuilders.typetest.ts
@@ -1,4 +1,5 @@
-import { createAsyncThunk, SerializedError } from '@internal/createAsyncThunk'
+import type { SerializedError } from '@internal/createAsyncThunk';
+import { createAsyncThunk } from '@internal/createAsyncThunk'
 import { executeReducerBuilderCallback } from '@internal/mapBuilders'
 import type { AnyAction } from '@reduxjs/toolkit'
 import { createAction } from '@reduxjs/toolkit'


### PR DESCRIPTION
Fixed lint [consistent-type-imports](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md#prefer) rule based on prefer type setting at [.eslintrc.js](https://github.com/reduxjs/redux-toolkit/blob/master/.eslintrc.js#L19) :)