### PR TITLE
feat(alm): add alm.clear() method

### DIFF
--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -14,8 +14,6 @@ import type {
   BaseActionCreator,
   AnyActionListenerPredicate,
   CreateListenerMiddlewareOptions,
-  ConditionFunction,
-  ListenerPredicate,
   TypedActionCreator,
   TypedAddListener,
   TypedAddListenerAction,
@@ -198,6 +196,18 @@ export const createListenerEntry: TypedCreateListenerEntry<unknown> = (
   }
 
   return entry
+}
+
+const createClearAllListeners = (listenerMap: Map<string, ListenerEntry>) => {
+  return () => {
+    listenerMap.forEach((entry) => {
+      entry.pending.forEach((controller) => {
+        controller.abort()
+      })
+    })
+
+    listenerMap.clear()
+  }
 }
 
 /**
@@ -491,6 +501,7 @@ export function createActionListenerMiddleware<
     {
       addListener,
       removeListener,
+      clear: createClearAllListeners(listenerMap),
       addListenerAction: addListenerAction as TypedAddListenerAction<S>,
     },
     {} as WithMiddlewareType<typeof middleware>

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -492,6 +492,64 @@ describe('createActionListenerMiddleware', () => {
     })
   })
 
+  test('clear() cancels running listeners and removes all subscriptions', async () => {
+    const listener1Test = deferred()
+
+    let listener1Calls = 0
+    let listener2Calls = 0
+
+    middleware.addListener({
+      actionCreator: testAction1,
+      async listener(_, listenerApi) {
+        listener1Calls++
+        listenerApi.signal.addEventListener(
+          'abort',
+          () => listener1Test.resolve(listener1Calls),
+          { once: true }
+        )
+        await listenerApi.condition(() => true)
+        listener1Test.reject(new Error('unreachable: listener1Test'))
+      },
+    })
+
+    middleware.addListener({
+      actionCreator: testAction2,
+      listener() {
+        listener2Calls++
+      },
+    })
+
+    store.dispatch(testAction1('a'))
+
+    middleware.clear()
+    store.dispatch(testAction1('b'))
+    store.dispatch(testAction2('c'))
+
+    expect(listener2Calls).toBe(0)
+    expect(await listener1Test).toBe(1)
+  })
+
+  test('clear() cancels all running forked tasks', async () => {
+    const fork1Test = deferred()
+
+    middleware.addListener({
+      actionCreator: testAction1,
+      async listener(_, { fork }) {
+        const taskResult = await fork(() => {
+          return 3
+        }).result
+        fork1Test.resolve(taskResult)
+      },
+    })
+
+    store.dispatch(testAction1('a'))
+
+    middleware.clear()
+    store.dispatch(testAction1('b'))
+
+    expect(await fork1Test).toHaveProperty('status', 'cancelled')
+  })
+
   describe('Listener API', () => {
     test('Passes both getState and getOriginalState in the API', () => {
       const store = configureStore({

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -219,7 +219,7 @@ export type ActionListenerMiddleware<
   removeListener: RemoveListenerOverloads<S, D>
   addListenerAction: TypedAddListenerAction<S, D>
   /**
-   * Removes all subscribed listeners, cancels running listeners and tasks.
+   * Unsubscribes all listeners, cancels running listeners and tasks.
    */
   clear: () => void
 }

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -218,6 +218,10 @@ export type ActionListenerMiddleware<
   addListener: AddListenerOverloads<Unsubscribe, S, D>
   removeListener: RemoveListenerOverloads<S, D>
   addListenerAction: TypedAddListenerAction<S, D>
+  /**
+   * Removes all subscribed listeners, cancels running listeners and tasks.
+   */
+  clear: () => void
 }
 
 /**


### PR DESCRIPTION
### Description

Adds the following apis

- `alm.clear()`: unsubscribes all listeners, cancels running listeners and tasks.
- `clearListenerMiddlewareAction`:  an action creator whose actions trigger `alm.clear()`.

Context: https://github.com/reduxjs/redux-toolkit/discussions/1648#discussioncomment-2009989

### SSR

I believe that this method can be very useful in SSR, because it provides a simple way to clean up all listeners that are still subscribed or running after rendering the page.

### Build log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run build
Build "actionListenerMiddleware" to dist/esm:
       1644 B: index.modern.js.gz
       1475 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.31 kB: index.js.gz
      2.06 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
       2.3 kB: index.js.gz
      2.06 kB: index.js.br
```

### Test log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run test --coverage
 PASS  src/tests/listenerMiddleware.test.ts
 PASS  src/tests/effectScenarios.test.ts
 PASS  src/tests/fork.test.ts
 PASS  src/tests/useCases.test.ts
---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |    97.6 |    92.86 |   94.64 |   97.42 |                   
 exceptions.ts |     100 |      100 |     100 |     100 |                   
 index.ts      |   97.48 |    95.24 |   92.68 |    97.4 | 181,194,232-233   
 task.ts       |   97.06 |       80 |     100 |    96.3 | 31                
 utils.ts      |     100 |      100 |     100 |     100 |                   
---------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       65 passed, 65 total
Snapshots:   0 total
Time:        5.46 s
Ran all test suites.
```