### PR TITLE
Fix example in Quickstart docs - missing named export and types

### DIFF
--- a/docs/tutorials/quick-start.mdx
+++ b/docs/tutorials/quick-start.mdx
@@ -167,12 +167,17 @@ import { configureStore } from '@reduxjs/toolkit'
 // highlight-next-line
 import counterReducer from '../features/counter/counterSlice'
 
-export default configureStore({
+export const store = configureStore({
   reducer: {
     // highlight-next-line
     counter: counterReducer,
   },
 })
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch
 ```
 
 ### Use Redux State and Actions in React Components


### PR DESCRIPTION
In the QuickStart Docs, the code example in ["Add Slice Reducers to the Store​"](https://redux-toolkit.js.org/tutorials/quick-start#add-slice-reducers-to-the-store) was missing the named `store` export and exported types shown in the previous example of this file in ["Create a Redux Store"](https://redux-toolkit.js.org/tutorials/quick-start#create-a-redux-store). 