### PR TITLE
Simplify dependency caching on CI and upgrade actions

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: andresz1/size-limit-action@v1
         with:
           directory: packages/toolkit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-
-      - uses: actions/cache@v2
-        with:
-          path: .yarn/cache
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
+          cache: 'yarn'
 
       - name: Install deps
         run: yarn install
@@ -52,15 +47,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-
-      - uses: actions/cache@v2
-        with:
-          path: .yarn/cache
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
+          cache: 'yarn'
 
       - name: Install deps
         run: yarn install
@@ -95,15 +85,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-
-      - uses: actions/cache@v2
-        with:
-          path: .yarn/cache
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
+          cache: 'yarn'
 
       - name: Install deps
         run: yarn install


### PR DESCRIPTION
This PR upgrades `actions/setup-node` from `v1` to `v2`. `v2` has dependency caching built into it, which has been added to this PR to simplify the CI workflow. This PR also upgrades other CI actions to their latest versions.

References:
* https://github.com/actions/setup-node#caching-packages-dependencies