### PR TITLE
split off signature without `AsyncThunkConfig` for better inference

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -423,10 +423,35 @@ export type AsyncThunk<
  *
  * @public
  */
+// separate signature without `AsyncThunkConfig` for better inference
+export function createAsyncThunk<Returned, ThunkArg = void>(
+  typePrefix: string,
+  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, {}>,
+  options?: AsyncThunkOptions<ThunkArg, {}>
+): AsyncThunk<Returned, ThunkArg, {}>
+
+/**
+ *
+ * @param typePrefix
+ * @param payloadCreator
+ * @param options
+ *
+ * @public
+ */
 export function createAsyncThunk<
   Returned,
-  ThunkArg = void,
-  ThunkApiConfig extends AsyncThunkConfig = {}
+  ThunkArg,
+  ThunkApiConfig extends AsyncThunkConfig
+>(
+  typePrefix: string,
+  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>,
+  options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>
+): AsyncThunk<Returned, ThunkArg, ThunkApiConfig>
+
+export function createAsyncThunk<
+  Returned,
+  ThunkArg,
+  ThunkApiConfig extends AsyncThunkConfig
 >(
   typePrefix: string,
   payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>,
@@ -533,7 +558,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
     return (dispatch, getState, extra) => {
       const requestId = options?.idGenerator
         ? options.idGenerator(arg)
-        : nanoid();
+        : nanoid()
 
       const abortController = new AC()
       let abortReason: string | undefined

--- a/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
@@ -481,8 +481,13 @@ const anyAction = { type: 'foo' } as AnyAction
 {
   // return values
   createAsyncThunk<'ret', void, {}>('test', (_, api) => 'ret' as const)
+  createAsyncThunk<'ret', void, {}>('test', async (_, api) => 'ret' as const)
   createAsyncThunk<'ret', void, { fulfilledMeta: string }>('test', (_, api) =>
     api.fulfillWithValue('ret' as const, '')
+  )
+  createAsyncThunk<'ret', void, { fulfilledMeta: string }>(
+    'test',
+    async (_, api) => api.fulfillWithValue('ret' as const, '')
   )
   createAsyncThunk<'ret', void, { fulfilledMeta: string }>(
     'test',
@@ -490,17 +495,34 @@ const anyAction = { type: 'foo' } as AnyAction
     (_, api) => 'ret' as const
   )
   createAsyncThunk<'ret', void, { fulfilledMeta: string }>(
+    'test',
+    // @ts-expect-error has to be a fulfilledWithValue call
+    async (_, api) => 'ret' as const
+  )
+  createAsyncThunk<'ret', void, { fulfilledMeta: string }>(
     'test', // @ts-expect-error should only allow returning with 'test'
     (_, api) => api.fulfillWithValue(5, '')
+  )
+  createAsyncThunk<'ret', void, { fulfilledMeta: string }>(
+    'test', // @ts-expect-error should only allow returning with 'test'
+    async (_, api) => api.fulfillWithValue(5, '')
   )
 
   // reject values
   createAsyncThunk<'ret', void, { rejectValue: string }>('test', (_, api) =>
     api.rejectWithValue('ret')
   )
+  createAsyncThunk<'ret', void, { rejectValue: string }>(
+    'test',
+    async (_, api) => api.rejectWithValue('ret')
+  )
   createAsyncThunk<'ret', void, { rejectValue: string; rejectedMeta: number }>(
     'test',
     (_, api) => api.rejectWithValue('ret', 5)
+  )
+  createAsyncThunk<'ret', void, { rejectValue: string; rejectedMeta: number }>(
+    'test',
+    async (_, api) => api.rejectWithValue('ret', 5)
   )
   createAsyncThunk<'ret', void, { rejectValue: string; rejectedMeta: number }>(
     'test',
@@ -513,7 +535,17 @@ const anyAction = { type: 'foo' } as AnyAction
   )
   createAsyncThunk<'ret', void, { rejectValue: string; rejectedMeta: number }>(
     'test',
+    // @ts-expect-error wrong rejectedMeta type
+    async (_, api) => api.rejectWithValue('ret', '')
+  )
+  createAsyncThunk<'ret', void, { rejectValue: string; rejectedMeta: number }>(
+    'test',
     // @ts-expect-error wrong rejectValue type
     (_, api) => api.rejectWithValue(5, '')
+  )
+  createAsyncThunk<'ret', void, { rejectValue: string; rejectedMeta: number }>(
+    'test',
+    // @ts-expect-error wrong rejectValue type
+    async (_, api) => api.rejectWithValue(5, '')
   )
 }


### PR DESCRIPTION
This supersedes #1626 and fixes #1605.

@loursbourg could you please give this a try?