### PR TITLE
feat(meta): Passes meta to result description functions [#1904]

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -47,6 +47,7 @@ export const build: SubMiddlewareBuilder = ({
             undefined,
             undefined,
             undefined,
+            undefined,
             assertTagType
           ),
           mwApi

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -513,6 +513,7 @@ export function calculateProvidedByThunk(
     isFulfilled(action) ? action.payload : undefined,
     isRejectedWithValue(action) ? action.payload : undefined,
     action.meta.arg.originalArgs,
+    action.meta,
     assertTagType
   )
 }

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -147,11 +147,13 @@ export type GetResultDescriptionFn<
   TagTypes extends string,
   ResultType,
   QueryArg,
-  ErrorType
+  ErrorType,
+  MetaType
 > = (
   result: ResultType | undefined,
   error: ErrorType | undefined,
-  arg: QueryArg
+  arg: QueryArg,
+  meta: MetaType
 ) => ReadonlyArray<TagDescription<TagTypes>>
 
 export type FullTagDescription<TagType> = {
@@ -163,10 +165,11 @@ export type ResultDescription<
   TagTypes extends string,
   ResultType,
   QueryArg,
-  ErrorType
+  ErrorType,
+  MetaType
 > =
   | ReadonlyArray<TagDescription<TagTypes>>
-  | GetResultDescriptionFn<TagTypes, ResultType, QueryArg, ErrorType>
+  | GetResultDescriptionFn<TagTypes, ResultType, QueryArg, ErrorType, MetaType>
 
 /** @deprecated please use `onQueryStarted` instead */
 export interface QueryApi<ReducerPath extends string, Context extends {}> {
@@ -236,7 +239,8 @@ export interface QueryExtraOptions<
     TagTypes,
     ResultType,
     QueryArg,
-    BaseQueryError<BaseQuery>
+    BaseQueryError<BaseQuery>,
+    BaseQueryMeta<BaseQuery>
   >
   /**
    * Not to be used. A query should not invalidate tags in the cache.
@@ -310,7 +314,8 @@ export interface MutationExtraOptions<
     TagTypes,
     ResultType,
     QueryArg,
-    BaseQueryError<BaseQuery>
+    BaseQueryError<BaseQuery>,
+    BaseQueryMeta<BaseQuery>
   >
   /**
    * Not to be used. A mutation should not provide tags to the cache.
@@ -429,17 +434,23 @@ export type EndpointBuilder<
 
 export type AssertTagTypes = <T extends FullTagDescription<string>>(t: T) => T
 
-export function calculateProvidedBy<ResultType, QueryArg, ErrorType>(
+export function calculateProvidedBy<ResultType, QueryArg, ErrorType, MetaType>(
   description:
-    | ResultDescription<string, ResultType, QueryArg, ErrorType>
+    | ResultDescription<string, ResultType, QueryArg, ErrorType, MetaType>
     | undefined,
   result: ResultType | undefined,
   error: ErrorType | undefined,
   queryArg: QueryArg,
+  meta: MetaType | undefined,
   assertTagTypes: AssertTagTypes
 ): readonly FullTagDescription<string>[] {
   if (isFunction(description)) {
-    return description(result as ResultType, error as undefined, queryArg)
+    return description(
+      result as ResultType,
+      error as undefined,
+      queryArg,
+      meta as MetaType
+    )
       .map(expandTagDescription)
       .map(assertTagTypes)
   }


### PR DESCRIPTION
The internal and public interfaces for result descriptions are getting a little spread out, but I didn't see an easy solution to simplify the result description callback interface without a breaking change. This seems perfectly functional and passes tests. I didn't see any existing testing for `calculateProvidedBy`, so I didn't try to take that on.

After feedback, I will be glad to update the corresponding docs.

References #1904 