### PR TITLE
Pass baseQueryMeta into calculateProvidedBy

### DIFF
--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -21,7 +21,6 @@ import { calculateProvidedBy } from '../endpointDefinitions'
 import type { AsyncThunkPayloadCreator, Draft } from '@reduxjs/toolkit'
 import {
   isAllOf,
-  isAnyOf,
   isFulfilled,
   isPending,
   isRejected,

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -500,30 +500,20 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
   }
 }
 
-type CalculatableAction = UnwrapPromise<
-  ReturnType<ReturnType<QueryThunk>> | ReturnType<ReturnType<MutationThunk>>
->
 export function calculateProvidedByThunk(
-  action: CalculatableAction,
+  action: UnwrapPromise<
+    ReturnType<ReturnType<QueryThunk>> | ReturnType<ReturnType<MutationThunk>>
+  >,
   type: 'providesTags' | 'invalidatesTags',
   endpointDefinitions: EndpointDefinitions,
   assertTagType: AssertTagTypes
 ) {
-  const isQuery = (action: CalculatableAction) =>
-    action.meta.arg.type === 'query'
-  const isFulfilledQuery = (action: any): action is QueryThunk =>
-    isQuery(action)
-  const isFulfilledMutation = (action: any): action is MutationThunk =>
-    !isQuery(action)
-
   return calculateProvidedBy(
     endpointDefinitions[action.meta.arg.endpointName][type],
     isFulfilled(action) ? action.payload : undefined,
     isRejectedWithValue(action) ? action.payload : undefined,
     action.meta.arg.originalArgs,
-    isAnyOf(isRejected, isFulfilledQuery, isFulfilledMutation)(action)
-      ? action.meta.baseQueryMeta
-      : undefined,
+    'baseQueryMeta' in action.meta ? action.meta.baseQueryMeta : undefined,
     assertTagType
   )
 }


### PR DESCRIPTION
Patches the work done in https://github.com/reduxjs/redux-toolkit/pull/1910 by ensuring that we're exposing `baseQueryMeta` aka `Request` and `Response` objects... which matches the `transformResponse` behavior for consistency. I debated on doing a full use case example here, but it seemed like it wouldn't really provide any real value and would be better served in usage docs.

Also note: I didn't update the docs for this as @bever1337 is working on those. 