### PR TITLE
Treat `null` as a valid plain object prototype in `isPlainObject()` in order to sync the util across `reduxjs/*` repositories

### DIFF
--- a/packages/toolkit/src/isPlainObject.ts
+++ b/packages/toolkit/src/isPlainObject.ts
@@ -11,10 +11,13 @@
 export default function isPlainObject(value: unknown): value is object {
   if (typeof value !== 'object' || value === null) return false
 
-  let proto = value
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
+  let proto = Object.getPrototypeOf(value)
+  if (proto === null) return true
+
+  let baseProto = proto
+  while (Object.getPrototypeOf(baseProto) !== null) {
+    baseProto = Object.getPrototypeOf(baseProto)
   }
 
-  return Object.getPrototypeOf(value) === proto
+  return proto === baseProto
 }

--- a/packages/toolkit/src/tests/isPlainObject.test.ts
+++ b/packages/toolkit/src/tests/isPlainObject.test.ts
@@ -20,5 +20,6 @@ describe('isPlainObject', () => {
     expect(isPlainObject(null)).toBe(false)
     expect(isPlainObject(undefined)).toBe(false)
     expect(isPlainObject({ x: 1, y: 2 })).toBe(true)
+    expect(isPlainObject(Object.create(null))).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes https://github.com/reduxjs/redux-toolkit/issues/1733