### PR TITLE
fix: use correct working directory for CLI test

### DIFF
--- a/packages/rtk-query-codegen-openapi/test/cli.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/cli.test.ts
@@ -5,8 +5,10 @@ import path from 'path';
 import del from 'del';
 
 function cli(args: string[], cwd: string): Promise<{ error: ExecException | null; stdout: string; stderr: string }> {
-  const cmd = `${require.resolve('ts-node/dist/bin')} -T -P ${path.resolve('./tsconfig.json')} ${path.resolve(
-    './src/bin/cli.ts'
+  const pwd = (process.env && process.env.PWD) || '.';
+  const cmd = `${require.resolve('ts-node/dist/bin')} -T -P ${path.resolve(pwd, 'tsconfig.json')} ${path.resolve(
+    pwd,
+    'src/bin/cli.ts'
   )} ${args.join(' ')}`;
   return new Promise((resolve) => {
     exec(cmd, { cwd }, (error, stdout, stderr) => {


### PR DESCRIPTION
I had some time to investigate this issue, and I think I found the root cause (and a fix). Test actions run successfully both locally and on actions: https://github.com/Lokaltog/redux-toolkit/runs/4130398633

    GitHub actions override the working directory in tests, which causes
    `path.resolve` to point to nonexisting files. There are some mentions of
    similar issues on SO.
    
    This fix resolves paths from `process.env.PWD` which points to the
    process working directory which is set correctly both on local runs and
    GitHub actions.

Update: The pipeline is still failing, but the issue appears unrelated to this PR. I'm unable to reproduce the build issue locally, and from the logs it appears related to the GraphQL generator.