### PR TITLE
Remove When option from middleware

### DIFF
--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -143,8 +143,6 @@ interface AddListenerOptions {
   predicate?: ListenerPredicate
 
   listener: (action: Action, listenerApi: ListenerApi) => void | Promise<void>
-
-  when?: 'beforeReducer' | 'afterReducer' | 'both'
 }
 ```
 
@@ -174,15 +172,7 @@ The return value is a standard `unsubscribe()` callback that will remove this li
 
 The `listener` callback will receive the current action as its first argument, as well as a "listener API" object similar to the "thunk API" object in `createAsyncThunk`.
 
-The listener may be configured to run _before_ an action reaches the reducer, _after_ the reducer, or both, by passing a `when` option when adding the listener. If the `when` option is not provided, the default is 'afterReducer':
-
-```ts
-middleware.addListener({
-  actionCreator: increment,
-  listener,
-  when: 'beforeReducer',
-})
-```
+All listener predicates and callbacks are checked _after_ the root reducer has already processed the action and updated the state. The `listenerApi.getOriginalState()` method can be used to get the state value that existed before the action that triggered this listener was processed.
 
 ### `listenerMiddleware.removeListener(typeOrActionCreator, listener)`
 
@@ -226,7 +216,6 @@ The `listenerApi` object is the second argument to each listener callback. It co
 
 #### Middleware Options
 
-- `currentPhase: 'beforeReducer' | 'afterReducer'`: an string indicating when the listener is being called relative to the action processing
 - `extra: unknown`: the "extra argument" that was provided as part of the middleware setup, if any
 
 `extra` can be used to inject a value such as an API service layer into the middleware at creation time, and is accessible here.

--- a/packages/action-listener-middleware/src/tests/effectScenarios.test.ts
+++ b/packages/action-listener-middleware/src/tests/effectScenarios.test.ts
@@ -7,21 +7,9 @@ import {
 
 import type { AnyAction, PayloadAction, Action } from '@reduxjs/toolkit'
 
-import {
-  createActionListenerMiddleware,
-  createListenerEntry,
-  addListenerAction,
-  removeListenerAction,
-  TaskAbortError,
-} from '../index'
+import { createActionListenerMiddleware, TaskAbortError } from '../index'
 
-import type {
-  When,
-  ActionListenerMiddlewareAPI,
-  TypedAddListenerAction,
-  TypedAddListener,
-  Unsubscribe,
-} from '../index'
+import type { TypedAddListener } from '../index'
 
 describe('Saga-style Effects Scenarios', () => {
   interface CounterState {

--- a/packages/action-listener-middleware/src/tests/useCases.test.ts
+++ b/packages/action-listener-middleware/src/tests/useCases.test.ts
@@ -5,22 +5,11 @@ import {
   isAnyOf,
 } from '@reduxjs/toolkit'
 
-import type { AnyAction, PayloadAction, Action } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
 
-import {
-  createActionListenerMiddleware,
-  createListenerEntry,
-  addListenerAction,
-  removeListenerAction,
-} from '../index'
+import { createActionListenerMiddleware } from '../index'
 
-import type {
-  When,
-  ActionListenerMiddlewareAPI,
-  TypedAddListenerAction,
-  TypedAddListener,
-  Unsubscribe,
-} from '../index'
+import type { TypedAddListener } from '../index'
 import { TaskAbortError } from '../exceptions'
 
 interface CounterState {

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -24,13 +24,6 @@ export interface TypedActionCreator<Type extends string> {
   match: MatchFunction<any>
 }
 
-/**
- * Action Listener Options types
- */
-export type MiddlewarePhase = 'beforeReducer' | 'afterReducer'
-
-export type When = MiddlewarePhase | 'both' | undefined
-
 export type AnyActionListenerPredicate<State> = (
   action: AnyAction,
   currentState: State,
@@ -153,7 +146,6 @@ export interface ActionListenerMiddlewareAPI<S, D extends Dispatch<AnyAction>>
    * @param promise
    */
   pause<M>(promise: Promise<M>): Promise<M>
-  currentPhase: MiddlewarePhase
   // TODO Figure out how to pass this through the other types correctly
   extra: unknown
 }
@@ -172,12 +164,7 @@ export interface ListenerErrorHandler {
 }
 
 export interface ActionListenerOptions {
-  /**
-   * Determines if the listener runs 'before' or 'after' the reducers have been called.
-   * If set to 'before', calling `api.stopPropagation()` from the listener becomes possible.
-   * Defaults to 'before'.
-   */
-  when?: When
+  /** TODO Empty after removing `when` - will leave here for now */
 }
 
 export interface CreateListenerMiddlewareOptions<ExtraArgument = unknown> {
@@ -359,7 +346,6 @@ export type ListenerEntry<
   D extends Dispatch<AnyAction> = Dispatch<AnyAction>
 > = {
   id: string
-  when: When
   listener: ActionListener<any, S, D>
   unsubscribe: () => void
   pendingSet: Set<AbortController>
@@ -408,10 +394,6 @@ export interface ListenerErrorInfo {
    * Which function has generated the exception.
    */
   raisedBy: 'listener' | 'predicate'
-  /**
-   * When the function that has raised the error has been called.
-   */
-  phase: MiddlewarePhase
 }
 
 /**

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -348,7 +348,7 @@ export type ListenerEntry<
   id: string
   listener: ActionListener<any, S, D>
   unsubscribe: () => void
-  pendingSet: Set<AbortController>
+  pending: Set<AbortController>
   type?: string
   predicate: ListenerPredicate<AnyAction, S>
 }


### PR DESCRIPTION
This PR:

- Removes the `When` option from the middleware, on the grounds that it is no longer useful ( https://github.com/reduxjs/redux-toolkit/discussions/1648#discussioncomment-1843701 ), including README updates
- Does some more byte-shaving (ESM build is down to 3494b min)