### PR TITLE
Update usePrefetchImmediately snippet

### DIFF
--- a/docs/rtk-query/usage/prefetching.mdx
+++ b/docs/rtk-query/usage/prefetching.mdx
@@ -89,9 +89,9 @@ export function usePrefetchImmediately<T extends EndpointNames>(
   arg: Parameters<typeof api.endpoints[T]['initiate']>[0],
   options: PrefetchOptions = {}
 ) {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   useEffect(() => {
-    dispatch(api.util.prefetch(endpoint, arg, options))
+    dispatch(api.util.prefetch(endpoint, arg as any, options))
   }, [])
 }
 


### PR DESCRIPTION
I opted to show using `useAppDispatch` here, even though it would be fine to `useDispatch`. I figured being that we're showing types, it's probably worthwhile to encourage it.

I thought about including that if you were to provide `options` that you'd want to memo them, but also feel like that goes beyond this scope.