### PR TITLE
Fix `addMatcher` typings

### DIFF
--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -15,8 +15,11 @@ import type { NoInfer } from './tsHelpers'
  */
 export type Actions<T extends keyof any = string> = Record<T, Action>
 
-export interface ActionMatcher<A> {
-  (action: any): action is A
+/**
+ * @deprecated use `TypeGuard` instead
+ */
+export interface ActionMatcher<A extends AnyAction> {
+  (action: AnyAction): action is A
 }
 
 export type ActionMatcherDescription<S, A extends AnyAction> = {

--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -15,8 +15,8 @@ import type { NoInfer } from './tsHelpers'
  */
 export type Actions<T extends keyof any = string> = Record<T, Action>
 
-export interface ActionMatcher<A extends AnyAction> {
-  (action: AnyAction): action is A
+export interface ActionMatcher<A> {
+  (action: any): action is A
 }
 
 export type ActionMatcherDescription<S, A extends AnyAction> = {

--- a/packages/toolkit/src/mapBuilders.ts
+++ b/packages/toolkit/src/mapBuilders.ts
@@ -96,9 +96,9 @@ const reducer = createReducer(initialState, (builder) => {
 });
 ```
    */
-  addMatcher<A extends AnyAction>(
-    matcher: ActionMatcher<A> | ((action: AnyAction) => boolean),
-    reducer: CaseReducer<State, A>
+  addMatcher<A>(
+    matcher: ActionMatcher<A> | ((action: any) => boolean),
+    reducer: CaseReducer<State, A extends AnyAction ? A : A & AnyAction>
   ): Omit<ActionReducerMapBuilder<State>, 'addCase'>
 
   /**
@@ -167,9 +167,9 @@ export function executeReducerBuilderCallback<S>(
       actionsMap[type] = reducer
       return builder
     },
-    addMatcher<A extends AnyAction>(
+    addMatcher<A>(
       matcher: ActionMatcher<A>,
-      reducer: CaseReducer<S, A>
+      reducer: CaseReducer<S, A extends AnyAction ? A : A & AnyAction>
     ) {
       if (process.env.NODE_ENV !== 'production') {
         if (defaultCaseReducer) {

--- a/packages/toolkit/src/mapBuilders.ts
+++ b/packages/toolkit/src/mapBuilders.ts
@@ -2,9 +2,9 @@ import type { Action, AnyAction } from 'redux'
 import type {
   CaseReducer,
   CaseReducers,
-  ActionMatcher,
   ActionMatcherDescriptionCollection,
 } from './createReducer'
+import type { TypeGuard } from './tsHelpers'
 
 export interface TypedActionCreator<Type extends string> {
   (...args: any[]): Action<Type>
@@ -97,7 +97,7 @@ const reducer = createReducer(initialState, (builder) => {
 ```
    */
   addMatcher<A>(
-    matcher: ActionMatcher<A> | ((action: any) => boolean),
+    matcher: TypeGuard<A> | ((action: any) => boolean),
     reducer: CaseReducer<State, A extends AnyAction ? A : A & AnyAction>
   ): Omit<ActionReducerMapBuilder<State>, 'addCase'>
 
@@ -168,7 +168,7 @@ export function executeReducerBuilderCallback<S>(
       return builder
     },
     addMatcher<A>(
-      matcher: ActionMatcher<A>,
+      matcher: TypeGuard<A>,
       reducer: CaseReducer<S, A extends AnyAction ? A : A & AnyAction>
     ) {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/toolkit/src/tests/mapBuilders.typetest.ts
+++ b/packages/toolkit/src/tests/mapBuilders.typetest.ts
@@ -1,4 +1,4 @@
-import type { SerializedError } from '@internal/createAsyncThunk';
+import type { SerializedError } from '@internal/createAsyncThunk'
 import { createAsyncThunk } from '@internal/createAsyncThunk'
 import { executeReducerBuilderCallback } from '@internal/mapBuilders'
 import type { AnyAction } from '@reduxjs/toolkit'
@@ -55,6 +55,20 @@ import { expectType } from './helpers'
     builder.addMatcher(increment.match, (state, action) => {
       expectType<ReturnType<typeof increment>>(action)
     })
+
+    {
+      // action type is inferred when type predicate lacks `type` property
+      type PredicateWithoutTypeProperty = {
+        payload: number
+      }
+
+      builder.addMatcher(
+        (action): action is PredicateWithoutTypeProperty => true,
+        (state, action) => {
+          expectType<PredicateWithoutTypeProperty>(action)
+        }
+      )
+    }
 
     // action type defaults to AnyAction if no type predicate matcher is passed
     builder.addMatcher(

--- a/packages/toolkit/src/tests/mapBuilders.typetest.ts
+++ b/packages/toolkit/src/tests/mapBuilders.typetest.ts
@@ -3,7 +3,7 @@ import { createAsyncThunk } from '@internal/createAsyncThunk'
 import { executeReducerBuilderCallback } from '@internal/mapBuilders'
 import type { AnyAction } from '@reduxjs/toolkit'
 import { createAction } from '@reduxjs/toolkit'
-import { expectType } from './helpers'
+import { expectExactType, expectType } from './helpers'
 
 /** Test:  alternative builder callback for actionMap */
 {
@@ -66,6 +66,7 @@ import { expectType } from './helpers'
         (action): action is PredicateWithoutTypeProperty => true,
         (state, action) => {
           expectType<PredicateWithoutTypeProperty>(action)
+          expectType<AnyAction>(action)
         }
       )
     }
@@ -74,6 +75,15 @@ import { expectType } from './helpers'
     builder.addMatcher(
       () => true,
       (state, action) => {
+        expectExactType({} as AnyAction)(action)
+      }
+    )
+
+    // with a boolean checker, action can also be typed by type argument
+    builder.addMatcher<{ foo: boolean }>(
+      () => true,
+      (state, action) => {
+        expectType<{ foo: boolean }>(action)
         expectType<AnyAction>(action)
       }
     )

--- a/packages/toolkit/src/tsHelpers.ts
+++ b/packages/toolkit/src/tsHelpers.ts
@@ -101,8 +101,12 @@ export type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>
 
+export interface TypeGuard<T> {
+  (value: any): value is T
+}
+
 export interface HasMatchFunction<T> {
-  match: (v: any) => v is T
+  match: TypeGuard<T>
 }
 
 export const hasMatchFunction = <T>(
@@ -112,7 +116,7 @@ export const hasMatchFunction = <T>(
 }
 
 /** @public */
-export type Matcher<T> = HasMatchFunction<T> | ((v: any) => v is T)
+export type Matcher<T> = HasMatchFunction<T> | TypeGuard<T>
 
 /** @public */
 export type ActionFromMatcher<M extends Matcher<any>> = M extends Matcher<


### PR DESCRIPTION
References #1861

Previously, the `action` argument passed down to the `reducer` function of `addMatcher(matcher, reducer)` would be incorrectly typed as `AnyAction` when the type predicate being tested by the `matcher` function didn't include a `type` property.

This PR attempts to resolve the issue:

- Widens the type argument of `ActionMatcher` from `A extends AnyAction` to `A`.
- Maintains the previous behavior of defaulting the type of the `action` argument to `AnyAction` when there is no type predicate.
- Intersects the `A` type argument with `AnyAction` to satisfy the second type argument to `CaseReducer` and offer better completion inside the reducer function.
- Adds a type test to the mapBuilders.typetest.ts file that verifies that the `action` argument is now correctly typed.

> "If you changed external-facing types, make sure to also build the project locally and include the updated API report file etc/redux-toolkit.api.md in your pull request."

I was unable to accomplish this. I ran the monorepo `build` script and the @reduxjs/toolkit `build` scripts but this file was never updated. All of the `build:*` scripts in the @reduxjs/toolkit workspace's package.json file include the `--skipExtraction` flag which seems like it would prevent the extraction tool from running. `addMatcher()` and `ActionMatcher` _are_ referenced in the etc/redux-toolkit.api.md file, so I think the file should be updated with this PR. If somebody could point me in the right direction on how to get the tooling to do that, I would be grateful.

Thanks for taking the time to look at this and let me know what you all think!