### PR TITLE
fix(useLazyQuery): added docs for preferCache option

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -179,6 +179,9 @@ export type UseLazyQueryLastPromiseInfo<
  * - Re-renders as the request status changes and data becomes available
  * - Accepts polling/re-fetching options to trigger automatic re-fetches when the corresponding criteria is met and the fetch has been manually called at least once
  *
+ * #### Note
+ *
+ * When the trigger function returned from a LazyQuery, it always initiates a new request to the server even if there is cached data. Set `preferredCacheValue`(the second argument to the function) as true if you want it to use cache.
  */
 export type UseLazyQuery<D extends QueryDefinition<any, any, any, any>> = <
   R = UseQueryStateDefaultResult<D>

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -181,17 +181,27 @@ export type UseLazyQueryLastPromiseInfo<
  *
  * #### Note
  *
- * When the trigger function returned from a LazyQuery, it always initiates a new request to the server even if there is cached data. Set `preferredCacheValue`(the second argument to the function) as true if you want it to use cache.
+ * When the trigger function returned from a LazyQuery, it always initiates a new request to the server even if there is cached data. Set `preferCacheValue`(the second argument to the function) as true if you want it to use cache.
  */
 export type UseLazyQuery<D extends QueryDefinition<any, any, any, any>> = <
   R = UseQueryStateDefaultResult<D>
 >(
   options?: SubscriptionOptions & Omit<UseQueryStateOptions<D, R>, 'skip'>
 ) => [
-  (arg: QueryArgFrom<D>) => void,
+  LazyQueryTrigger<D>,
   UseQueryStateResult<D, R>,
   UseLazyQueryLastPromiseInfo<D>
 ]
+
+export type LazyQueryTrigger<D extends QueryDefinition<any, any, any, any>> = {
+  /**
+   * Triggers a lazy query.
+   *
+   * By default, this will start a new request even if there is already a value in the cache.
+   * If you want to use the cache value and only start a request if there is no cache value, set the second argument to `true`.
+   */
+  (arg: QueryArgFrom<D>, preferCacheValue?: boolean): void
+}
 
 /**
  * A React hook similar to [`useQuerySubscription`](#usequerysubscription), but with manual control over when the data fetching occurs.


### PR DESCRIPTION
Hey,

This PR is based on the discussion we had [here] (https://github.com/reduxjs/redux-toolkit/discussions/1279). I've updated the documentation, but still can't find the type which returns the `trigger` function. I saw a definition of a `trigger()` method that matched your description but it was part of the `useLazyQuerySubscription` and not `useLazyQuery`.

Looking forward to your reply! Thanks.