### PR TITLE
Fix maxRetries documentation

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -12,7 +12,7 @@ import { HandledError } from './HandledError'
  * 5. 9600ms * random(0.4, 1.4)
  *
  * @param attempt - Current attempt
- * @param maxRetries - Maximum number of retries
+ * @param maxRetries - Maximum value of the exponential
  */
 async function defaultBackoff(attempt: number = 0, maxRetries: number = 5) {
   const attempts = Math.min(attempt, maxRetries)


### PR DESCRIPTION
The parameters `maxRetries` is not actually a maximum number of retries. It's just a maximum value on the exponential term.

Ideally the variable name would be updated because it's a very misleading name, but at least we should update the comment