### PR TITLE
remove typeof undefined checks where not necessary 🐃🪒

### DIFF
--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -253,7 +253,7 @@ export function createReducer<S extends NotFunction<any>>(
           const draft = previousState as Draft<S> // We can assume this is already a draft
           const result = caseReducer(draft, action)
 
-          if (typeof result === 'undefined') {
+          if (result === undefined) {
             return previousState
           }
 
@@ -263,7 +263,7 @@ export function createReducer<S extends NotFunction<any>>(
           // return the caseReducer func and not wrap it with produce.
           const result = caseReducer(previousState as any, action)
 
-          if (typeof result === 'undefined') {
+          if (result === undefined) {
             if (previousState === null) {
               return previousState
             }

--- a/packages/toolkit/src/immutableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/immutableStateInvariantMiddleware.ts
@@ -67,12 +67,7 @@ function getSerialize(
  * @public
  */
 export function isImmutableDefault(value: unknown): boolean {
-  return (
-    typeof value !== 'object' ||
-    value === null ||
-    typeof value === 'undefined' ||
-    Object.isFrozen(value)
-  )
+  return typeof value !== 'object' || value == null || Object.isFrozen(value)
 }
 
 export function trackForMutations(

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -104,7 +104,7 @@ function stripUndefined(obj: any) {
   }
   const copy: Record<string, any> = { ...obj }
   for (const [k, v] of Object.entries(copy)) {
-    if (typeof v === 'undefined') delete copy[k]
+    if (v === undefined) delete copy[k]
   }
   return copy
 }

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -58,8 +58,8 @@ import type { BaseQueryFn } from '../baseQueryTypes'
 // Copy-pasted from React-Redux
 export const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' &&
-  typeof window.document !== 'undefined' &&
-  typeof window.document.createElement !== 'undefined'
+  window.document &&
+  window.document.createElement
     ? useLayoutEffect
     : useEffect
 

--- a/packages/toolkit/src/serializableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/serializableStateInvariantMiddleware.ts
@@ -14,8 +14,7 @@ import { getTimeMeasureUtils } from './utils'
 export function isPlain(val: any) {
   const type = typeof val
   return (
-    type === 'undefined' ||
-    val === null ||
+    val == null ||
     type === 'string' ||
     type === 'boolean' ||
     type === 'number' ||


### PR DESCRIPTION
This is just a bit of yak shaving, but I noticed we are doing the `typeof x === 'undefined'` check in quite some places where we would not need to. I changed it to `x === undefined` (or `x == null` if there was an `x === null` check going on in parallel anyways).

I kept the behaviour for non-local variables like `window`, `navigator`, `process` and `AbortController`.