### PR TITLE
feat: generic type for `BaseQueryApi`

### DIFF
--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -25,10 +25,11 @@ export type BaseQueryFn<
   Result = unknown,
   Error = unknown,
   DefinitionExtraOptions = {},
-  Meta = {}
+  Meta = {},
+  QueryApi extends BaseQueryApi = BaseQueryApi,
 > = (
   args: Args,
-  api: BaseQueryApi,
+  api: QueryApi,
   extraOptions: DefinitionExtraOptions
 ) => MaybePromise<QueryReturnValue<Result, Error, Meta>>
 


### PR DESCRIPTION
## Description 

This pull request is to see if it's needed or not, or if it's useful or not to have generic type for BaseQueryAPI which can be different based on the extra argument that we inject at store level https://github.com/reduxjs/redux-toolkit/issues/1685 

I didn't test this example, this might not work