### PR TITLE
Add `extra` to `prepareHeaders`, update documentation + tests

### DIFF
--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -19,10 +19,18 @@ It takes all standard options from fetch's [`RequestInit`](https://developer.moz
   - Typically a string like `https://api.your-really-great-app.com/v1/`. If you don't provide a `baseUrl`, it defaults to a relative path from where the request is being made. You should most likely _always_ specify this.
 - `prepareHeaders` _(optional)_
 
-  - Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token.
+  - Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
 
   - ```ts title="prepareHeaders signature" no-transpile
-    ;(headers: Headers, api: { getState: () => unknown }) => Headers
+    ;(
+      headers: Headers,
+      api: {
+        getState: () => unknown
+        endpoint: string
+        type: 'query' | 'mutation'
+        forced: boolean | undefined
+      }
+    ) => Headers
     ```
 
 - `paramsSerializer` _(optional)_

--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -19,13 +19,14 @@ It takes all standard options from fetch's [`RequestInit`](https://developer.moz
   - Typically a string like `https://api.your-really-great-app.com/v1/`. If you don't provide a `baseUrl`, it defaults to a relative path from where the request is being made. You should most likely _always_ specify this.
 - `prepareHeaders` _(optional)_
 
-  - Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
+  - Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
 
   - ```ts title="prepareHeaders signature" no-transpile
     ;(
       headers: Headers,
       api: {
         getState: () => unknown
+        extra: unknown
         endpoint: string
         type: 'query' | 'mutation'
         forced: boolean | undefined

--- a/docs/rtk-query/usage/automated-refetching.mdx
+++ b/docs/rtk-query/usage/automated-refetching.mdx
@@ -800,7 +800,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
 import { Post, LoginResponse } from './types'
 
 const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
   tagTypes: ['Post', 'UNAUTHORIZED', 'UNKNOWN_ERROR'],
   endpoints: (build) => ({
     postById: build.query<Post, number>({
@@ -856,7 +856,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
 import { Post, User } from './types'
 
 const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
   tagTypes: ['Post', 'User'],
   endpoints: (build) => ({
     getPosts: build.query<Post[], void>({
@@ -920,7 +920,7 @@ function providesList<R extends { id: string | number }[], T extends string>(
 // highlight-end
 
 const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
   tagTypes: ['Post', 'User'],
   endpoints: (build) => ({
     getPosts: build.query({

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -271,7 +271,7 @@ const axiosBaseQuery =
 const api = createApi({
   // highlight-start
   baseQuery: axiosBaseQuery({
-    baseUrl: 'http://example.com',
+    baseUrl: 'https://example.com',
   }),
   // highlight-end
   endpoints(build) {

--- a/packages/rtk-query-codegen-openapi/test/mocks/server.ts
+++ b/packages/rtk-query-codegen-openapi/test/mocks/server.ts
@@ -7,10 +7,10 @@ import petstoreYAML from '../fixtures/petstore.yaml.mock';
 // This configures a request mocking server with the given request handlers.
 
 export const server = setupServer(
-  rest.get('http://example.com/echo', (req, res, ctx) =>
+  rest.get('https://example.com/echo', (req, res, ctx) =>
     res(ctx.json({ ...req, headers: req.headers.getAllHeaders() }))
   ),
-  rest.post('http://example.com/echo', (req, res, ctx) =>
+  rest.post('https://example.com/echo', (req, res, ctx) =>
     res(ctx.json({ ...req, headers: req.headers.getAllHeaders() }))
   ),
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -47,7 +47,6 @@
     "axios": "^0.19.2",
     "console-testing-library": "^0.3.1",
     "convert-source-map": "^1.7.0",
-    "cross-fetch": "^3.1.4",
     "esbuild": "^0.11.13",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1751,11 +1751,11 @@ describe('hooks with createApi defaults set', () => {
       posts = [...initialPosts]
 
       const handlers = [
-        rest.get('http://example.com/posts', (req, res, ctx) => {
+        rest.get('https://example.com/posts', (req, res, ctx) => {
           return res(ctx.json(posts))
         }),
         rest.put<Partial<Post>>(
-          'http://example.com/post/:id',
+          'https://example.com/post/:id',
           (req, res, ctx) => {
             const id = Number(req.params.id)
             const idx = posts.findIndex((post) => post.id === id)
@@ -1775,7 +1775,7 @@ describe('hooks with createApi defaults set', () => {
             return res(ctx.json(posts))
           }
         ),
-        rest.post('http://example.com/post', (req, res, ctx) => {
+        rest.post('https://example.com/post', (req, res, ctx) => {
           let post = req.body as Omit<Post, 'id'>
           startingId += 1
           posts.concat({
@@ -1799,7 +1799,7 @@ describe('hooks with createApi defaults set', () => {
     type PostsResponse = Post[]
 
     const api = createApi({
-      baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com/' }),
+      baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com/' }),
       tagTypes: ['Posts'],
       endpoints: (build) => ({
         getPosts: build.query<PostsResponse, void>({

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 test(`query: await cleanup, defaults`, async () => {
   const { store, api } = storeForApi(
     createApi({
-      baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+      baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
       endpoints: (build) => ({
         query: build.query<unknown, string>({
           query: () => '/success',
@@ -35,7 +35,7 @@ test(`query: await cleanup, defaults`, async () => {
 test(`query: await cleanup, keepUnusedDataFor set`, async () => {
   const { store, api } = storeForApi(
     createApi({
-      baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+      baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
       endpoints: (build) => ({
         query: build.query<unknown, string>({
           query: () => '/success',
@@ -55,7 +55,7 @@ test(`query: await cleanup, keepUnusedDataFor set`, async () => {
 describe(`query: await cleanup, keepUnusedDataFor set`, () => {
   const { store, api } = storeForApi(
     createApi({
-      baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+      baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
       endpoints: (build) => ({
         query: build.query<unknown, string>({
           query: () => '/success',

--- a/packages/toolkit/src/query/tests/cacheLifecycle.test.ts
+++ b/packages/toolkit/src/query/tests/cacheLifecycle.test.ts
@@ -8,7 +8,7 @@ beforeAll(() => {
 })
 
 const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
   endpoints: () => ({}),
 })
 const storeRef = setupApiStore(api)

--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -503,7 +503,7 @@ describe('additional transformResponse behaviors', () => {
   type SuccessResponse = { value: 'success' }
   type EchoResponseData = { banana: 'bread' }
   const api = createApi({
-    baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+    baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
     endpoints: (build) => ({
       echo: build.mutation({
         query: () => ({ method: 'PUT', url: '/echo' }),
@@ -541,7 +541,7 @@ describe('additional transformResponse behaviors', () => {
       query: build.query<SuccessResponse & EchoResponseData, void>({
         query: () => '/success',
         transformResponse: async (response: SuccessResponse) => {
-          const res = await fetch('http://example.com/echo', {
+          const res = await fetch('https://example.com/echo', {
             method: 'POST',
             body: JSON.stringify({ banana: 'bread' }),
           }).then((res) => res.json())
@@ -640,7 +640,7 @@ describe('query endpoint lifecycles - onStart, onSuccess, onError', () => {
 
   type SuccessResponse = { value: 'success' }
   const api = createApi({
-    baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+    baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
     endpoints: (build) => ({
       echo: build.mutation({
         query: () => ({ method: 'PUT', url: '/echo' }),
@@ -677,7 +677,7 @@ describe('query endpoint lifecycles - onStart, onSuccess, onError', () => {
   test('query lifecycle events fire properly', async () => {
     // We intentionally fail the first request so we can test all lifecycles
     server.use(
-      rest.get('http://example.com/success', (_, res, ctx) =>
+      rest.get('https://example.com/success', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json({ value: 'failed' }))
       )
     )
@@ -701,7 +701,7 @@ describe('query endpoint lifecycles - onStart, onSuccess, onError', () => {
   test('mutation lifecycle events fire properly', async () => {
     // We intentionally fail the first request so we can test all lifecycles
     server.use(
-      rest.post('http://example.com/success', (_, res, ctx) =>
+      rest.post('https://example.com/success', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json({ value: 'failed' }))
       )
     )

--- a/packages/toolkit/src/query/tests/devWarnings.test.tsx
+++ b/packages/toolkit/src/query/tests/devWarnings.test.tsx
@@ -20,7 +20,7 @@ afterEach(() => {
   restore()
 })
 
-const baseUrl = 'http://example.com'
+const baseUrl = 'https://example.com'
 
 function createApis() {
   const api1 = createApi({

--- a/packages/toolkit/src/query/tests/errorHandling.test.tsx
+++ b/packages/toolkit/src/query/tests/errorHandling.test.tsx
@@ -13,7 +13,7 @@ import { useDispatch } from 'react-redux'
 import type { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
 import type { BaseQueryApi } from '../baseQueryTypes'
 
-const baseQuery = fetchBaseQuery({ baseUrl: 'http://example.com' })
+const baseQuery = fetchBaseQuery({ baseUrl: 'https://example.com' })
 
 const api = createApi({
   baseQuery,
@@ -76,7 +76,7 @@ describe('fetchBaseQuery', () => {
 describe('query error handling', () => {
   test('success', async () => {
     server.use(
-      rest.get('http://example.com/query', (_, res, ctx) =>
+      rest.get('https://example.com/query', (_, res, ctx) =>
         res(ctx.json({ value: 'success' }))
       )
     )
@@ -97,7 +97,7 @@ describe('query error handling', () => {
 
   test('error', async () => {
     server.use(
-      rest.get('http://example.com/query', (_, res, ctx) =>
+      rest.get('https://example.com/query', (_, res, ctx) =>
         res(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -121,7 +121,7 @@ describe('query error handling', () => {
 
   test('success -> error', async () => {
     server.use(
-      rest.get('http://example.com/query', (_, res, ctx) =>
+      rest.get('https://example.com/query', (_, res, ctx) =>
         res(ctx.json({ value: 'success' }))
       )
     )
@@ -140,7 +140,7 @@ describe('query error handling', () => {
     )
 
     server.use(
-      rest.get('http://example.com/query', (_, res, ctx) =>
+      rest.get('https://example.com/query', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -165,12 +165,12 @@ describe('query error handling', () => {
 
   test('error -> success', async () => {
     server.use(
-      rest.get('http://example.com/query', (_, res, ctx) =>
+      rest.get('https://example.com/query', (_, res, ctx) =>
         res(ctx.json({ value: 'success' }))
       )
     )
     server.use(
-      rest.get('http://example.com/query', (_, res, ctx) =>
+      rest.get('https://example.com/query', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -208,7 +208,7 @@ describe('query error handling', () => {
 describe('mutation error handling', () => {
   test('success', async () => {
     server.use(
-      rest.post('http://example.com/mutation', (_, res, ctx) =>
+      rest.post('https://example.com/mutation', (_, res, ctx) =>
         res(ctx.json({ value: 'success' }))
       )
     )
@@ -233,7 +233,7 @@ describe('mutation error handling', () => {
 
   test('error', async () => {
     server.use(
-      rest.post('http://example.com/mutation', (_, res, ctx) =>
+      rest.post('https://example.com/mutation', (_, res, ctx) =>
         res(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -261,7 +261,7 @@ describe('mutation error handling', () => {
 
   test('success -> error', async () => {
     server.use(
-      rest.post('http://example.com/mutation', (_, res, ctx) =>
+      rest.post('https://example.com/mutation', (_, res, ctx) =>
         res(ctx.json({ value: 'success' }))
       )
     )
@@ -286,7 +286,7 @@ describe('mutation error handling', () => {
     }
 
     server.use(
-      rest.post('http://example.com/mutation', (_, res, ctx) =>
+      rest.post('https://example.com/mutation', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -314,12 +314,12 @@ describe('mutation error handling', () => {
 
   test('error -> success', async () => {
     server.use(
-      rest.post('http://example.com/mutation', (_, res, ctx) =>
+      rest.post('https://example.com/mutation', (_, res, ctx) =>
         res(ctx.json({ value: 'success' }))
       )
     )
     server.use(
-      rest.post('http://example.com/mutation', (_, res, ctx) =>
+      rest.post('https://example.com/mutation', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -403,7 +403,7 @@ describe('custom axios baseQuery', () => {
   type SuccessResponse = { value: 'success' }
   const api = createApi({
     baseQuery: axiosBaseQuery({
-      baseUrl: 'http://example.com',
+      baseUrl: 'https://example.com',
     }),
     endpoints(build) {
       return {
@@ -433,7 +433,7 @@ describe('custom axios baseQuery', () => {
 
   test('axios errors behave as expected', async () => {
     server.use(
-      rest.get('http://example.com/success', (_, res, ctx) =>
+      rest.get('https://example.com/success', (_, res, ctx) =>
         res(ctx.status(500), ctx.json({ value: 'error' }))
       )
     )
@@ -458,7 +458,7 @@ describe('error handling in a component', () => {
   const mockSuccessResponse = { value: 'success' }
 
   const api = createApi({
-    baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+    baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
     endpoints: (build) => ({
       update: build.mutation<typeof mockSuccessResponse, any>({
         query: () => ({ url: 'success' }),
@@ -472,7 +472,7 @@ describe('error handling in a component', () => {
 
   test('a mutation is unwrappable and has the correct types', async () => {
     server.use(
-      rest.get('http://example.com/success', (_, res, ctx) =>
+      rest.get('https://example.com/success', (_, res, ctx) =>
         res.once(ctx.status(500), ctx.json(mockErrorResponse))
       )
     )

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -536,6 +536,45 @@ describe('fetchBaseQuery', () => {
 
       expect(request.headers['authorization']).toBe(`Bearer ${token}`)
     })
+
+    test('prepareHeaders provides extra api information for getState, endpoint, type and forced', async () => {
+      let _getState, _endpoint, _type, _forced
+
+      const baseQuery = fetchBaseQuery({
+        baseUrl,
+        fetchFn: fetchFn as any,
+        prepareHeaders: (headers, { getState, endpoint, type, forced }) => {
+          _getState = getState
+          _endpoint = endpoint
+          _type = type
+          _forced = forced
+
+          return headers
+        },
+      })
+
+      const doRequest = async () =>
+        baseQuery(
+          { url: '/echo' },
+          {
+            signal: new AbortController().signal,
+            dispatch: storeRef.store.dispatch,
+            getState: storeRef.store.getState,
+            extra: undefined,
+            type: 'query',
+            forced: true,
+            endpoint: 'someEndpointName',
+          },
+          {}
+        )
+
+      await doRequest()
+
+      expect(_getState).toBeDefined()
+      expect(_endpoint).toBe('someEndpointName')
+      expect(_type).toBe('query')
+      expect(_forced).toBe(true)
+    })
   })
 
   test('lets a header be undefined', async () => {

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -2,7 +2,9 @@ import { createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
 import { setupApiStore } from './helpers'
 import { server } from './mocks/server'
-import { default as crossFetch } from 'cross-fetch'
+// @ts-ignore
+import nodeFetch from 'node-fetch'
+
 import { rest } from 'msw'
 import queryString from 'query-string'
 import type { BaseQueryApi } from '../baseQueryTypes'
@@ -13,7 +15,7 @@ const defaultHeaders: Record<string, string> = {
   delete2: '1',
 }
 
-const baseUrl = 'http://example.com'
+const baseUrl = 'https://example.com'
 
 // @ts-ignore
 const fetchFn = jest.fn<Promise<any>, any[]>(global.fetch)
@@ -136,7 +138,7 @@ describe('fetchBaseQuery', () => {
   describe('non-JSON-body', () => {
     it('success: should return data ("text" responseHandler)', async () => {
       server.use(
-        rest.get('http://example.com/success', (_, res, ctx) =>
+        rest.get('https://example.com/success', (_, res, ctx) =>
           res.once(ctx.text(`this is not json!`))
         )
       )
@@ -156,7 +158,7 @@ describe('fetchBaseQuery', () => {
 
     it('success: should fail gracefully (default="json" responseHandler)', async () => {
       server.use(
-        rest.get('http://example.com/success', (_, res, ctx) =>
+        rest.get('https://example.com/success', (_, res, ctx) =>
           res.once(ctx.text(`this is not json!`))
         )
       )
@@ -177,7 +179,7 @@ describe('fetchBaseQuery', () => {
 
     it('server error: should fail normally with a 500 status ("text" responseHandler)', async () => {
       server.use(
-        rest.get('http://example.com/error', (_, res, ctx) =>
+        rest.get('https://example.com/error', (_, res, ctx) =>
           res(ctx.status(500), ctx.text(`this is not json!`))
         )
       )
@@ -200,7 +202,7 @@ describe('fetchBaseQuery', () => {
 
     it('server error: should fail gracefully (default="json" responseHandler)', async () => {
       server.use(
-        rest.get('http://example.com/error', (_, res, ctx) =>
+        rest.get('https://example.com/error', (_, res, ctx) =>
           res(ctx.status(500), ctx.text(`this is not json!`))
         )
       )
@@ -537,21 +539,29 @@ describe('fetchBaseQuery', () => {
       expect(request.headers['authorization']).toBe(`Bearer ${token}`)
     })
 
-    test('prepareHeaders provides extra api information for getState, endpoint, type and forced', async () => {
-      let _getState, _endpoint, _type, _forced
+    test('prepareHeaders provides extra api information for getState, extra, endpoint, type and forced', async () => {
+      let _getState, _extra, _endpoint, _type, _forced
 
       const baseQuery = fetchBaseQuery({
         baseUrl,
         fetchFn: fetchFn as any,
-        prepareHeaders: (headers, { getState, endpoint, type, forced }) => {
+        prepareHeaders: (
+          headers,
+          { getState, extra, endpoint, type, forced }
+        ) => {
           _getState = getState
           _endpoint = endpoint
           _type = type
           _forced = forced
+          _extra = extra
 
           return headers
         },
       })
+
+      const fakeAuth0Client = {
+        getTokenSilently: async () => 'fakeToken',
+      }
 
       const doRequest = async () =>
         baseQuery(
@@ -560,7 +570,7 @@ describe('fetchBaseQuery', () => {
             signal: new AbortController().signal,
             dispatch: storeRef.store.dispatch,
             getState: storeRef.store.getState,
-            extra: undefined,
+            extra: fakeAuth0Client,
             type: 'query',
             forced: true,
             endpoint: 'someEndpointName',
@@ -574,6 +584,7 @@ describe('fetchBaseQuery', () => {
       expect(_endpoint).toBe('someEndpointName')
       expect(_type).toBe('query')
       expect(_forced).toBe(true)
+      expect(_extra).toBe(fakeAuth0Client)
     })
   })
 
@@ -623,14 +634,13 @@ describe('fetchBaseQuery', () => {
 
 describe('fetchFn', () => {
   test('accepts a custom fetchFn', async () => {
-    const baseUrl = 'http://example.com'
+    const baseUrl = 'https://example.com'
     const params = new URLSearchParams({ apple: 'fruit' })
 
     const baseQuery = fetchBaseQuery({
       baseUrl,
-      fetchFn: crossFetch,
+      fetchFn: nodeFetch as any,
     })
-
     let request: any
     ;({ data: request } = await baseQuery(
       { url: '/echo', params },
@@ -642,7 +652,7 @@ describe('fetchFn', () => {
   })
 
   test('respects mocking window.fetch after a fetch base query is created', async () => {
-    const baseUrl = 'http://example.com'
+    const baseUrl = 'https://example.com'
     const baseQuery = fetchBaseQuery({ baseUrl })
 
     const fakeResponse = {

--- a/packages/toolkit/src/query/tests/matchers.test.tsx
+++ b/packages/toolkit/src/query/tests/matchers.test.tsx
@@ -18,7 +18,7 @@ interface ArgType {
   count: 3
 }
 
-const baseQuery = fetchBaseQuery({ baseUrl: 'http://example.com' })
+const baseQuery = fetchBaseQuery({ baseUrl: 'https://example.com' })
 const api = createApi({
   baseQuery,
   endpoints(build) {

--- a/packages/toolkit/src/query/tests/mocks/server.ts
+++ b/packages/toolkit/src/query/tests/mocks/server.ts
@@ -14,26 +14,26 @@ export const posts: Record<number, Post> = {
 }
 
 export const server = setupServer(
-  rest.get('http://example.com/echo', (req, res, ctx) =>
+  rest.get('https://example.com/echo', (req, res, ctx) =>
     res(ctx.json({ ...req, headers: req.headers.all() }))
   ),
-  rest.post('http://example.com/echo', (req, res, ctx) =>
+  rest.post('https://example.com/echo', (req, res, ctx) =>
     res(ctx.json({ ...req, headers: req.headers.all() }))
   ),
-  rest.get('http://example.com/success', (_, res, ctx) =>
+  rest.get('https://example.com/success', (_, res, ctx) =>
     res(ctx.json({ value: 'success' }))
   ),
-  rest.post('http://example.com/success', (_, res, ctx) =>
+  rest.post('https://example.com/success', (_, res, ctx) =>
     res(ctx.json({ value: 'success' }))
   ),
-  rest.get('http://example.com/empty', (_, res, ctx) => res(ctx.body(''))),
-  rest.get('http://example.com/error', (_, res, ctx) =>
+  rest.get('https://example.com/empty', (_, res, ctx) => res(ctx.body(''))),
+  rest.get('https://example.com/error', (_, res, ctx) =>
     res(ctx.status(500), ctx.json({ value: 'error' }))
   ),
-  rest.post('http://example.com/error', (_, res, ctx) =>
+  rest.post('https://example.com/error', (_, res, ctx) =>
     res(ctx.status(500), ctx.json({ value: 'error' }))
   ),
-  rest.get('http://example.com/nonstandard-error', (_, res, ctx) =>
+  rest.get('https://example.com/nonstandard-error', (_, res, ctx) =>
     res(
       ctx.status(200),
       ctx.json({
@@ -42,19 +42,19 @@ export const server = setupServer(
       })
     )
   ),
-  rest.get('http://example.com/mirror', (req, res, ctx) =>
+  rest.get('https://example.com/mirror', (req, res, ctx) =>
     res(ctx.json(req.params))
   ),
-  rest.post('http://example.com/mirror', (req, res, ctx) =>
+  rest.post('https://example.com/mirror', (req, res, ctx) =>
     res(ctx.json(req.params))
   ),
-  rest.get('http://example.com/posts/random', (req, res, ctx) => {
+  rest.get('https://example.com/posts/random', (req, res, ctx) => {
     // just simulate an api that returned a random ID
     const { id, ..._post } = posts[1]
     return res(ctx.json({ id }))
   }),
   rest.get<Post, any, { id: number }>(
-    'http://example.com/post/:id',
+    'https://example.com/post/:id',
     (req, res, ctx) => {
       return res(ctx.json(posts[req.params.id]))
     }

--- a/packages/toolkit/src/query/tests/queryFn.test.tsx
+++ b/packages/toolkit/src/query/tests/queryFn.test.tsx
@@ -307,7 +307,7 @@ describe('usage scenario tests', () => {
     return { collection, doc }
   }
 
-  const baseQuery = fetchBaseQuery({ baseUrl: 'http://example.com/' })
+  const baseQuery = fetchBaseQuery({ baseUrl: 'https://example.com/' })
   const api = createApi({
     baseQuery,
     endpoints: (build) => ({

--- a/packages/toolkit/src/query/tests/queryLifecycle.test.tsx
+++ b/packages/toolkit/src/query/tests/queryLifecycle.test.tsx
@@ -10,7 +10,7 @@ import { server } from './mocks/server'
 import { rest } from 'msw'
 
 const api = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
   endpoints: () => ({}),
 })
 const storeRef = setupApiStore(api)
@@ -397,7 +397,7 @@ test('query: updateCachedData', async () => {
   // request 2: error
   expect(onError).not.toHaveBeenCalled()
   server.use(
-    rest.get('http://example.com/success', (_, req, ctx) =>
+    rest.get('https://example.com/success', (_, req, ctx) =>
       req.once(ctx.status(500), ctx.json({ value: 'failed' }))
     )
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5356,7 +5356,6 @@ __metadata:
     axios: ^0.19.2
     console-testing-library: ^0.3.1
     convert-source-map: ^1.7.0
-    cross-fetch: ^3.1.4
     esbuild: ^0.11.13
     eslint: ^7.25.0
     eslint-config-prettier: ^8.3.0
@@ -10260,7 +10259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:3.1.4, cross-fetch@npm:^3.0.4, cross-fetch@npm:^3.0.6, cross-fetch@npm:^3.1.4":
+"cross-fetch@npm:3.1.4, cross-fetch@npm:^3.0.4, cross-fetch@npm:^3.0.6":
   version: 3.1.4
   resolution: "cross-fetch@npm:3.1.4"
   dependencies:


### PR DESCRIPTION
- Adds documentation for #1917.
- Adds a test to assert that `endpoint`, `type`, `forced`, and `extra` are passed through to `prepareHeaders`
- Adds `extra` to `prepareHeaders` 🎉 