### PR TITLE
action-listener-middleware: add async error handling

### DIFF
--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -102,7 +102,7 @@ Current options are:
 
 - `extra`: an optional "extra argument" that will be injected into the `listenerApi` parameter of each listener. Equivalent to [the "extra argument" in the Redux Thunk middleware](https://redux.js.org/usage/writing-logic-thunks#injecting-config-values-into-thunks).
 
-- `onError`: an optional error handler that gets called with synchronous errors raised by `listener` and `predicate`.
+- `onError`: an optional error handler that gets called with synchronous and async errors raised by `listener` and synchronous errors thrown by `predicate`.
 
 ### `listenerMiddleware.addListener(predicate, listener, options?) : Unsubscribe`
 

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -318,18 +318,6 @@ export type ListenerPredicateGuardedActionType<T> = T extends ListenerPredicate<
   ? Action
   : never
 
-export type SyncActionListener<
-  A extends AnyAction,
-  S,
-  D extends Dispatch<AnyAction>
-> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => void
-
-export type AsyncActionListener<
-  A extends AnyAction,
-  S,
-  D extends Dispatch<AnyAction>
-> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => Promise<void>
-
 /**
  * Additional infos regarding the error raised.
  */

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -83,7 +83,7 @@ export type ActionListener<
   A extends AnyAction,
   S,
   D extends Dispatch<AnyAction>
-> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => void
+> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => void | Promise<void>
 
 export interface ListenerErrorHandler {
   (error: unknown): void
@@ -317,3 +317,47 @@ export type ListenerPredicateGuardedActionType<T> = T extends ListenerPredicate<
 >
   ? Action
   : never
+
+export type SyncActionListener<
+  A extends AnyAction,
+  S,
+  D extends Dispatch<AnyAction>
+> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => void
+
+export type AsyncActionListener<
+  A extends AnyAction,
+  S,
+  D extends Dispatch<AnyAction>
+> = (action: A, api: ActionListenerMiddlewareAPI<S, D>) => Promise<void>
+
+/**
+ * Additional infos regarding the error raised.
+ */
+export interface ListenerErrorInfo {
+  async: boolean
+  /**
+   * Which function has generated the exception.
+   */
+  raisedBy: 'listener' | 'predicate'
+  /**
+   * When the function that has raised the error has been called.
+   */
+  phase: MiddlewarePhase
+}
+
+/**
+ * Gets notified with synchronous and asynchronous errors raised by `listeners` or `predicates`.
+ * @param error The thrown error.
+ * @param errorInfo Additional information regarding the thrown error.
+ */
+export interface ListenerErrorHandler {
+  (error: unknown, errorInfo: ListenerErrorInfo): void
+}
+
+export interface CreateListenerMiddlewareOptions<ExtraArgument = unknown> {
+  extra?: ExtraArgument
+  /**
+   * Receives synchronous and asynchronous errors that are raised by `listener` and `listenerOption.predicate`.
+   */
+  onError?: ListenerErrorHandler
+}


### PR DESCRIPTION
### Notable changes

- Handle async errors thrown by listeners
- Changed signature of `AsyncActionListener`
- `onError` now receives a second argument `ListenerErrorInfo` that provides additional information regarding the exception.

### Context:

- https://github.com/reduxjs/redux-toolkit/discussions/1648#discussioncomment-1635556

- https://github.com/reduxjs/redux-toolkit/discussions/1648

- https://github.com/reduxjs/redux-toolkit/pull/547

### Build output

```ts
Build "actionListenerMiddleware" to dist/esm:
       1148 B: index.modern.js.gz
       1037 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
       1672 B: index.js.gz
       1509 B: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
       1661 B: index.js.gz
       1493 B: index.js.br
```