### PR TITLE
fix(alm): prevent memory leaks caused by getOriginalState

### DIFF
--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -210,8 +210,7 @@ The `listenerApi` object is the second argument to each listener callback. It co
 
 - `dispatch: Dispatch`: the standard `store.dispatch` method
 - `getState: () => State`: the standard `store.getState` method
-- `getOriginalState: () => State`: returns the store state as it existed when the action was originally dispatched, _before_ the reducers ran.
-  This method can only be called synchronously, it throws error otherwise.
+- `getOriginalState: () => State`: returns the store state as it existed when the action was originally dispatched, _before_ the reducers ran. (**Note**: this method can only be called synchronously, during the initial dispatch call stack, to avoid memory leaks. Calling it asynchronously will throw an error.)
 
 `dispatch` and `getState` are exactly the same as in a thunk. `getOriginalState` can be used to compare the original state before the listener was started.
 

--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -210,7 +210,8 @@ The `listenerApi` object is the second argument to each listener callback. It co
 
 - `dispatch: Dispatch`: the standard `store.dispatch` method
 - `getState: () => State`: the standard `store.getState` method
-- `getOriginalState: () => State`: returns the store state as it existed when the action was originally dispatched, _before_ the reducers ran
+- `getOriginalState: () => State`: returns the store state as it existed when the action was originally dispatched, _before_ the reducers ran.
+  This method can only be called synchronously, it throws error otherwise.
 
 `dispatch` and `getState` are exactly the same as in a thunk. `getOriginalState` can be used to compare the original state before the listener was started.
 

--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -31,7 +31,7 @@ import type {
   ForkedTaskExecutor,
   ForkedTask,
 } from './types'
-import { assertFunction, catchRejection, INTERNAL_NIL_TOKEN } from './utils'
+import { assertFunction, catchRejection } from './utils'
 import { TaskAbortError } from './exceptions'
 import {
   runTask,
@@ -64,6 +64,10 @@ export type {
 
 //Overly-aggressive byte-shaving
 const { assign } = Object
+/**
+ * @internal
+ */
+const INTERNAL_NIL_TOKEN = {} as const
 
 const alm = 'actionListenerMiddleware' as const
 

--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -31,7 +31,7 @@ import type {
   ForkedTaskExecutor,
   ForkedTask,
 } from './types'
-import { assertFunction, catchRejection } from './utils'
+import { assertFunction, catchRejection, INTERNAL_NIL_TOKEN } from './utils'
 import { TaskAbortError } from './exceptions'
 import {
   runTask,
@@ -432,33 +432,51 @@ export function createActionListenerMiddleware<
     }
 
     // Need to get this state _before_ the reducer processes the action
-    const originalState = api.getState()
-    const getOriginalState = () => originalState
+    let originalState: S | typeof INTERNAL_NIL_TOKEN = api.getState()
 
-    // Actually forward the action to the reducer before we handle listeners
-    const result: unknown = next(action)
-
-    if (listenerMap.size > 0) {
-      let currentState = api.getState()
-      for (let entry of listenerMap.values()) {
-        let runListener = false
-
-        try {
-          runListener = entry.predicate(action, currentState, originalState)
-        } catch (predicateError) {
-          runListener = false
-
-          safelyNotifyError(onError, predicateError, {
-            raisedBy: 'predicate',
-          })
-        }
-
-        if (!runListener) {
-          continue
-        }
-
-        notifyListener(entry, action, api, getOriginalState)
+    // `getOriginalState` can only be called synchronously.
+    // @see https://github.com/reduxjs/redux-toolkit/discussions/1648#discussioncomment-1932820
+    const getOriginalState = (): S => {
+      if (originalState === INTERNAL_NIL_TOKEN) {
+        throw new Error(
+          `${alm}: getOriginalState can only be called synchronously`
+        )
       }
+
+      return originalState as S
+    }
+
+    let result: unknown
+
+    try {
+      // Actually forward the action to the reducer before we handle listeners
+      result = next(action)
+
+      if (listenerMap.size > 0) {
+        let currentState = api.getState()
+        for (let entry of listenerMap.values()) {
+          let runListener = false
+
+          try {
+            runListener = entry.predicate(action, currentState, originalState)
+          } catch (predicateError) {
+            runListener = false
+
+            safelyNotifyError(onError, predicateError, {
+              raisedBy: 'predicate',
+            })
+          }
+
+          if (!runListener) {
+            continue
+          }
+
+          notifyListener(entry, action, api, getOriginalState)
+        }
+      }
+    } finally {
+      // Remove `originalState` store from this scope.
+      originalState = INTERNAL_NIL_TOKEN
     }
 
     return result

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -118,6 +118,30 @@ export interface ForkedTask<T> {
  */
 export interface ActionListenerMiddlewareAPI<S, D extends Dispatch<AnyAction>>
   extends MiddlewareAPI<D, S> {
+  /**
+   * Returns the store state as it existed when the action was originally dispatched, _before_ the reducers ran.
+   *
+   * ### Synchronous invocation
+   *
+   * This function can **only** be invoked **synchronously**, it throws error otherwise.
+   *
+   * @example
+   *
+   * ```ts
+   * middleware.addListener({
+   *  predicate: () => true,
+   *  async listener(_, { getOriginalState }) {
+   *    getOriginalState(); // sync: OK!
+   *
+   *    setTimeout(getOriginalState, 0); // async: throws Error
+   *
+   *    await Promise().resolve();
+   *
+   *    getOriginalState() // async: throws Error
+   *  }
+   * })
+   * ```
+   */
   getOriginalState: () => S
   unsubscribe(): void
   subscribe(): void

--- a/packages/action-listener-middleware/src/utils.ts
+++ b/packages/action-listener-middleware/src/utils.ts
@@ -20,3 +20,8 @@ export const catchRejection = <T>(
 
   return promise
 }
+
+/**
+ * @internal
+ */
+export const INTERNAL_NIL_TOKEN = {} as const

--- a/packages/action-listener-middleware/src/utils.ts
+++ b/packages/action-listener-middleware/src/utils.ts
@@ -20,8 +20,3 @@ export const catchRejection = <T>(
 
   return promise
 }
-
-/**
- * @internal
- */
-export const INTERNAL_NIL_TOKEN = {} as const


### PR DESCRIPTION
This PR prevents memory leaks caused by `getOriginalState` and adds the following BREAKING CHANGE:
`getOriginalState` now throws error if it is called asynchronously.

See relevant discussion: https://github.com/reduxjs/redux-toolkit/discussions/1648#discussioncomment-1932820

### Build log

```bash
Build "actionListenerMiddleware" to dist/esm:
       1592 B: index.modern.js.gz
       1431 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.25 kB: index.js.gz
      2.01 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
      2.24 kB: index.js.gz
         2 kB: index.js.br
```

### Bundle size

```bash
stat -f%z packages/action-listener-middleware/dist/esm/index.modern.js

3572
```

### Test log

```bash
﻿﻿PASS src/tests/listenerMiddleware.test.ts
PASS src/tests/effectScenarios.test.ts
PASS src/tests/fork.test.ts
PASS src/tests/useCases.test.ts

Test Suites: 4 passed, 4 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        1.93 s, estimated 2 s
Ran all test suites.
```
