### PR TITLE
🐛 Fix bug with `useMutation` shared results

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -827,7 +827,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       const reset = useCallback(() => {
         if (promise) {
           setPromise(undefined)
-        } else if (fixedCacheKey) {
+        }
+        if (fixedCacheKey) {
           dispatch(
             api.internalActions.removeMutationResult({
               requestId,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -825,17 +825,19 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       const originalArgs =
         fixedCacheKey == null ? promise?.arg.originalArgs : undefined
       const reset = useCallback(() => {
-        if (promise) {
-          setPromise(undefined)
-        }
-        if (fixedCacheKey) {
-          dispatch(
-            api.internalActions.removeMutationResult({
-              requestId,
-              fixedCacheKey,
-            })
-          )
-        }
+        batch(() => {
+          if (promise) {
+            setPromise(undefined)
+          }
+          if (fixedCacheKey) {
+            dispatch(
+              api.internalActions.removeMutationResult({
+                requestId,
+                fixedCacheKey,
+              })
+            )
+          }
+        })
       }, [dispatch, fixedCacheKey, promise, requestId])
       const finalState = useMemo(
         () => ({ ...currentState, originalArgs, reset }),


### PR DESCRIPTION
- Fix a scenario where the component calling `reset` needed to call it twice when using shared component results

Addresses the scenario described here: https://github.com/reduxjs/redux-toolkit/pull/1477#discussion_r730278289

A regression test is included.