### PR TITLE
Remove duplicate documentation block

### DIFF
--- a/docs/rtk-query/overview.md
+++ b/docs/rtk-query/overview.md
@@ -83,16 +83,6 @@ The functionality included in RTK Query quickly pays for the added bundle size, 
 
 ### Create an API Slice
 
-RTK Query is included within the installation of the core Redux Toolkit package. It is available via either of the two entry points below:
-
-```ts
-import { createApi } from '@reduxjs/toolkit/query'
-
-/* React-specific entry point that automatically generates
-   hooks corresponding to the defined endpoints */
-import { createApi } from '@reduxjs/toolkit/query/react'
-```
-
 For typical usage with React, start by importing `createApi` and defining an "API slice" that lists the server's base URL and which endpoints we want to interact with:
 
 ```ts


### PR DESCRIPTION
This looks like the same block of documentation as [lines 52-60](https://github.com/reduxjs/redux-toolkit/blob/master/docs/rtk-query/overview.md?plain=1#L52-L60). Would it make sense to only include the first instance?