### PR TITLE
[action-listener-middleware] re-enable 34 skipped tests + byte shaving

### DIFF
--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -263,10 +263,10 @@ describe('createActionListenerMiddleware', () => {
       let listener1Calls = 0
 
       middleware.addListener({
-        predicate: (action, state, previousState) => {
+        predicate: (action, state) => {
           return (state as CounterState).value > 1
         },
-        listener: (action, listenerApi) => {
+        listener: () => {
           listener1Calls++
         },
       })
@@ -280,7 +280,7 @@ describe('createActionListenerMiddleware', () => {
             (prevState as CounterState).value % 2 === 0
           )
         },
-        listener: (action, listenerApi) => {
+        listener: () => {
           listener2Calls++
         },
       })
@@ -291,7 +291,7 @@ describe('createActionListenerMiddleware', () => {
       store.dispatch(increment())
 
       expect(listener1Calls).toBe(3)
-      expect(listener2Calls).toBe(2)
+      expect(listener2Calls).toBe(1)
     })
 
     test('subscribing with the same listener will not make it trigger twice (like EventTarget.addEventListener())', () => {
@@ -690,7 +690,7 @@ describe('createActionListenerMiddleware', () => {
   })
 
   describe('take and condition methods', () => {
-    test.only('take resolves to the tuple [A, CurrentState, PreviousState] when the predicate matches the action', async () => {
+    test('take resolves to the tuple [A, CurrentState, PreviousState] when the predicate matches the action', async () => {
       const store = configureStore({
         reducer: counterSlice.reducer,
         middleware: (gDM) => gDM().prepend(middleware),
@@ -766,10 +766,10 @@ describe('createActionListenerMiddleware', () => {
       let listenerStarted = false
 
       middleware.addListener({
-        predicate: (action, currentState) => {
+        predicate: (action, _, previousState) => {
           return (
             increment.match(action) &&
-            (currentState as CounterState).value === 0
+            (previousState as CounterState).value === 0
           )
         },
         listener: async (action, listenerApi) => {
@@ -785,6 +785,7 @@ describe('createActionListenerMiddleware', () => {
       })
 
       store.dispatch(increment())
+
       expect(listenerStarted).toBe(true)
       await delay(25)
       store.dispatch(increment())
@@ -808,7 +809,7 @@ describe('createActionListenerMiddleware', () => {
         predicate: (action, currentState) => {
           return (
             increment.match(action) &&
-            (currentState as CounterState).value === 0
+            (currentState as CounterState).value === 1
           )
         },
         listener: async (action, listenerApi) => {


### PR DESCRIPTION
### Changes

- removes an .only that prevented the execution of 34 tests
- fix: 'Can subscribe with an action predicate function' test
- fix: 'condition method resolves promise when there is a timeout'
- fix: 'condition method resolves promise when the predicate succeeds'
- perf(alm): additional byte shaving

### Byte shaving

`3.4K  index.modern.js`

**After**

```bash
Build "actionListenerMiddleware" to dist/esm:
       1542 B: index.modern.js.gz
       1381 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.19 kB: index.js.gz
      1.96 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
      2.19 kB: index.js.gz
      1.95 kB: index.js.br
```

**Before**

```bash
Build "actionListenerMiddleware" to dist/esm:
       1561 B: index.modern.js.gz
       1408 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.21 kB: index.js.gz
      1.97 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
       2.2 kB: index.js.gz
      1.96 kB: index.js.br
```

