### PR TITLE
Add option to display the last update time on docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,6 +14,7 @@ module.exports = {
           docLayoutComponent: '../src/theme/DocPageWithBraveWarning',
           path: '../docs',
           sidebarPath: require.resolve('./sidebars.json'),
+          showLastUpdateTime: true,
           routeBasePath: '/',
           include: [
             '{api,assets,introduction,rtk-query,tutorials,usage}/**/*.{md,mdx}',


### PR DESCRIPTION
There's no way to tell if we are reading a new version of the docs besides reading it entirely (or looking at the Git history).

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148601214-a369c88c-bc0f-4730-9170-ecb8f20f9d8d.png)