### PR TITLE
Feature/docs re authorization mutex example

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "@types/react": "^16.9.46",
     "@types/react-redux": "^7.1.9",
     "@types/redux-logger": "^3.0.8",
+    "async-mutex": "^0.3.2",
     "axios": "^0.20.0",
     "formik": "^2.1.5",
     "graphql-request": "^3.4.0",

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -392,7 +392,7 @@ const baseQueryWithReauth: BaseQueryFn<
 
 #### Preventing multiple unauthorized errors
 
-Implementing [`async-mutex`](https://github.com/DirtyHairy/async-mutex) to prevent multiple calls to '/refreshToken' when multiple calls fail with [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) errors.
+Using [`async-mutex`](https://github.com/DirtyHairy/async-mutex) to prevent multiple calls to '/refreshToken' when multiple calls fail with [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) errors.
 
 ```ts title="Preventing multiple calls to '/refreshToken'"
 // file: authSlice.ts noEmit

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -392,9 +392,9 @@ const baseQueryWithReauth: BaseQueryFn<
 
 #### Preventing multiple unauthorized errors
 
-Implementing [`async-mutex`](https://github.com/DirtyHairy/async-mutex) to prevent multiple calls to '/auth/refreshToken' when multiple calls fail with [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) errors.
+Implementing [`async-mutex`](https://github.com/DirtyHairy/async-mutex) to prevent multiple calls to '/refreshToken' when multiple calls fail with [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) errors.
 
-```ts title="Preventing multiple calls to '/auth/refreshToken'"
+```ts title="Preventing multiple calls to '/refreshToken'"
 // file: authSlice.ts noEmit
 declare function tokenReceived(args?: any): void
 declare function loggedOut(): void

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -390,6 +390,80 @@ const baseQueryWithReauth: BaseQueryFn<
 }
 ```
 
+#### Preventing multiple unauthorized errors
+
+Implementing [`async-mutex`](https://github.com/DirtyHairy/async-mutex) to prevent multiple calls to '/auth/refreshToken' when multiple calls fail with [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) errors.
+
+```ts title="Preventing multiple calls to '/auth/refreshToken'"
+// file: authSlice.ts noEmit
+declare function tokenReceived(args?: any): void
+declare function loggedOut(): void
+export { tokenReceived, loggedOut }
+// file: baseQueryWithReauth.ts
+
+import {
+  BaseQueryFn,
+  FetchArgs,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+} from '@reduxjs/toolkit/query'
+import { tokenReceived, loggedOut } from './authSlice'
+// highlight-start
+import { Mutex } from 'async-mutex'
+// highlight-end
+
+// create a new mutex
+// highlight-start
+const mutex = new Mutex()
+// highlight-end
+const baseQuery = fetchBaseQuery({ baseUrl: '/' })
+const baseQueryWithReauth: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  // wait until the mutex is available without locking it
+  // highlight-start
+  await mutex.waitForUnlock()
+  // highlight-end
+  let result = await baseQuery(args, api, extraOptions)
+  if (result.error && result.error.status === 401) {
+    // checking whether the mutex is locked
+    // highlight-start
+    if (!mutex.isLocked()) {
+      const release = await mutex.acquire()
+      // highlight-end
+      try {
+        const refreshResult = await baseQuery(
+          '/refreshToken',
+          api,
+          extraOptions
+        )
+        if (refreshResult.data) {
+          api.dispatch(tokenReceived(refreshResult.data))
+          // retry the initial query
+          result = await baseQuery(args, api, extraOptions)
+        } else {
+          api.dispatch(loggedOut())
+        }
+      } finally {
+        // release must be called once the mutex should be released again.
+        // highlight-start
+        release()
+        // highlight-end
+      }
+    } else {
+      // wait until the mutex is available without locking it
+      // highlight-start
+      await mutex.waitForUnlock()
+      // highlight-end
+      result = await baseQuery(args, api, extraOptions)
+    }
+  }
+  return result
+}
+```
+
 ### Automatic retries
 
 RTK Query exports a utility called `retry` that you can wrap the `baseQuery` in your API definition with. It defaults to 5 attempts with a basic exponential backoff.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7995,6 +7995,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-mutex@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "async-mutex@npm:0.3.2"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 620b771dfdea1cad0a6b712915c31a1e3ca880a8cf1eae92b4590f435995e0260929c6ebaae0b9126b1456790ea498064b5bb9a506948cda760f48d3d0dcc4c8
+  languageName: node
+  linkType: hard
+
 "async@npm:^2.6.2":
   version: 2.6.3
   resolution: "async@npm:2.6.3"
@@ -11303,6 +11312,7 @@ __metadata:
     "@types/react": ^16.9.46
     "@types/react-redux": ^7.1.9
     "@types/redux-logger": ^3.0.8
+    async-mutex: ^0.3.2
     axios: ^0.20.0
     formik: ^2.1.5
     graphql-request: ^3.4.0


### PR DESCRIPTION
Adding example for using mutex to prevent multiple queries when using re-authorization as found here :

https://github.com/reduxjs/redux-toolkit/issues/1782#issuecomment-985985120