### PR TITLE
Add prepareHeader to graphqlrequestbasequery

### DIFF
--- a/packages/rtk-query-graphql-request-base-query/package.json
+++ b/packages/rtk-query-graphql-request-base-query/package.json
@@ -22,7 +22,7 @@
     "graphql-request": "^3.4.0"
   },
   "peerDependencies": {
-    "@reduxjs/toolkit": "^1.6.0",
+    "@reduxjs/toolkit": "^1.7.1",
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {

--- a/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
+++ b/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
@@ -1,0 +1,44 @@
+import type { GraphQLClient } from 'graphql-request'
+import type { ThunkDispatch } from 'redux-thunk'
+
+export interface GraphqlBaseQueryApi {
+  dispatch: ThunkDispatch<any, any, any>
+  getState: () => unknown
+}
+
+export type GraphqlRequestBaseQueryArgs = {
+  options:
+    | {
+        url: string
+      }
+    | { client: GraphQLClient }
+  prepareHeaders?: (
+    headers: Headers,
+    api: Pick<GraphqlBaseQueryApi, 'getState'>
+  ) => MaybePromise<Headers>
+}
+
+export type BaseQueryFn<
+  Args = any,
+  Result = unknown,
+  Error = unknown,
+  DefinitionExtraOptions = {},
+  Meta = {}
+> = (
+  args: Args,
+  api: GraphqlBaseQueryApi,
+  extraOptions: DefinitionExtraOptions
+) => MaybePromise<QueryReturnValue<Result, Error, Meta>>
+
+export type QueryReturnValue<T = unknown, E = unknown, M = unknown> =
+  | {
+      error: E
+      data?: undefined
+      meta?: M
+    }
+  | {
+      error?: undefined
+      data: T
+      meta?: M
+    }
+export type MaybePromise<T> = T | PromiseLike<T>

--- a/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
+++ b/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
@@ -1,15 +1,10 @@
+import type { BaseQueryApi } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
 import type { GraphQLClient } from 'graphql-request'
-import type { ThunkDispatch } from 'redux-thunk'
 
 type P = Parameters<GraphQLClient['request']>
 export type Document = P[0]
 export type Variables = P[1]
 export type RequestHeaders = P[2]
-
-export interface GraphqlBaseQueryApi {
-  dispatch: ThunkDispatch<any, any, any>
-  getState: () => unknown
-}
 
 export type GraphqlRequestBaseQueryArgs = {
   options:
@@ -20,21 +15,9 @@ export type GraphqlRequestBaseQueryArgs = {
     | { client: GraphQLClient }
   prepareHeaders?: (
     headers: Headers,
-    api: Pick<GraphqlBaseQueryApi, 'getState'>
+    api: Pick<BaseQueryApi, 'getState' | 'endpoint' | 'type' | 'forced'>
   ) => MaybePromise<Headers>
 }
-
-export type BaseQueryFn<
-  Args = any,
-  Result = unknown,
-  Error = unknown,
-  DefinitionExtraOptions = {},
-  Meta = {}
-> = (
-  args: Args,
-  api: GraphqlBaseQueryApi,
-  extraOptions: DefinitionExtraOptions
-) => MaybePromise<QueryReturnValue<Result, Error, Meta>>
 
 export type QueryReturnValue<T = unknown, E = unknown, M = unknown> =
   | {

--- a/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
+++ b/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
@@ -1,6 +1,11 @@
 import type { GraphQLClient } from 'graphql-request'
 import type { ThunkDispatch } from 'redux-thunk'
 
+type P = Parameters<GraphQLClient['request']>
+export type Document = P[0]
+export type Variables = P[1]
+export type RequestHeaders = P[2]
+
 export interface GraphqlBaseQueryApi {
   dispatch: ThunkDispatch<any, any, any>
   getState: () => unknown
@@ -10,6 +15,7 @@ export type GraphqlRequestBaseQueryArgs = {
   options:
     | {
         url: string
+        requestHeaders?: RequestHeaders
       }
     | { client: GraphQLClient }
   prepareHeaders?: (

--- a/packages/rtk-query-graphql-request-base-query/src/index.ts
+++ b/packages/rtk-query-graphql-request-base-query/src/index.ts
@@ -26,7 +26,7 @@ export const graphqlRequestBaseQuery = ({
     { getState, endpoint, forced, type }
   ) => {
     try {
-      const headers = new Headers(stripUndefined({}))
+      const headers = new Headers(stripUndefined(requestHeaders))
 
       client.setHeaders(
         await prepareHeaders(headers, { getState, endpoint, forced, type })

--- a/packages/rtk-query-graphql-request-base-query/src/index.ts
+++ b/packages/rtk-query-graphql-request-base-query/src/index.ts
@@ -1,36 +1,36 @@
-import { BaseQueryFn } from "@reduxjs/toolkit/query/react";
-import { DocumentNode } from "graphql";
-import { GraphQLClient, ClientError } from "graphql-request";
+import type { DocumentNode } from 'graphql'
+import { GraphQLClient, ClientError } from 'graphql-request'
+import type {
+  BaseQueryFn,
+  GraphqlRequestBaseQueryArgs,
+} from './GraphqlBaseQueryTypes'
 
-type P = Parameters<GraphQLClient["request"]>;
-export type Document = P[0];
-export type Variables = P[1];
-export type RequestHeaders = P[2];
+type P = Parameters<GraphQLClient['request']>
+export type Document = P[0]
+export type Variables = P[1]
+export type RequestHeaders = P[2]
 
-export const graphqlRequestBaseQuery = (
-  options:
-    | { url: string; requestHeaders?: RequestHeaders }
-    | { client: GraphQLClient }
-): BaseQueryFn<
+export const graphqlRequestBaseQuery = ({
+  options,
+  prepareHeaders = (x) => x,
+}: GraphqlRequestBaseQueryArgs): BaseQueryFn<
   { document: string | DocumentNode; variables?: any },
   unknown,
-  Pick<ClientError, "name" | "message" | "stack">,
-  Partial<Pick<ClientError, "request" | "response">>
+  Pick<ClientError, 'name' | 'message' | 'stack'>,
+  Partial<Pick<ClientError, 'request' | 'response'>>
 > => {
   const client =
-    "client" in options ? options.client : new GraphQLClient(options.url);
-  if ("requestHeaders" in options) {
-    client.setHeaders(options.requestHeaders);
-  }
-  return async ({ document, variables }) => {
+    'client' in options ? options.client : new GraphQLClient(options.url)
+  return async ({ document, variables }, { getState }) => {
     try {
-      return { data: await client.request(document, variables), meta: {} };
+      client.setHeaders(await prepareHeaders(new Headers({}), { getState }))
+      return { data: await client.request(document, variables), meta: {} }
     } catch (error) {
       if (error instanceof ClientError) {
-        const { name, message, stack, request, response } = error;
-        return { error: { name, message, stack }, meta: { request, response } };
+        const { name, message, stack, request, response } = error
+        return { error: { name, message, stack }, meta: { request, response } }
       }
-      throw error;
+      throw error
     }
-  };
-};
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5563,7 +5563,7 @@ __metadata:
     microbundle: ^0.13.3
     typescript: ^4.3.4
   peerDependencies:
-    "@reduxjs/toolkit": ^1.6.0
+    "@reduxjs/toolkit": ^1.7.1
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR adds an optional `prepareHeaders` function to the `graphqlRequestBaseQuery` that'd allow injecting headers on requests. The function provides a Headers object and receives the Redux's `getState` function to have access to the Redux store.

cc @phryneas 