### PR TITLE
fix: point sourceMappingURL to correct sourcemaps in build artifacts

### DIFF
--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -6,13 +6,10 @@ import rollup from 'rollup'
 import path from 'path'
 import fs from 'fs-extra'
 import ts from 'typescript'
-import { RawSourceMap, SourceMapConsumer } from 'source-map'
+import type { RawSourceMap } from 'source-map'
 import merge from 'merge-source-map'
-import {
-  Extractor,
-  ExtractorConfig,
-  ExtractorResult,
-} from '@microsoft/api-extractor'
+import type { ExtractorResult } from '@microsoft/api-extractor'
+import { Extractor, ExtractorConfig } from '@microsoft/api-extractor'
 import yargs from 'yargs/yargs'
 
 import { extractInlineSourcemap, removeInlineSourceMap } from './sourcemap'
@@ -201,6 +198,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     const origin = chunk.text
     const sourcemap = extractInlineSourcemap(origin)
     const result = ts.transpileModule(removeInlineSourceMap(origin), {
+      fileName: chunk.path.replace(/.js$/, '.ts'),
       compilerOptions: {
         sourceMap: true,
         module:
@@ -218,7 +216,11 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
       const transformResult = await terser.minify(
         appendInlineSourceMap(code, mapping),
         {
-          sourceMap: { content: 'inline', asObject: true } as any,
+          sourceMap: {
+            content: 'inline',
+            asObject: true,
+            url: path.basename(chunk.path) + '.map',
+          } as any,
           output: {
             comments: false,
           },

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -207,6 +207,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
           format !== 'cjs' ? ts.ModuleKind.ES2015 : ts.ModuleKind.CommonJS,
         target: esVersion,
       },
+      fileName: chunk.path
     })
 
     const mergedSourcemap = merge(sourcemap, result.sourceMapText)


### PR DESCRIPTION
Fixes #1154 

looks like all our sourceMaps have been referring to non-existing `module.ts` and `module.js.map` since the esbuild migration
Thanks to @many20 for his analysis [here](https://github.com/reduxjs/redux-toolkit/issues/1154#issuecomment-865987638)

diff in `dist` after this change
```diff
Common subdirectories: dist-1/entities and dist-2/entities
Common subdirectories: dist-1/query and dist-2/query
diff '--exclude=*.map' dist-1/redux-toolkit.cjs.development.js dist-2/redux-toolkit.cjs.development.js
1374c1374
< //# sourceMappingURL=module.js.map
\ No newline at end of file
---
> //# sourceMappingURL=redux-toolkit.cjs.development.js.map
\ No newline at end of file
diff '--exclude=*.map' dist-1/redux-toolkit.esm.js dist-2/redux-toolkit.esm.js
1315c1315
< //# sourceMappingURL=module.js.map
\ No newline at end of file
---
> //# sourceMappingURL=redux-toolkit.esm.js.map
\ No newline at end of file
diff '--exclude=*.map' dist-1/redux-toolkit.modern.development.js dist-2/redux-toolkit.modern.development.js
1148c1148
< //# sourceMappingURL=module.js.map
\ No newline at end of file
---
> //# sourceMappingURL=redux-toolkit.modern.development.js.map
\ No newline at end of file
diff '--exclude=*.map' dist-1/redux-toolkit.modern.js dist-2/redux-toolkit.modern.js
1148c1148
< //# sourceMappingURL=module.js.map
\ No newline at end of file
---
> //# sourceMappingURL=redux-toolkit.modern.js.map
\ No newline at end of file

```