### PR TITLE
fix issue where the global RTK object got overwritten in the UMD files

### DIFF
--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -97,18 +97,21 @@ const entryPoints: EntryPointOptions[] = [
     folder: '',
     entryPoint: 'src/index.ts',
     extractionConfig: 'api-extractor.json',
+    globalName: 'RTK',
   },
   {
     prefix: 'rtk-query',
     folder: 'query',
     entryPoint: 'src/query/index.ts',
     extractionConfig: 'api-extractor.query.json',
+    globalName: 'RTK.QUERY',
   },
   {
     prefix: 'rtk-query-react',
     folder: 'query/react',
     entryPoint: 'src/query/react/index.ts',
     extractionConfig: 'api-extractor.query-react.json',
+    globalName: 'RTK.QUERY.REACT',
   },
 ]
 
@@ -250,10 +253,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
 /**
  * since esbuild doesn't support umd, we use rollup to convert esm to umd
  */
-async function buildUMD(outputPath: string, prefix: string) {
-  // All RTK UMD files share the same global variable name, regardless
-  const globalName = 'RTK'
-
+async function buildUMD(outputPath: string, prefix: string, globalName: string) {
   for (let umdExtension of ['umd', 'umd.min']) {
     const input = path.join(outputPath, `${prefix}.${umdExtension}.js`)
     const instance = await rollup.rollup({
@@ -319,7 +319,7 @@ async function main({ skipExtraction = false, local = false }: BuildArgs) {
   for (let entryPoint of entryPoints) {
     const { folder } = entryPoint
     const outputPath = path.join('dist', folder)
-    await buildUMD(outputPath, entryPoint.prefix)
+    await buildUMD(outputPath, entryPoint.prefix, entryPoint.globalName)
   }
 
   // We need one additional package.json file in dist to support

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -104,14 +104,14 @@ const entryPoints: EntryPointOptions[] = [
     folder: 'query',
     entryPoint: 'src/query/index.ts',
     extractionConfig: 'api-extractor.query.json',
-    globalName: 'RTK.QUERY',
+    globalName: 'RTKQ',
   },
   {
     prefix: 'rtk-query-react',
     folder: 'query/react',
     entryPoint: 'src/query/react/index.ts',
     extractionConfig: 'api-extractor.query-react.json',
-    globalName: 'RTK.QUERY.REACT',
+    globalName: 'RTKQ',
   },
 ]
 

--- a/packages/toolkit/scripts/types.ts
+++ b/packages/toolkit/scripts/types.ts
@@ -19,4 +19,6 @@ export interface EntryPointOptions {
   folder: string
   entryPoint: string
   extractionConfig: string
+  // globalName is used in the conversion to umd files to separate rtk from rtk-query on a global name space
+  globalName: string
 }

--- a/packages/toolkit/scripts/types.ts
+++ b/packages/toolkit/scripts/types.ts
@@ -19,6 +19,6 @@ export interface EntryPointOptions {
   folder: string
   entryPoint: string
   extractionConfig: string
-  // globalName is used in the conversion to umd files to separate rtk from rtk-query on a global name space
+  // globalName is used in the conversion to umd files to separate rtk from rtk-query on a global namespace
   globalName: string
 }


### PR DESCRIPTION
  fix #1761 where the global variable RTK gets overwritten by the other entries in the UMD build