### PR TITLE
Add info about `preferCacheValue` for lazy queries to docs

### DIFF
--- a/docs/rtk-query/api/created-api/hooks.mdx
+++ b/docs/rtk-query/api/created-api/hooks.mdx
@@ -490,7 +490,7 @@ type UseLazyQueryOptions = {
   selectFromResult?: (result: UseQueryStateDefaultResult) => any
 }
 
-type UseLazyQueryTrigger<T> = (arg: any) => Promise<
+type UseLazyQueryTrigger<T> = (arg: any, preferCacheValue?: boolean) => Promise<
   QueryResultSelectorResult
 > & {
   arg: unknown // Whatever argument was provided to the query
@@ -559,7 +559,10 @@ type UseLazyQuerySubscriptionOptions = {
   refetchOnFocus?: boolean
 }
 
-type UseLazyQuerySubscriptionTrigger = (arg: any) => void
+type UseLazyQuerySubscriptionTrigger = (
+  arg: any,
+  preferCacheValue?: boolean
+) => void
 ```
 
 - **Parameters**

--- a/docs/rtk-query/usage/queries.mdx
+++ b/docs/rtk-query/usage/queries.mdx
@@ -109,9 +109,9 @@ There are 5 query-related hooks:
 3. [`useQueryState`](../api/created-api/hooks.mdx#usequerystate)
    - Returns the query state and accepts `skip` and `selectFromResult`. Reads the request status and cached data from the Redux store.
 4. [`useLazyQuery`](../api/created-api/hooks.mdx#uselazyquery)
-   - Returns a tuple with a `fetch` function, the query result, and last promise info. Similar to `useQuery`, but with manual control over when the data fetching occurs.
+   - Returns a tuple with a `trigger` function, the query result, and last promise info. Similar to `useQuery`, but with manual control over when the data fetching occurs. **Note: the `trigger` function takes a second argument of `preferCacheValue?: boolean` in the event you want to skip making a request if cached data already exists.**
 5. [`useLazyQuerySubscription`](../api/created-api/hooks.mdx#uselazyquerysubscription)
-   - Returns a tuple with a `fetch` function, and last promise info. Similar to `useQuerySubscription`, but with manual control over when the data fetching occurs.
+   - Returns a tuple with a `trigger` function, and last promise info. Similar to `useQuerySubscription`, but with manual control over when the data fetching occurs. **Note: the `trigger` function takes a second argument of `preferCacheValue?: boolean` in the event you want to skip making a request if cached data already exists.**
 
 In practice, the standard `useQuery`-based hooks such as `useGetPostQuery` will be the primary hooks used in your application, but the other hooks are available for specific use cases.
 

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -185,7 +185,7 @@ export type UseLazyQueryLastPromiseInfo<
  *
  * #### Note
  *
- * When the trigger function returned from a LazyQuery, it always initiates a new request to the server even if there is cached data. Set `preferCacheValue`(the second argument to the function) as true if you want it to use cache.
+ * When the trigger function returned from a LazyQuery, it always initiates a new request to the server even if there is cached data. Set `preferCacheValue`(the second argument to the function) as `true` if you want it to immediately return a cached value if one exists.
  */
 export type UseLazyQuery<D extends QueryDefinition<any, any, any, any>> = <
   R = UseQueryStateDefaultResult<D>


### PR DESCRIPTION
Addresses comments in https://github.com/reduxjs/redux-toolkit/issues/1873 about `preferCacheValue` not being visible enough in the docs.