### PR TITLE
Add test for #1456

### DIFF
--- a/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
@@ -7,7 +7,10 @@ import type { AxiosError } from 'axios'
 import apiRequest from 'axios'
 import type { IsAny, IsUnknown } from '@internal/tsHelpers'
 import { expectType } from './helpers'
-import { AsyncThunkPayloadCreator } from '@internal/createAsyncThunk'
+import type {
+  AsyncThunkFulfilledActionCreator,
+  AsyncThunkRejectedActionCreator,
+} from '@internal/createAsyncThunk'
 
 const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, AnyAction>
 const anyAction = { type: 'foo' } as AnyAction
@@ -382,6 +385,44 @@ const anyAction = { type: 'foo' } as AnyAction
     return 'ret' as const
   })
   expectType<AsyncThunk<'ret', void, {}>>(thunk)
+}
+
+// createAsyncThunk rejectWithValue without generics: Expect correct return type
+{
+  const asyncThunk = createAsyncThunk(
+    'test',
+    (_: void, { rejectWithValue }) => {
+      try {
+        return Promise.resolve(true)
+      } catch (e) {
+        return rejectWithValue(e)
+      }
+    }
+  )
+
+  defaultDispatch(asyncThunk())
+    .then((result) => {
+      if (asyncThunk.fulfilled.match(result)) {
+        expectType<ReturnType<AsyncThunkFulfilledActionCreator<boolean, void>>>(
+          result
+        )
+        expectType<boolean>(result.payload)
+        // @ts-expect-error
+        expectType<any>(result.error)
+      } else {
+        expectType<ReturnType<AsyncThunkRejectedActionCreator<unknown, void>>>(
+          result
+        )
+        expectType<SerializedError>(result.error)
+        expectType<unknown>(result.payload)
+      }
+
+      return result
+    })
+    .then(unwrapResult)
+    .then((unwrapped) => {
+      expectType<boolean>(unwrapped)
+    })
 }
 
 {


### PR DESCRIPTION
- Test `createAsyncThunk` + `rejectWithValue` without generics. This test works
    in 1.5.1 but not in 1.6.0 - 1.6.1 as described in #1456 