### PR TITLE
Fix named export used as default export in example

### DIFF
--- a/docs/tutorials/rtk-query.mdx
+++ b/docs/tutorials/rtk-query.mdx
@@ -148,7 +148,7 @@ import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 
 import App from './App'
-import store from './app/store'
+import { store } from './app/store'
 
 const rootElement = document.getElementById('root')
 render(


### PR DESCRIPTION
Problem: In the rtk-query tutorial ([link](https://redux-toolkit.js.org/tutorials/rtk-query#wrap-your-application-with-the-provider)) in store.ts, we have a names export called store. In our entry file, we are importing it as default export. Probably a typo.

Fix: Updated the import statement.