### PR TITLE
match endpoints with a function, exclude endpoints

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -15,7 +15,7 @@ import {
 } from 'oazapfts/lib/codegen/tscodegen';
 import type { OpenAPIV3 } from 'openapi-types';
 import { generateReactHooks } from './generators/react-hooks';
-import type { EndpointOverrides, GenerationOptions, OperationDefinition } from './types';
+import type { EndpointMatcher, EndpointOverrides, GenerationOptions, OperationDefinition, TextMatcher } from './types';
 import { capitalize, getOperationDefinitions, getV3Doc, isQuery as testIsQuery, removeUndefined } from './utils';
 import type { ObjectPropertyDefinitions } from './codegen';
 import { generateCreateApiCall, generateEndpointDefinition, generateImportNode } from './codegen';
@@ -33,14 +33,23 @@ function getOperationName({ verb, path, operation }: Pick<OperationDefinition, '
   return _getOperationName(verb, path, operation.operationId);
 }
 
-function patternMatches(pattern?: string | RegExp | (string | RegExp)[]) {
+function patternMatches(pattern?: TextMatcher) {
   const filters = Array.isArray(pattern) ? pattern : [pattern];
-  return function matcher(operationDefinition: OperationDefinition) {
+  return function matcher(operationName: string) {
     if (!pattern) return true;
-    const operationName = getOperationName(operationDefinition);
     return filters.some((filter) =>
       typeof filter === 'string' ? filter === operationName : filter?.test(operationName)
     );
+  };
+}
+
+function operationMatches(pattern?: EndpointMatcher, negative?: boolean) {
+  const checkMatch = typeof pattern === 'function' ? pattern : patternMatches(pattern);
+  return function matcher(operationDefinition: OperationDefinition) {
+    if (!pattern) return true;
+    const operationName = getOperationName(operationDefinition);
+    const matches = checkMatch(operationName, operationDefinition);
+    return negative ? !matches : matches;
   };
 }
 
@@ -48,7 +57,7 @@ export function getOverrides(
   operation: OperationDefinition,
   endpointOverrides?: EndpointOverrides[]
 ): EndpointOverrides | undefined {
-  return endpointOverrides?.find((override) => patternMatches(override.pattern)(operation));
+  return endpointOverrides?.find((override) => operationMatches(override.pattern)(operation));
 }
 
 export async function generateApi(
@@ -63,6 +72,7 @@ export async function generateApi(
     outputFile,
     isDataResponse = defaultIsDataResponse,
     filterEndpoints,
+    excludeEndpoints,
     endpointOverrides,
   }: GenerationOptions
 ) {
@@ -70,7 +80,9 @@ export async function generateApi(
 
   const apiGen = new ApiGenerator(v3Doc, {});
 
-  const operationDefinitions = getOperationDefinitions(v3Doc).filter(patternMatches(filterEndpoints));
+  const operationDefinitions = getOperationDefinitions(v3Doc)
+    .filter(operationMatches(filterEndpoints, false))
+    .filter(operationMatches(excludeEndpoints, true));
 
   const resultFile = ts.createSourceFile(
     'someFileName.ts',

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -43,13 +43,12 @@ function patternMatches(pattern?: TextMatcher) {
   };
 }
 
-function operationMatches(pattern?: EndpointMatcher, negative?: boolean) {
+function operationMatches(pattern?: EndpointMatcher) {
   const checkMatch = typeof pattern === 'function' ? pattern : patternMatches(pattern);
   return function matcher(operationDefinition: OperationDefinition) {
     if (!pattern) return true;
     const operationName = getOperationName(operationDefinition);
-    const matches = checkMatch(operationName, operationDefinition);
-    return negative ? !matches : matches;
+    return checkMatch(operationName, operationDefinition);
   };
 }
 
@@ -72,7 +71,6 @@ export async function generateApi(
     outputFile,
     isDataResponse = defaultIsDataResponse,
     filterEndpoints,
-    excludeEndpoints,
     endpointOverrides,
   }: GenerationOptions
 ) {
@@ -80,9 +78,7 @@ export async function generateApi(
 
   const apiGen = new ApiGenerator(v3Doc, {});
 
-  const operationDefinitions = getOperationDefinitions(v3Doc)
-    .filter(operationMatches(filterEndpoints, false))
-    .filter(operationMatches(excludeEndpoints, true));
+  const operationDefinitions = getOperationDefinitions(v3Doc).filter(operationMatches(filterEndpoints));
 
   const resultFile = ts.createSourceFile(
     'someFileName.ts',

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -55,9 +55,9 @@ export interface CommonOptions {
 
 export type TextMatcher = string | RegExp | (string | RegExp)[];
 
-export type EndpointMatchFunction = (operationName: string, operationDefinition: OperationDefinition) => boolean;
+export type EndpointMatcherFunction = (operationName: string, operationDefinition: OperationDefinition) => boolean;
 
-export type EndpointMatcher = TextMatcher | EndpointMatchFunction;
+export type EndpointMatcher = TextMatcher | EndpointMatcherFunction;
 
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -53,14 +53,21 @@ export interface CommonOptions {
   hooks?: boolean;
 }
 
+export type TextMatcher = string | RegExp | (string | RegExp)[];
+
+export type EndpointMatchFunction = (operationName: string, operationDefinition: OperationDefinition) => boolean;
+
+export type EndpointMatcher = TextMatcher | EndpointMatchFunction;
+
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;
-  filterEndpoints?: string | RegExp | (string | RegExp)[];
+  filterEndpoints?: EndpointMatcher;
+  excludeEndpoints?: EndpointMatcher;
   endpointOverrides?: EndpointOverrides[];
 }
 
 export interface EndpointOverrides {
-  pattern: string | RegExp | (string | RegExp)[];
+  pattern: EndpointMatcher;
   type: 'mutation' | 'query';
 }
 

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -62,7 +62,6 @@ export type EndpointMatcher = TextMatcher | EndpointMatchFunction;
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;
   filterEndpoints?: EndpointMatcher;
-  excludeEndpoints?: EndpointMatcher;
   endpointOverrides?: EndpointOverrides[];
 }
 

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -46,7 +46,7 @@ test('negated endpoint filtering', async () => {
   const api = await generateEndpoints({
     apiFile: './fixtures/emptyApi.ts',
     schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
-    excludeEndpoints: [/user/i],
+    filterEndpoints: (name) => !/user/i.test(name),
   });
   expect(api).not.toMatch(/loginUser:/);
 });

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -31,6 +31,26 @@ test('endpoint filtering', async () => {
   expect(api).toMatchSnapshot('should only have endpoints loginUser, placeOrder, getOrderById, deleteOrder');
 });
 
+test('endpoint filtering by function', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    filterEndpoints: (name, endpoint) => name.match(/order/i) !== null && endpoint.verb === 'get',
+  });
+  expect(api).toMatch(/getOrderById:/);
+  expect(api).not.toMatch(/placeOrder:/);
+  expect(api).not.toMatch(/loginUser:/);
+});
+
+test('negated endpoint filtering', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    excludeEndpoints: [/user/i],
+  });
+  expect(api).not.toMatch(/loginUser:/);
+});
+
 test('endpoint overrides', async () => {
   const api = await generateEndpoints({
     apiFile: './fixtures/emptyApi.ts',


### PR DESCRIPTION
Following up with the discussion [here](https://github.com/reduxjs/redux-toolkit/pull/1680#issuecomment-963892589), I am moving [my PR](https://github.com/rtk-incubator/rtk-query-codegen/pull/82) from the rtk-query-codegen repo to this monorepo and also adding the ability to filter endpoints using a function.  The function is called with the operation name and the operation definition -- are these the desired arguments?  Should it be the operation definition only?

I am still [unclear](https://github.com/reduxjs/redux-toolkit/pull/1680#issuecomment-964423073) on whether we actually *want* the `excludeEndpoint` option.

TODO: update documentation