### PR TITLE
bugfxing on useState

### DIFF
--- a/examples/query/react/mutations/src/features/posts/PostDetail.tsx
+++ b/examples/query/react/mutations/src/features/posts/PostDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 import {
   useDeletePostMutation,
@@ -29,7 +29,10 @@ const EditablePostName = ({
   onCancel: () => void
   isLoading?: boolean
 }) => {
-  const [name, setName] = useState(initialName)
+
+  useEffect(() => {
+    setName(initialName)
+}, [initialName]);
 
   const handleChange = ({
     target: { value },


### PR DESCRIPTION
Note:  this only a bug-fixing on examples. 

In `mutation` example,  This bug can be reproduced by enable the edit mode of a  post, then shift the post in the post list, you can find the name of the post in edit mode is not synced at all.

the reason is,  it uses the value from **props** as the initial value of `setState` hook, however,  the  value of **state** cannot be  re-initialized if the **props** changes.  For details,  please refer to https://stackoverflow.com/questions/54865764/react-usestate-does-not-reload-state-from-props