### PR TITLE
fix(action-listener-middleware): unhandledRejections caused by listenerApi

### DIFF
--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -32,7 +32,7 @@ import type {
   ForkedTaskExecutor,
   ForkedTask,
 } from './types'
-import { assertFunction } from './utils'
+import { assertFunction,   catchRejection, } from './utils'
 import { TaskAbortError } from './exceptions'
 import {
   runTask,
@@ -161,7 +161,10 @@ const createTakePattern = <S>(
     }
   }
 
-  return take as TakePattern<S>
+  return ((
+    predicate: AnyActionListenerPredicate<S>,
+    timeout: number | undefined
+  ) => catchRejection(take(predicate, timeout))) as TakePattern<S>
 }
 
 /** Accepts the possible options for creating a listener, and returns a formatted listener entry */

--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -32,7 +32,7 @@ import type {
   ForkedTaskExecutor,
   ForkedTask,
 } from './types'
-import { assertFunction,   catchRejection, } from './utils'
+import { assertFunction, catchRejection } from './utils'
 import { TaskAbortError } from './exceptions'
 import {
   runTask,

--- a/packages/action-listener-middleware/src/task.ts
+++ b/packages/action-listener-middleware/src/task.ts
@@ -1,6 +1,6 @@
 import { TaskAbortError } from './exceptions'
 import type { TaskResult } from './types'
-import { noop } from './utils'
+import { noop, catchRejection } from './utils'
 
 /**
  * Synchronously raises {@link TaskAbortError} if the task tied to the input `signal` has been cancelled.
@@ -23,7 +23,7 @@ export const promisifyAbortSignal = (
   signal: AbortSignal,
   reason?: string
 ): Promise<never> => {
-  const promise = new Promise<never>((_, reject) => {
+  return catchRejection(new Promise<never>((_, reject) => {
     const notifyRejection = () => reject(new TaskAbortError(reason))
 
     if (signal.aborted) {
@@ -31,12 +31,7 @@ export const promisifyAbortSignal = (
     } else {
       signal.addEventListener('abort', notifyRejection, { once: true })
     }
-  })
-
-  // We do not want 'unhandledRejection' warnings or crashes caused by cancelled tasks
-  promise.catch(noop)
-
-  return promise
+  }))
 }
 
 /**
@@ -74,11 +69,13 @@ export const runTask = async <T>(
  * @returns
  */
 export const createPause = <T>(signal: AbortSignal) => {
-  return async (promise: Promise<T>): Promise<T> => {
-    validateActive(signal)
-    const result = await Promise.race([promisifyAbortSignal(signal), promise])
-    validateActive(signal)
-    return result
+  return (promise: Promise<T>): Promise<T> => {
+    return catchRejection(
+      Promise.race([promisifyAbortSignal(signal), promise]).then((output) => {
+        validateActive(signal)
+        return output
+      })
+    )
   }
 }
 

--- a/packages/action-listener-middleware/src/task.ts
+++ b/packages/action-listener-middleware/src/task.ts
@@ -23,15 +23,17 @@ export const promisifyAbortSignal = (
   signal: AbortSignal,
   reason?: string
 ): Promise<never> => {
-  return catchRejection(new Promise<never>((_, reject) => {
-    const notifyRejection = () => reject(new TaskAbortError(reason))
+  return catchRejection(
+    new Promise<never>((_, reject) => {
+      const notifyRejection = () => reject(new TaskAbortError(reason))
 
-    if (signal.aborted) {
-      notifyRejection()
-    } else {
-      signal.addEventListener('abort', notifyRejection, { once: true })
-    }
-  }))
+      if (signal.aborted) {
+        notifyRejection()
+      } else {
+        signal.addEventListener('abort', notifyRejection, { once: true })
+      }
+    })
+  )
 }
 
 /**

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -931,19 +931,25 @@ describe('createActionListenerMiddleware', () => {
         predicate: () => true,
         listener: async (_, listenerApi) => {
           listenerApi.unsubscribe() // run once
-          listenerApi.signal.addEventListener('abort', deferredCompletedEvt.resolve)
+          listenerApi.signal.addEventListener(
+            'abort',
+            deferredCompletedEvt.resolve
+          )
           listenerApi.take(() => true) // missing await
-        }
+        },
       })
 
       middleware.addListener({
         predicate: () => true,
         listener: async (_, listenerApi) => {
           listenerApi.cancelPrevious()
-          listenerApi.signal.addEventListener('abort', deferredCancelledEvt.resolve)
+          listenerApi.signal.addEventListener(
+            'abort',
+            deferredCancelledEvt.resolve
+          )
           listenerApi.take(() => true) // missing await
           await listenerApi.pause(godotPauseTrigger)
-        }
+        },
       })
 
       store.dispatch({ type: 'type' })

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -623,6 +623,47 @@ describe('createActionListenerMiddleware', () => {
 
       expect(reducer.mock.calls).toEqual([[{}, testAction1('a')]])
     })
+
+    test('listenerApi.delay does not trigger unhandledRejections for completed or cancelled listners', async () => {
+      let deferredCompletedEvt = deferred()
+      let deferredCancelledEvt = deferred()
+      const godotPauseTrigger = deferred()
+
+      // Unfortunately we cannot test declaratively unhandleRejections in jest: https://github.com/facebook/jest/issues/5620
+      // This test just fails if an `unhandledRejection` occurs.
+      middleware.addListener({
+        actionCreator: increment,
+        listener: async (_, listenerApi) => {
+          listenerApi.unsubscribe()
+          listenerApi.signal.addEventListener(
+            'abort',
+            deferredCompletedEvt.resolve,
+            { once: true }
+          )
+          listenerApi.delay(100) // missing await
+        },
+      })
+
+      middleware.addListener({
+        actionCreator: increment,
+        listener: async (_, listenerApi) => {
+          listenerApi.cancelPrevious()
+          listenerApi.signal.addEventListener(
+            'abort',
+            deferredCancelledEvt.resolve,
+            { once: true }
+          )
+          listenerApi.delay(100) // missing await
+          listenerApi.pause(godotPauseTrigger)
+        },
+      })
+
+      store.dispatch(increment())
+      store.dispatch(increment())
+
+      expect(await deferredCompletedEvt).toBeDefined()
+      expect(await deferredCancelledEvt).toBeDefined()
+    })
   })
 
   describe('Error handling', () => {
@@ -875,6 +916,39 @@ describe('createActionListenerMiddleware', () => {
       store.dispatch(increment())
 
       expect(finalCount).toBe(2)
+    })
+
+    test('take does not trigger unhandledRejections for completed or cancelled tasks', async () => {
+      let deferredCompletedEvt = deferred()
+      let deferredCancelledEvt = deferred()
+      const store = configureStore({
+        reducer: counterSlice.reducer,
+        middleware: (gDM) => gDM().prepend(middleware),
+      })
+      const godotPauseTrigger = deferred()
+
+      middleware.addListener({
+        predicate: () => true,
+        listener: async (_, listenerApi) => {
+          listenerApi.unsubscribe() // run once
+          listenerApi.signal.addEventListener('abort', deferredCompletedEvt.resolve)
+          listenerApi.take(() => true) // missing await
+        }
+      })
+
+      middleware.addListener({
+        predicate: () => true,
+        listener: async (_, listenerApi) => {
+          listenerApi.cancelPrevious()
+          listenerApi.signal.addEventListener('abort', deferredCancelledEvt.resolve)
+          listenerApi.take(() => true) // missing await
+          await listenerApi.pause(godotPauseTrigger)
+        }
+      })
+
+      store.dispatch({ type: 'type' })
+      store.dispatch({ type: 'type' })
+      expect(await deferredCompletedEvt).toBeDefined()
     })
   })
 

--- a/packages/action-listener-middleware/src/utils.ts
+++ b/packages/action-listener-middleware/src/utils.ts
@@ -11,3 +11,12 @@ export const assertFunction: (
 }
 
 export const noop = () => {}
+
+export const catchRejection = <T>(
+  promise: Promise<T>,
+  onError = noop
+): Promise<T> => {
+  promise.catch(onError)
+
+  return promise
+}


### PR DESCRIPTION


Closes: #1843

### Test log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run test
 PASS  src/tests/listenerMiddleware.test.ts
 PASS  src/tests/effectScenarios.test.ts
 PASS  src/tests/fork.test.ts
 PASS  src/tests/useCases.test.ts

Test Suites: 4 passed, 4 total
Tests:       66 passed, 66 total
Snapshots:   0 total
Time:        1.964 s, estimated 2 s
Ran all test suites.
```

### Build log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run build
Build "actionListenerMiddleware" to dist/esm:
       1660 B: index.modern.js.gz
       1499 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.33 kB: index.js.gz
      2.07 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
      2.32 kB: index.js.gz
      2.07 kB: index.js.br

$ du -h packages/action-listener-middleware/dist/esm/index.modern.js
4.0K    packages/action-listener-middleware/dist/esm/index.modern.js
```

