### PR TITLE
[RFC] 🥅 Improve feedback for infinite query loops

### DIFF
--- a/docs/rtk-query/usage/queries.mdx
+++ b/docs/rtk-query/usage/queries.mdx
@@ -123,7 +123,29 @@ The `queryArg` param will be passed through to the underlying `query` callback t
 
 :::caution
 
-The `queryArg` param is handed to a `useEffect` dependency array internally. RTK Query tries to keep the argument stable by performing a `shallowEquals` diff on the value, however if you pass a deeper nested argument, you will need to keep the param stable yourself, e.g. with `useMemo`.
+The `queryArg` param is handed to a `useEffect` dependency array internally.
+RTK Query tries to keep the argument stable by performing a `shallowEquals` diff on the value,
+however if you pass a deeper nested argument, you will need to keep the param stable yourself,
+e.g. with `useMemo`.
+
+```diff
+  function FilterList({ kind, sortField = 'created_at', sortOrder = 'ASC' }) {
+-   // The `sort` object would fail the internal shallow stability check and be new every render
+-   const result = useMyQuery({
+-     kind,
+-     sort: { field: sortField, order: sortOrder },
+-   })
+
++   // `useMemo` can be used to maintain stability for the entire argument object
++   const queryArg = useMemo(
++     () => ({ kind, sort: { field: sortField, order: sortOrder } }),
++     [kind, sortField, sortOrder]
++   )
++   const result = useMyQuery(queryArg)
+
+    return <div>...</div>
+  }
+```
 
 :::
 

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -46,6 +46,7 @@ import type {
 } from '@reduxjs/toolkit/dist/query/core/module'
 import type { ReactHooksModuleOptions } from './module'
 import { useShallowStableValue } from './useShallowStableValue'
+import { useStabilityMonitor } from './useStabilityMonitor'
 import type { UninitializedValue } from './constants'
 import { UNINITIALIZED_VALUE } from './constants'
 
@@ -506,6 +507,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       >
       const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>()
       const stableArg = useShallowStableValue(skip ? skipToken : arg)
+      useStabilityMonitor(stableArg, {
+        errMsg:
+          'The Query argument has been detected as changing too many times within a short period. See https://redux-toolkit.js.org/rtk-query/usage/queries#query-hook-options for more information on how to stabilize the argument and fix this issue.',
+      })
       const stableSubscriptionOptions = useShallowStableValue({
         refetchOnReconnect,
         refetchOnFocus,

--- a/packages/toolkit/src/query/react/useStabilityMonitor.ts
+++ b/packages/toolkit/src/query/react/useStabilityMonitor.ts
@@ -1,0 +1,42 @@
+import { useRef, useEffect } from 'react'
+
+/**
+ * Monitors the 'stability' of the provided value across renders.
+ * If the value changes more times than the threshold within the provided
+ * time delta, an error will be through.
+ *
+ * Defaults to throwing if changing 10 times in 10 consecutive renders within 1000ms
+ */
+export function useStabilityMonitor<T>(
+  value: T,
+  {
+    delta = 1000,
+    threshold = 10,
+    errMsg = 'Value changed too many times.',
+  } = {}
+) {
+  const lastValue = useRef(value)
+  const consecutiveTimestamps = useRef<number[]>([])
+
+  useEffect(() => {
+    // where a render occurs but value didn't change, consider the value to be 'stable'
+    // and clear recorded timestamps.
+    // i.e. only keep timestamps if the value changes every render
+    if (lastValue.current === value) consecutiveTimestamps.current = []
+    lastValue.current = value
+  })
+
+  useEffect(() => {
+    const now = Date.now()
+    consecutiveTimestamps.current.push(now)
+    consecutiveTimestamps.current = consecutiveTimestamps.current.filter((timestamp) => {
+      return timestamp > now - delta
+    })
+
+    if (consecutiveTimestamps.current.length >= threshold) {
+      const err = new Error(errMsg)
+      Error.captureStackTrace(err, useStabilityMonitor)
+      throw err
+    }
+  }, [value, delta, threshold, errMsg])
+}


### PR DESCRIPTION
- Throw an error when query args are detected as changing every
render too frequently, after factoring shallow stabilisation attempts
- Expand docs explanation about stable query arg requirements

The topic of infinite re-renders with unstable query args comes up every now and then (e.g. #1526). This aims to provide more explicit, immediate feedback about the cause, and point to the relevant part of the docs as a solution.

A few things to consider:
- Is this safe from false positives?
  > I think it should be safe. The criteria to throw an error is "value changes 10 times in 10 consecutive renders within 1000ms, *after* attempting stabilization". I don't think that criteria would ever intersect with intentional behaviour.
- Should it actually be throwing an error, or only logging an error message?
  > I think throwing an error is better here. If it's meeting that criteria, I think it's a safe bet to assume that it will either freeze your browser tab, continue looping indefinitely, or throw react's internal infinite loop error ("Uncaught Error: Too many re-renders. React limits the number of renders to prevent an infinite loop."). I believe that throwing our error earlier is more useful than just logging alongside any of those three options, and has less chance of being missed.
- Is the additional runtime code overhead actually worth having for what is a relatively niche case?
  > tbh I'm not sure about this