### PR TITLE
Add url key for query

### DIFF
--- a/docs/rtk-query/usage/code-splitting.mdx
+++ b/docs/rtk-query/usage/code-splitting.mdx
@@ -46,7 +46,7 @@ import { emptySplitApi } from './emptySplitApi'
 const extendedApi = emptySplitApi.injectEndpoints({
   endpoints: (build) => ({
     example: build.query({
-      query: () => 'test',
+      query: () => ({ url: 'test' }),
     }),
   }),
   overrideExisting: false,


### PR DESCRIPTION
The current example does not work if we use axios-based baseQuery instead of fetchBaseQuery