### PR TITLE
[action-listener-middleware] add error handling

### DIFF
--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -100,6 +100,8 @@ Current options are:
 
 - `extra`: an optional "extra argument" that will be injected into the `listenerApi` parameter of each listener. Equivalent to [the "extra argument" in the Redux Thunk middleware](https://redux.js.org/usage/writing-logic-thunks#injecting-config-values-into-thunks).
 
+- `onError`: an optional error handler that gets called with synchronous errors raised by `listener` and `predicate`.
+
 ### `listenerMiddleware.addListener(predicate, listener, options?) : Unsubscribe`
 
 Statically adds a new listener callback to the middleware.


### PR DESCRIPTION
Context:

- https://github.com/reduxjs/redux-toolkit/pull/547#discussion_r659277212

- https://github.com/reduxjs/redux-toolkit/discussions/1648


```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run build

No name was provided for external module '@reduxjs/toolkit' in output.globals – guessing 'toolkit'
Build "actionListenerMiddleware" to dist:
       1534 B: index.js.gz
       1387 B: index.js.br
       1054 B: index.modern.js.gz
        946 B: index.modern.js.br
       1534 B: index.module.js.gz
       1390 B: index.module.js.br
       1603 B: index.umd.js.gz
       1438 B: index.umd.js.br
  ```