### PR TITLE
rtk-query-codegen-openap: Fixed relative `apiFile` path when generating on Windows

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -102,6 +102,7 @@ export async function generateApi(
     outputFile = path.resolve(process.cwd(), outputFile);
     if (apiFile.startsWith('.')) {
       apiFile = path.relative(path.dirname(outputFile), apiFile);
+      apiFile = apiFile.replace(/\\/g, '/')
       if (!apiFile.startsWith('.')) apiFile = './' + apiFile;
     }
   }


### PR DESCRIPTION
### Summary

Running the generator on Windows where the `outputFile` and `apiFile` are not in the same folder, the generated import `api` import statement would use backslash instead of forward slashes due to operating system differences.

### Issue
Sample configuration:
```typescript
const config: ConfigFile = {
  schemaFile: './openapi-definition.yaml',
  apiFile: './api.ts',
  outputFile: 'generated/index.ts',
}
```

Before fix:
```typescript
import { api } from '..\\api'
```

After fix:
```typescript
import { api } from '../api'
```

### Solution
Normalize `apiFile` path to use forward slashes after relative path computation.