### PR TITLE
Codegen: update `hooks` to accept a boolean or granular config object

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -87,7 +87,9 @@ interface SimpleUsage {
   exportName?: string
   argSuffix?: string
   responseSuffix?: string
-  hooks?: boolean
+  hooks?:
+    | boolean
+    | { queries: boolean; lazyQueries: boolean; mutations: boolean }
   outputFile: string
   filterEndpoints?:
     | string
@@ -130,6 +132,10 @@ const withOverride: ConfigFile = {
   ],
 }
 ```
+
+#### Generating hooks
+
+Setting `hooks: true` will generate `useQuery` and `useMuation` hook exports. If you also want `useLazyQuery` hooks generated or more granular control, you can also pass an object in the shape of: `{ queries: boolean; lazyQueries: boolean; mutations: boolean }`.
 
 #### Multiple output files
 

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -142,7 +142,14 @@ export async function generateApi(
         ...Object.values(interfaces),
         ...apiGen['aliases'],
         ...(hooks
-          ? [generateReactHooks({ exportName: generatedApiName, operationDefinitions, endpointOverrides })]
+          ? [
+              generateReactHooks({
+                exportName: generatedApiName,
+                operationDefinitions,
+                endpointOverrides,
+                config: hooks,
+              }),
+            ]
           : []),
       ],
       factory.createToken(ts.SyntaxKind.EndOfFileToken),

--- a/packages/rtk-query-codegen-openapi/src/generators/react-hooks.ts
+++ b/packages/rtk-query-codegen-openapi/src/generators/react-hooks.ts
@@ -1,13 +1,16 @@
 import ts from 'typescript';
 import { getOperationName } from '@rtk-query/oazapfts-patched/lib/codegen/generate';
 import { capitalize, isQuery } from '../utils';
-import type { OperationDefinition, EndpointOverrides } from '../types';
+import type { OperationDefinition, EndpointOverrides, ConfigFile } from '../types';
 import { getOverrides } from '../generate';
 import { factory } from '../utils/factory';
+
+type HooksConfigOptions = NonNullable<ConfigFile['hooks']>;
 
 type GetReactHookNameParams = {
   operationDefinition: OperationDefinition;
   endpointOverrides: EndpointOverrides[] | undefined;
+  config: HooksConfigOptions;
 };
 
 type CreateBindingParams = {
@@ -32,7 +35,7 @@ const createBinding = ({
     undefined
   );
 
-const getReactHookName = ({ operationDefinition, endpointOverrides }: GetReactHookNameParams) => {
+const getReactHookName = ({ operationDefinition, endpointOverrides, config }: GetReactHookNameParams) => {
   const overrides = getOverrides(operationDefinition, endpointOverrides);
 
   const baseParams = {
@@ -40,17 +43,36 @@ const getReactHookName = ({ operationDefinition, endpointOverrides }: GetReactHo
     overrides,
   };
 
-  return isQuery(operationDefinition.verb, overrides)
-    ? [createBinding(baseParams), createBinding({ ...baseParams, isLazy: true })]
-    : createBinding(baseParams);
+  const _isQuery = isQuery(operationDefinition.verb, overrides);
+
+  // If `config` is true, just generate everything
+  if (typeof config === 'boolean') {
+    return createBinding(baseParams);
+  }
+
+  // `config` is an object and we need to check for the configuration of each property
+  if (_isQuery) {
+    return [
+      ...(config.queries ? [createBinding(baseParams)] : []),
+      ...(config.lazyQueries ? [createBinding({ ...baseParams, isLazy: true })] : []),
+    ];
+  }
+
+  return config.mutations ? createBinding(baseParams) : [];
 };
 
 type GenerateReactHooksParams = {
   exportName: string;
   operationDefinitions: OperationDefinition[];
   endpointOverrides: EndpointOverrides[] | undefined;
+  config: HooksConfigOptions;
 };
-export const generateReactHooks = ({ exportName, operationDefinitions, endpointOverrides }: GenerateReactHooksParams) =>
+export const generateReactHooks = ({
+  exportName,
+  operationDefinitions,
+  endpointOverrides,
+  config,
+}: GenerateReactHooksParams) =>
   factory.createVariableStatement(
     [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     factory.createVariableDeclarationList(
@@ -58,7 +80,7 @@ export const generateReactHooks = ({ exportName, operationDefinitions, endpointO
         factory.createVariableDeclaration(
           factory.createObjectBindingPattern(
             operationDefinitions
-              .map((operationDefinition) => getReactHookName({ operationDefinition, endpointOverrides }))
+              .map((operationDefinition) => getReactHookName({ operationDefinition, endpointOverrides, config }))
               .flat()
           ),
           undefined,

--- a/packages/rtk-query-codegen-openapi/src/index.ts
+++ b/packages/rtk-query-codegen-openapi/src/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import type { CommonOptions, ConfigFile, GenerationOptions, OutputFileOptions } from './types';
 import { isValidUrl, prettify } from './utils';
-export { ConfigFile } from './types';
+export type { ConfigFile } from './types';
 
 export async function generateEndpoints(options: GenerationOptions): Promise<string | void> {
   const schemaLocation = options.schemaFile;

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -47,7 +47,8 @@ export interface CommonOptions {
    */
   responseSuffix?: string;
   /**
-   * defaults to false
+   * defaults to `false`
+   * `true` will generate hooks for queries and mutations, but no lazyQueries
    */
   hooks?: boolean | { queries: boolean; lazyQueries: boolean; mutations: boolean };
 

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -1,4 +1,3 @@
-import * as ts from 'typescript';
 import type { OpenAPIV3 } from 'openapi-types';
 
 export type OperationDefinition = {
@@ -50,7 +49,7 @@ export interface CommonOptions {
   /**
    * defaults to false
    */
-  hooks?: boolean;
+  hooks?: boolean | { queries: boolean; lazyQueries: boolean; mutations: boolean };
 
   /**
    * defaults to false

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -420,7 +420,7 @@ export type Pet = {
   tags?: Tag[] | undefined;
   status?: ('available' | 'pending' | 'sold') | undefined;
 };
-export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
+export const { useAddPetMutation, useGetPetByIdQuery, useLazyGetPetByIdQuery } = injectedRtkApi;
 
 `;
 
@@ -736,20 +736,28 @@ export const {
   useUpdatePetMutation,
   useAddPetMutation,
   useFindPetsByStatusQuery,
+  useLazyFindPetsByStatusQuery,
   useFindPetsByTagsQuery,
+  useLazyFindPetsByTagsQuery,
   useGetPetByIdQuery,
+  useLazyGetPetByIdQuery,
   useUpdatePetWithFormMutation,
   useDeletePetMutation,
   useUploadFileMutation,
   useGetInventoryQuery,
+  useLazyGetInventoryQuery,
   usePlaceOrderMutation,
   useGetOrderByIdQuery,
+  useLazyGetOrderByIdQuery,
   useDeleteOrderMutation,
   useCreateUserMutation,
   useCreateUsersWithListInputMutation,
   useLoginUserQuery,
+  useLazyLoginUserQuery,
   useLogoutUserQuery,
+  useLazyLogoutUserQuery,
   useGetUserByNameQuery,
+  useLazyGetUserByNameQuery,
   useUpdateUserMutation,
   useDeleteUserMutation,
 } = injectedRtkApi;
@@ -798,7 +806,7 @@ export type GetStructureDefinitionApiArg = {
   /** Some description */
   naming_conflict?: any;
 };
-export const { useGetStructureDefinitionQuery } = injectedRtkApi;
+export const { useGetStructureDefinitionQuery, useLazyGetStructureDefinitionQuery } = injectedRtkApi;
 
 `;
 
@@ -1059,20 +1067,28 @@ export const {
   useUpdatePetMutation,
   useAddPetMutation,
   useFindPetsByStatusQuery,
+  useLazyFindPetsByStatusQuery,
   useFindPetsByTagsQuery,
+  useLazyFindPetsByTagsQuery,
   useGetPetByIdQuery,
+  useLazyGetPetByIdQuery,
   useUpdatePetWithFormMutation,
   useDeletePetMutation,
   useUploadFileMutation,
   useGetInventoryQuery,
+  useLazyGetInventoryQuery,
   usePlaceOrderMutation,
   useGetOrderByIdQuery,
+  useLazyGetOrderByIdQuery,
   useDeleteOrderMutation,
   useCreateUserMutation,
   useCreateUsersWithListInputMutation,
   useLoginUserQuery,
+  useLazyLoginUserQuery,
   useLogoutUserQuery,
+  useLazyLogoutUserQuery,
   useGetUserByNameQuery,
+  useLazyGetUserByNameQuery,
   useUpdateUserMutation,
   useDeleteUserMutation,
 } = injectedRtkApi;

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -292,20 +292,20 @@ export type GetPetByIdApiArg = {
   petId: number;
 };
 export type Category = {
-  id?: number;
-  name?: string;
+  id?: number | undefined;
+  name?: string | undefined;
 };
 export type Tag = {
-  id?: number;
-  name?: string;
+  id?: number | undefined;
+  name?: string | undefined;
 };
 export type Pet = {
-  id?: number;
+  id?: number | undefined;
   name: string;
-  category?: Category;
+  category?: Category | undefined;
   photoUrls: string[];
-  tags?: Tag[];
-  status?: 'available' | 'pending' | 'sold';
+  tags?: Tag[] | undefined;
+  status?: ('available' | 'pending' | 'sold') | undefined;
 };
 export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
 
@@ -474,20 +474,20 @@ export type GetPetByIdApiArg = {
   petId: number;
 };
 export type Category = {
-  id?: number | undefined;
-  name?: string | undefined;
+  id?: number;
+  name?: string;
 };
 export type Tag = {
-  id?: number | undefined;
-  name?: string | undefined;
+  id?: number;
+  name?: string;
 };
 export type Pet = {
-  id?: number | undefined;
+  id?: number;
   name: string;
-  category?: Category | undefined;
+  category?: Category;
   photoUrls: string[];
-  tags?: Tag[] | undefined;
-  status?: ('available' | 'pending' | 'sold') | undefined;
+  tags?: Tag[];
+  status?: 'available' | 'pending' | 'sold';
 };
 export const { useAddPetMutation, useGetPetByIdQuery, useLazyGetPetByIdQuery } = injectedRtkApi;
 

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -263,6 +263,54 @@ export type User = {
 
 `;
 
+exports[`default hooks generation: should generate an \`useGetPetByIdQuery\` query hook and an \`useAddPetMutation\` mutation hook 1`] = `
+import { api } from './fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: 'POST',
+        body: queryArg.pet,
+      }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type Category = {
+  id?: number;
+  name?: string;
+};
+export type Tag = {
+  id?: number;
+  name?: string;
+};
+export type Pet = {
+  id?: number;
+  name: string;
+  category?: Category;
+  photoUrls: string[];
+  tags?: Tag[];
+  status?: 'available' | 'pending' | 'sold';
+};
+export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
+
+`;
+
 exports[`endpoint filtering: should only have endpoints loginUser, placeOrder, getOrderById, deleteOrder 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({
@@ -376,7 +424,28 @@ export const { useLoginUserMutation } = injectedRtkApi;
 
 `;
 
-exports[`hooks generation: should generate an \`useGetPetByIdQuery\` query hook and an \`useAddPetMutation\` mutation hook 1`] = `
+exports[`should use brackets in a querystring urls arg, when the arg contains full stops 1`] = `
+import { api } from './fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    patchApiV1ListByItemId: build.mutation<PatchApiV1ListByItemIdApiResponse, PatchApiV1ListByItemIdApiArg>({
+      query: (queryArg) => ({
+        url: \`/api/v1/list/\${queryArg['item.id']}\`,
+        method: 'PATCH',
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type PatchApiV1ListByItemIdApiResponse = /** status 200 A successful response. */ string;
+export type PatchApiV1ListByItemIdApiArg = {
+  'item.id': string;
+};
+
+`;
+
+exports[`supports granular hooks generation that includes all query types 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -424,24 +493,147 @@ export const { useAddPetMutation, useGetPetByIdQuery, useLazyGetPetByIdQuery } =
 
 `;
 
-exports[`should use brackets in a querystring urls arg, when the arg contains full stops 1`] = `
+exports[`supports granular hooks generation with only lazy queries 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
-    patchApiV1ListByItemId: build.mutation<PatchApiV1ListByItemIdApiResponse, PatchApiV1ListByItemIdApiArg>({
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
       query: (queryArg) => ({
-        url: \`/api/v1/list/\${queryArg['item.id']}\`,
-        method: 'PATCH',
+        url: \`/pet\`,
+        method: 'POST',
+        body: queryArg.pet,
       }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
     }),
   }),
   overrideExisting: false,
 });
 export { injectedRtkApi as enhancedApi };
-export type PatchApiV1ListByItemIdApiResponse = /** status 200 A successful response. */ string;
-export type PatchApiV1ListByItemIdApiArg = {
-  'item.id': string;
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
 };
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type Category = {
+  id?: number;
+  name?: string;
+};
+export type Tag = {
+  id?: number;
+  name?: string;
+};
+export type Pet = {
+  id?: number;
+  name: string;
+  category?: Category;
+  photoUrls: string[];
+  tags?: Tag[];
+  status?: 'available' | 'pending' | 'sold';
+};
+export const { useLazyGetPetByIdQuery } = injectedRtkApi;
+
+`;
+
+exports[`supports granular hooks generation with only mutations 1`] = `
+import { api } from './fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: 'POST',
+        body: queryArg.pet,
+      }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type Category = {
+  id?: number;
+  name?: string;
+};
+export type Tag = {
+  id?: number;
+  name?: string;
+};
+export type Pet = {
+  id?: number;
+  name: string;
+  category?: Category;
+  photoUrls: string[];
+  tags?: Tag[];
+  status?: 'available' | 'pending' | 'sold';
+};
+export const { useAddPetMutation } = injectedRtkApi;
+
+`;
+
+exports[`supports granular hooks generation with only queries 1`] = `
+import { api } from './fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: 'POST',
+        body: queryArg.pet,
+      }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type Category = {
+  id?: number;
+  name?: string;
+};
+export type Tag = {
+  id?: number;
+  name?: string;
+};
+export type Pet = {
+  id?: number;
+  name: string;
+  category?: Category;
+  photoUrls: string[];
+  tags?: Tag[];
+  status?: 'available' | 'pending' | 'sold';
+};
+export const { useGetPetByIdQuery } = injectedRtkApi;
 
 `;
 
@@ -736,28 +928,20 @@ export const {
   useUpdatePetMutation,
   useAddPetMutation,
   useFindPetsByStatusQuery,
-  useLazyFindPetsByStatusQuery,
   useFindPetsByTagsQuery,
-  useLazyFindPetsByTagsQuery,
   useGetPetByIdQuery,
-  useLazyGetPetByIdQuery,
   useUpdatePetWithFormMutation,
   useDeletePetMutation,
   useUploadFileMutation,
   useGetInventoryQuery,
-  useLazyGetInventoryQuery,
   usePlaceOrderMutation,
   useGetOrderByIdQuery,
-  useLazyGetOrderByIdQuery,
   useDeleteOrderMutation,
   useCreateUserMutation,
   useCreateUsersWithListInputMutation,
   useLoginUserQuery,
-  useLazyLoginUserQuery,
   useLogoutUserQuery,
-  useLazyLogoutUserQuery,
   useGetUserByNameQuery,
-  useLazyGetUserByNameQuery,
   useUpdateUserMutation,
   useDeleteUserMutation,
 } = injectedRtkApi;
@@ -806,7 +990,7 @@ export type GetStructureDefinitionApiArg = {
   /** Some description */
   naming_conflict?: any;
 };
-export const { useGetStructureDefinitionQuery, useLazyGetStructureDefinitionQuery } = injectedRtkApi;
+export const { useGetStructureDefinitionQuery } = injectedRtkApi;
 
 `;
 
@@ -1067,28 +1251,20 @@ export const {
   useUpdatePetMutation,
   useAddPetMutation,
   useFindPetsByStatusQuery,
-  useLazyFindPetsByStatusQuery,
   useFindPetsByTagsQuery,
-  useLazyFindPetsByTagsQuery,
   useGetPetByIdQuery,
-  useLazyGetPetByIdQuery,
   useUpdatePetWithFormMutation,
   useDeletePetMutation,
   useUploadFileMutation,
   useGetInventoryQuery,
-  useLazyGetInventoryQuery,
   usePlaceOrderMutation,
   useGetOrderByIdQuery,
-  useLazyGetOrderByIdQuery,
   useDeleteOrderMutation,
   useCreateUserMutation,
   useCreateUsersWithListInputMutation,
   useLoginUserQuery,
-  useLazyLoginUserQuery,
   useLogoutUserQuery,
-  useLazyLogoutUserQuery,
   useGetUserByNameQuery,
-  useLazyGetUserByNameQuery,
   useUpdateUserMutation,
   useDeleteUserMutation,
 } = injectedRtkApi;

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -73,7 +73,7 @@ test('endpoint overrides', async () => {
   expect(api).toMatchSnapshot('loginUser should be a mutation');
 });
 
-test('hooks generation', async () => {
+test('default hooks generation', async () => {
   const api = await generateEndpoints({
     unionUndefined: true,
     apiFile: './fixtures/emptyApi.ts',
@@ -86,6 +86,74 @@ test('hooks generation', async () => {
   expect(api).toMatchSnapshot(
     'should generate an `useGetPetByIdQuery` query hook and an `useAddPetMutation` mutation hook'
   );
+});
+
+it('supports granular hooks generation that includes all query types', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    filterEndpoints: ['getPetById', 'addPet'],
+    hooks: {
+      queries: true,
+      lazyQueries: true,
+      mutations: true,
+    },
+  });
+  expect(api).toContain('useGetPetByIdQuery');
+  expect(api).toContain('useLazyGetPetByIdQuery');
+  expect(api).toContain('useAddPetMutation');
+  expect(api).toMatchSnapshot();
+});
+
+it('supports granular hooks generation with only queries', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    filterEndpoints: ['getPetById', 'addPet'],
+    hooks: {
+      queries: true,
+      lazyQueries: false,
+      mutations: false,
+    },
+  });
+  expect(api).toContain('useGetPetByIdQuery');
+  expect(api).not.toContain('useLazyGetPetByIdQuery');
+  expect(api).not.toContain('useAddPetMutation');
+  expect(api).toMatchSnapshot();
+});
+
+it('supports granular hooks generation with only lazy queries', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    filterEndpoints: ['getPetById', 'addPet'],
+    hooks: {
+      queries: false,
+      lazyQueries: true,
+      mutations: false,
+    },
+  });
+  expect(api).not.toContain('useGetPetByIdQuery');
+  expect(api).toContain('useLazyGetPetByIdQuery');
+  expect(api).not.toContain('useAddPetMutation');
+  expect(api).toMatchSnapshot();
+});
+
+it('supports granular hooks generation with only mutations', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    filterEndpoints: ['getPetById', 'addPet'],
+    hooks: {
+      queries: false,
+      lazyQueries: false,
+      mutations: true,
+    },
+  });
+  expect(api).not.toContain('useGetPetByIdQuery');
+  expect(api).not.toContain('useLazyGetPetByIdQuery');
+  expect(api).toContain('useAddPetMutation');
+  expect(api).toMatchSnapshot();
 });
 
 test('hooks generation uses overrides', async () => {


### PR DESCRIPTION
Addresses #1951. Allows the `hooks` config option to be :

```ts
hooks?: boolean | { queries: boolean; lazyQueries: boolean; mutations: boolean };
```

By specifying `hooks: true`, we'll keep the same behavior that exists today where only Queries and Mutations are generated. In order to generate lazy queries, the config object must be set. This was done to keep expected behavior for folks that upgrade.
