### PR TITLE
Only set originalArgs if they're not undefined

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -37,7 +37,6 @@ import {
   copyWithStructuralSharing,
 } from '../utils'
 import type { ApiContext } from '../apiTypes'
-import { defaultMemoize } from 'reselect'
 
 function updateQuerySubstateIfExists(
   state: QueryState<any>,
@@ -145,7 +144,9 @@ export function buildSlice({
           updateQuerySubstateIfExists(draft, arg.queryCacheKey, (substate) => {
             substate.status = QueryStatus.pending
             substate.requestId = meta.requestId
-            substate.originalArgs = arg.originalArgs
+            if (typeof arg.originalArgs !== 'undefined') {
+              substate.originalArgs = arg.originalArgs
+            }
             substate.startedTimeStamp = meta.startedTimeStamp
           })
         })

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -144,7 +144,7 @@ export function buildSlice({
           updateQuerySubstateIfExists(draft, arg.queryCacheKey, (substate) => {
             substate.status = QueryStatus.pending
             substate.requestId = meta.requestId
-            if (typeof arg.originalArgs !== 'undefined') {
+            if (arg.originalArgs !== undefined) {
               substate.originalArgs = arg.originalArgs
             }
             substate.startedTimeStamp = meta.startedTimeStamp


### PR DESCRIPTION
Fixes #1709. 

I believe we can just skip setting this property in the substate when it's `undefined`. I double-checked all of the invalidation behavior and this appears to be a non-issue. 

For a user that uses `originalArgs`, there is no difference in the check they'd have to use for this anyways?

https://codesandbox.io/s/rtkq-beta-ssr-repro-7q819 - CSB running this build