### PR TITLE
Rename `cancelPrevious` to `cancelActiveListeners`

### DIFF
--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -388,7 +388,7 @@ export function createActionListenerMiddleware<
             subscribe: () => {
               listenerMap.set(entry.id, entry)
             },
-            cancelPrevious: () => {
+            cancelActiveListeners: () => {
               entry.pending.forEach((controller, _, set) => {
                 if (controller !== internalTaskController) {
                   controller.abort()

--- a/packages/action-listener-middleware/src/tests/effectScenarios.test.ts
+++ b/packages/action-listener-middleware/src/tests/effectScenarios.test.ts
@@ -129,7 +129,7 @@ describe('Saga-style Effects Scenarios', () => {
         listenerCalls++
 
         // Cancel any in-progress instances of this listener
-        listenerApi.cancelPrevious()
+        listenerApi.cancelActiveListeners()
 
         // Delay before starting actual work
         await listenerApi.delay(15)
@@ -335,7 +335,7 @@ describe('Saga-style Effects Scenarios', () => {
             canceledCheck = true
           }
         } else if (decrement.match(action)) {
-          listenerApi.cancelPrevious()
+          listenerApi.cancelActiveListeners()
         }
       },
     })

--- a/packages/action-listener-middleware/src/tests/fork.test.ts
+++ b/packages/action-listener-middleware/src/tests/fork.test.ts
@@ -97,7 +97,7 @@ describe('fork', () => {
     middleware.addListener({
       actionCreator: increment,
       listener: async (_, listenerApi) => {
-        listenerApi.cancelPrevious()
+        listenerApi.cancelActiveListeners()
         const result = await listenerApi.fork(async () => {
           await delay(20)
 
@@ -374,7 +374,7 @@ describe('fork', () => {
     middleware.addListener({
       actionCreator: increment,
       listener: async (_, listenerApi) => {
-        listenerApi.cancelPrevious()
+        listenerApi.cancelActiveListeners()
         const forkedTask = listenerApi.fork(async (forkApi) => {
           await forkApi.pause(delay(30))
 

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -36,7 +36,7 @@ const middlewareApi = {
   dispatch: expect.any(Function),
   unsubscribe: expect.any(Function),
   subscribe: expect.any(Function),
-  cancelPrevious: expect.any(Function),
+  cancelActiveListeners: expect.any(Function),
 }
 
 const noop = () => {}
@@ -569,7 +569,7 @@ describe('createActionListenerMiddleware', () => {
       middleware.addListener({
         actionCreator: increment,
         listener: async (_, listenerApi) => {
-          listenerApi.cancelPrevious()
+          listenerApi.cancelActiveListeners()
           listenerApi.signal.addEventListener(
             'abort',
             deferredCancelledEvt.resolve,
@@ -858,7 +858,7 @@ describe('createActionListenerMiddleware', () => {
       middleware.addListener({
         predicate: () => true,
         listener: async (_, listenerApi) => {
-          listenerApi.cancelPrevious()
+          listenerApi.cancelActiveListeners()
           listenerApi.signal.addEventListener(
             'abort',
             deferredCancelledEvt.resolve
@@ -897,7 +897,7 @@ describe('createActionListenerMiddleware', () => {
               }
             }
           } else {
-            listenerApi.cancelPrevious()
+            listenerApi.cancelActiveListeners()
           }
         },
       })

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -123,7 +123,7 @@ export interface ActionListenerMiddlewareAPI<S, D extends Dispatch<AnyAction>>
   subscribe(): void
   condition: ConditionFunction<S>
   take: TakePattern<S>
-  cancelPrevious: () => void
+  cancelActiveListeners: () => void
   /**
    * An abort signal whose `aborted` property is set to `true`
    * if the listener execution is either aborted or completed.


### PR DESCRIPTION
This PR:

- Renames the `listenerApi.cancelPrevious` method to be `cancelActiveListeners` instead

The name "cancelPrevious" didn't correctly describe the behavior. It always cancels _all other_ running listeners, regardless of order.

We might split this into different functions later on, but for now we're renaming it to be accurate about what it does.