### PR TITLE
📝 Fix manual cache update examples

### DIFF
--- a/docs/rtk-query/usage/manual-cache-updates.mdx
+++ b/docs/rtk-query/usage/manual-cache-updates.mdx
@@ -95,7 +95,6 @@ const api = createApi({
         method: 'PATCH',
         body: patch,
       }),
-      invalidatesTags: ['Post'],
       // highlight-start
       async onQueryStarted({ id, ...patch }, { dispatch, queryFulfilled }) {
         const patchResult = dispatch(
@@ -187,7 +186,6 @@ const api = createApi({
         method: 'PATCH',
         body: patch,
       }),
-      invalidatesTags: ['Post'],
       // highlight-start
       async onQueryStarted({ id, ...patch }, { dispatch, queryFulfilled }) {
         try {


### PR DESCRIPTION
Remove excessive tag invalidation in examples which would otherwise interfere with the manual cache update

Raised by @thedriveman [here](https://github.com/reduxjs/redux-toolkit/pull/1525#issuecomment-933069402) in #1525

Having it always invalidate tags on manual cache updates is incorrect and seems to have always been left in so far as an oversight.