### PR TITLE
Rewrite action listener middleware types for better DX

### DIFF
--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -73,17 +73,12 @@ export type WithMiddlewareType<T extends Middleware<any, any, any>> = {
 export type MiddlewarePhase = 'beforeReducer' | 'afterReducer'
 
 export type When = MiddlewarePhase | 'both' | undefined
-type WhenFromOptions<O extends ActionListenerOptions> =
-  O extends ActionListenerOptions ? O['when'] : never
 
 /**
  * @alpha
  */
-export interface ActionListenerMiddlewareAPI<
-  S,
-  D extends Dispatch<AnyAction>,
-  O extends ActionListenerOptions
-> extends MiddlewareAPI<D, S> {
+export interface ActionListenerMiddlewareAPI<S, D extends Dispatch<AnyAction>>
+  extends MiddlewareAPI<D, S> {
   getOriginalState: () => S
   unsubscribe(): void
   condition: ConditionFunction<AnyAction, S>
@@ -98,9 +93,8 @@ export interface ActionListenerMiddlewareAPI<
 export type ActionListener<
   A extends AnyAction,
   S,
-  D extends Dispatch<AnyAction>,
-  O extends ActionListenerOptions
-> = (action: A, api: ActionListenerMiddlewareAPI<S, D, O>) => void
+  D extends Dispatch<AnyAction>
+> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => void
 
 export interface ListenerErrorHandler {
   (error: unknown): void
@@ -126,14 +120,12 @@ export interface CreateListenerMiddlewareOptions<ExtraArgument = unknown> {
 export interface AddListenerAction<
   A extends AnyAction,
   S,
-  D extends Dispatch<AnyAction>,
-  O extends ActionListenerOptions
+  D extends Dispatch<AnyAction>
 > {
   type: 'actionListenerMiddleware/add'
   payload: {
     type: string
-    listener: ActionListener<A, S, D, O>
-    options?: O
+    listener: ActionListener<A, S, D>
   }
 }
 
@@ -166,7 +158,7 @@ export const addListenerAction = createAction(
   'actionListenerMiddleware/add',
   function prepare(
     typeOrActionCreator: string | TypedActionCreator<string>,
-    listener: ActionListener<any, any, any, any>,
+    listener: ActionListener<any, any, any>,
     options?: ActionListenerOptions
   ) {
     const type =
@@ -185,7 +177,7 @@ export const addListenerAction = createAction(
 ) as BaseActionCreator<
   {
     type: string
-    listener: ActionListener<any, any, any, any>
+    listener: ActionListener<any, any, any>
     options: ActionListenerOptions
   },
   'actionListenerMiddleware/add'
@@ -197,15 +189,15 @@ export const addListenerAction = createAction(
     O extends ActionListenerOptions
   >(
     actionCreator: C,
-    listener: ActionListener<ReturnType<C>, S, D, O>,
+    listener: ActionListener<ReturnType<C>, S, D>,
     options?: O
-  ): AddListenerAction<ReturnType<C>, S, D, O>
+  ): AddListenerAction<ReturnType<C>, S, D>
 
   <S, D extends Dispatch, O extends ActionListenerOptions>(
     type: string,
-    listener: ActionListener<AnyAction, S, D, O>,
+    listener: ActionListener<AnyAction, S, D>,
     options?: O
-  ): AddListenerAction<AnyAction, S, D, O>
+  ): AddListenerAction<AnyAction, S, D>
 }
 
 interface RemoveListenerAction<
@@ -216,7 +208,7 @@ interface RemoveListenerAction<
   type: 'actionListenerMiddleware/remove'
   payload: {
     type: string
-    listener: ActionListener<A, S, D, any>
+    listener: ActionListener<A, S, D>
   }
 }
 
@@ -227,7 +219,7 @@ export const removeListenerAction = createAction(
   'actionListenerMiddleware/remove',
   function prepare(
     typeOrActionCreator: string | TypedActionCreator<string>,
-    listener: ActionListener<any, any, any, any>
+    listener: ActionListener<any, any, any>
   ) {
     const type =
       typeof typeOrActionCreator === 'string'
@@ -242,17 +234,17 @@ export const removeListenerAction = createAction(
     }
   }
 ) as BaseActionCreator<
-  { type: string; listener: ActionListener<any, any, any, any> },
+  { type: string; listener: ActionListener<any, any, any> },
   'actionListenerMiddleware/remove'
 > & {
   <C extends TypedActionCreator<any>, S, D extends Dispatch>(
     actionCreator: C,
-    listener: ActionListener<ReturnType<C>, S, D, any>
+    listener: ActionListener<ReturnType<C>, S, D>
   ): RemoveListenerAction<ReturnType<C>, S, D>
 
   <S, D extends Dispatch>(
     type: string,
-    listener: ActionListener<AnyAction, S, D, any>
+    listener: ActionListener<AnyAction, S, D>
   ): RemoveListenerAction<AnyAction, S, D>
 }
 
@@ -273,7 +265,7 @@ export function createActionListenerMiddleware<
 >(middlewareOptions: CreateListenerMiddlewareOptions<ExtraArgument> = {}) {
   type ListenerEntry = ActionListenerOptions & {
     id: string
-    listener: ActionListener<any, S, D, any>
+    listener: ActionListener<any, S, D>
     unsubscribe: () => void
     type?: string
     predicate: ListenerPredicate<any, any>
@@ -367,13 +359,13 @@ export function createActionListenerMiddleware<
     O extends ActionListenerOptions
   >(
     actionCreator: C,
-    listener: ActionListener<ReturnType<C>, S, D, O>,
+    listener: ActionListener<ReturnType<C>, S, D>,
     options?: O
   ): Unsubscribe
   // eslint-disable-next-line no-redeclare
   function addListener<T extends string, O extends ActionListenerOptions>(
     type: T,
-    listener: ActionListener<Action<T>, S, D, O>,
+    listener: ActionListener<Action<T>, S, D>,
     options?: O
   ): Unsubscribe
   // eslint-disable-next-line no-redeclare
@@ -383,7 +375,7 @@ export function createActionListenerMiddleware<
     O extends ActionListenerOptions
   >(
     matcher: M,
-    listener: ActionListener<GuardedType<M>, S, D, O>,
+    listener: ActionListener<GuardedType<M>, S, D>,
     options?: O
   ): Unsubscribe
   // eslint-disable-next-line no-redeclare
@@ -393,7 +385,7 @@ export function createActionListenerMiddleware<
     O extends ActionListenerOptions
   >(
     matcher: M,
-    listener: ActionListener<AnyAction, S, D, O>,
+    listener: ActionListener<AnyAction, S, D>,
     options?: O
   ): Unsubscribe
   // eslint-disable-next-line no-redeclare
@@ -402,7 +394,7 @@ export function createActionListenerMiddleware<
       | string
       | TypedActionCreator<any>
       | ListenerPredicate<any, any>,
-    listener: ActionListener<AnyAction, S, D, any>,
+    listener: ActionListener<AnyAction, S, D>,
     options?: ActionListenerOptions
   ): Unsubscribe {
     let predicate: ListenerPredicate<any, any>
@@ -448,17 +440,17 @@ export function createActionListenerMiddleware<
 
   function removeListener<C extends TypedActionCreator<any>>(
     actionCreator: C,
-    listener: ActionListener<ReturnType<C>, S, D, any>
+    listener: ActionListener<ReturnType<C>, S, D>
   ): boolean
   // eslint-disable-next-line no-redeclare
   function removeListener(
     type: string,
-    listener: ActionListener<AnyAction, S, D, any>
+    listener: ActionListener<AnyAction, S, D>
   ): boolean
   // eslint-disable-next-line no-redeclare
   function removeListener(
     typeOrActionCreator: string | TypedActionCreator<any>,
-    listener: ActionListener<AnyAction, S, D, any>
+    listener: ActionListener<AnyAction, S, D>
   ): boolean {
     const type =
       typeof typeOrActionCreator === 'string'

--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -1,6 +1,4 @@
-import {
-  createAction,
-  nanoid,
+import type {
   PayloadAction,
   Middleware,
   Dispatch,
@@ -9,6 +7,7 @@ import {
   Action,
   ThunkDispatch,
 } from '@reduxjs/toolkit'
+import { createAction, nanoid } from '@reduxjs/toolkit'
 
 interface BaseActionCreator<P, T extends string, M = never, E = never> {
   type: T

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -806,10 +806,15 @@ describe('createActionListenerMiddleware', () => {
       })
 
       middleware.addListener({
-        predicate: (action, currentState): action is PayloadAction<number> => {
-          return typeof action.payload === 'number'
+        predicate: (
+          action,
+          currentState,
+          previousState
+        ): action is PayloadAction<number> => {
+          return typeof action.payload === 'boolean'
         },
         listener: (action, listenerApi) => {
+          // @ts-expect-error
           expectExactType<PayloadAction<number>>(action)
         },
       })
@@ -878,12 +883,18 @@ describe('createActionListenerMiddleware', () => {
 
       // Can pass a predicate function with fewer args
       typedMiddleware.addListener({
-        predicate: (action, currentState): action is AnyAction => {
+        // TODO Why won't this infer the listener's `action` with implicit argument types?
+        predicate: (
+          action: AnyAction,
+          currentState: CounterState
+        ): action is PayloadAction<number> => {
           expectNotAny(currentState)
           expectExactType<CounterState>(currentState)
           return true
         },
         listener: (action, listenerApi) => {
+          expectType<PayloadAction<number>>(action)
+
           const listenerState = listenerApi.getState()
           expectExactType<CounterState>(listenerState)
           listenerApi.dispatch((dispatch, getState) => {


### PR DESCRIPTION
This PR:

- Adds a bunch of type tests for desired action listener middleware behavior
- Splits out normal and type imports
- Removes an unneeded "options" generic
- Combines changes from @josh-degraw in https://github.com/reduxjs/redux-toolkit/pull/1723 and @phryneas in https://github.com/phryneas/redux-toolkit/tree/ts-fix-listenerMw to come up with the desired API and TypeScript DX behavior we want

The major changes in API/DX are:

- Both `middleware.addListener` and `addListenerAction` now take the exact same params - an `options` object containing the `listener` callback and `when` option, with five possible variations in how the middleware decides what actions will trigger the listener callback:
  - a plain action type string
  - an RTK action creator
  - an RTK "matcher" function
  - a "listener predicate" like `(action, currentState, originalState) => boolean`
  - a "listener predicate" which is also a type guard for the action
- The common overloads are now extracted as a reusable type that accepts the right return value
- It now exports `TypedAddListener<State>` and `TypedAddListenerAction<State>` types that can be used to create "pre-typed" versions of `middleware.addListener` and `addListenerAction`
- There's a `createListenerEntry` function that does the real work of looking at the options and assembling a listener entry
- `createActionListenerMiddleware()` defaults the state to `unknown`
- The middleware now includes `addListenerAction` as one of its attached fields, which means that if you do `createActionListenerMiddleware<MyState>()`, then `middleware.addListener/addListenerAction` are pre-typed.

The net results are that it should be fairly straightforward for users to ensure proper typing for their listener callbacks with the right state and action types, similar to how we define "pre-typed" hooks.

The _one_ thing that appears to be not working atm is that a `ListenerPredicate` of `(action, currentState, previousState) : action is PayloadAction<number> => {}` does not appear to be inferring the type of `action` in the listener callback (see test file line 813).  You can see the failure in the test job run.