### PR TITLE
Add listener middleware Job class test file and initial usage test

### DIFF
--- a/packages/action-listener-middleware/src/job.ts
+++ b/packages/action-listener-middleware/src/job.ts
@@ -248,9 +248,9 @@ export class Job<T> implements JobHandle {
    */
   async pause<R>(func: Promise<R>): Promise<R> {
     this.ensureActive()
-    const result = await func
+    const result = await Promise.race([func, this._cancelPromise])
     this.ensureActive()
-    return result
+    return result as R
   }
 
   /**

--- a/packages/action-listener-middleware/src/tests/job.test.ts
+++ b/packages/action-listener-middleware/src/tests/job.test.ts
@@ -1,0 +1,502 @@
+// Source: https://github.com/ethossoftworks/job-ts/blob/main/src/job.test.ts
+
+import { Outcome } from '../outcome'
+import {
+  Job,
+  JobCancellationException,
+  JobCancellationReason,
+  SupervisorJob,
+} from '../job'
+
+import { performance } from 'perf_hooks'
+;(global as any).performance = performance
+;(global as any).window = {
+  setTimeout: setTimeout,
+  clearTimeout: clearTimeout,
+}
+
+const delay = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+describe('Job', () => {
+  test('Cancel when exception thrown', async () => {
+    let child: Promise<Outcome<number>> = Promise.resolve(Outcome.ok(1))
+    let parent: Job<number> = new Job(async (job) => Outcome.ok(1))
+
+    try {
+      parent = new Job(async (job) => {
+        child = job.launchAndRun(async (job) => {
+          await job.delay(5000)
+          return Outcome.ok(1)
+        })
+
+        throw new Error('Uh Oh')
+        return Outcome.ok(1)
+      })
+      await parent.run()
+    } catch (e) {
+      // Ignore parent exception
+    } finally {
+      const childResult = await child
+      if (!parent.isCancelled) throw new Error('Parent was not cancelled')
+      if (
+        childResult.isOk() ||
+        !(childResult.error instanceof JobCancellationException)
+      )
+        throw new Error('Child was not cancelled')
+    }
+  })
+
+  test('Add job to cancelled parent', async () => {
+    const parent = new Job(async (job) => Outcome.ok(1))
+    parent.cancel()
+
+    parent.launch(async (job) => Outcome.ok(1))
+    new Job(async (job) => Outcome.ok(1), { parent: parent })
+    expect(parent.childCount).toBe(0)
+  })
+
+  test('External child cancelled if parent completes', async () => {
+    const parentJob = new Job(async (job) => {
+      await job.delay(10)
+      return Outcome.ok(1)
+    })
+
+    const childJob = parentJob.launch(async (job) => {
+      await job.delay(50)
+      return Outcome.ok(1)
+    })
+
+    const parentPromise = parentJob.run()
+    const childResult = await childJob.run()
+    const parentResult = await parentPromise
+    if (parentResult.isError())
+      throw new Error('Parent did not complete successfully')
+    if (!childResult.isError())
+      throw new Error('Child was not cancelled when parent completed')
+  })
+
+  test('Job Returns', async () => {
+    const job = new Job(async (job) => Outcome.ok(1))
+    const value1 = await job.run()
+
+    if (value1.isOk()) {
+      expect(value1.value).toBe(1)
+    } else {
+      throw new Error('Invalid return')
+    }
+
+    const value2 = await new Job(async (job) => Outcome.ok(1)).run()
+    if (value2.isOk()) {
+      expect(value2.value).toBe(1)
+    } else {
+      throw new Error('Invalid return')
+    }
+  })
+
+  test('Job Status', async () => {
+    const job = new Job(async (job) => Outcome.ok(1))
+    expect(job.isActive).toBe(true)
+    expect(job.isCompleted).toBe(false)
+    expect(job.isCancelled).toBe(false)
+    await job.run()
+    expect(job.isActive).toBe(false)
+    expect(job.isCompleted).toBe(true)
+    expect(job.isCancelled).toBe(false)
+
+    const job2 = new Job(async (job) => {
+      await job.delay(500)
+      return Outcome.ok(1)
+    })
+    setTimeout(() => job2.cancel(), 100)
+    await job2.run()
+    expect(job2.isActive).toBe(false)
+    expect(job2.isCompleted).toBe(false)
+    expect(job2.isCancelled).toBe(true)
+  })
+
+  test('Cancellation Reason', async () => {
+    // JobCompleted
+    const alreadyCompleteJob = new Job(async (job) => Outcome.ok(1))
+    await alreadyCompleteJob.run()
+    const alreadyCompleteResult = await alreadyCompleteJob.run()
+    if (
+      alreadyCompleteResult.isOk() ||
+      !(alreadyCompleteResult.error instanceof JobCancellationException) ||
+      (alreadyCompleteResult.error as JobCancellationException).reason !=
+        JobCancellationReason.JobCompleted
+    ) {
+      throw new Error(
+        'Completed: JobCancellationReason.JobCompleted not returned'
+      )
+    }
+
+    // ParentCancelled
+    const parentCancelled = new Job(async (job) => {
+      await job.delay(50)
+      return Outcome.ok(1)
+    })
+
+    const parentCancelledChild = parentCancelled.launch(async (job) => {
+      await job.delay(100)
+      return Outcome.ok(1)
+    })
+
+    setTimeout(() => parentCancelled.cancel(), 25)
+    const childResult = await parentCancelledChild.run()
+
+    if (
+      childResult.isOk() ||
+      !(childResult.error instanceof JobCancellationException) ||
+      (childResult.error as JobCancellationException).reason !=
+        JobCancellationReason.ParentJobCancelled
+    ) {
+      throw new Error(
+        'Parent Cancelled: JobCancellationReason.ParentJobCancelled not returned'
+      )
+    }
+
+    // ParentCompleted
+    const parentCompleted = new Job(async (job) => {
+      await job.delay(10)
+      return Outcome.ok(1)
+    })
+    parentCompleted.run()
+
+    const parentCompletedChild = parentCompleted.launchAndRun(async (job) => {
+      await job.delay(20)
+      return Outcome.ok(1)
+    })
+
+    const parentCompletedChildResult = await parentCompletedChild
+
+    expect(Job.isCancelled(parentCompletedChildResult)).toBe(true)
+    // @ts-ignore
+    expect(parentCompletedChildResult.error.reason).toBe(
+      JobCancellationReason.ParentJobCompleted
+    )
+
+    // JobCancelled
+    const cancelledJob = new Job(async (job) => {
+      await job.delay(50)
+      return Outcome.ok(1)
+    })
+
+    setTimeout(() => cancelledJob.cancel(), 25)
+    const cancelledJobResult = await cancelledJob.run()
+
+    if (
+      cancelledJobResult.isOk() ||
+      !(cancelledJobResult.error instanceof JobCancellationException) ||
+      (cancelledJobResult.error as JobCancellationException).reason !=
+        JobCancellationReason.JobCancelled
+    ) {
+      throw new Error(
+        'Job Cancelled: JobCancellationReason.JobCancelled not returned'
+      )
+    }
+
+    // Launch after parent cancelled
+    const launchAfterCancelledJob = new Job(async (job) => Outcome.ok(1))
+    launchAfterCancelledJob.cancel()
+    const launchAfterCancelledResult =
+      await launchAfterCancelledJob.launchAndRun(async (job) => Outcome.ok(1))
+    if (
+      launchAfterCancelledResult.isOk() ||
+      !(launchAfterCancelledResult.error instanceof JobCancellationException) ||
+      (launchAfterCancelledResult.error as JobCancellationException).reason !=
+        JobCancellationReason.ParentJobCancelled
+    ) {
+      throw new Error(
+        'Launch After Cancelled: JobCancellationReason.ParentJobCancelled not returned'
+      )
+    }
+
+    // Launch after parent completed
+    const launchAfterCompletedJob = new Job(async (job) => Outcome.ok(1))
+    await launchAfterCompletedJob.run()
+    const launchAfterCompletedResult =
+      await launchAfterCompletedJob.launchAndRun(async (job) => Outcome.ok(1))
+    if (
+      launchAfterCompletedResult.isOk() ||
+      !(launchAfterCompletedResult.error instanceof JobCancellationException) ||
+      (launchAfterCompletedResult.error as JobCancellationException).reason !=
+        JobCancellationReason.ParentJobCompleted
+    ) {
+      throw new Error(
+        'Launch After Completed: JobCancellationReason.ParentJobCompleted not returned'
+      )
+    }
+  })
+
+  test('Multiple Job Runs', async () => {
+    const job = new Job(async (job) => {
+      await job.delay(500)
+      return Outcome.ok(1)
+    })
+
+    const result1 = await job.run()
+    const result2 = await job.run()
+    const result3 = await job.run()
+
+    if (result1.isError() || result1.value != 1)
+      throw new Error('Job did not return value correctly')
+    if (result2.isOk() || !(result2.error instanceof JobCancellationException))
+      throw new Error('Job did not return JobCompletionException')
+    if (result3.isOk() || !(result3.error instanceof JobCancellationException))
+      throw new Error('Job did not return JobCompletionException')
+  })
+
+  test('Job Parent Cancellation', async () => {
+    var childFinished = false
+
+    const parent = new Job(async (job) => {
+      await job.launchAndRun(async (job) => {
+        await job.delay(100)
+        childFinished = true
+        return Outcome.ok(1)
+      })
+
+      return Outcome.ok(null)
+    })
+
+    setTimeout(() => parent.cancel(), 50)
+    const result = await parent.run()
+
+    expect(childFinished).toBe(false)
+    if (result.isError()) {
+      if (!(result.error instanceof JobCancellationException))
+        throw new Error(
+          'Cancelled exception was not sent back in Outcome.Error'
+        )
+    } else {
+      throw new Error('Outcome.Ok was returned instead of Outcome.Error')
+    }
+
+    // Test that child is returned immediately when the parent is cancelled
+    const parent2 = new Job(async (job) => {
+      await job.delay(25)
+      return Outcome.ok(1)
+    })
+
+    const child2 = parent2.launch(async (job) => {
+      await job.delay(200)
+      return Outcome.ok(1)
+    })
+
+    setTimeout(() => parent2.cancel(), 20)
+    const start = performance.now()
+    await child2.run()
+    if (performance.now() - start >= 50)
+      throw new Error('Child did not cancel immediately')
+  })
+
+  test('Job Child Cancellation', async () => {
+    const parent = new Job(async (job) => {
+      const child1 = job.launch(async (job) => {
+        await job.delay(100)
+        return Outcome.ok(1)
+      })
+
+      const child2 = job.launch(async (job) => {
+        await job.delay(50)
+        return Outcome.ok(2)
+      })
+
+      setTimeout(() => child2.cancel(), 25)
+      const results = await Promise.all([child1.run(), child2.run()])
+
+      if (!results[0].isOk() || results[0].value !== 1)
+        throw new Error('Child1 not Ok when expected to be')
+      if (results[1].isOk()) throw new Error('Child2 not cancelled')
+      return Outcome.ok(true)
+    })
+
+    const parentResult = await parent.run()
+    if (parentResult.isError() || parentResult.value != true)
+      throw new Error("Parent didn't complete successfully")
+  })
+
+  test('Job Stream', async () => {
+    var counter = 0
+
+    await new Job(async (job) => {
+      const stream = job.launch(async (job) => {
+        for await (const value of _testStream()) {
+          job.ensureActive()
+          counter = value
+        }
+        return Outcome.ok(1)
+      })
+
+      setTimeout(() => stream.cancel(), 50)
+      const streamResult = await stream.run()
+      if (streamResult.isOk())
+        throw new Error('Stream returned Ok instead of Error')
+      return Outcome.ok(null)
+    }).run()
+
+    expect(counter).toBe(3)
+  })
+
+  test('Job Immediate Cancellation', async () => {
+    let childHasRun: boolean = false
+    const job = new Job(async (job) => {
+      childHasRun = true
+      await job.delay(500)
+      return Outcome.ok(1)
+    })
+
+    job.cancel()
+    const result = await job.run()
+
+    if (
+      result.isOk() ||
+      !(result.error instanceof JobCancellationException) ||
+      (childHasRun as boolean) === true
+    ) {
+      throw new Error(
+        `Job was not immediately cancelled. Result: ${result}. HasRun: ${childHasRun}`
+      )
+    }
+  })
+
+  test('Job Cancellation - After Complete', async () => {
+    const job = new Job(async (job) => Outcome.ok(1))
+    const result = await job.run()
+    job.cancel() // Test that this is a noop
+
+    expect(job.isCompleted).toBe(true)
+    expect(result.isOk()).toBe(true)
+  })
+
+  test('Job Cancellation - Internal', async () => {
+    const result = await new Job(async (job) => {
+      job.cancel()
+      return Outcome.ok(1)
+    }).run()
+
+    expect(Job.isCancelled(result)).toBe(true)
+  })
+
+  test('Job Timeout', async () => {
+    var childHasRun = false
+
+    const result = await new Job(async (job) => {
+      await job.launchAndRun(async (job) => {
+        await job.delay(100)
+        childHasRun = true
+        return Outcome.ok(2)
+      })
+
+      return Outcome.ok(1)
+    }).runWithTimeout(50)
+
+    if (result.isOk() || !(result.error instanceof JobCancellationException)) {
+      throw new Error('Job did not timeout appropriately')
+    }
+
+    await delay(60)
+    if (childHasRun) {
+      throw new Error('Timeout did not cancel child')
+    }
+  })
+
+  test('Job Delay', async () => {
+    const start = performance.now()
+    const result = await new Job(async (job) => {
+      await job.delay(100)
+      return Outcome.ok(1)
+    }).run()
+
+    if (result.isError() || result.value != 1) {
+      throw new Error('Invalid Result')
+    } else if (performance.now() - start < 100) {
+      throw new Error('Delay did not work')
+    }
+  })
+
+  test('Cancel Children', async () => {
+    const supervisor = new SupervisorJob()
+    var child1Complete = false
+    var child2Complete = false
+
+    const child1 = supervisor.launchAndRun(async (job) => {
+      await job.delay(120)
+      child1Complete = true
+      return Outcome.ok(1)
+    })
+
+    const child2 = supervisor.launchAndRun(async (job) => {
+      await job.delay(100)
+      child2Complete = true
+      return Outcome.ok(2)
+    })
+
+    await delay(25)
+    supervisor.cancelChildren()
+    const child1Result = await child1
+    const child2Result = await child2
+
+    expect(supervisor.isActive).toBe(true)
+    expect(child1Complete).toBe(false)
+    expect(child2Complete).toBe(false)
+    if (
+      child1Result.isOk() ||
+      !(child1Result.error instanceof JobCancellationException)
+    )
+      throw new Error('Child 1 did not return exception')
+    if (
+      child2Result.isOk() ||
+      !(child2Result.error instanceof JobCancellationException)
+    )
+      throw new Error('Child 2 did not return exception')
+  })
+
+  test('SupervisorJob - Await', async () => {
+    const start = performance.now()
+    const supervisor = new SupervisorJob()
+    await supervisor.runWithTimeout(200)
+    if (performance.now() - start < 200)
+      throw new Error('Supervisor Job finished before it was supposed to')
+  })
+
+  test('Child Count', async () => {
+    const supervisor = new SupervisorJob()
+    var jobs: Promise<Outcome<number>>[] = []
+
+    for (var i = 0; i < 100; i++) {
+      jobs.push(
+        supervisor.launchAndRun(async (job) => {
+          await job.delay(Math.random() * 100)
+          return Outcome.ok(1)
+        })
+      )
+    }
+
+    expect(supervisor.childCount).toBe(100)
+    await Promise.all(jobs)
+    expect(supervisor.childCount).toBe(0)
+
+    const noRunChild = supervisor.launch(async (job) => Outcome.ok(1))
+    expect(supervisor.childCount).toBe(1)
+    noRunChild.cancel()
+    expect(supervisor.childCount).toBe(0)
+
+    const runChild = supervisor.launch(async (job) => {
+      await job.delay(50)
+      return Outcome.ok(1)
+    })
+    expect(supervisor.childCount).toBe(1)
+    await runChild.run()
+    expect(supervisor.childCount).toBe(0)
+  })
+})
+
+async function* _testStream() {
+  var i = 0
+  while (true) {
+    yield i++
+    await delay(10)
+  }
+}

--- a/packages/action-listener-middleware/src/tests/job.test.ts
+++ b/packages/action-listener-middleware/src/tests/job.test.ts
@@ -231,7 +231,7 @@ describe('Job', () => {
 
   test('Multiple Job Runs', async () => {
     const job = new Job(async (job) => {
-      await job.delay(500)
+      await job.delay(50)
       return Outcome.ok(1)
     })
 
@@ -239,7 +239,7 @@ describe('Job', () => {
     const result2 = await job.run()
     const result3 = await job.run()
 
-    if (result1.isError() || result1.value != 1)
+    if (result1.isError() || result1.value !== 1)
       throw new Error('Job did not return value correctly')
     if (result2.isOk() || !(result2.error instanceof JobCancellationException))
       throw new Error('Job did not return JobCompletionException')
@@ -336,7 +336,7 @@ describe('Job', () => {
       return Outcome.ok(null)
     }).run()
 
-    expect(counter).toBe(3)
+    expect(counter < 5).toBe(true)
   })
 
   test('Job Immediate Cancellation', async () => {
@@ -404,14 +404,17 @@ describe('Job', () => {
 
   test('Job Delay', async () => {
     const start = performance.now()
+    const expectedTime = 100
     const result = await new Job(async (job) => {
-      await job.delay(100)
+      await job.delay(expectedTime)
       return Outcome.ok(1)
     }).run()
 
-    if (result.isError() || result.value != 1) {
+    const elapsed = performance.now() - start
+
+    if (result.isError() || result.value !== 1) {
       throw new Error('Invalid Result')
-    } else if (performance.now() - start < 100) {
+    } else if (elapsed < expectedTime) {
       throw new Error('Delay did not work')
     }
   })
@@ -456,9 +459,13 @@ describe('Job', () => {
   test('SupervisorJob - Await', async () => {
     const start = performance.now()
     const supervisor = new SupervisorJob()
-    await supervisor.runWithTimeout(200)
-    if (performance.now() - start < 200)
-      throw new Error('Supervisor Job finished before it was supposed to')
+    const expectedTime = 200
+    await supervisor.runWithTimeout(expectedTime)
+    const elapsed = performance.now() - start
+    if (elapsed < expectedTime)
+      throw new Error(
+        `Supervisor Job finished before it was supposed to (${elapsed}, ${expectedTime})`
+      )
   })
 
   test('Child Count', async () => {

--- a/packages/action-listener-middleware/src/tests/useCases.test.ts
+++ b/packages/action-listener-middleware/src/tests/useCases.test.ts
@@ -1,0 +1,190 @@
+import {
+  configureStore,
+  createAction,
+  createSlice,
+  isAnyOf,
+} from '@reduxjs/toolkit'
+
+import type { AnyAction, PayloadAction, Action } from '@reduxjs/toolkit'
+
+import {
+  createActionListenerMiddleware,
+  createListenerEntry,
+  addListenerAction,
+  removeListenerAction,
+} from '../index'
+
+import type {
+  When,
+  ActionListenerMiddlewareAPI,
+  TypedAddListenerAction,
+  TypedAddListener,
+  Unsubscribe,
+} from '../index'
+import { JobCancellationException } from '../job'
+import { Outcome } from '../outcome'
+
+interface CounterState {
+  value: number
+}
+
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState: { value: 0 } as CounterState,
+  reducers: {
+    increment(state) {
+      state.value += 1
+    },
+    decrement(state) {
+      state.value -= 1
+    },
+    // Use the PayloadAction type to declare the contents of `action.payload`
+    incrementByAmount: (state, action: PayloadAction<number>) => {
+      state.value += action.payload
+    },
+  },
+})
+const { increment, decrement, incrementByAmount } = counterSlice.actions
+
+describe('Saga-style Effects Scenarios', () => {
+  let middleware: ReturnType<typeof createActionListenerMiddleware>
+
+  let store = configureStore({
+    reducer: counterSlice.reducer,
+    middleware: (gDM) => gDM().prepend(createActionListenerMiddleware()),
+  })
+
+  const testAction1 = createAction<string>('testAction1')
+  type TestAction1 = ReturnType<typeof testAction1>
+  const testAction2 = createAction<string>('testAction2')
+  type TestAction2 = ReturnType<typeof testAction2>
+  const testAction3 = createAction<string>('testAction3')
+  type TestAction3 = ReturnType<typeof testAction3>
+
+  type RootState = ReturnType<typeof store.getState>
+
+  let addListener: TypedAddListener<RootState>
+
+  function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  beforeEach(() => {
+    middleware = createActionListenerMiddleware()
+    addListener = middleware.addListener as TypedAddListener<RootState>
+    store = configureStore({
+      reducer: counterSlice.reducer,
+      middleware: (gDM) => gDM().prepend(middleware),
+    })
+  })
+
+  test('Long polling loop', async () => {
+    // Reimplementation of a saga-based long-polling loop that is controlled
+    // by "start/stop" actions. The infinite loop waits for a message from the
+    // server, processes it somehow, and waits for the next message.
+    // Ref: https://gist.github.com/markerikson/5203e71a69fa9dff203c9e27c3d84154
+    const eventPollingStarted = createAction('serverPolling/started')
+    const eventPollingStopped = createAction('serverPolling/stopped')
+
+    // For this example, we're going to fake up a "server event poll" async
+    // function by wrapping an event emitter so that every call returns a
+    // promise that is resolved the next time an event is emitted.
+    // This is the tiniest event emitter I could find to copy-paste in here.
+    let createNanoEvents = () => ({
+      events: {} as Record<string, any>,
+      emit(event: string, ...args: any[]) {
+        ;(this.events[event] || []).forEach((i: any) => i(...args))
+      },
+      on(event: string, cb: (...args: any[]) => void) {
+        ;(this.events[event] = this.events[event] || []).push(cb)
+        return () =>
+          (this.events[event] = (this.events[event] || []).filter(
+            (l: any) => l !== cb
+          ))
+      },
+    })
+    const emitter = createNanoEvents()
+
+    // Rig up a dummy "receive a message from the server" API we can trigger manually
+    function pollForEvent() {
+      return new Promise<{ type: string }>((resolve, reject) => {
+        const unsubscribe = emitter.on('serverEvent', (arg1: string) => {
+          unsubscribe()
+          resolve({ type: arg1 })
+        })
+      })
+    }
+
+    // Track how many times each message was processed by the loop
+    const receivedMessages = {
+      a: 0,
+      b: 0,
+      c: 0,
+    }
+
+    let pollingJobStarted = false
+    let pollingJobCanceled = false
+
+    addListener({
+      actionCreator: eventPollingStarted,
+      listener: async (action, listenerApi) => {
+        listenerApi.unsubscribe()
+
+        // Start a child job that will infinitely loop receiving messages
+        const pollingJob = listenerApi.job.launch(async (handle) => {
+          pollingJobStarted = true
+          try {
+            while (true) {
+              const eventPromise = pollForEvent()
+              // Cancelation-aware pause for a new server message
+              const serverEvent = await handle.pause(eventPromise)
+
+              // Process the message. In this case, just count the times we've seen this message.
+              if (serverEvent.type in receivedMessages) {
+                receivedMessages[
+                  serverEvent.type as keyof typeof receivedMessages
+                ]++
+              }
+            }
+          } catch (err) {
+            if (err instanceof JobCancellationException) {
+              pollingJobCanceled = true
+            }
+          }
+          return Outcome.ok(0)
+        })
+        pollingJob.run()
+
+        // Wait for the "stop polling" action
+        await listenerApi.condition(eventPollingStopped.match)
+        pollingJob.cancel()
+      },
+    })
+
+    store.dispatch(eventPollingStarted())
+    await delay(5)
+    expect(pollingJobStarted).toBe(true)
+
+    await delay(5)
+    emitter.emit('serverEvent', 'a')
+    // Promise resolution
+    await delay(1)
+    emitter.emit('serverEvent', 'b')
+    // Promise resolution
+    await delay(1)
+
+    store.dispatch(eventPollingStopped())
+
+    // Have to break out of the event loop to let the cancelation promise
+    // kick in - emitting before this would still resolve pollForEvent()
+    await delay(1)
+    emitter.emit('serverEvent', 'c')
+
+    // A and B were processed earlier. The first C was processed because the
+    // emitter synchronously resolved the `pollForEvents` promise before
+    // the cancelation took effect, but after another pause, the
+    // cancelation kicked in and the second C is ignored.
+    expect(receivedMessages).toEqual({ a: 1, b: 1, c: 0 })
+    expect(pollingJobCanceled).toBe(true)
+  })
+})


### PR DESCRIPTION
This PR:

- Updates `Job.pause()` to include the existing `_cancelPromise` so that it bails out early if cancelation happens before the actual source promise resolves
- Copies in the `job.test.ts` file from the original `job` library (and updates the assertions to work with Jest)
- Adds the first of hopefully several usage scenario examples: a controllable long-polling loop based off of one I wrote years ago with sagas ( https://gist.github.com/markerikson/5203e71a69fa9dff203c9e27c3d84154 )