### PR TITLE
Improve listener middleware size and update README docs

### DIFF
--- a/packages/action-listener-middleware/src/exceptions.ts
+++ b/packages/action-listener-middleware/src/exceptions.ts
@@ -1,8 +1,7 @@
 export class TaskAbortError implements Error {
-  name: string
-  message: string
-  constructor(public reason?: string) {
-    this.name = 'TaskAbortError'
-    this.message = `task cancelled` + (reason != null ? `: "${reason}"` : '')
+  name = 'TaskAbortError'
+  message = ''
+  constructor(public reason = 'unknown') {
+    this.message = `task cancelled (reason: ${reason})`
   }
 }

--- a/packages/action-listener-middleware/src/tests/effectScenarios.test.ts
+++ b/packages/action-listener-middleware/src/tests/effectScenarios.test.ts
@@ -343,7 +343,6 @@ describe('Saga-style Effects Scenarios', () => {
         } else if (incrementByAmount.match(action)) {
           // do a non-cancelation-aware wait
           await delay(15)
-          // Or can check based on `job.isCancelled`
           if (listenerApi.signal.aborted) {
             canceledCheck = true
           }

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -373,13 +373,12 @@ export type WithMiddlewareType<T extends Middleware<any, any, any>> = {
 }
 
 // A shorthand form of the accepted args, solely so that `createListenerEntry` has validly-typed conditional logic when checking the options contents
-export type FallbackAddListenerOptions = (
-  | { actionCreator: TypedActionCreator<string> }
-  | { type: string }
-  | { matcher: MatchFunction<any> }
-  | { predicate: ListenerPredicate<any, any> }
-) &
-  ActionListenerOptions & { listener: ActionListener<any, any, any> }
+export type FallbackAddListenerOptions = {
+  actionCreator?: TypedActionCreator<string>
+  type?: string
+  matcher?: MatchFunction<any>
+  predicate?: ListenerPredicate<any, any>
+} & ActionListenerOptions & { listener: ActionListener<any, any, any> }
 
 /**
  * Utility Types


### PR DESCRIPTION
This PR:

- Optimizes the logic and code in the middleware to further shrink the bundle size
- Updates the README to describe the latest "task" approach in the API reference and usage section

Size-wise, I'm seeing these results for the ES "modern" build (which is already minified):

- 0.4.0: 6K
- #1823 : 4K
- This PR: 3.7K