### PR TITLE
⬆️ Bump Docusaurus to 2.0 beta 7

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,8 +9,8 @@
     "deploy": "docusaurus deploy"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.4",
-    "@docusaurus/preset-classic": "2.0.0-beta.4",
+    "@docusaurus/core": "2.0.0-beta.7",
+    "@docusaurus/preset-classic": "2.0.0-beta.7",
     "classnames": "^2.2.6",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/cache-browser-local-storage@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/cache-browser-local-storage@npm:4.10.5"
+  dependencies:
+    "@algolia/cache-common": 4.10.5
+  checksum: 487743d4b56012ecc4df541fa36ff0654f179971758f36ae05509d8161ca98f54fab63d915a5a5833f2879c4d859c729e83af9b58397b9ef33403d197280063d
+  languageName: node
+  linkType: hard
+
 "@algolia/cache-browser-local-storage@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/cache-browser-local-storage@npm:4.9.1"
@@ -42,10 +51,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/cache-common@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/cache-common@npm:4.10.5"
+  checksum: 3dc76ac28e8fd1e064333c39bd43917da93d68054b29874f9917459543ffff35da24d083ac4b59a8fb631dc16c5e0eb336ef3c8af896d214b052b96d60be33f2
+  languageName: node
+  linkType: hard
+
 "@algolia/cache-common@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/cache-common@npm:4.9.1"
   checksum: bf776cf0213fd28c5627e8280004b8882e776f5fa19b59f3e88bac2c6734418fe15ac029ed7484fc4f5d41eea37667ffe5410985488a6a99c598fa698be862e8
+  languageName: node
+  linkType: hard
+
+"@algolia/cache-in-memory@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/cache-in-memory@npm:4.10.5"
+  dependencies:
+    "@algolia/cache-common": 4.10.5
+  checksum: 7e41d1360cb98e157ba2320e444891b5d91838119645a4a7d07850fdf1bca35bbb046e32ed6978a9f06c3a77afd3540e8a8fadc5098c023c84620e76e878998f
   languageName: node
   linkType: hard
 
@@ -58,6 +83,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/client-account@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/client-account@npm:4.10.5"
+  dependencies:
+    "@algolia/client-common": 4.10.5
+    "@algolia/client-search": 4.10.5
+    "@algolia/transporter": 4.10.5
+  checksum: 018ce844abc6c917f46e3d4e4c68c5c8f8130aafa6b4d29113606e77f13afded242e3520f2b3305c390aa08de6645edd2294c98b3fb1c983a2a42f700a91c189
+  languageName: node
+  linkType: hard
+
 "@algolia/client-account@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/client-account@npm:4.9.1"
@@ -66,6 +102,18 @@ __metadata:
     "@algolia/client-search": 4.9.1
     "@algolia/transporter": 4.9.1
   checksum: fc4f58a2ae3dfb51228f6d728ab16185441b1334877fde2599a218c19a16dc7b27c1b9cf02b74de11a167a8ca711f520ba7d60a802055a0cce21dca2f712835e
+  languageName: node
+  linkType: hard
+
+"@algolia/client-analytics@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/client-analytics@npm:4.10.5"
+  dependencies:
+    "@algolia/client-common": 4.10.5
+    "@algolia/client-search": 4.10.5
+    "@algolia/requester-common": 4.10.5
+    "@algolia/transporter": 4.10.5
+  checksum: fd34417cc526cb65a594e2b40b97a15aed19c8bcd1b5152c3dda583341d24572b9834595068c1b9f7c81ae6106c80851ada192a1e694e4109cea9357004a8dff
   languageName: node
   linkType: hard
 
@@ -81,6 +129,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/client-common@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/client-common@npm:4.10.5"
+  dependencies:
+    "@algolia/requester-common": 4.10.5
+    "@algolia/transporter": 4.10.5
+  checksum: 258691cc9c883a58198ddbdd0db07556dcb6a96d12d2d12afb2b929681d610abc6c35aeac9194c1b1c534cd8a5dea9d3d342f911b39f339d716f68e6b8efd630
+  languageName: node
+  linkType: hard
+
 "@algolia/client-common@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/client-common@npm:4.9.1"
@@ -88,6 +146,17 @@ __metadata:
     "@algolia/requester-common": 4.9.1
     "@algolia/transporter": 4.9.1
   checksum: ffc7311225a8fdc9a28f6d24b089372c73672ea627f60a129c81d5ded4c2dee46ac5f6f4bc6071a907132e2690725d4a4957c427c7d1d723316fe53e6d3f9bd1
+  languageName: node
+  linkType: hard
+
+"@algolia/client-personalization@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/client-personalization@npm:4.10.5"
+  dependencies:
+    "@algolia/client-common": 4.10.5
+    "@algolia/requester-common": 4.10.5
+    "@algolia/transporter": 4.10.5
+  checksum: e5bc686ab21d977bf576287b88804df87310baf703a71bd2b896818754dc166d461a79b3cb0cc08dc4c19f78385f843f31631a798c04392f2fbd1199bea0afbb
   languageName: node
   linkType: hard
 
@@ -102,6 +171,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/client-search@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/client-search@npm:4.10.5"
+  dependencies:
+    "@algolia/client-common": 4.10.5
+    "@algolia/requester-common": 4.10.5
+    "@algolia/transporter": 4.10.5
+  checksum: e3e2af5f23d32ca1f2cbd1e66fc29c34fa16b008ec5ad7ed0c1df85fc646987564aab5b24cdafccbbe0a111664cd08d983ae31e91016d70044f742c7b11c03ed
+  languageName: node
+  linkType: hard
+
 "@algolia/client-search@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/client-search@npm:4.9.1"
@@ -113,10 +193,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/logger-common@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/logger-common@npm:4.10.5"
+  checksum: e2ec589bacedee1da3e17e9d4c56b8e74fd44fa750dfcc7be4e4efcee3165ba221cc1e9996fe3cd97f49c36eeecba0922c1682ab75743ce404378a17ab2f8905
+  languageName: node
+  linkType: hard
+
 "@algolia/logger-common@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/logger-common@npm:4.9.1"
   checksum: 1db3532458faecb36f72a2df288b6ecbe72a7a0e8f501d92b17c41246c0ae60e0af69326da7819561650a232df072c9d59c80a884fe30a60c9c2dc15d519292a
+  languageName: node
+  linkType: hard
+
+"@algolia/logger-console@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/logger-console@npm:4.10.5"
+  dependencies:
+    "@algolia/logger-common": 4.10.5
+  checksum: a069ccbe132a7cdec9dd75a5e22820e52423e89524cb5d484f32b37ec434f77756f8a8563cec4752d53f08baa721cbd4b3850fbf5ccf45e1d5a1e20b77fdcbfc
   languageName: node
   linkType: hard
 
@@ -129,12 +225,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/requester-browser-xhr@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/requester-browser-xhr@npm:4.10.5"
+  dependencies:
+    "@algolia/requester-common": 4.10.5
+  checksum: 5f0db108a0af5351c83ea86be7c2cb8de3dca0516334065659e28eaed7efc258fdaa5a2d8f9d5cefc2ce4f73eefaae3fe1b9cd885f4cfb8696b8be6222d4a11b
+  languageName: node
+  linkType: hard
+
 "@algolia/requester-browser-xhr@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/requester-browser-xhr@npm:4.9.1"
   dependencies:
     "@algolia/requester-common": 4.9.1
   checksum: 84bb63f39dd23adbdaa6743d7b2a6566e67e6640c0e2254e5e6641d5db8bb10b7149bb1380f3945a662e9752fdbe1857fd7ab386d8786308d8b11a03f9710aa0
+  languageName: node
+  linkType: hard
+
+"@algolia/requester-common@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/requester-common@npm:4.10.5"
+  checksum: 60cff8834df4c8a0c88fa38884aa8877d95bad3d75a5a666925902b183ce9dd117f7e979151696d9d856bf0964e560ce75b47c8cb42c268c67e8100a3d9b02a9
   languageName: node
   linkType: hard
 
@@ -145,12 +257,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/requester-node-http@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/requester-node-http@npm:4.10.5"
+  dependencies:
+    "@algolia/requester-common": 4.10.5
+  checksum: 22a22007294e775b2b1ae9e3fbc2e5ecabdb76e548185762a8cdec5144967f31a4ab14fc055056bfc26e65db7d2f376bfd1c184d161f89747402a4e1d73c1be8
+  languageName: node
+  linkType: hard
+
 "@algolia/requester-node-http@npm:4.9.1":
   version: 4.9.1
   resolution: "@algolia/requester-node-http@npm:4.9.1"
   dependencies:
     "@algolia/requester-common": 4.9.1
   checksum: b55076c87a4368d5939b0486b9b0098d597497df0d495b44f59c6c7098fd1ec4cac765f254cf1c625b5860bca65942dedb9ba41d916f061eb1f319ccf2f6ba08
+  languageName: node
+  linkType: hard
+
+"@algolia/transporter@npm:4.10.5":
+  version: 4.10.5
+  resolution: "@algolia/transporter@npm:4.10.5"
+  dependencies:
+    "@algolia/cache-common": 4.10.5
+    "@algolia/logger-common": 4.10.5
+    "@algolia/requester-common": 4.10.5
+  checksum: c6eab38b8dbe2dad9c50463d21210acf84c0e54091b7fdd85083611707b6ea8f04859763d1f7bcee3f50cf7ae4eb40049af7ea0224063ea5bd93a3a1efe6072a
   languageName: node
   linkType: hard
 
@@ -205,6 +337,13 @@ __metadata:
   version: 7.14.7
   resolution: "@babel/compat-data@npm:7.14.7"
   checksum: f50909f7565cac9a7f1dd31b9817b7a90070c7eac1207b1272f6e8d862e69589f08861d2a5d8b70e6eba2e8afcea02210be4176e259d9d11bf6cda3a5563eee3
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/compat-data@npm:7.15.0"
+  checksum: 76db9ec4fb897b6a1de1057411a65b134bc2016b156ebf7ce39fbe97b4f1eeaf661b81d457126a71164cbc2de31a06c68f74d0ebbdce3720a000139683f787d0
   languageName: node
   linkType: hard
 
@@ -290,12 +429,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.15.4":
+  version: 7.15.8
+  resolution: "@babel/generator@npm:7.15.8"
+  dependencies:
+    "@babel/types": ^7.15.6
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 047174e57cc79679ad5dcc422233ed1191eba5539229d15a9bbe2da4a5b2d313d6e0b19a0dee714f08f6d0adfaf6454ba67509ef1108004c9c8ccb4b39bab2af
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-annotate-as-pure@npm:7.14.5"
   dependencies:
     "@babel/types": ^7.14.5
   checksum: b9cde67dc39aefc758414f4935b560ae16bbf3eaeb5a07de1530106532ab9fffab67f50aabc96e6bcc9b06adb2c6688f340921e4ca0f78a3abda9613e076cc57
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-annotate-as-pure@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: 183ef3386922e7982163ee537f63a73c5360c06a6abecd6fed8af1df6298a1ad5812648042327404b345881c43e889d97ddcd484cd2b61ad271cec2f1e900bc3
   languageName: node
   linkType: hard
 
@@ -323,6 +482,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-compilation-targets@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-compilation-targets@npm:7.15.4"
+  dependencies:
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-validator-option": ^7.14.5
+    browserslist: ^4.16.6
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 539e4d209324fe56cd624aa3ae4a843bd479a644f28240322ec3b93154e35087731b43a16f13e1e0037c651afdf589a06b5937adc77941bbf71e062ce9d85b89
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.14.4, @babel/helper-create-class-features-plugin@npm:^7.14.5":
   version: 7.14.6
   resolution: "@babel/helper-create-class-features-plugin@npm:7.14.6"
@@ -336,6 +509,22 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 833222da49f33c32d341c99cda796b622bd7cd7824a49c532296ed96bbfe5935187abfe59f6e5886879825140cd7f71516bff8a6afa20ceec1c32cde2d388eb9
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-class-features-plugin@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.15.4"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.15.4
+    "@babel/helper-function-name": ^7.15.4
+    "@babel/helper-member-expression-to-functions": ^7.15.4
+    "@babel/helper-optimise-call-expression": ^7.15.4
+    "@babel/helper-replace-supers": ^7.15.4
+    "@babel/helper-split-export-declaration": ^7.15.4
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: bac93753f1c213fd6b874358b0f6b55baf61e8dd9248beb523023722fd83a6a2741fb91888f758b820e86603d43f7de74b275a57122bbf99d1b6f9f5fae1f18c
   languageName: node
   linkType: hard
 
@@ -389,12 +578,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-function-name@npm:7.15.4"
+  dependencies:
+    "@babel/helper-get-function-arity": ^7.15.4
+    "@babel/template": ^7.15.4
+    "@babel/types": ^7.15.4
+  checksum: 74ec8a86b1e4263f502447409098c71f1461e09794495e11514d659857c1d8794fb0552afadeaebb4a6c93b75f800ad48c531174a672126bd645b1f49f2fa13f
+  languageName: node
+  linkType: hard
+
 "@babel/helper-get-function-arity@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-get-function-arity@npm:7.14.5"
   dependencies:
     "@babel/types": ^7.14.5
   checksum: 1bd0ae6c25af61a7795032452500362bb3f63042aadb1076184ebccc0afcb38e0565da3f02534f806ea0acb915efd75bc1de8530417f7be10f74c4a3efbacb3a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-get-function-arity@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-get-function-arity@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: c60ed72a9cf00222e20a5c7608f37a649c88af469f3021bd497dada07ccad109772b75cdf83ac363c48d1f135e80c367683f6aa6a015d21e5c4b9fbaf9682e56
   languageName: node
   linkType: hard
 
@@ -407,6 +616,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-hoist-variables@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-hoist-variables@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: b500f154f9444b5251548deaa62f3553d0a2ff277ab1478e4f8ec94f2b669474cc968c62b3451a9b9739d48c5e8818d48f03d07d75fe14fa247e574ee6aa674b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.14.5":
   version: 7.14.7
   resolution: "@babel/helper-member-expression-to-functions@npm:7.14.7"
@@ -416,12 +634,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.12.1, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.13.12, @babel/helper-module-imports@npm:^7.14.5":
+"@babel/helper-member-expression-to-functions@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: 7180912838c00f3199dfe5c6299975a0c966b80e1aad7a0a448298b619c292103bd90a7fce2c748c8933f8e4b042138bdf1868d614c8fc303cec13a51fd9706d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.12.1, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-module-imports@npm:7.14.5"
   dependencies:
     "@babel/types": ^7.14.5
   checksum: 483919bf31611dc5905acb6a01b888fad1264ddcecaae706c0dde46ff81fa708d98c4a093ab0d4ad71791eb0a30b6dafbfa5364003e71486d6b3c5c718eccf7d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-module-imports@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: efb532958154817da2f5f4e9c12818500f97c2256eb6b99f01c7c537e506b8b2e609b0444d91503956ed3102eaba50826607a3352ef563d04430f9b5f502061b
   languageName: node
   linkType: hard
 
@@ -441,12 +677,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.15.4":
+  version: 7.15.8
+  resolution: "@babel/helper-module-transforms@npm:7.15.8"
+  dependencies:
+    "@babel/helper-module-imports": ^7.15.4
+    "@babel/helper-replace-supers": ^7.15.4
+    "@babel/helper-simple-access": ^7.15.4
+    "@babel/helper-split-export-declaration": ^7.15.4
+    "@babel/helper-validator-identifier": ^7.15.7
+    "@babel/template": ^7.15.4
+    "@babel/traverse": ^7.15.4
+    "@babel/types": ^7.15.6
+  checksum: 0d2ee0241bd2f110d454f6fbec2d017a49d65650a2a02805eeb9f529903ef18ca0de14a434bc418cceba21c174d4c3243d03fbbcefd1ed5b379eba7a1467edcd
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-optimise-call-expression@npm:7.14.5"
   dependencies:
     "@babel/types": ^7.14.5
   checksum: 68845ee7fb88cf7bfbea9635d3fddcc953818b86732985f3fb228f77012652b36f4e41f00d8e7b5e3be2b2d41b6b9f189a36fd49874e58a29dd2e3b1dc753f5c
+  languageName: node
+  linkType: hard
+
+"@babel/helper-optimise-call-expression@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-optimise-call-expression@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: 96d837b5d28679cebd0da6d7d1ead844c8f59854eb228033f290ecfe9385ca8a0201d5f8ff21f7fb04b14d20c94931f115332f283e2d5e73ce49c632566b8651
   languageName: node
   linkType: hard
 
@@ -475,6 +736,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-remap-async-to-generator@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.15.4"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.15.4
+    "@babel/helper-wrap-function": ^7.15.4
+    "@babel/types": ^7.15.4
+  checksum: 84065985fb12ad7a66145001a883f7f5a83b39a7dd4c6a1f5a58c74a876ce80ef66728ff892995feb4f91a46dabf9f101de065d98cdbafd91e6d2c992ac38ac4
+  languageName: node
+  linkType: hard
+
 "@babel/helper-replace-supers@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-replace-supers@npm:7.14.5"
@@ -487,12 +759,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-replace-supers@npm:7.15.4"
+  dependencies:
+    "@babel/helper-member-expression-to-functions": ^7.15.4
+    "@babel/helper-optimise-call-expression": ^7.15.4
+    "@babel/traverse": ^7.15.4
+    "@babel/types": ^7.15.4
+  checksum: 44291cc084e5c36f9d05948614f0cf8efd36feccba5a291f5644280a5fa03b5eeb2a6fc18caaafd990747499fa4c4115c6e94ae27c46cf2008b28e947566ab29
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-simple-access@npm:7.14.5"
   dependencies:
     "@babel/types": ^7.14.5
   checksum: dd6de62de59ab05121aa1198d01080415584ac4a4d4f5d4e53fd22a1c8d5359d19667cd61663937dffa9ab7761aecbe66eee9e1d266def6a59b4ede2dc15ea57
+  languageName: node
+  linkType: hard
+
+"@babel/helper-simple-access@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-simple-access@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: ac7f1403b4345258181c38640ff725aece0dc880a909e60e8492f0c0a847d11b14743a6b01cc4b53528210e67931e8aa76c21487183265de35aa8186d19fec98
   languageName: node
   linkType: hard
 
@@ -505,6 +798,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: 30cdd0f8b810d45138277dc7a5c60c87d3160ca875205b12f95d392ec73aba412608c2dbb002942aeaf60d6bc77ee113eabebc7f44c8061640444576f27558fb
+  languageName: node
+  linkType: hard
+
 "@babel/helper-split-export-declaration@npm:^7.12.13, @babel/helper-split-export-declaration@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-split-export-declaration@npm:7.14.5"
@@ -514,10 +816,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-split-export-declaration@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-split-export-declaration@npm:7.15.4"
+  dependencies:
+    "@babel/types": ^7.15.4
+  checksum: 17179ddcbaff87aa2fc00ec0c65282265a171918c49b66a7ebfbc519687bf24d584fbf0e535250a1ff76050c425263982f1114c598ea73dbe582b42eb7ce10e3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.12.11, @babel/helper-validator-identifier@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-validator-identifier@npm:7.14.5"
   checksum: 778312189a7c5228daac9f7767795a74f11d1eac595ca38bfea248324666459b24aaae6aef43c957ce01bbe61672039ea1c08c5623067c3701beeb1bb1f1ee33
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.14.9, @babel/helper-validator-identifier@npm:^7.15.7":
+  version: 7.15.7
+  resolution: "@babel/helper-validator-identifier@npm:7.15.7"
+  checksum: eb3eaea69de1e69c0c74e15b3934aa844b248d3bda6d5fa97f8c46fc16eada6153d2f519379ec3801b794bb5b72a88e087a18bbe6682cd72ce0c7a69144f2f7a
   languageName: node
   linkType: hard
 
@@ -537,6 +855,18 @@ __metadata:
     "@babel/traverse": ^7.14.5
     "@babel/types": ^7.14.5
   checksum: 9affb141a89fa7cdfd89f16e360ec0ea63fbdd03c6e5c4d82fc9d8c20557f4c9522dfabd1fd5840db2d542ff58bea4be07671acaea819ba1651685c96a12fa63
+  languageName: node
+  linkType: hard
+
+"@babel/helper-wrap-function@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/helper-wrap-function@npm:7.15.4"
+  dependencies:
+    "@babel/helper-function-name": ^7.15.4
+    "@babel/template": ^7.15.4
+    "@babel/traverse": ^7.15.4
+    "@babel/types": ^7.15.4
+  checksum: 0a33ea44a76e63efa2e691a7c6b7536b80a4af2d9ba57920fd83efdf2391bcfd3902dd1f53d9277c82923aa534e5323e39401589cc5a7932f6eceadaa7792b6a
   languageName: node
   linkType: hard
 
@@ -580,6 +910,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.15.4":
+  version: 7.15.8
+  resolution: "@babel/parser@npm:7.15.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 73911701bcb2136c2d0148f6abed268aff28ba186ac183fca9ee160c9d96ced4111158526acb0765aa8cfce3f896a059fe4ef939ed2961f090dc32ab2d5d3206
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.14.5"
@@ -593,6 +932,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.15.4"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.15.4
+    "@babel/plugin-proposal-optional-chaining": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.13.0
+  checksum: b91c51fd1769bf34240d6a35722c1dd7c9f785b285cbd91ef12f563e6534315261f2a8c2ace9ba3c188b743230c6dd4a6793e8115e1fc5d1c468d079c16bed4f
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-async-generator-functions@npm:^7.12.1, @babel/plugin-proposal-async-generator-functions@npm:^7.14.7":
   version: 7.14.7
   resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.14.7"
@@ -603,6 +955,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: fea5bd2fc8b8e25454e05f53837661326906b0c1eedb9171fe36a7c83e89bec7226216b64bf6c48a9ed68e673b5d65b975b6d8a93345d1796f99bda646db8234
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-async-generator-functions@npm:^7.15.8":
+  version: 7.15.8
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.15.8"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-remap-async-to-generator": ^7.15.4
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 70c66a9f926954a60e8a1649854408d795474f63e0030d98a07a3c7ce9d17ea204fb6bfe30251b7ef15212ddcca0325c1b167af7af8fc4225184e5f269c3ba55
   languageName: node
   linkType: hard
 
@@ -640,6 +1005,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.12.0
   checksum: 1a104e33a441facd1adbfc8fe8f5ef4737191c98f5e3fbfc6b6bed7bb3747d5cb97c46f8e3791d067e9c5ae3bcffa56e915f7c0bc0d7fd17dba4bb228a9e4bfc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-static-block@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-proposal-class-static-block@npm:7.15.4"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.12.0
+  checksum: 36ac2676b205969892e1bacd6e36b2c8ae7bf9c6c1a6a11764607917b148294524297a31a06a1bddcc2f5739ba0798360cd77a9c20f88c5146eb348c13a0aef4
   languageName: node
   linkType: hard
 
@@ -780,6 +1158,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-object-rest-spread@npm:^7.15.6":
+  version: 7.15.6
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.15.6"
+  dependencies:
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-transform-parameters": ^7.15.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 31a1e62f2acc6c733c01041729b97aa4127cd666535f0bcfc2ef7e5247682af951d32ee5d0641f19650fde73ab2e3b640549c4c8033e7fb06bfe7612655d2bcb
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-optional-catch-binding@npm:^7.12.1, @babel/plugin-proposal-optional-catch-binding@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-proposal-optional-catch-binding@npm:7.14.5"
@@ -841,6 +1234,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 4aa86a5a8a011a46aad76f18a29d1bf889a0906aaba0d22045e332816c01a578c3dadc88183e3d0baedd22bd9aae793c034fba8dc7e59dcf472eb1b67dfa0d26
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-property-in-object@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.15.4"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.15.4
+    "@babel/helper-create-class-features-plugin": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9f740fa8dd6401dcefd520181745959b80b1d64d5706f204afedc1e223519c33e1c510ca3c49d815982bda29991be7300755b83bded8c0807aaf736d2080ce82
   languageName: node
   linkType: hard
 
@@ -1133,6 +1540,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-block-scoping@npm:^7.15.3":
+  version: 7.15.3
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.15.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 22e7411a9d0d390de956e534a21927238b57cc49f50fca139a825ec3f05e5f0d7abd76f0d69a76d4c0ea67b8e57b905c7fde5c7f1f7edc2388ecb1cc29cd09af
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-classes@npm:^7.0.0, @babel/plugin-transform-classes@npm:^7.12.1, @babel/plugin-transform-classes@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-transform-classes@npm:7.14.5"
@@ -1147,6 +1565,23 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: fccd44e38a2aaf96aa8cb54fee7f1a50a1c538de79eb2a263e5d3b9eaa6b7123843afb9f7aa1f099650881edd145acf9947e3c3fc5c277dd4cedec444c7a6039
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-classes@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-transform-classes@npm:7.15.4"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.15.4
+    "@babel/helper-function-name": ^7.15.4
+    "@babel/helper-optimise-call-expression": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-replace-supers": ^7.15.4
+    "@babel/helper-split-export-declaration": ^7.15.4
+    globals: ^11.1.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6ab359386a6db4da1ad23bb7193c40b8b04496cfdce86421e3dfc7afe138bef37f188e503d06cff79a934790613d43e62183c0a65c4aae98b0199f28171baf3d
   languageName: node
   linkType: hard
 
@@ -1242,6 +1677,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-for-of@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-transform-for-of@npm:7.15.4"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 5ab523faf805cce4aa4fc87a7530575c77f101dbe0da6ef650c8453fd0e310e67f17d8793935b3796a567c33c5bb5734e02d68577881028150b1ebe2d9298086
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-function-name@npm:^7.0.0, @babel/plugin-transform-function-name@npm:^7.12.1, @babel/plugin-transform-function-name@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-transform-function-name@npm:7.14.5"
@@ -1303,6 +1749,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-modules-commonjs@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.15.4"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-simple-access": ^7.15.4
+    babel-plugin-dynamic-import-node: ^2.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b26fb3925e41f5bfc0a23f7635ca173cb714e5c8ed8f2be0d4cea376d932287e01b1bc175f78c6b3a9fb9a62195d9e29aa5c11c636b9959c51488ad7dff1591d
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-modules-systemjs@npm:^7.12.1, @babel/plugin-transform-modules-systemjs@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.14.5"
@@ -1315,6 +1775,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 39f24ab207a3baab190ff3dcab7878805c8f063e31c3b487afcfbea0dcb108fb457d011428a1242b84b451df95b30237458d6131b09acdbd5dd824c46bcf5582
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-systemjs@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.15.4"
+  dependencies:
+    "@babel/helper-hoist-variables": ^7.15.4
+    "@babel/helper-module-transforms": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-validator-identifier": ^7.14.9
+    babel-plugin-dynamic-import-node: ^2.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2e00e7102981096d7ccd1f8b4c913bcf7fb099818408e8b08e56ecd1a5659e8a690db77a785e835be2aba4785e2400d7a22cd513ef0b70552d58c712aa2208d5
   languageName: node
   linkType: hard
 
@@ -1338,6 +1813,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: f035d73a38dd7c1eaab66d0f867fde93ea5e833fe5d0cf41e0673f9e7bd2b27ca8a28aab4f124d7d1d8854c413e48b24730a0a13cbbccef2e3567e5dfaa65465
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.14.9":
+  version: 7.14.9
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.14.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 348f3f3190ba6da26d12637ab41d6eaad076fda0aa70588765ee308f250d81a1e7f5fcc416366686841fdc99f16a9ef836ca51d332216850a63de397433a3891
   languageName: node
   linkType: hard
 
@@ -1372,6 +1858,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 42419b3db8dc9c84ce8a2b819d56bf2678177ab982401c1e7b93ffed31adb2ad54b9cb6ff745bb03e6e657ece7deacb69d74e0169f21a5911faa2455e305d153
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-parameters@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/plugin-transform-parameters@npm:7.15.4"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a158bbb06725ba26c8265182389153d3cdd7da2c3543a3f2e5ddddfc8c1d4bfcd44335c738e86d7248e890f39885c5c60795cd907d32acb90baa0fbfbd9c51b7
   languageName: node
   linkType: hard
 
@@ -1515,19 +2012,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.12.15":
-  version: 7.14.3
-  resolution: "@babel/plugin-transform-runtime@npm:7.14.3"
+"@babel/plugin-transform-runtime@npm:^7.15.0":
+  version: 7.15.8
+  resolution: "@babel/plugin-transform-runtime@npm:7.15.8"
   dependencies:
-    "@babel/helper-module-imports": ^7.13.12
-    "@babel/helper-plugin-utils": ^7.13.0
-    babel-plugin-polyfill-corejs2: ^0.2.0
-    babel-plugin-polyfill-corejs3: ^0.2.0
-    babel-plugin-polyfill-regenerator: ^0.2.0
+    "@babel/helper-module-imports": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    babel-plugin-polyfill-corejs2: ^0.2.2
+    babel-plugin-polyfill-corejs3: ^0.2.5
+    babel-plugin-polyfill-regenerator: ^0.2.2
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 2c8d211a468a394cd467a85ae002a7914be765d79ddc12c22d3aa6e07fa5163b274fd5d3782b2d156f4f20926e83259aae0cdb9ca01a05ac92abfc19945c72e6
+  checksum: 60255e05bba0b77cf663c549ed09cddefdcdfaf2f5d462cf0c06cfe73f21874819613cab0a7b15ac4ed4f7dece1707799a27cb0c233891570663fca74ade7f40
   languageName: node
   linkType: hard
 
@@ -1551,6 +2048,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9511fd90a53a2537f209e9165ad7efc28fc50985bedf5fc6fedb5a2acaab3f3e3bb8c8ad6247c0ec164d2e96e9b8afcd3dd8c20310459081cb5ae3f0ba246e56
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-spread@npm:^7.15.8":
+  version: 7.15.8
+  resolution: "@babel/plugin-transform-spread@npm:7.15.8"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.15.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 751b5e2a90b1f837d33dd18660274b4d968ce9f76fb3fee68c6199c38d120c599a9f2a9d859cdbd5f0b22089b78939db7f2b252d773f43b62963a16cdfffe2f5
   languageName: node
   linkType: hard
 
@@ -1699,7 +2208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.12.1, @babel/preset-env@npm:^7.12.11, @babel/preset-env@npm:^7.12.16, @babel/preset-env@npm:^7.8.4":
+"@babel/preset-env@npm:^7.12.1, @babel/preset-env@npm:^7.12.11, @babel/preset-env@npm:^7.8.4":
   version: 7.14.7
   resolution: "@babel/preset-env@npm:7.14.7"
   dependencies:
@@ -1779,6 +2288,89 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 50c21b42c47a2d7ae26f70d6f5e77b83ab803fb54b22ae6e398a4ab6b388f7397207ff6ca51e5cb697de14d31965988147a2b65009e638fb04a3b8a5c60676c8
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:^7.15.6":
+  version: 7.15.8
+  resolution: "@babel/preset-env@npm:7.15.8"
+  dependencies:
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-validator-option": ^7.14.5
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.15.4
+    "@babel/plugin-proposal-async-generator-functions": ^7.15.8
+    "@babel/plugin-proposal-class-properties": ^7.14.5
+    "@babel/plugin-proposal-class-static-block": ^7.15.4
+    "@babel/plugin-proposal-dynamic-import": ^7.14.5
+    "@babel/plugin-proposal-export-namespace-from": ^7.14.5
+    "@babel/plugin-proposal-json-strings": ^7.14.5
+    "@babel/plugin-proposal-logical-assignment-operators": ^7.14.5
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.14.5
+    "@babel/plugin-proposal-numeric-separator": ^7.14.5
+    "@babel/plugin-proposal-object-rest-spread": ^7.15.6
+    "@babel/plugin-proposal-optional-catch-binding": ^7.14.5
+    "@babel/plugin-proposal-optional-chaining": ^7.14.5
+    "@babel/plugin-proposal-private-methods": ^7.14.5
+    "@babel/plugin-proposal-private-property-in-object": ^7.15.4
+    "@babel/plugin-proposal-unicode-property-regex": ^7.14.5
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+    "@babel/plugin-syntax-class-properties": ^7.12.13
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+    "@babel/plugin-syntax-top-level-await": ^7.14.5
+    "@babel/plugin-transform-arrow-functions": ^7.14.5
+    "@babel/plugin-transform-async-to-generator": ^7.14.5
+    "@babel/plugin-transform-block-scoped-functions": ^7.14.5
+    "@babel/plugin-transform-block-scoping": ^7.15.3
+    "@babel/plugin-transform-classes": ^7.15.4
+    "@babel/plugin-transform-computed-properties": ^7.14.5
+    "@babel/plugin-transform-destructuring": ^7.14.7
+    "@babel/plugin-transform-dotall-regex": ^7.14.5
+    "@babel/plugin-transform-duplicate-keys": ^7.14.5
+    "@babel/plugin-transform-exponentiation-operator": ^7.14.5
+    "@babel/plugin-transform-for-of": ^7.15.4
+    "@babel/plugin-transform-function-name": ^7.14.5
+    "@babel/plugin-transform-literals": ^7.14.5
+    "@babel/plugin-transform-member-expression-literals": ^7.14.5
+    "@babel/plugin-transform-modules-amd": ^7.14.5
+    "@babel/plugin-transform-modules-commonjs": ^7.15.4
+    "@babel/plugin-transform-modules-systemjs": ^7.15.4
+    "@babel/plugin-transform-modules-umd": ^7.14.5
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.14.9
+    "@babel/plugin-transform-new-target": ^7.14.5
+    "@babel/plugin-transform-object-super": ^7.14.5
+    "@babel/plugin-transform-parameters": ^7.15.4
+    "@babel/plugin-transform-property-literals": ^7.14.5
+    "@babel/plugin-transform-regenerator": ^7.14.5
+    "@babel/plugin-transform-reserved-words": ^7.14.5
+    "@babel/plugin-transform-shorthand-properties": ^7.14.5
+    "@babel/plugin-transform-spread": ^7.15.8
+    "@babel/plugin-transform-sticky-regex": ^7.14.5
+    "@babel/plugin-transform-template-literals": ^7.14.5
+    "@babel/plugin-transform-typeof-symbol": ^7.14.5
+    "@babel/plugin-transform-unicode-escapes": ^7.14.5
+    "@babel/plugin-transform-unicode-regex": ^7.14.5
+    "@babel/preset-modules": ^0.1.4
+    "@babel/types": ^7.15.6
+    babel-plugin-polyfill-corejs2: ^0.2.2
+    babel-plugin-polyfill-corejs3: ^0.2.5
+    babel-plugin-polyfill-regenerator: ^0.2.2
+    core-js-compat: ^3.16.0
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3b3ed9c38512f17faae42f68d377c1486d5fdf7d6a968886a2df574d17cfa07223d51d9afb6d7a276cc7db76367415af217a6a1cedbd86da6ce116df1384fd7e
   languageName: node
   linkType: hard
 
@@ -1868,13 +2460,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.10.2, @babel/runtime-corejs3@npm:^7.12.13":
+"@babel/runtime-corejs3@npm:^7.10.2":
   version: 7.14.0
   resolution: "@babel/runtime-corejs3@npm:7.14.0"
   dependencies:
     core-js-pure: ^3.0.0
     regenerator-runtime: ^0.13.4
   checksum: 0b3184c384f061e90c879406a072643493d9a1c7fa33bcbccf72ab0588df12ad85fb3539a3b8355f4d96934836f420c0a70d9a0848c7954f6a5ec511bb5bb2ef
+  languageName: node
+  linkType: hard
+
+"@babel/runtime-corejs3@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/runtime-corejs3@npm:7.15.4"
+  dependencies:
+    core-js-pure: ^3.16.0
+    regenerator-runtime: ^0.13.4
+  checksum: acd1ebce7759195ccfbfdecac89e828fbccd8e0565eb99b9b4af364b8a5cf7c8f20600ab4c1a386310550b178c93ea9d9fe7b27c8a37b28edbbcfef78b9d38a8
   languageName: node
   linkType: hard
 
@@ -1896,6 +2498,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/runtime@npm:7.15.4"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 64b6c250fd02a664f40835b7bfc3ec0b473d251bf4881b06b689b60662bf2ae17adc6fa32fb0e0de308de5d4bc383738c6030ad93d823066fb9fd7c18f552b56
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.10.4, @babel/template@npm:^7.12.7, @babel/template@npm:^7.14.5, @babel/template@npm:^7.3.3":
   version: 7.14.5
   resolution: "@babel/template@npm:7.14.5"
@@ -1904,6 +2515,17 @@ __metadata:
     "@babel/parser": ^7.14.5
     "@babel/types": ^7.14.5
   checksum: 71619e2e3d6d518bf6c40ebd610379b050a6e8e9a2ec0cda8b5c28aea5105f69006758b575dae63a21a6d4f64f854e92c0cb6cf8841d59f5585596165df78060
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/template@npm:7.15.4"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/parser": ^7.15.4
+    "@babel/types": ^7.15.4
+  checksum: d4d366d8812a8e461d43bc8cbd25a183a20317c49af129d1a5bee45ce2bca8f1e3f9baa80d19216173c7bfc391d5d4c55af9540ffab419741122d7182dd7092f
   languageName: node
   linkType: hard
 
@@ -1941,6 +2563,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.15.4":
+  version: 7.15.4
+  resolution: "@babel/traverse@npm:7.15.4"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.15.4
+    "@babel/helper-function-name": ^7.15.4
+    "@babel/helper-hoist-variables": ^7.15.4
+    "@babel/helper-split-export-declaration": ^7.15.4
+    "@babel/parser": ^7.15.4
+    "@babel/types": ^7.15.4
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: d023925a4683732b096447290b2c7348ef5203ce44fc7d2fed11d82f287d743c941a8f86217e1884d9949b47958e3fd2034931f3a6f17dc78f9100c3587f8b7b
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:7.12.13":
   version: 7.12.13
   resolution: "@babel/types@npm:7.12.13"
@@ -1959,6 +2598,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.14.5
     to-fast-properties: ^2.0.0
   checksum: 45575b46df5ec0e63454b794a60f362596c6f16beda7df3693b134db5be15eb43f7b98ca7b2a5a9628171db5192eed5b8965e43c0a6f5383bca4ddefd0ea8d30
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.15.4, @babel/types@npm:^7.15.6":
+  version: 7.15.6
+  resolution: "@babel/types@npm:7.15.6"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.9
+    to-fast-properties: ^2.0.0
+  checksum: 34c8048bdec27e9935fa22cb1bd02f7b7c92c3bce21e96a85a92791c7e648868bb39039f0a1293dadc3fda51242040077d65e0a3d9601993ea5e4d9dd0821da4
   languageName: node
   linkType: hard
 
@@ -2757,51 +3406,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/core@npm:2.0.0-beta.4"
+"@docusaurus/core@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/core@npm:2.0.0-beta.7"
   dependencies:
     "@babel/core": ^7.12.16
     "@babel/generator": ^7.12.15
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-runtime": ^7.12.15
-    "@babel/preset-env": ^7.12.16
+    "@babel/plugin-transform-runtime": ^7.15.0
+    "@babel/preset-env": ^7.15.6
     "@babel/preset-react": ^7.12.13
     "@babel/preset-typescript": ^7.12.16
-    "@babel/runtime": ^7.12.5
-    "@babel/runtime-corejs3": ^7.12.13
+    "@babel/runtime": ^7.15.4
+    "@babel/runtime-corejs3": ^7.15.4
     "@babel/traverse": ^7.12.13
-    "@docusaurus/cssnano-preset": 2.0.0-beta.4
+    "@docusaurus/cssnano-preset": 2.0.0-beta.7
     "@docusaurus/react-loadable": 5.5.0
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-common": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-common": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     "@slorber/static-site-generator-webpack-plugin": ^4.0.0
     "@svgr/webpack": ^5.5.0
-    autoprefixer: ^10.2.5
+    autoprefixer: ^10.3.5
     babel-loader: ^8.2.2
     babel-plugin-dynamic-import-node: 2.3.0
     boxen: ^5.0.1
-    chalk: ^4.1.1
-    chokidar: ^3.5.1
-    clean-css: ^5.1.2
+    chalk: ^4.1.2
+    chokidar: ^3.5.2
+    clean-css: ^5.1.5
     commander: ^5.1.0
-    copy-webpack-plugin: ^9.0.0
-    core-js: ^3.9.1
+    copy-webpack-plugin: ^9.0.1
+    core-js: ^3.18.0
     css-loader: ^5.1.1
-    css-minimizer-webpack-plugin: ^3.0.1
-    cssnano: ^5.0.4
+    css-minimizer-webpack-plugin: ^3.0.2
+    cssnano: ^5.0.8
     del: ^6.0.0
     detect-port: ^1.3.0
     escape-html: ^1.0.3
-    eta: ^1.12.1
+    eta: ^1.12.3
     express: ^4.17.1
     file-loader: ^6.2.0
     fs-extra: ^10.0.0
-    github-slugger: ^1.3.0
+    github-slugger: ^1.4.0
     globby: ^11.0.2
-    html-minifier-terser: ^5.1.1
+    html-minifier-terser: ^6.0.2
     html-tags: ^3.1.0
     html-webpack-plugin: ^5.3.2
     import-fresh: ^3.3.0
@@ -2811,8 +3460,8 @@ __metadata:
     mini-css-extract-plugin: ^1.6.0
     module-alias: ^2.2.2
     nprogress: ^0.2.0
-    postcss: ^8.2.15
-    postcss-loader: ^5.3.0
+    postcss: ^8.3.7
+    postcss-loader: ^6.1.1
     prompts: ^2.4.1
     react-dev-utils: ^11.0.1
     react-error-overlay: ^6.0.9
@@ -2822,18 +3471,19 @@ __metadata:
     react-router: ^5.2.0
     react-router-config: ^5.1.1
     react-router-dom: ^5.2.0
+    remark-admonitions: ^1.2.1
     resolve-pathname: ^3.0.0
-    rtl-detect: ^1.0.3
+    rtl-detect: ^1.0.4
     semver: ^7.3.4
     serve-handler: ^6.1.3
     shelljs: ^0.8.4
     std-env: ^2.2.1
     strip-ansi: ^6.0.0
-    terser-webpack-plugin: ^5.1.3
-    tslib: ^2.2.0
+    terser-webpack-plugin: ^5.2.4
+    tslib: ^2.3.1
     update-notifier: ^5.1.0
     url-loader: ^4.1.1
-    wait-on: ^5.3.0
+    wait-on: ^6.0.0
     webpack: ^5.40.0
     webpack-bundle-analyzer: ^4.4.2
     webpack-dev-server: ^3.11.2
@@ -2844,36 +3494,36 @@ __metadata:
     react-dom: ^16.8.4 || ^17.0.0
   bin:
     docusaurus: bin/docusaurus.js
-  checksum: 2ddbd07c3849b267f00780e373d137f624f5cc69ad20474cbd0ea53b7a3e8ce903917fe66a3c9bf58f3f6f4d6d7c6d9ab93f4f6dc12e4b72ff3872cee07d939b
+  checksum: 0a66946edbd5fc0335221d07043898413d0b09ad5016562e0fcd1663025ee804627e56576c3a40fdb3c64006c3467805019fc2dbe3783e397b80aa96b5fff3b2
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.4"
+"@docusaurus/cssnano-preset@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.7"
   dependencies:
-    cssnano-preset-advanced: ^5.1.1
-    postcss: ^8.2.15
-    postcss-sort-media-queries: ^3.10.11
-  checksum: aa9f222f97aaab93bdd038cad9eacb101a448c515d5779f10f44b16be04ec7d674ee6ce2c9ecdfc14a7ef95d807e2656bb11d80a33937ae77ef2253b5653f3bc
+    cssnano-preset-advanced: ^5.1.4
+    postcss: ^8.3.7
+    postcss-sort-media-queries: ^4.1.0
+  checksum: 16404ad7633777fe55b0188353f9a16aefda9065c1c219b0274c1d7359006049530bfbef6388b432efac91cdcd8a4245a045d79a9a9b1c355a26e63dc605e5ec
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.4"
+"@docusaurus/mdx-loader@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.7"
   dependencies:
     "@babel/parser": ^7.12.16
     "@babel/traverse": ^7.12.13
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.1
+    chalk: ^4.1.2
     escape-html: ^1.0.3
     file-loader: ^6.2.0
     fs-extra: ^10.0.0
-    github-slugger: ^1.3.0
+    github-slugger: ^1.4.0
     gray-matter: ^4.0.3
     mdast-util-to-string: ^2.0.0
     remark-emoji: ^2.1.0
@@ -2884,47 +3534,49 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 74b221483ddbe9c3028f38cd182aa909bdbe59eafb524a53286d9fd7b53ddacef4aa9e98cfa570dbc8a10b378f29a2d18774d440969adfcecbc6055cf7639b85
+  checksum: 222cda9caacf9d4449a74e5259823539e74461ffc9efdf08dea541b82ff4e5680c09310413d5d5a272004d8ca42edb0fb7d7aaf9ae575602538b9c032905535b
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.4"
+"@docusaurus/plugin-content-blog@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/mdx-loader": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
-    chalk: ^4.1.1
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/mdx-loader": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
+    chalk: ^4.1.2
     escape-string-regexp: ^4.0.0
     feed: ^4.2.2
     fs-extra: ^10.0.0
     globby: ^11.0.2
+    js-yaml: ^4.0.0
     loader-utils: ^2.0.0
     lodash: ^4.17.20
-    reading-time: ^1.3.0
+    reading-time: ^1.5.0
     remark-admonitions: ^1.2.1
-    tslib: ^2.2.0
+    tslib: ^2.3.1
+    utility-types: ^3.10.0
     webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 84a07b115844cd6995b043b79d0ffbdf0a2a3d8c762c4764709a65ab12205b9f8419d74eb0249d5f818efb49a39180022e77cb6e2a1936d009b3b3dc32e2c637
+  checksum: c771af740a730a7e5fa353c5e5cf58b06e0c4f1085d35c718479bdd30da74f53b8925a7d6571b1205a99e5fd43f817a58782b0a4cea4988d78a66a058fb39cc8
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.4"
+"@docusaurus/plugin-content-docs@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/mdx-loader": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
-    chalk: ^4.1.1
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/mdx-loader": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
+    chalk: ^4.1.2
     combine-promises: ^1.1.0
     escape-string-regexp: ^4.0.0
     execa: ^5.0.0
@@ -2932,118 +3584,119 @@ __metadata:
     globby: ^11.0.2
     import-fresh: ^3.2.2
     js-yaml: ^4.0.0
-    loader-utils: ^1.2.3
+    loader-utils: ^2.0.0
     lodash: ^4.17.20
     remark-admonitions: ^1.2.1
     shelljs: ^0.8.4
-    tslib: ^2.2.0
+    tslib: ^2.3.1
     utility-types: ^3.10.0
     webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: a633d1062f57c4ef153595bf9b7ca997682e4bb3a04f48e677e1ae76052189b9bcb40388ded1923cfcf74b97d5fd4fe16de59f249c13eab1534ac8b6912112e1
+  checksum: 457f7cfe2f812b00531bef6b50c22fa0cf0a3d30b392b853475491dccfc52b9c2b85f7419db9c34f38141c0edf3442bd457b9259300285abd244cf31bfcfddef
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.4"
+"@docusaurus/plugin-content-pages@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/mdx-loader": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/mdx-loader": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     globby: ^11.0.2
     lodash: ^4.17.20
     remark-admonitions: ^1.2.1
-    tslib: ^2.1.0
+    tslib: ^2.3.1
     webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 25f3059f2101ad380d25cf3b1dee4fc054e0533f1de1a22b381f3570dbde2f7452b51ef5c4135b52e5f676bb61a46417ef6e239ac188f80c27e0ad1fa8ff0c08
+  checksum: 8e720fbf61cb02b089cec7accb17c761b91c7420cbe667f3f9260b69b9e75f9d06a01b5a91f423efb729783d53f887a7146e3c34f5642040eade41643c2a2dd2
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.4"
+"@docusaurus/plugin-debug@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    fs-extra: ^10.0.0
     react-json-view: ^1.21.3
-    tslib: ^2.1.0
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 23b25d0c57c0551ddde44eba7949face94a3178d937d154dc58842f9fb864cb93d9b6d931321f23c89b85bee9bc87983e6574ffe5e0f24f75796c60d27b5edf4
+  checksum: cdf8265f7917c09f36fcb6548c286543f0033595e6947b6e84f8df5655bd274638b1bba419e648ac0e324a0c44de7214db1aa83db5835207d8cf4867491879de
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.4"
+"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 725dd8f05e9e6787cfdfd37a3ad1e487874bd8f1ad2fdc9e285cbf54f3df15d04f46c587c71e8029bb0e92f73da058d29ba8630611db23d11fc43b8f2c617d58
+  checksum: bb11a4f57084a4bb811926f13dbf9ad571b08e9faed1cc256512d70c3e201825aa6019ba85a24d00e97f679f8cf5b3082d4ebd59f6e12db7c65352fa55f769e4
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.4"
+"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: f84c583c8784265bb135f2de605fdc624ae33227a001322e81b9a749d046c69fffef444f9fa86aad2d7986f8ced175238b7d96dc8b8408f515f941d3fad9b82f
+  checksum: 9b12675f9cc553867bf1c44e159a97fb20c7b89ea08e8880455a3903c9806d8ef7e8c34e87cade962591620f639012ce3a6d45854273d29720427cf1aa96d43a
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.4"
+"@docusaurus/plugin-sitemap@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-common": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-common": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     fs-extra: ^10.0.0
     sitemap: ^7.0.0
-    tslib: ^2.2.0
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 3bcc3e2311f9b645a5861839c63fe4cb2090d30f8ce8d1c1b4d7678ce9e794c9c4e633462d4bec560a2eb9ec26e9bb625bc4fa8609b3424817f9a8ffcb618ccb
+  checksum: 890b5b22551a0866b77a97c9ba8aa1dbe01d048bbca6c598c85274dacb8e10e5ea627d50fc6244a1afd029731645fb17bbef3116528db14945642f9024b9f646
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.4"
+"@docusaurus/preset-classic@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.4
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.4
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.4
-    "@docusaurus/plugin-debug": 2.0.0-beta.4
-    "@docusaurus/plugin-google-analytics": 2.0.0-beta.4
-    "@docusaurus/plugin-google-gtag": 2.0.0-beta.4
-    "@docusaurus/plugin-sitemap": 2.0.0-beta.4
-    "@docusaurus/theme-classic": 2.0.0-beta.4
-    "@docusaurus/theme-search-algolia": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.7
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.7
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.7
+    "@docusaurus/plugin-debug": 2.0.0-beta.7
+    "@docusaurus/plugin-google-analytics": 2.0.0-beta.7
+    "@docusaurus/plugin-google-gtag": 2.0.0-beta.7
+    "@docusaurus/plugin-sitemap": 2.0.0-beta.7
+    "@docusaurus/theme-classic": 2.0.0-beta.7
+    "@docusaurus/theme-search-algolia": 2.0.0-beta.7
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: ab96fb4e06de3eb909a2cb8669729f2e5bbe4b2bf0171d8a78cfc153632612a513d7223fb8b8ca12b10b560f0b9e83171fd9a98515b724131ba375944a05d6b5
+  checksum: 2603a7a07809918c45103d987c32bc192e1fd04ba8ce4c3f16124bc6824f8aee6f5246186b623245fc2d48adbd5d32e3feb8b549d78efc50a390198e60802275
   languageName: node
   linkType: hard
 
@@ -3058,134 +3711,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.4"
+"@docusaurus/theme-classic@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.4
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.4
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.4
-    "@docusaurus/theme-common": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-common": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.7
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.7
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.7
+    "@docusaurus/theme-common": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-common": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.1
+    chalk: ^4.1.2
     clsx: ^1.1.1
     copy-text-to-clipboard: ^3.0.1
     fs-extra: ^10.0.0
     globby: ^11.0.2
-    infima: 0.2.0-alpha.29
+    infima: 0.2.0-alpha.34
     lodash: ^4.17.20
-    parse-numeric-range: ^1.2.0
-    postcss: ^8.2.15
+    parse-numeric-range: ^1.3.0
+    postcss: ^8.3.7
     prism-react-renderer: ^1.2.1
     prismjs: ^1.23.0
     prop-types: ^15.7.2
     react-router-dom: ^5.2.0
-    rtlcss: ^3.1.2
+    rtlcss: ^3.3.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: c4c8b37ea8ad7abd69ee282348a9443b5cd5791aac2bf3ccaf1310a10bb4a5ca3302ace7a37e448113de04bc46b3caaeef303a4f72dfcadb7b58fcdcbcdb2ad2
+  checksum: 38e043b8a42aa6634cd87ed260ceee222d7852fa688210232f1d908feec119794ac67b4e324c9d89b71ec28c3ef15b20621458177fa0e52c29e509f5229dbc03
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.4"
+"@docusaurus/theme-common@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.4
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.4
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.7
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.7
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
     clsx: ^1.1.1
     fs-extra: ^10.0.0
-    tslib: ^2.1.0
+    tslib: ^2.3.1
+    utility-types: ^3.10.0
   peerDependencies:
     prism-react-renderer: ^1.2.1
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 89a062c00d589ed78904027e41cd9e0578faf1cb8d269749fc926cb5e2ee72ef29ee2d728f8bbcbe5928b8303fd7ce263fda3b6a289f35bb9170206f0eddd99a
+  checksum: 64a22ed88ab44e179c743cc7e2d6e9ca199f3d61b2d211fc8f133e50daf4a88ecacc17803ade730e82be2aaf873d3f55833e933e26f0a27f6bc0399389de0e3a
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.4"
+"@docusaurus/theme-search-algolia@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.7"
   dependencies:
     "@docsearch/react": ^3.0.0-alpha.39
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/theme-common": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
-    algoliasearch: ^4.8.4
-    algoliasearch-helper: ^3.3.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/theme-common": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
+    algoliasearch: ^4.10.5
+    algoliasearch-helper: ^3.5.5
     clsx: ^1.1.1
-    eta: ^1.12.1
+    eta: ^1.12.3
     lodash: ^4.17.20
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 3e2160c700a0aa2f2d8cbef3342799f3e3fdbcf5322167e47b1aeb7bca98c024117e3eb9aa6ba73b7e0e56893b6f2db80877a465d336c44ba1009f1c173a05c8
+  checksum: 8df515cedeff3ceeeb8bc0bfc35d0b74313539b0c317209faecb42717f5b944713435ef1e39e879ed258f2e97d9d7a41a926ecac223d84cb02e37c7b8b8c2305
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/types@npm:2.0.0-beta.4"
+"@docusaurus/types@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/types@npm:2.0.0-beta.7"
   dependencies:
     commander: ^5.1.0
-    joi: ^17.4.0
+    joi: ^17.4.2
     querystring: 0.2.0
+    utility-types: ^3.10.0
     webpack: ^5.40.0
     webpack-merge: ^5.8.0
-  checksum: ba4ea7aef74bec0abcaf087b31a643a0d509faa8b7da698bb436e6184f94393afb886b99591dea5f9bdecc5f6ea226e5666736bb0f4fec0b32c666bc572d459a
+  checksum: a05f663c77ddc0613a2a4f1e2000dc54b2c4d773c573e3edd474d2877c2731f26cc2a64314863243429edf477dce21abe516e7d86dda2e07f26e361520cd087d
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.4"
+"@docusaurus/utils-common@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.4
-    tslib: ^2.2.0
-  checksum: cf8da7993e2b9a12935f63e15785c921b007250d5c3f7e015593c95451e4ddc0d43f7d7696684b9c9e5c001e16f4ce77aff62daafd1b6b9305fab6b6c23e3abf
+    "@docusaurus/types": 2.0.0-beta.7
+    tslib: ^2.3.1
+  checksum: 173fdf856ed7a611fa9292bd673340081c30d33767d57d09fc4860f9028333f1103154c09d4df99f2833f2b8bcce1f331893355edbdc1f95187752504cb143c4
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.4"
+"@docusaurus/utils-validation@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/utils": 2.0.0-beta.4
-    chalk: ^4.1.1
-    joi: ^17.4.0
-    tslib: ^2.1.0
-  checksum: b9a6594dcace4f260e9e8012eeb99b6bdd84519ef46bd613951d077a6b8da67f7da3b223e3f9668b6a8f35c4ba8b7512f03ba02aa6d43befdec02c9abab1bdd9
+    "@docusaurus/utils": 2.0.0-beta.7
+    chalk: ^4.1.2
+    joi: ^17.4.2
+    tslib: ^2.3.1
+  checksum: 78eb56055913130cd3fde696adcf008711b7d8a7eb9f53ae8bb610130167c95330e169966026ea38204e9bce36f0f82d5e56a4098fd77431c0386540115952aa
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/utils@npm:2.0.0-beta.4"
+"@docusaurus/utils@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/utils@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.4
+    "@docusaurus/types": 2.0.0-beta.7
+    "@mdx-js/runtime": ^1.6.22
     "@types/github-slugger": ^1.3.0
-    chalk: ^4.1.1
+    chalk: ^4.1.2
     escape-string-regexp: ^4.0.0
     fs-extra: ^10.0.0
     globby: ^11.0.4
     gray-matter: ^4.0.3
     lodash: ^4.17.20
     micromatch: ^4.0.4
+    remark-mdx-remove-exports: ^1.6.22
+    remark-mdx-remove-imports: ^1.6.22
     resolve-pathname: ^3.0.0
-    tslib: ^2.2.0
-  checksum: 5d687aa6ded085fa042e7d20042e5e74e0b6eabb9a8b94fbecf85d5360bc5868d7e1f2f1034b21803f1f126acc1a12fd217d6d06a5f5f5aad0f85d5cb3497362
+    tslib: ^2.3.1
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: f19f538f9ac764a334b5d06cab3ed0c02bc19a2406c75a9e182bed9ea3b4c764abeb5661941799a9c618eac58f67748024e1c03363ea88b35c56e015cac96d37
   languageName: node
   linkType: hard
 
@@ -4665,7 +5326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/mdx@npm:^1.6.21":
+"@mdx-js/mdx@npm:1.6.22, @mdx-js/mdx@npm:^1.6.21":
   version: 1.6.22
   resolution: "@mdx-js/mdx@npm:1.6.22"
   dependencies:
@@ -4692,12 +5353,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/react@npm:^1.6.21":
+"@mdx-js/react@npm:1.6.22, @mdx-js/react@npm:^1.6.21":
   version: 1.6.22
   resolution: "@mdx-js/react@npm:1.6.22"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
   checksum: 3a0a189aa04a3b73e4846f8311573d45404c4ec74a1a4b196e7829492fedabe38b869016125620403bcf5f999f58ab75c9f54279f7557e361c239b57e5ed2267
+  languageName: node
+  linkType: hard
+
+"@mdx-js/runtime@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "@mdx-js/runtime@npm:1.6.22"
+  dependencies:
+    "@mdx-js/mdx": 1.6.22
+    "@mdx-js/react": 1.6.22
+    buble-jsx-only: ^0.19.8
+  peerDependencies:
+    react: ^16.13.1
+  checksum: c66910c1bbdd23eb11416fb7b50020c1c0227a3855f6261aa427fce06c736de111e0ff183e05d7f7e498c86fdbf9e552072a9ac6dfc2e112c0a4b2eca196b651
   languageName: node
   linkType: hard
 
@@ -5915,6 +6589,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.8":
+  version: 7.0.9
+  resolution: "@types/json-schema@npm:7.0.9"
+  checksum: 3252f0faa7aada7ad27c59bb64ff7bee0c9ad0fb7c21a3b7d255f56c732b94fe94a876f5a5f6fee27a41feac09efac082fad54314c3ce542db02445d7a6059f8
+  languageName: node
+  linkType: hard
+
 "@types/json-stable-stringify@npm:^1.0.32":
   version: 1.0.32
   resolution: "@types/json-stable-stringify@npm:1.0.32"
@@ -6915,6 +7596,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-dynamic-import@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "acorn-dynamic-import@npm:4.0.0"
+  peerDependencies:
+    acorn: ^6.0.0
+  checksum: ce61df77522b5eaee93f4a61043af9b059590d382bdbf5bf4a3717416d0cfb7bebbacb736d82764ba51381d2d55db4b27477384bb7e2642283941b52bcd9d008
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -6922,6 +7612,15 @@ __metadata:
     acorn: ^7.1.1
     acorn-walk: ^7.1.1
   checksum: 078ed9bc354e95a30893efd260e2dc566dfc34d8e1d24a54b9ad59984bea53ff93cb1986a85b2b5e2b8e573cb00d34ad8767371b852941a1947f81c37c1be759
+  languageName: node
+  linkType: hard
+
+"acorn-jsx@npm:^5.0.1":
+  version: 5.3.2
+  resolution: "acorn-jsx@npm:5.3.2"
+  peerDependencies:
+    acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 41c748fd26345f63fd27508c61596ffba5c4f23a8c98fffd2e75cf650c3928bb35af8658bf40d1ed18e56630cc9f4aa34d82bd5a3f53476df27d768eb03e9281
   languageName: node
   linkType: hard
 
@@ -6948,7 +7647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^6.4.1":
+"acorn@npm:^6.1.1, acorn@npm:^6.4.1":
   version: 6.4.2
   resolution: "acorn@npm:6.4.2"
   bin:
@@ -7073,18 +7772,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"algoliasearch-helper@npm:^3.3.4":
-  version: 3.4.4
-  resolution: "algoliasearch-helper@npm:3.4.4"
+"algoliasearch-helper@npm:^3.5.5":
+  version: 3.6.1
+  resolution: "algoliasearch-helper@npm:3.6.1"
   dependencies:
     events: ^1.1.1
   peerDependencies:
     algoliasearch: ">= 3.1 < 5"
-  checksum: 3dde09d29fdc02b6f008ae2cf45c1b1d5b3cb6caf2db9403f572deda2ccb29b195b0d5818d629ad38ab98ad1b8a77bdb65e61309b47e55ee058a2391771eee6b
+  checksum: 378f1e9edd3ff99ab78c4afd40d36d5eb3508150d9997601c158cb0868eedb26fce9d6edb7dbce2da8eda2b44e1578b5300caf763607b50dd6c9d621ec58a781
   languageName: node
   linkType: hard
 
-"algoliasearch@npm:^4.0.0, algoliasearch@npm:^4.8.4":
+"algoliasearch@npm:^4.0.0":
   version: 4.9.1
   resolution: "algoliasearch@npm:4.9.1"
   dependencies:
@@ -7103,6 +7802,28 @@ __metadata:
     "@algolia/requester-node-http": 4.9.1
     "@algolia/transporter": 4.9.1
   checksum: 0127dd9cb07250db4e5666dc5929701563d27726b546c1c7df07318aeadeb8c06d52d6d2addb87bf2c981a2812bd44af0ed1c10b2ec2ae54e15f6c9361b723d4
+  languageName: node
+  linkType: hard
+
+"algoliasearch@npm:^4.10.5":
+  version: 4.10.5
+  resolution: "algoliasearch@npm:4.10.5"
+  dependencies:
+    "@algolia/cache-browser-local-storage": 4.10.5
+    "@algolia/cache-common": 4.10.5
+    "@algolia/cache-in-memory": 4.10.5
+    "@algolia/client-account": 4.10.5
+    "@algolia/client-analytics": 4.10.5
+    "@algolia/client-common": 4.10.5
+    "@algolia/client-personalization": 4.10.5
+    "@algolia/client-search": 4.10.5
+    "@algolia/logger-common": 4.10.5
+    "@algolia/logger-console": 4.10.5
+    "@algolia/requester-browser-xhr": 4.10.5
+    "@algolia/requester-common": 4.10.5
+    "@algolia/requester-node-http": 4.10.5
+    "@algolia/transporter": 4.10.5
+  checksum: 09d9b5178000b26f017a64c6e49546dd464336b1613a98537fa094f4357b5f78d2110d0ce3cca97c1748782aba64c67417e21390f73ecb97b48f59e9b289435f
   languageName: node
   linkType: hard
 
@@ -7238,7 +7959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.0, anymatch@npm:^3.0.3, anymatch@npm:~3.1.1":
+"anymatch@npm:^3.0.0, anymatch@npm:^3.0.3, anymatch@npm:~3.1.1, anymatch@npm:~3.1.2":
   version: 3.1.2
   resolution: "anymatch@npm:3.1.2"
   dependencies:
@@ -7539,7 +8260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.1.0, autoprefixer@npm:^10.2.0, autoprefixer@npm:^10.2.5":
+"autoprefixer@npm:^10.1.0, autoprefixer@npm:^10.2.0":
   version: 10.2.6
   resolution: "autoprefixer@npm:10.2.6"
   dependencies:
@@ -7554,6 +8275,24 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: 805414d4efe4f25c6162edc65ad999235ea28cf11b6a1ed838b055ef1f777368dd16c978b44d0b48bb96a3420948d26da27066d5caa4f81bcee1946e9a269532
+  languageName: node
+  linkType: hard
+
+"autoprefixer@npm:^10.3.5":
+  version: 10.3.7
+  resolution: "autoprefixer@npm:10.3.7"
+  dependencies:
+    browserslist: ^4.17.3
+    caniuse-lite: ^1.0.30001264
+    fraction.js: ^4.1.1
+    normalize-range: ^0.1.2
+    picocolors: ^0.2.1
+    postcss-value-parser: ^4.1.0
+  peerDependencies:
+    postcss: ^8.1.0
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: bbd835343f14de4aaa9246d2196374eaafa59f2f9de3070ac4f9d7c5a92901b8fd6d03b5b0b33ed2b33c971946a010a69dc3703005456774ced5d98bb0e275e0
   languageName: node
   linkType: hard
 
@@ -7784,7 +8523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.2.0, babel-plugin-polyfill-corejs2@npm:^0.2.2":
+"babel-plugin-polyfill-corejs2@npm:^0.2.2":
   version: 0.2.2
   resolution: "babel-plugin-polyfill-corejs2@npm:0.2.2"
   dependencies:
@@ -7797,7 +8536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs3@npm:^0.2.0, babel-plugin-polyfill-corejs3@npm:^0.2.2":
+"babel-plugin-polyfill-corejs3@npm:^0.2.2":
   version: 0.2.3
   resolution: "babel-plugin-polyfill-corejs3@npm:0.2.3"
   dependencies:
@@ -7809,7 +8548,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-regenerator@npm:^0.2.0, babel-plugin-polyfill-regenerator@npm:^0.2.2":
+"babel-plugin-polyfill-corejs3@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.2.5"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": ^0.2.2
+    core-js-compat: ^3.16.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7cd786d8c6d460f0aed35e7fc67d435d2698a09865ae542c9a3306dfd9d9b918cf3b2eb94007b579b59ef5f48870eae7705f5bf9035f5e5bccca43f08409726f
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-regenerator@npm:^0.2.2":
   version: 0.2.2
   resolution: "babel-plugin-polyfill-regenerator@npm:0.2.2"
   dependencies:
@@ -8339,6 +9090,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.17.3":
+  version: 4.17.4
+  resolution: "browserslist@npm:4.17.4"
+  dependencies:
+    caniuse-lite: ^1.0.30001265
+    electron-to-chromium: ^1.3.867
+    escalade: ^3.1.1
+    node-releases: ^2.0.0
+    picocolors: ^1.0.0
+  bin:
+    browserslist: cli.js
+  checksum: b2b7acf1a8c983902de3bc9ed4f23ad471e402d987ed12cc11766b05373a6c239343ca04d28ab0ac06c9e76bf0e37ffbd7f0dcf9bd9f54f4782c26211d40c08a
+  languageName: node
+  linkType: hard
+
 "bs-logger@npm:0.x":
   version: 0.2.6
   resolution: "bs-logger@npm:0.2.6"
@@ -8354,6 +9120,23 @@ __metadata:
   dependencies:
     node-int64: ^0.4.0
   checksum: 302af195672988c21be9590b0b4fcacf9bd5bc116a32cbb5f613b21800fce8ee6aa1c57e76bbfa15a60269fe48885d062383e353fbaa821dbf06e92f72cc8b7d
+  languageName: node
+  linkType: hard
+
+"buble-jsx-only@npm:^0.19.8":
+  version: 0.19.8
+  resolution: "buble-jsx-only@npm:0.19.8"
+  dependencies:
+    acorn: ^6.1.1
+    acorn-dynamic-import: ^4.0.0
+    acorn-jsx: ^5.0.1
+    chalk: ^2.4.2
+    magic-string: ^0.25.3
+    minimist: ^1.2.0
+    regexpu-core: ^4.5.4
+  bin:
+    buble: ./bin/buble
+  checksum: a2b3e1e307506388f0b6f884a1f6c99bd1d508402173c67e3d887046d53b8fadfff40d91fb89502e00b6b3022e9a0bcbf748ed52b414f3acba51adc9b83863a0
   languageName: node
   linkType: hard
 
@@ -8613,6 +9396,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001265":
+  version: 1.0.30001269
+  resolution: "caniuse-lite@npm:1.0.30001269"
+  checksum: e544bd20bf4186cc32ef24881ec45a8d61898e37ff4efc7736ad0f7419baf2ec2560de308ec28209f0aae637ec76baea9f1517eaa13cd06b35a14de86b25fc68
+  languageName: node
+  linkType: hard
+
 "capital-case@npm:^1.0.4":
   version: 1.0.4
   resolution: "capital-case@npm:1.0.4"
@@ -8678,6 +9468,16 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 445c12db7aeed0046500a1e4184d31209a77d165654c885a789c41c8598a6a95bd2392180987cac572c967b93a2a730dda778bb7f87fa06ca63fd8592f8cc59f
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: e3901b97d953991712bf0b941d586175be7ca5da56a97d25187e07453c6b26cae0ac8d9c7aa9e87e7c5c986fff870771b3a8e2705b3becda868829e2e12c2a65
   languageName: node
   linkType: hard
 
@@ -8834,6 +9634,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "chokidar@npm:3.5.2"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 52fbff3acebf06ec0125872110f6c8403e66cd3d613264c83405496e199554d99380342d9b3a7ffd7910c53c5865e242ed7dd72fcb2e883d8e3ad3f3883aee6c
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^1.1.1":
   version: 1.1.4
   resolution: "chownr@npm:1.1.4"
@@ -8921,12 +9740,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-css@npm:^5.1.2":
-  version: 5.1.3
-  resolution: "clean-css@npm:5.1.3"
+"clean-css@npm:^5.1.5":
+  version: 5.2.1
+  resolution: "clean-css@npm:5.2.1"
   dependencies:
     source-map: ~0.6.0
-  checksum: 07055f71d9370d0290c00c46e3d97404d0c0c2e0c3ef7ed25e600ce86581eb2782dd9c7f1ee27bc78d1cd339fc27691dfd7a6ee732344c6167523579d446bb01
+  checksum: 0d94030bcf04ecc0bd5b25ffcad52744aaa50e9f4d3322b21140d18e4279f7d04f39b216f3efe708b033c1b0b654dbea169a35c87d1bdbd6af037e914d9addbe
   languageName: node
   linkType: hard
 
@@ -9172,6 +9991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colord@npm:^2.6":
+  version: 2.8.0
+  resolution: "colord@npm:2.8.0"
+  checksum: 3a4d13ae0846e2b37214cd25ebdeba284eb849dafd1369e25a5066930ba996423f42ca949858c8ba5792ea7500e3bc8584c050dff0a41aa60423e7a7e35569e3
+  languageName: node
+  linkType: hard
+
 "colorette@npm:^1.2.1, colorette@npm:^1.2.2":
   version: 1.2.2
   resolution: "colorette@npm:1.2.2"
@@ -9241,6 +10067,13 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: bdc0eca5e25cd24af8440163d3c9a996785bbac4b49a590365699cdc1ed08cefbac8f268153208ab2bc5dc3cb1d3fb573fd1590c681e36e371342186bd331a4c
+  languageName: node
+  linkType: hard
+
+"commander@npm:^8.1.0":
+  version: 8.2.0
+  resolution: "commander@npm:8.2.0"
+  checksum: e41e680f2afa0a409aa21d3cad6f06a3d9d2d1086e76223ebd600181b588085e6ad0c7387cf491cb96c60de0a0a50815130368b40bfde017744210d4a8fb75a7
   languageName: node
   linkType: hard
 
@@ -9526,7 +10359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:^9.0.0":
+"copy-webpack-plugin@npm:^9.0.1":
   version: 9.0.1
   resolution: "copy-webpack-plugin@npm:9.0.1"
   dependencies:
@@ -9553,10 +10386,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js-compat@npm:^3.16.0, core-js-compat@npm:^3.16.2":
+  version: 3.18.3
+  resolution: "core-js-compat@npm:3.18.3"
+  dependencies:
+    browserslist: ^4.17.3
+    semver: 7.0.0
+  checksum: 9baf240ac712e97e54baa15fc5a1871d4ab0db0770a3bd6873d2464b328c98b79628dc8a9f991c4bc2d66148e1ea23e7c4e91b86f9c441506e4d9827dfa57651
+  languageName: node
+  linkType: hard
+
 "core-js-pure@npm:^3.0.0":
   version: 3.14.0
   resolution: "core-js-pure@npm:3.14.0"
   checksum: 8afceb673f05fd3fa384783f063b69f20f4f9a7963a66ac2330e3c63c14cb1e63b520e0195eba7019ee64bc3d5c3389000ef225b612dbadc8e1cfce7de54c907
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.16.0":
+  version: 3.18.3
+  resolution: "core-js-pure@npm:3.18.3"
+  checksum: 07ac3e103eaedec50ef8ce776ace608f802521f9a162108c628bd763f0e3f27c6605a8d8ef488925be3b5d638822d5b37d60ff0c105fe5338ba66ac7eeb4e41d
   languageName: node
   linkType: hard
 
@@ -9567,7 +10417,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.6.5, core-js@npm:^3.9.1":
+"core-js@npm:^3.18.0":
+  version: 3.18.3
+  resolution: "core-js@npm:3.18.3"
+  checksum: 01a927d02974a95313bc2325d9f832bbb4801c0c7e69639392574799f87041ce3dae52bdee3646c7cd58b4f38750a6093ca05363bf9f772be9c38dc69608c25c
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.6.5":
   version: 3.14.0
   resolution: "core-js@npm:3.14.0"
   checksum: fc830e61146f50241f431c711674a6af0a3633269a2a2afada3da1054f0c3b3a8b571fb4ca4c87d53193def47a4f56a18c32e832e6587b363ff0ff153508f300
@@ -9882,15 +10739,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-minimizer-webpack-plugin@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "css-minimizer-webpack-plugin@npm:3.0.2"
+"css-minimizer-webpack-plugin@npm:^3.0.2":
+  version: 3.1.1
+  resolution: "css-minimizer-webpack-plugin@npm:3.1.1"
   dependencies:
     cssnano: ^5.0.6
     jest-worker: ^27.0.2
     p-limit: ^3.0.2
     postcss: ^8.3.5
-    schema-utils: ^3.0.0
+    schema-utils: ^3.1.0
     serialize-javascript: ^6.0.0
     source-map: ^0.6.1
   peerDependencies:
@@ -9900,7 +10757,9 @@ __metadata:
       optional: true
     csso:
       optional: true
-  checksum: 179debffae069fe5ec44be5a0bb8bda0df48f0adae7fde1cbc266f2b28a9d5c5a13d843c22c8682279ac3bd0371bbfe78146cbf5e92538fccb6b662316f6cf2d
+    esbuild:
+      optional: true
+  checksum: 037827f89ba4fb9bf04295840591eb893f4d1ac0c7d5d5c86d7b412ccf80adfafe78beb2bbc26db04a2c1b7435cdd178b421fbadb8bfb4348344907847d44385
   languageName: node
   linkType: hard
 
@@ -10057,19 +10916,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-advanced@npm:^5.1.1":
-  version: 5.1.3
-  resolution: "cssnano-preset-advanced@npm:5.1.3"
+"cssnano-preset-advanced@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "cssnano-preset-advanced@npm:5.1.4"
   dependencies:
     autoprefixer: ^10.2.0
-    cssnano-preset-default: ^5.1.3
+    cssnano-preset-default: ^5.1.4
     postcss-discard-unused: ^5.0.1
     postcss-merge-idents: ^5.0.1
     postcss-reduce-idents: ^5.0.1
     postcss-zindex: ^5.0.1
   peerDependencies:
     postcss: ^8.2.15
-  checksum: fac9686e2d2dd7ef30467bf820724fdac018762960482d84a38898ea2ec3f6bb047e400743e3946c566235ec81355e8f9b86d0a2370d4008401dd24edd345044
+  checksum: c54e0fca95d9c61e310ea92fb8d753d9e3a1ffa4efe13349d1092bd0e3a5c1f502a8ca85928562b17159bdf8f6804c9d6069b0e3c97ba0d472b796cdebb683b3
   languageName: node
   linkType: hard
 
@@ -10150,6 +11009,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssnano-preset-default@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "cssnano-preset-default@npm:5.1.4"
+  dependencies:
+    css-declaration-sorter: ^6.0.3
+    cssnano-utils: ^2.0.1
+    postcss-calc: ^8.0.0
+    postcss-colormin: ^5.2.0
+    postcss-convert-values: ^5.0.1
+    postcss-discard-comments: ^5.0.1
+    postcss-discard-duplicates: ^5.0.1
+    postcss-discard-empty: ^5.0.1
+    postcss-discard-overridden: ^5.0.1
+    postcss-merge-longhand: ^5.0.2
+    postcss-merge-rules: ^5.0.2
+    postcss-minify-font-values: ^5.0.1
+    postcss-minify-gradients: ^5.0.2
+    postcss-minify-params: ^5.0.1
+    postcss-minify-selectors: ^5.1.0
+    postcss-normalize-charset: ^5.0.1
+    postcss-normalize-display-values: ^5.0.1
+    postcss-normalize-positions: ^5.0.1
+    postcss-normalize-repeat-style: ^5.0.1
+    postcss-normalize-string: ^5.0.1
+    postcss-normalize-timing-functions: ^5.0.1
+    postcss-normalize-unicode: ^5.0.1
+    postcss-normalize-url: ^5.0.2
+    postcss-normalize-whitespace: ^5.0.1
+    postcss-ordered-values: ^5.0.2
+    postcss-reduce-initial: ^5.0.1
+    postcss-reduce-transforms: ^5.0.1
+    postcss-svgo: ^5.0.2
+    postcss-unique-selectors: ^5.0.1
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 2c3e33496c2832e169070f0ad37226ab53d64274be8419f59fd37e826e2940772fc2789db9d4a07b95b1af4ec124dd010ef1209d1411b696730799bd185e6202
+  languageName: node
+  linkType: hard
+
 "cssnano-util-get-arguments@npm:^4.0.0":
   version: 4.0.0
   resolution: "cssnano-util-get-arguments@npm:4.0.0"
@@ -10201,7 +11099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:^5.0.2, cssnano@npm:^5.0.4, cssnano@npm:^5.0.6":
+"cssnano@npm:^5.0.2, cssnano@npm:^5.0.6":
   version: 5.0.6
   resolution: "cssnano@npm:5.0.6"
   dependencies:
@@ -10211,6 +11109,20 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 086ad98e2c55f2307ab3ca15c584d2ed8924456c3893a755155778bf2203ba5318699fefb4e91e15e6e4c4b38cb364c889e366ca44c95b3a4c9d34c23fedb9a2
+  languageName: node
+  linkType: hard
+
+"cssnano@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "cssnano@npm:5.0.8"
+  dependencies:
+    cssnano-preset-default: ^5.1.4
+    is-resolvable: ^1.1.0
+    lilconfig: ^2.0.3
+    yaml: ^1.10.2
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 9dfcd57d9f887d986443f6ed55a07b17a4d28e1c288cdfe05f4a2c2065513d94236062e1cb2847c9835db29011828fc6eef2de38b6872fe9d9e94ce97487dd0f
   languageName: node
   linkType: hard
 
@@ -10989,6 +11901,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.3.867":
+  version: 1.3.871
+  resolution: "electron-to-chromium@npm:1.3.871"
+  checksum: 9226692a6b8291047f220a1706b527d6952e4de37b2f87ead9374a3f7eb70989cf98156d333316e3e7d5b1c6cc93c8dd276807c41a94ee0f434e5807f2a84b76
+  languageName: node
+  linkType: hard
+
 "elegant-spinner@npm:^1.0.1":
   version: 1.0.1
   resolution: "elegant-spinner@npm:1.0.1"
@@ -11015,13 +11934,6 @@ __metadata:
   version: 0.7.2
   resolution: "emittery@npm:0.7.2"
   checksum: 34acfef51922a1b73d75cb658bf43ecb279633b263ffa831fb87697abbbd3aa4241ef15d204eeaa6a3c62656bd7563de7145c416a2bb18c4805e54ce6d7cdac6
-  languageName: node
-  linkType: hard
-
-"emoji-regex@npm:>=6.0.0 <=6.1.1":
-  version: 6.1.1
-  resolution: "emoji-regex@npm:6.1.1"
-  checksum: 1d35436f24d1a00d53451573271ee1ea01e8b978bcc105ac7677633c35c665a796c317086d39b19eda6261d1861415185e98e28d39d2437cd2a9fd3dfcc0f54a
   languageName: node
   linkType: hard
 
@@ -11730,10 +12642,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eta@npm:^1.12.1":
-  version: 1.12.1
-  resolution: "eta@npm:1.12.1"
-  checksum: 9a21474b544b596515ab8c4e7131effa36fa650a298ef12bdbe85146f169782315fdad83fc32c653e59629b441b7bfe2f98e1d1ed84705062fddcdc5701412f5
+"eta@npm:^1.12.3":
+  version: 1.12.3
+  resolution: "eta@npm:1.12.3"
+  checksum: 901654d8848028b872b13f392d540fec69c93e297b15faa2697d4cfb13bb007847c8b6cb9fbcf98e6bfc48703e96fee9a986513fc257068c87684c2db9439b11
   languageName: node
   linkType: hard
 
@@ -12774,12 +13686,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"github-slugger@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "github-slugger@npm:1.3.0"
-  dependencies:
-    emoji-regex: ">=6.0.0 <=6.1.1"
-  checksum: 1f5961777b75d2ce2df5ae8d16a1eba49145a9896c5808341ca4100894631a4182ab010dea260a8a22855ea89d383f61412507dd34977a67b3a641168af19e10
+"github-slugger@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "github-slugger@npm:1.4.0"
+  checksum: f6767047f38d6ed15024feae284286447ee11308af38b43422720ca39bb5a4197aa202e4673c5e97410192495689e953cea407e5e83c00360dea802ca3569c87
   languageName: node
   linkType: hard
 
@@ -12793,7 +13703,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.0, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.0":
+"glob-parent@npm:^5.1.0, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.0, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -13465,7 +14375,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"html-minifier-terser@npm:^5.0.1, html-minifier-terser@npm:^5.1.1":
+"html-minifier-terser@npm:^5.0.1":
   version: 5.1.1
   resolution: "html-minifier-terser@npm:5.1.1"
   dependencies:
@@ -13479,6 +14389,23 @@ fsevents@^1.2.7:
   bin:
     html-minifier-terser: cli.js
   checksum: d05dea891f5977a35691306b1fb40438cffd6620c2f5a69d7ecb67bfa836af1d36c24978edd1616dc6d27e230561bd756c5f11b3054e6ebf2f8448289e3ca73d
+  languageName: node
+  linkType: hard
+
+"html-minifier-terser@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "html-minifier-terser@npm:6.0.2"
+  dependencies:
+    camel-case: ^4.1.2
+    clean-css: ^5.1.5
+    commander: ^8.1.0
+    he: ^1.2.0
+    param-case: ^3.0.4
+    relateurl: ^0.2.7
+    terser: ^5.7.2
+  bin:
+    html-minifier-terser: cli.js
+  checksum: 1decfcbd28970b83aff6467a8053459b2a9ee0ae595fc2ab93e2bca00e3f3fe4169bb9a59b0d2ad18def45b946dea7e8c2ac856ddaf3520565e07a1945d358da
   languageName: node
   linkType: hard
 
@@ -13926,10 +14853,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"infima@npm:0.2.0-alpha.29":
-  version: 0.2.0-alpha.29
-  resolution: "infima@npm:0.2.0-alpha.29"
-  checksum: 15e7f4097c20f005b7ecb0b918e8857a88c0a1ec3f8bc3ec190befdc5422dd9b85e21011f82d33c3f6ef3d91f20ede85d2d0404e5e5a3abdbd8abdbc951b86fe
+"infima@npm:0.2.0-alpha.34":
+  version: 0.2.0-alpha.34
+  resolution: "infima@npm:0.2.0-alpha.34"
+  checksum: 654a348d79059cf1517f14b11723ee61625eca4b4cf28bb586de670e61140fde753671ede54af21fe81cf40c7e6c81c39409f3720aada36c4ec23567fd886fab
   languageName: node
   linkType: hard
 
@@ -15455,6 +16382,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^27.0.6":
+  version: 27.3.0
+  resolution: "jest-worker@npm:27.3.0"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 6129c7e4c199457c32eba4873c19193cdbff9c308dd40856ee47cd23999663e57f66bc67ac356fdfc85bfc03426f5aea1e76b2ea57748eedbe5fcf61c1da127f
+  languageName: node
+  linkType: hard
+
 "jest@npm:26.6.0":
   version: 26.6.0
   resolution: "jest@npm:26.6.0"
@@ -15488,7 +16426,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.3.0, joi@npm:^17.4.0":
+"joi@npm:^17.4.0":
   version: 17.4.0
   resolution: "joi@npm:17.4.0"
   dependencies:
@@ -15498,6 +16436,19 @@ fsevents@^1.2.7:
     "@sideway/formula": ^3.0.0
     "@sideway/pinpoint": ^2.0.0
   checksum: 2f6203d4513c063d457a935dab5e8060413479880d55af2c4fada987c7fe1bedff46d46eec36b14cf433ecc4df3b580fe1c0a0fed5b73a265b78011f97ff5c2d
+  languageName: node
+  linkType: hard
+
+"joi@npm:^17.4.2":
+  version: 17.4.2
+  resolution: "joi@npm:17.4.2"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+    "@hapi/topo": ^5.0.0
+    "@sideway/address": ^4.1.0
+    "@sideway/formula": ^3.0.0
+    "@sideway/pinpoint": ^2.0.0
+  checksum: 4aee05091f6d1dcd3dd5e9e286cd2b399b8f371327f81f3382750bbcf5c461387ab0c36a3c0377f2a80db6f1f04745a77a4bf8194674643d14ca7d47a079a2b0
   languageName: node
   linkType: hard
 
@@ -16443,7 +17394,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.25.0, magic-string@npm:^0.25.7":
+"magic-string@npm:^0.25.0, magic-string@npm:^0.25.3, magic-string@npm:^0.25.7":
   version: 0.25.7
   resolution: "magic-string@npm:0.25.7"
   dependencies:
@@ -17221,6 +18172,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.1.28":
+  version: 3.1.30
+  resolution: "nanoid@npm:3.1.30"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 440f685e9890bd96433cf6c01535165b1e9677ba4a5c4179e1a61612f0b4c428cc628425fe232038b93304d15b191892d7ced9503fa558d1296e4e95fe80a627
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -17414,6 +18374,13 @@ fsevents@^1.2.7:
   version: 1.1.72
   resolution: "node-releases@npm:1.1.72"
   checksum: a9ded860baa3c90fa6fde2e1be597959b238940cda1e5bbeceb5de6a16faa1db81982b629429fd6ebbec98f7dd241378cda5918a57c9baf68cb6a6e002b4fc15
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "node-releases@npm:2.0.0"
+  checksum: 072914baf9eab6cc4fb051935acf6a4f9974ab47224794375c817513ca3645dc9f3a65a821e9c6a6d54213e771c4d49db8cff0b6b8bb6b9b31424c815c716829
   languageName: node
   linkType: hard
 
@@ -18135,10 +19102,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"parse-numeric-range@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "parse-numeric-range@npm:1.2.0"
-  checksum: 40557750b3bd855a912fb0ef0754eef21497b7093fdc5da7d19afdd2d2c8ed1dae7299dfc49288fb55942a1e6a05e27b7780a9d5345dc0718c3c2531ebae9548
+"parse-numeric-range@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "parse-numeric-range@npm:1.3.0"
+  checksum: d051fd4f459cbfe75236216a12fdd90a62a4d2e8cb13008f9ae4c48602e79570d8ce11c413803c52d418c2599cd6a6040ea7692a35f404ca3942cb4b008e48f8
   languageName: node
   linkType: hard
 
@@ -18325,6 +19292,20 @@ fsevents@^1.2.7:
   version: 2.1.0
   resolution: "performance-now@npm:2.1.0"
   checksum: bb4ebed0b03d6c3ad3ae4eddd1182c895d385cff9096af441c19c130aaae3ea70229438ebc3297dfc52c86022f6becf177a810050823d01bf5280779cd2de624
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "picocolors@npm:0.2.1"
+  checksum: 84da675558ed004c61a7fa7b0bcce6338c8e3ef1eadb43b5263059d1d745f4567464aa6aa603c506a82942a5a7dfda5bb023605a5f4c9888d7adc154845d579e
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "picocolors@npm:1.0.0"
+  checksum: 6616d34dd03bde8881c63402dea34f0b5972845b04b791b234446d4a408bc3d7f932acea3970a6b671d8f5c5aae1b1ce9fc1f89b0ed9a363469cf9da8e916b71
   languageName: node
   linkType: hard
 
@@ -18878,17 +19859,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-loader@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "postcss-loader@npm:5.3.0"
+"postcss-loader@npm:^6.1.1":
+  version: 6.2.0
+  resolution: "postcss-loader@npm:6.2.0"
   dependencies:
     cosmiconfig: ^7.0.0
     klona: ^2.0.4
-    semver: ^7.3.4
+    semver: ^7.3.5
   peerDependencies:
     postcss: ^7.0.0 || ^8.0.1
     webpack: ^5.0.0
-  checksum: fd7a1a673b0e8f238392b3d449f2727767522febb2f60bfc9bb5cd4e373b07ba8df621f4e2fad92bf085765dcdea0f049497ae799ce1c9f1a592820275cc7e65
+  checksum: 2583b1d33c7ec964431adc768adfed1e339f59803bf6fbf6cc76226159cf01e67d7f83773e4926f183e44c9ce38ef82e52b2a1ef9d9e4288f789622fa97b6af8
   languageName: node
   linkType: hard
 
@@ -19019,6 +20000,19 @@ fsevents@^1.2.7:
   peerDependencies:
     postcss: ^8.2.15
   checksum: b5a401d189dc2720513ec34f63a46389a49dcd0f94d98b351117dd404d00ba0d7f9845151490ac5f5598e832bcfcb760819895dc04e5f3ef18fd39c7a47d8868
+  languageName: node
+  linkType: hard
+
+"postcss-minify-gradients@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "postcss-minify-gradients@npm:5.0.2"
+  dependencies:
+    colord: ^2.6
+    cssnano-utils: ^2.0.1
+    postcss-value-parser: ^4.1.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 1d518ae8ada6f1a301f0ad5275710a352aec7a57c75958256d6b3239ebb96cbbe5d5628bb90144bdf250ea01cc6f33ab9aefdd46f2980b0f58f2ec6885b244c7
   languageName: node
   linkType: hard
 
@@ -19637,14 +20631,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-sort-media-queries@npm:^3.10.11":
-  version: 3.11.12
-  resolution: "postcss-sort-media-queries@npm:3.11.12"
+"postcss-sort-media-queries@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "postcss-sort-media-queries@npm:4.1.0"
   dependencies:
-    sort-css-media-queries: 1.5.4
+    sort-css-media-queries: 2.0.4
   peerDependencies:
-    postcss: ^8.3.1
-  checksum: 18e378536f5aef6292e0e790329c135cf3087bb922314e5ff6ab17ede8eb1ea0d169deaaa2335de16887a3a4a6e8d357700b2d15bb4af630d4aa4ad3c84de460
+    postcss: ^8.3.6
+  checksum: b1f67387688e02c9b2719d80a83cfb95256ff51a43da0fbdf8773fa1d771b63ba6471ab6469e9a4e9cdd30a783a7ae4855cd01ae3cf307102bbe8f10cd314025
   languageName: node
   linkType: hard
 
@@ -19770,6 +20764,17 @@ fsevents@^1.2.7:
     nanoid: ^3.1.23
     source-map-js: ^0.6.2
   checksum: 87dc16efcf40286fad4ded0a433497ddbc55dfad3d7ddb200ba9c0761ec376280fa2c06a522628583c9284def85894c52bc361cffedf0679f4936370c084a145
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.3.7":
+  version: 8.3.9
+  resolution: "postcss@npm:8.3.9"
+  dependencies:
+    nanoid: ^3.1.28
+    picocolors: ^0.2.1
+    source-map-js: ^0.6.2
+  checksum: f67654ab01ec6ec9126eb5ed64b06f602dfce7e6a38aa7f4d3cdb67fe40fe97234286c5fd6769f56138206ea80e944c62f909052b00c351239064ef3b850664d
   languageName: node
   linkType: hard
 
@@ -20886,10 +21891,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"reading-time@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "reading-time@npm:1.3.0"
-  checksum: c1613eb67eacbe8b275da832d59c0dd3c957f9fc6d0ad71eff7ed6f601b8bffa28b8a9d28ae8f6a1e286adc6f719304b41166d7e34c4c3b1bd4893d266121554
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: ^2.2.1
+  checksum: 7da2fe8d5abf17ae0bf97a052718e16d29fa185f3e461153035728d93642326ae8e44c17b9a9b3a5fa616dff160e96be3184e0323efaac7211f80c0aab5f622b
+  languageName: node
+  linkType: hard
+
+"reading-time@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "reading-time@npm:1.5.0"
+  checksum: 2d2342095a8640dfa787dc44c52cfc567d9ed7143b86b28476e9e8ce521a2e3be7d0aa7ee30b5e5af430c0dc79ec8aa5afa745987c4538df322a478c2a69541d
   languageName: node
   linkType: hard
 
@@ -20945,7 +21959,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"regenerate@npm:^1.4.0":
+"regenerate-unicode-properties@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "regenerate-unicode-properties@npm:9.0.0"
+  dependencies:
+    regenerate: ^1.4.2
+  checksum: 39128612e6360b4434536f376cad0a6054bb6e64ca75a34eaca56786d72c10fed07d8e87fd5554ea0e93d9decd67db3d6214520f946694d9aa3e425469bdfc98
+  languageName: node
+  linkType: hard
+
+"regenerate@npm:^1.4.0, regenerate@npm:^1.4.2":
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 54275a99effd8a439bcdd88942b61f68a769133df841e90d94df9ae7c250cb6537c0a28dd913116539772b3415edbcb3c8d81c22275595d3755cf0353976dfa4
@@ -21009,6 +22032,20 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"regexpu-core@npm:^4.5.4":
+  version: 4.8.0
+  resolution: "regexpu-core@npm:4.8.0"
+  dependencies:
+    regenerate: ^1.4.2
+    regenerate-unicode-properties: ^9.0.0
+    regjsgen: ^0.5.2
+    regjsparser: ^0.7.0
+    unicode-match-property-ecmascript: ^2.0.0
+    unicode-match-property-value-ecmascript: ^2.0.0
+  checksum: b6171300e5b2544c53ad721026bacd12a5fd1a67afe289f2832504f04ab120702fdc4b7a8b46727b77e943f831e4c414474ea5ee733fbb549883025c14f534af
+  languageName: node
+  linkType: hard
+
 "regexpu-core@npm:^4.7.1":
   version: 4.7.1
   resolution: "regexpu-core@npm:4.7.1"
@@ -21041,7 +22078,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"regjsgen@npm:^0.5.1":
+"regjsgen@npm:^0.5.1, regjsgen@npm:^0.5.2":
   version: 0.5.2
   resolution: "regjsgen@npm:0.5.2"
   checksum: 629afab3d9ce61e104064cda66aca74ec9a1921151cc985d93c5cb58453ed7f7c23479bdb1a4a0826d200ed28c3871a7b8a8938e634ab00194195012893bccbc
@@ -21056,6 +22093,17 @@ fsevents@^1.2.7:
   bin:
     regjsparser: bin/parser
   checksum: ad533fe6ce6d156efb2a144a61166747317598069530205f9d9e3414e2642ff63eb59dbd7d01fcbc0daf18115b510d6494fa49ce30491f76c323695f3a16f2db
+  languageName: node
+  linkType: hard
+
+"regjsparser@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "regjsparser@npm:0.7.0"
+  dependencies:
+    jsesc: ~0.5.0
+  bin:
+    regjsparser: bin/parser
+  checksum: 0ab8823280290f99dfd3a0df3b457cc7ba1a3b290033cfbda521d7c9536bf5ef0642fecee72af27e5538951436881970466db6f68b03065018f4a4479aa45397
   languageName: node
   linkType: hard
 
@@ -21141,6 +22189,24 @@ fsevents@^1.2.7:
   version: 2.0.0
   resolution: "remark-footnotes@npm:2.0.0"
   checksum: fbf8224b7f84be15098847ff9dc31ba8886be16a83c42f69ea7aa81070cdfa121f7b694ff24adc54aea65beab4825e148e6ff8a145fee446befa0471ff0a780f
+  languageName: node
+  linkType: hard
+
+"remark-mdx-remove-exports@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "remark-mdx-remove-exports@npm:1.6.22"
+  dependencies:
+    unist-util-remove: 2.0.0
+  checksum: e868a3372e5b86fe6b6ce84951c02791d5fdc01b1bdd3c492cad9f659952161fe00db251894faa7b17ba73e538b5010144fd99325019eebceb538306172b4328
+  languageName: node
+  linkType: hard
+
+"remark-mdx-remove-imports@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "remark-mdx-remove-imports@npm:1.6.22"
+  dependencies:
+    unist-util-remove: 2.0.0
+  checksum: 42cf716898db678ba5d6566ff032bfc0916096429f5519e8d921aa2fee34a38bb3a7cbddfaeff95f251079077625377e79e05e120a28996e3f82b32461e460dd
   languageName: node
   linkType: hard
 
@@ -21715,16 +22781,16 @@ resolve@~1.19.0:
   languageName: unknown
   linkType: soft
 
-"rtl-detect@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "rtl-detect@npm:1.0.3"
-  checksum: 8ec281630d1e7fc5c1d409f65dc7e9637e9c81527f96420c439f44a5d73d0fe8b8936867a9628d4198ecac39d4f5cc8b4b04c3681d3fb3aa49bffe2f87bd4c95
+"rtl-detect@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "rtl-detect@npm:1.0.4"
+  checksum: 63e6b4a1e6ff0e8df91d2c0ed76c2c0626ec35844cc8912f80d371dd2e9f1a6f48636ae315fe2e25c6136fe606038894ef9bab3b264cd2769c95ec4198a08f21
   languageName: node
   linkType: hard
 
-"rtlcss@npm:^3.1.2":
-  version: 3.2.0
-  resolution: "rtlcss@npm:3.2.0"
+"rtlcss@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "rtlcss@npm:3.3.0"
   dependencies:
     chalk: ^4.1.0
     find-up: ^5.0.0
@@ -21735,7 +22801,7 @@ resolve@~1.19.0:
     postcss: ^8.2.4
   bin:
     rtlcss: bin/rtlcss.js
-  checksum: cd176f407f4db6912e49ebb645bc6f5a7b0e26ce50e302f52aeb4e2909481f8d8a2694b9ba5faacb4a698d6a9ceef09eb7bd5ddd9574ab493fa971cb78b72c19
+  checksum: c5fbd799a5d2463b9b521396015bd28c5225e43d0eae1c3e8298d684b8cae38d3ae564e6df450b2b8e1a981315f67014fdaa1aa99081f5af9a9f5cd67a63f2a4
   languageName: node
   linkType: hard
 
@@ -21770,6 +22836,15 @@ resolve@~1.19.0:
   dependencies:
     tslib: ^1.9.0
   checksum: 1146975cbd5388ee5e61450235dc5670931e43cce71813f567977d334acc4d75c6e8d9d293df67e1fb31510b99fc8957943d4a9b550d109e4dc69967a8471543
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.1.0":
+  version: 7.4.0
+  resolution: "rxjs@npm:7.4.0"
+  dependencies:
+    tslib: ~2.1.0
+  checksum: e58ecc0496ba710fcf00238f1fd44968f7133e87a0a43c244e508494425c188f20078905fa397c427d270cc6496b62d07de7bb3252d71c93d62d13cdc958b577
   languageName: node
   linkType: hard
 
@@ -21926,6 +23001,17 @@ resolve@~1.19.0:
     ajv: ^6.12.5
     ajv-keywords: ^3.5.2
   checksum: a084f593f222560c412a4d8f40c92386c01c1c709f27c0672c2f02927a4d4d475f57f8b8e91198d0defb452add160476a03f07a05b26200a64b5124fa874e158
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "schema-utils@npm:3.1.1"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: c4f4c4c511a07ac7a0be5bf1da60b1756753effc3ff9c1f5153b0238f7e293aa4494466fb436b0a778d63e70e8e6b2cd6ac1d7a1cce176dde6e3f3e3a31d2962
   languageName: node
   linkType: hard
 
@@ -22494,10 +23580,10 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
-"sort-css-media-queries@npm:1.5.4":
-  version: 1.5.4
-  resolution: "sort-css-media-queries@npm:1.5.4"
-  checksum: d45cfe2578438bdc88dae0aed9f6d6bca98ae62f0bc4ac8e27dd753a75a7676116b97a5b959aad6c2b0bc71f12b8cc8713cdc170bd251b99c0a1c33d663ad75b
+"sort-css-media-queries@npm:2.0.4":
+  version: 2.0.4
+  resolution: "sort-css-media-queries@npm:2.0.4"
+  checksum: 4785c3436ee306bff5f1896dfe069eeeb3ec287bdb8687e7a545aa3595e2329689938ec2e2a1a68093e6fae1447a4eeb7098e685ba1306331ccad030ab836212
   languageName: node
   linkType: hard
 
@@ -22544,6 +23630,16 @@ resolve@~1.19.0:
     buffer-from: ^1.0.0
     source-map: ^0.6.0
   checksum: 59d4efaae97755155b078413ecba63517e3ef054cc7ab767bbd30e6f3054be2ae8e8f5cce7eef53b7eb93e98fe27a58dd8f5e7abfb13144ba420ddaf5267bbb2
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:~0.5.20":
+  version: 0.5.20
+  resolution: "source-map-support@npm:0.5.20"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 2c5821ee94732b2ddbb1e1d9e61ed76ef00f72415fa686ab96d5f5c711789d55424866fa7d6c493beea380e44418053d86ec490b82c101008eac311463da84a9
   languageName: node
   linkType: hard
 
@@ -23421,6 +24517,29 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
+"terser-webpack-plugin@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "terser-webpack-plugin@npm:5.2.4"
+  dependencies:
+    jest-worker: ^27.0.6
+    p-limit: ^3.1.0
+    schema-utils: ^3.1.1
+    serialize-javascript: ^6.0.0
+    source-map: ^0.6.1
+    terser: ^5.7.2
+  peerDependencies:
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 6ba5e19dcfbb81643d8a4865e841ea0b2ad2e59ab59528fd1617fed3139113a0cee682c65223f9f4176d16cda49076f2430a33fbef132908a4a1b1a6cab4ef77
+  languageName: node
+  linkType: hard
+
 "terser@npm:^4.1.2, terser@npm:^4.6.2, terser@npm:^4.6.3":
   version: 4.8.0
   resolution: "terser@npm:4.8.0"
@@ -23444,6 +24563,19 @@ resolve@~1.19.0:
   bin:
     terser: bin/terser
   checksum: 9604fed5b093ee8000282cc69b07ff7a4e651aa13cb6e34055bf77592a4e1d0fed80c19ee80fe3a4e92f5485badcafb5aeed414fe8b5b7185599707236111900
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.7.2":
+  version: 5.9.0
+  resolution: "terser@npm:5.9.0"
+  dependencies:
+    commander: ^2.20.0
+    source-map: ~0.7.2
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: 7603e5a3dc0317cc4b3251e855aa90ef397b03780a1d0d747b20b832d857b50d4c017b1342007f562e20e3e538044daa71e5addd5ab6aad64ee926c5d4b0c88f
   languageName: node
   linkType: hard
 
@@ -23842,10 +24974,17 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:~2.3.0":
+"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:~2.3.0":
   version: 2.3.0
   resolution: "tslib@npm:2.3.0"
   checksum: 7b4fc9feff0f704743c3760f5d8d708f6417fac6458159e63df3a6b1100f0736e3b99edb9fe370f274ad15160a1f49ff05cb49402534c818ff552c48e38c3e6e
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "tslib@npm:2.3.1"
+  checksum: 5ae2f209c5127bad284974c78916f02c72082615f65889a7ed0c7ca6d5f935c30338a0ee7310e1d9652dabc7b7507fd2905035487446d09d45fc1f19de71cf05
   languageName: node
   linkType: hard
 
@@ -24068,6 +25207,13 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
+"unicode-canonical-property-names-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
+  checksum: d5c02b4d5a450f99f20b93b11915302bea95a54cb5c728fd37cdafcc678e3df8b76961071d4ed1767914e0b989b72b5428d407779a102d13cbc59305503c6c69
+  languageName: node
+  linkType: hard
+
 "unicode-match-property-ecmascript@npm:^1.0.4":
   version: 1.0.4
   resolution: "unicode-match-property-ecmascript@npm:1.0.4"
@@ -24078,6 +25224,16 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
+"unicode-match-property-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-match-property-ecmascript@npm:2.0.0"
+  dependencies:
+    unicode-canonical-property-names-ecmascript: ^2.0.0
+    unicode-property-aliases-ecmascript: ^2.0.0
+  checksum: b765c345723332af6ed583de33325a8f534af9c7f034bee3efd76348dee7625689c0e304c84b98ecdf628ce073dd46f8b70da3fb635644288edbf78ca1afd473
+  languageName: node
+  linkType: hard
+
 "unicode-match-property-value-ecmascript@npm:^1.2.0":
   version: 1.2.0
   resolution: "unicode-match-property-value-ecmascript@npm:1.2.0"
@@ -24085,10 +25241,24 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
+"unicode-match-property-value-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-match-property-value-ecmascript@npm:2.0.0"
+  checksum: 055269931710d52fed29fbdb7f5097992a0b85776e3471355e157cc0fc1f1a793d2c8226d34b06c073b4929a24298850c71b5238ce1f18cfb3ac31db7fbff11a
+  languageName: node
+  linkType: hard
+
 "unicode-property-aliases-ecmascript@npm:^1.0.4":
   version: 1.1.0
   resolution: "unicode-property-aliases-ecmascript@npm:1.1.0"
   checksum: 2fa80e62a6ec395af3ee4747ce9738d2fee25ef963fb5650e358b2eb878d7f047f5ccdbd5f92e9605d13276f995fc3c4e3084475b03722cdd7ce9d58a148b2bd
+  languageName: node
+  linkType: hard
+
+"unicode-property-aliases-ecmascript@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-property-aliases-ecmascript@npm:2.0.0"
+  checksum: 7e470e0355be45eda46a05bae35d5754cc3277f5fbdaf4b4745a1d9d638f4da98704d7c206535d29e601850792bd364854de75061e1af1f9b29e78dd573734b7
   languageName: node
   linkType: hard
 
@@ -24222,6 +25392,15 @@ resolve@~1.19.0:
   dependencies:
     unist-util-visit: ^2.0.0
   checksum: 0b1a7046c45ab74da969ff269d4fad711d4e15e2dba6f6aa9020845b0a4c2a2733d9fdd437ad46da49be6146f88fbc66db92ee8c45c6d195943003303dc2f8b0
+  languageName: node
+  linkType: hard
+
+"unist-util-remove@npm:2.0.0":
+  version: 2.0.0
+  resolution: "unist-util-remove@npm:2.0.0"
+  dependencies:
+    unist-util-is: ^4.0.0
+  checksum: 7e79d9f95d14ad9697d80e5e74094262d6a2bf207cff75b079257f1123c614b30a9192007724e9cea10f598cb1b16fc243ed0ef7bce71c56253b17127a2f0c08
   languageName: node
   linkType: hard
 
@@ -24712,18 +25891,18 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
-"wait-on@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "wait-on@npm:5.3.0"
+"wait-on@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "wait-on@npm:6.0.0"
   dependencies:
     axios: ^0.21.1
-    joi: ^17.3.0
+    joi: ^17.4.0
     lodash: ^4.17.21
     minimist: ^1.2.5
-    rxjs: ^6.6.3
+    rxjs: ^7.1.0
   bin:
     wait-on: bin/wait-on
-  checksum: 405cad859a3ede2b48ebe7a3e39e543adff21333ac3e309b1469bffa71952db0c0920bebabf5d7282e8709bd43c2bab312ed6e764cdae149986b57dc0b263ff9
+  checksum: c43c09f02b0b23582150cab4d6779e76fa511f78dc920ce892c3ccd4cc9e342726ef993c2186fead7f5760d8ea2b01bcab6b2fd075ffdfa97a1db0957345a568
   languageName: node
   linkType: hard
 
@@ -25138,8 +26317,8 @@ resolve@~1.19.0:
   version: 0.0.0-use.local
   resolution: "website@workspace:website"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/preset-classic": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/preset-classic": 2.0.0-beta.7
     classnames: ^2.2.6
     netlify-plugin-cache: ^1.0.3
     react: 17.0.2


### PR DESCRIPTION
Closes #1487 (see https://github.com/facebook/docusaurus/pull/5694 for implementation)

| Before (`Examples` obscured) | After (`Examples` shown correctly) |
|-----------------------|-------------------------|
|              ![2021-10-18 21_25_20-Window](https://user-images.githubusercontent.com/22929669/137714192-a04291b6-4728-4956-bc27-66735f28b8c5.png)         |          ![2021-10-18 21_25_27-Window](https://user-images.githubusercontent.com/22929669/137714214-8a201941-2c13-4433-9690-0b866db5ca87.png)              |


Toggling between TS/JS tabs will now retain the page position (see https://github.com/facebook/docusaurus/pull/5618 for implementation)

| Before (page jumping) | After (no page jumping) |
|-----------------------|-------------------------|
|            ![tab-page-position-before](https://user-images.githubusercontent.com/22929669/137714324-c2e34388-f796-486a-9065-ccc6b9f30af5.gif)           |           ![tab-page-position-after](https://user-images.githubusercontent.com/22929669/137714335-b3402419-6dd0-487d-8640-35d99542b565.gif)              |