### PR TITLE
Codegen: Update import paths from old package name to new

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -29,7 +29,6 @@ We provide a package for RTK Query code generation from OpenAPI schemas. It is p
 Create an empty api using `createApi` like
 
 ```ts no-transpile title="src/store/emptyApi.ts"
-
 // Or from '@reduxjs/toolkit/query' if not using the auto-generated hooks
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
@@ -43,8 +42,7 @@ export const emptySplitApi = createApi({
 Generate a config file (json, js or ts) with contents like
 
 ```ts no-transpile title="openapi-config.ts"
-
-import { ConfigFile } from '@rtk-query/codegen-openapi'
+import type { ConfigFile } from '@rtk-query/codegen-openapi'
 
 const config: ConfigFile = {
   schemaFile: 'https://petstore3.swagger.io/api/v3/openapi.json',
@@ -67,7 +65,6 @@ npx @rtk-query/codegen-openapi openapi-config.ts
 ### Programmatic usage
 
 ```ts no-transpile title="src/store/petApi.ts"
-
 import { generateEndpoints } from '@rtk-query/codegen-openapi'
 
 const api = await generateEndpoints({

--- a/packages/rtk-query-codegen-openapi/test/config.example.js
+++ b/packages/rtk-query-codegen-openapi/test/config.example.js
@@ -1,5 +1,5 @@
 /**
- * @type {import("@rtk-incubator/rtk-query-codegen-openapi").ConfigFile}
+ * @type {import("@rtk-query/codegen-openapi").ConfigFile}
  */
 module.exports = {
   schemaFile: './fixtures/petstore.yaml',

--- a/packages/rtk-query-codegen-openapi/test/config.example.ts
+++ b/packages/rtk-query-codegen-openapi/test/config.example.ts
@@ -1,4 +1,4 @@
-import type { ConfigFile } from '@rtk-incubator/rtk-query-codegen-openapi';
+import type { ConfigFile } from '@rtk-query/codegen-openapi';
 
 const config: ConfigFile = {
   schemaFile: './fixtures/petstore.yaml',

--- a/packages/rtk-query-codegen-openapi/test/tsconfig.json
+++ b/packages/rtk-query-codegen-openapi/test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./test/fixtures/*"],
-      "@rtk-incubator/rtk-query-codegen-openapi": ["./src"]
+      "@rtk-query/codegen-openapi": ["./src"]
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Just fixes the import paths as mentioned in https://github.com/reduxjs/redux-toolkit/issues/1775