### PR TITLE
fix(docs): fix the docs' example error.

### DIFF
--- a/docs/api/createReducer.mdx
+++ b/docs/api/createReducer.mdx
@@ -271,11 +271,11 @@ const reducer = createReducer(0, (builder) => {
   builder
     .addCase('increment', (state) => state + 1)
     .addMatcher(
-      (action) => action.startsWith('i'),
+      (action) => action.type.startsWith('i'),
       (state) => state * 5
     )
     .addMatcher(
-      (action) => action.endsWith('t'),
+      (action) => action.type.endsWith('t'),
       (state) => state + 2
     )
 })


### PR DESCRIPTION
action type is Object, doesn't have  'startsWith' and 'endsWith';
It will make an error like the picture below~
![image](https://user-images.githubusercontent.com/9697295/141953327-1d799ea6-2a01-4e14-be36-b98961f5a90c.png)
