### PR TITLE
allow for circular references by building reducer lazily on first reducer call

### DIFF
--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -1,4 +1,5 @@
-import type { Reducer } from 'redux'
+import type { AnyAction, Reducer } from 'redux'
+import { createNextState } from '.'
 import type {
   ActionCreatorWithoutPayload,
   PayloadAction,
@@ -7,7 +8,11 @@ import type {
   _ActionCreatorWithPreparedPayload,
 } from './createAction'
 import { createAction } from './createAction'
-import type { CaseReducer, CaseReducers } from './createReducer'
+import type {
+  CaseReducer,
+  CaseReducers,
+  ReducerWithInitialState,
+} from './createReducer'
 import { createReducer, NotFunction } from './createReducer'
 import type { ActionReducerMapBuilder } from './mapBuilders'
 import { executeReducerBuilderCallback } from './mapBuilders'
@@ -253,19 +258,16 @@ export function createSlice<
 >(
   options: CreateSliceOptions<State, CaseReducers, Name>
 ): Slice<State, CaseReducers, Name> {
-  const { name, initialState } = options
+  const { name } = options
   if (!name) {
     throw new Error('`name` is a required option for createSlice')
   }
+  const initialState =
+    typeof options.initialState == 'function'
+      ? options.initialState
+      : createNextState(options.initialState, () => {})
+
   const reducers = options.reducers || {}
-  const [
-    extraReducers = {},
-    actionMatchers = [],
-    defaultCaseReducer = undefined,
-  ] =
-    typeof options.extraReducers === 'function'
-      ? executeReducerBuilderCallback(options.extraReducers)
-      : [options.extraReducers]
 
   const reducerNames = Object.keys(reducers)
 
@@ -294,19 +296,36 @@ export function createSlice<
       : createAction(type)
   })
 
-  const finalCaseReducers = { ...extraReducers, ...sliceCaseReducersByType }
-  const reducer = createReducer(
-    initialState,
-    finalCaseReducers as any,
-    actionMatchers,
-    defaultCaseReducer
-  )
+  function buildReducer() {
+    const [
+      extraReducers = {},
+      actionMatchers = [],
+      defaultCaseReducer = undefined,
+    ] =
+      typeof options.extraReducers === 'function'
+        ? executeReducerBuilderCallback(options.extraReducers)
+        : [options.extraReducers]
+
+    const finalCaseReducers = { ...extraReducers, ...sliceCaseReducersByType }
+    return createReducer(
+      initialState,
+      finalCaseReducers as any,
+      actionMatchers,
+      defaultCaseReducer
+    )
+  }
+
+  let _reducer: ReducerWithInitialState<State>
 
   return {
     name,
-    reducer,
+    reducer(state, action) {
+      return (_reducer ??= buildReducer())(state, action)
+    },
     actions: actionCreators as any,
     caseReducers: sliceCaseReducersByName as any,
-    getInitialState: reducer.getInitialState,
+    getInitialState() {
+      return (_reducer ??= buildReducer()).getInitialState()
+    },
   }
 }

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -320,12 +320,16 @@ export function createSlice<
   return {
     name,
     reducer(state, action) {
-      return (_reducer ??= buildReducer())(state, action)
+      if (!_reducer) _reducer = buildReducer()
+
+      return _reducer(state, action)
     },
     actions: actionCreators as any,
     caseReducers: sliceCaseReducersByName as any,
     getInitialState() {
-      return (_reducer ??= buildReducer()).getInitialState()
+      if (!_reducer) _reducer = buildReducer()
+
+      return _reducer.getInitialState()
     },
   }
 }


### PR DESCRIPTION
This would solve most long-standing problem of circular references between slices by calling the builder callback lazily when the reducer is called first instead of immediately on reducer creation.