### PR TITLE
export `RetryOptions` interface from `retry.ts`

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -23,7 +23,7 @@ async function defaultBackoff(attempt: number = 0, maxRetries: number = 5) {
   )
 }
 
-interface StaggerOptions {
+export interface RetryOptions {
   /**
    * How many times the query will be retried (default: 5)
    */
@@ -42,8 +42,8 @@ function fail(e: any): never {
 
 const retryWithBackoff: BaseQueryEnhancer<
   unknown,
-  StaggerOptions,
-  StaggerOptions | void
+  RetryOptions,
+  RetryOptions | void
 > = (baseQuery, defaultOptions) => async (args, api, extraOptions) => {
   const options = {
     maxRetries: 5,


### PR DESCRIPTION
fixes re-exporting a typed `retry` wrapped `baseQuery` when `tsConfig.declaration = true`. 

Specifically resolves error:

> Exported variable '{retry_wrapped_basequery}' has or is using name 'StaggerOptions' from external module "*/node_modules/@reduxjs/toolkit/dist/query/retry" but cannot be named.