### PR TITLE
Export StaggerOptions type

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -23,7 +23,7 @@ async function defaultBackoff(attempt: number = 0, maxRetries: number = 5) {
   )
 }
 
-interface StaggerOptions {
+export interface StaggerOptions {
   /**
    * How many times the query will be retried (default: 5)
    */


### PR DESCRIPTION
If you want to make a function that only accepts a base query that has retry functionality supported, you would do this by having the function take in a `BaseQueryFn` that has `StaggerOptions` as part of its `DefinitionExtraOptions`, but this can't be done because the `StaggerOptions` isn't exported