### PR TITLE
[action-listener][counter-example]: polish store setup code

### DIFF
--- a/examples/action-listener/counter/src/services/counter/listeners.ts
+++ b/examples/action-listener/counter/src/services/counter/listeners.ts
@@ -60,16 +60,31 @@ async function onUpdateAsync(
   }
 }
 
+/**
+ * Subscribes counter listeners and returns a `teardown` function.
+ * @example
+ * ```ts
+ * useEffect(() => {
+ *   const unsubscribe = setupCounterListeners();
+ *   return unsubscribe;
+ * }, []);
+ * ```
+ */
 export function setupCounterListeners(
   actionListener: AppActionListenerMiddleware
 ) {
-  actionListener.addListener({
-    actionCreator: counterActions.updateByPeriodically,
-    listener: onUpdateByPeriodically,
-  })
+  const subscriptions = [
+    actionListener.addListener({
+      actionCreator: counterActions.updateByPeriodically,
+      listener: onUpdateByPeriodically,
+    }),
+    actionListener.addListener({
+      actionCreator: counterActions.updateByAsync,
+      listener: onUpdateAsync,
+    }),
+  ]
 
-  actionListener.addListener({
-    actionCreator: counterActions.updateByAsync,
-    listener: onUpdateAsync,
-  })
+  return () => {
+    subscriptions.forEach((unsubscribe) => unsubscribe())
+  }
 }

--- a/examples/action-listener/counter/src/services/theme/listeners.ts
+++ b/examples/action-listener/counter/src/services/theme/listeners.ts
@@ -14,7 +14,7 @@ function onChangeColorScheme(
 export function setupThemeListeners(
   actionListener: AppActionListenerMiddleware
 ) {
-  actionListener.addListener({
+  return actionListener.addListener({
     actionCreator: themeActions.changeColorScheme,
     listener: onChangeColorScheme,
   })

--- a/examples/action-listener/counter/src/store.ts
+++ b/examples/action-listener/counter/src/store.ts
@@ -10,7 +10,7 @@ import { themeSlice } from './services/theme/slice'
 import { setupCounterListeners } from './services/counter/listeners'
 import { setupThemeListeners } from './services/theme/listeners'
 
-export const actionListener = createActionListenerMiddleware({
+const actionListenerMiddleware = createActionListenerMiddleware({
   onError: () => console.error,
 })
 
@@ -19,7 +19,7 @@ const store = configureStore({
     [counterSlice.name]: counterSlice.reducer,
     [themeSlice.name]: themeSlice.reducer,
   },
-  middleware: (gDM) => gDM().prepend(actionListener),
+  middleware: (gDM) => gDM().prepend(actionListenerMiddleware),
 })
 
 export { store }
@@ -35,11 +35,13 @@ export type AppActionListenerMiddleware = ActionListenerMiddleware<
   AppDispatch
 >
 
-actionListener as AppActionListenerMiddleware
+// Typed version of `actionListenerMiddleware`
+export const appActionListener =
+  actionListenerMiddleware as AppActionListenerMiddleware
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>()
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 
-setupCounterListeners(actionListener as AppActionListenerMiddleware)
-setupThemeListeners(actionListener as AppActionListenerMiddleware)
+setupCounterListeners(appActionListener)
+setupThemeListeners(appActionListener)


### PR DESCRIPTION
This PR improves `action-listener` setup in `examples/action-listener/counter`:

1. Removed useless type cast.
2.  fixed type of exported middleware in `./store.ts` (`appActionListener`).
3. `setupCounterListeners` & `setupThemeListeners` now return an unsubscribe function.