### PR TITLE
 fix: api.util.resetApiState should reset useQuery hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,12 @@ module.exports = {
       'error',
       { prefer: 'type-imports', disallowTypeAnnotations: false },
     ],
+    'react-hooks/exhaustive-deps': [
+      'warn',
+      {
+        additionalHooks: '(usePossiblyImmediateEffect)',
+      },
+    ],
   },
   overrides: [
     // {

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -55,6 +55,7 @@ export type QueryActionCreatorResult<
   unsubscribe(): void
   refetch(): void
   updateSubscriptionOptions(options: SubscriptionOptions): void
+  queryCacheKey: string
 }
 
 type StartMutationActionCreator<
@@ -284,6 +285,7 @@ Features like automatic cache collection, automatic refetching etc. will not be 
             arg,
             requestId,
             subscriptionOptions,
+            queryCacheKey,
             abort,
             refetch() {
               dispatch(

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -542,10 +542,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           endpointName,
         })
       )
-        return {
-          isFetching: false,
-          ...currentState,
-        }
+      lastResult = undefined
     }
 
     // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -460,33 +460,6 @@ export type MutationTrigger<D extends MutationDefinition<any, any, any, any>> =
 const defaultQueryStateSelector: QueryStateSelector<any, any> = (x) => x
 const defaultMutationStateSelector: MutationStateSelector<any, any> = (x) => x
 
-const queryStatePreSelector = (
-  currentState: QueryResultSelectorResult<any>,
-  lastResult: UseQueryStateDefaultResult<any>
-): UseQueryStateDefaultResult<any> => {
-  // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
-  let data = currentState.isSuccess ? currentState.data : lastResult?.data
-  if (data === undefined) data = currentState.data
-
-  const hasData = data !== undefined
-
-  // isFetching = true any time a request is in flight
-  const isFetching = currentState.isLoading
-  // isLoading = true only when loading while no data is present yet (initial load with no data in the cache)
-  const isLoading = !hasData && isFetching
-  // isSuccess = true when data is present
-  const isSuccess = currentState.isSuccess || (isFetching && hasData)
-
-  return {
-    ...currentState,
-    data,
-    currentData: currentState.data,
-    isFetching,
-    isLoading,
-    isSuccess,
-  } as UseQueryStateDefaultResult<any>
-}
-
 /**
  * Wrapper around `defaultQueryStateSelector` to be used in `useQuery`.
  * We want the initial render to already come back with
@@ -545,6 +518,33 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   ) => void = unstable__sideEffectsInRender ? (cb) => cb() : useEffect
 
   return { buildQueryHooks, buildMutationHook, usePrefetch }
+
+  function queryStatePreSelector(
+    currentState: QueryResultSelectorResult<any>,
+    lastResult?: UseQueryStateDefaultResult<any>
+  ): UseQueryStateDefaultResult<any> {
+    // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
+    let data = currentState.isSuccess ? currentState.data : lastResult?.data
+    if (data === undefined) data = currentState.data
+
+    const hasData = data !== undefined
+
+    // isFetching = true any time a request is in flight
+    const isFetching = currentState.isLoading
+    // isLoading = true only when loading while no data is present yet (initial load with no data in the cache)
+    const isLoading = !hasData && isFetching
+    // isSuccess = true when data is present
+    const isSuccess = currentState.isSuccess || (isFetching && hasData)
+
+    return {
+      ...currentState,
+      data,
+      currentData: currentState.data,
+      isFetching,
+      isLoading,
+      isSuccess,
+    } as UseQueryStateDefaultResult<any>
+  }
 
   function usePrefetch<EndpointName extends QueryKeys<Definitions>>(
     endpointName: EndpointName,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -633,38 +633,35 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       }, [subscriptionRemoved])
 
       usePossiblyImmediateEffect((): void | undefined => {
-        batch(() => {
-          const lastPromise = promiseRef.current
-          if (
-            typeof process !== 'undefined' &&
-            process.env.NODE_ENV === 'removeMeOnCompilation'
-          ) {
-            // this is only present to enforce the rule of hooks to keep `isSubscribed` in the dependency array
-            console.log(subscriptionRemoved)
-          }
+        const lastPromise = promiseRef.current
+        if (
+          typeof process !== 'undefined' &&
+          process.env.NODE_ENV === 'removeMeOnCompilation'
+        ) {
+          // this is only present to enforce the rule of hooks to keep `isSubscribed` in the dependency array
+          console.log(subscriptionRemoved)
+        }
 
-          if (stableArg === skipToken) {
-            lastPromise?.unsubscribe()
-            promiseRef.current = undefined
-            return
-          }
+        if (stableArg === skipToken) {
+          lastPromise?.unsubscribe()
+          promiseRef.current = undefined
+          return
+        }
 
-          const lastSubscriptionOptions =
-            promiseRef.current?.subscriptionOptions
+        const lastSubscriptionOptions = promiseRef.current?.subscriptionOptions
 
-          if (!lastPromise || lastPromise.arg !== stableArg) {
-            lastPromise?.unsubscribe()
-            const promise = dispatch(
-              initiate(stableArg, {
-                subscriptionOptions: stableSubscriptionOptions,
-                forceRefetch: refetchOnMountOrArgChange,
-              })
-            )
-            promiseRef.current = promise
-          } else if (stableSubscriptionOptions !== lastSubscriptionOptions) {
-            lastPromise.updateSubscriptionOptions(stableSubscriptionOptions)
-          }
-        })
+        if (!lastPromise || lastPromise.arg !== stableArg) {
+          lastPromise?.unsubscribe()
+          const promise = dispatch(
+            initiate(stableArg, {
+              subscriptionOptions: stableSubscriptionOptions,
+              forceRefetch: refetchOnMountOrArgChange,
+            })
+          )
+          promiseRef.current = promise
+        } else if (stableSubscriptionOptions !== lastSubscriptionOptions) {
+          lastPromise.updateSubscriptionOptions(stableSubscriptionOptions)
+        }
       }, [
         dispatch,
         initiate,

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -547,6 +547,53 @@ describe('hooks tests', () => {
         expect(screen.getByTestId('amount').textContent).toBe('2')
       )
     })
+
+    describe('api.util.resetApiState resets hook', () => {
+      test('without `selectFromResult`', async () => {
+        const { result } = renderHook(() => api.endpoints.getUser.useQuery(5), {
+          wrapper: storeRef.wrapper,
+        })
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        act(() => void storeRef.store.dispatch(api.util.resetApiState()))
+
+        expect(result.current).toEqual({
+          isError: false,
+          isFetching: true,
+          isLoading: true,
+          isSuccess: false,
+          isUninitialized: false,
+          refetch: expect.any(Function),
+          status: 'pending',
+        })
+      })
+      test('with `selectFromResult`', async () => {
+        const { result } = renderHook(
+          () =>
+            api.endpoints.getUser.useQuery(5, {
+              selectFromResult: (x) => x,
+            }),
+          {
+            wrapper: storeRef.wrapper,
+          }
+        )
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        act(() => void storeRef.store.dispatch(api.util.resetApiState()))
+
+        expect(result.current).toEqual({
+          isError: false,
+          isFetching: false,
+          isLoading: false,
+          isSuccess: false,
+          isUninitialized: true,
+          refetch: expect.any(Function),
+          status: 'uninitialized',
+        })
+      })
+    })
   })
 
   describe('useLazyQuery', () => {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -558,38 +558,37 @@ describe('hooks tests', () => {
 
         act(() => void storeRef.store.dispatch(api.util.resetApiState()))
 
-        expect(result.current).toEqual({
-          isError: false,
-          isFetching: true,
-          isLoading: true,
-          isSuccess: false,
-          isUninitialized: false,
-          refetch: expect.any(Function),
-          status: 'pending',
-        })
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isError: false,
+            isFetching: true,
+            isLoading: true,
+            isSuccess: false,
+            isUninitialized: false,
+            refetch: expect.any(Function),
+            status: 'pending',
+          })
+        )
       })
       test('with `selectFromResult`', async () => {
+        const selectFromResult = jest.fn((x) => x)
         const { result } = renderHook(
-          () =>
-            api.endpoints.getUser.useQuery(5, {
-              selectFromResult: (x) => x,
-            }),
+          () => api.endpoints.getUser.useQuery(5, { selectFromResult }),
           {
             wrapper: storeRef.wrapper,
           }
         )
 
         await waitFor(() => expect(result.current.isSuccess).toBe(true))
-
+        selectFromResult.mockClear()
         act(() => void storeRef.store.dispatch(api.util.resetApiState()))
 
-        expect(result.current).toEqual({
+        expect(selectFromResult).toHaveBeenNthCalledWith(1, {
           isError: false,
           isFetching: false,
           isLoading: false,
           isSuccess: false,
           isUninitialized: true,
-          refetch: expect.any(Function),
           status: 'uninitialized',
         })
       })

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -17,6 +17,7 @@ import {
   createConsole,
   getLog,
 } from 'console-testing-library/pure'
+import { cleanup } from '@testing-library/react'
 
 export const ANY = 0 as any
 
@@ -213,6 +214,7 @@ export function setupApiStore<
     }
   })
   afterEach(() => {
+    cleanup()
     if (!withoutListeners) {
       cleanupListeners()
     }


### PR DESCRIPTION
This should provide a fix for #1725.

@ayushsharma82 could you please try this? In a few minutes, the CodeSandbox bot should comment on this issue and one of the links there should lead to installation instructions for this build.