### PR TITLE
feat(alm):  improve removeListener & removeListenerAction

### DIFF
--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -201,7 +201,6 @@ middleware.removeListener({
 A standard RTK action creator that tells the middleware to dynamically add a new listener at runtime. It accepts exactly the same options as `middleware.addListener()`
 
 Dispatching this action returns an `unsubscribe()` callback from `dispatch`.
-It throws error if listener is not a function.
 
 ```js
 // Per above, provide `predicate` or any of the other comparison options
@@ -212,7 +211,7 @@ const unsubscribe = store.dispatch(addListenerAction({ predicate, listener }))
 
 A standard RTK action creator that tells the middleware to remove a listener at runtime. Accepts the same arguments as `middleware.removeListener()`:
 Returns `true` if the `options.listener` listener has been removed, `false` if no subscription matching the input provided has been found.
-It throws error if listener is not a function.
+
 
 ```js
 store.dispatch(removeListenerAction({ predicate, listener }))

--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -322,7 +322,9 @@ export function createActionListenerMiddleware<
           : entry.predicate === predicate
 
       return matchPredicateOrType && entry.listener === listener
-    })?.unsubscribe()
+    })
+
+    entry?.unsubscribe()
 
     return !!entry
   }

--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -9,6 +9,7 @@ import type {
 import { createAction, nanoid } from '@reduxjs/toolkit'
 
 import type {
+  ActionListenerMiddleware,
   AddListenerOverloads,
   AnyActionListenerPredicate,
   CreateListenerMiddlewareOptions,
@@ -461,10 +462,7 @@ export function createActionListenerMiddleware<
     {
       addListener: addListener as TypedAddListener<S, D>,
       removeListener: removeListener as TypedRemoveListener<S, D>,
-      addListenerAction: addListenerAction as TypedAddListenerAction<S>,
-      removeListenerAction:
-        removeListenerAction as TypedRemoveListenerAction<S>,
-      clear: clearListenerMiddleware,
+      clearListeners: clearListenerMiddleware,
     },
     {} as WithMiddlewareType<typeof middleware>
   )

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -24,7 +24,11 @@ import type {
   Unsubscribe,
   ActionListenerMiddleware,
 } from '../index'
-import type { ActionListener, AddListenerOverloads } from '../types'
+import type {
+  ActionListener,
+  AddListenerOverloads,
+  TypedRemoveListenerAction,
+} from '../types'
 
 const middlewareApi = {
   getState: expect.any(Function),
@@ -138,6 +142,10 @@ describe('createActionListenerMiddleware', () => {
 
   let reducer: jest.Mock
   let middleware: ReturnType<typeof createActionListenerMiddleware>
+  let addTypedListenerAction =
+    addListenerAction as TypedAddListenerAction<CounterState>
+  let removeTypedListenerAction =
+    removeListenerAction as TypedRemoveListenerAction<CounterState>
   // let middleware: ActionListenerMiddleware<CounterState> //: ReturnType<typeof createActionListenerMiddleware>
 
   const testAction1 = createAction<string>('testAction1')
@@ -237,7 +245,7 @@ describe('createActionListenerMiddleware', () => {
 
       expect(
         store.dispatch(
-          middleware.removeListenerAction({
+          removeTypedListenerAction({
             actionCreator: testAction2,
             listener,
           })
@@ -245,7 +253,7 @@ describe('createActionListenerMiddleware', () => {
       ).toBe(false)
       expect(
         store.dispatch(
-          middleware.removeListenerAction({
+          removeTypedListenerAction({
             actionCreator: testAction1,
             listener,
           })
@@ -657,7 +665,7 @@ describe('createActionListenerMiddleware', () => {
 
       store.dispatch(testAction1('a'))
 
-      middleware.clear()
+      middleware.clearListeners()
       store.dispatch(testAction1('b'))
       store.dispatch(testAction2('c'))
 
@@ -680,7 +688,7 @@ describe('createActionListenerMiddleware', () => {
 
       store.dispatch(testAction1('a'))
 
-      middleware.clear()
+      middleware.clearListeners()
       store.dispatch(testAction1('b'))
 
       expect(await fork1Test).toHaveProperty('status', 'cancelled')
@@ -1385,7 +1393,7 @@ describe('createActionListenerMiddleware', () => {
       })
 
       store.dispatch(
-        typedMiddleware.addListenerAction({
+        addTypedListenerAction({
           predicate: (
             action,
             currentState,
@@ -1409,7 +1417,7 @@ describe('createActionListenerMiddleware', () => {
       )
 
       store.dispatch(
-        typedMiddleware.addListenerAction({
+        addTypedListenerAction({
           predicate: (
             action,
             currentState,

--- a/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
+++ b/packages/action-listener-middleware/src/tests/listenerMiddleware.test.ts
@@ -211,6 +211,48 @@ describe('createActionListenerMiddleware', () => {
       ])
     })
 
+    test('removeListener returns true if an entry has been unsubscribed, false otherwise', () => {
+      const listener = jest.fn((_: TestAction1) => {})
+
+      middleware.addListener({
+        actionCreator: testAction1,
+        listener,
+      })
+
+      expect(
+        middleware.removeListener({ actionCreator: testAction2, listener })
+      ).toBe(false)
+      expect(
+        middleware.removeListener({ actionCreator: testAction1, listener })
+      ).toBe(true)
+    })
+
+    test('dispatch(removeListenerAction({...})) returns true if an entry has been unsubscribed, false otherwise', () => {
+      const listener = jest.fn((_: TestAction1) => {})
+
+      middleware.addListener({
+        actionCreator: testAction1,
+        listener,
+      })
+
+      expect(
+        store.dispatch(
+          middleware.removeListenerAction({
+            actionCreator: testAction2,
+            listener,
+          })
+        )
+      ).toBe(false)
+      expect(
+        store.dispatch(
+          middleware.removeListenerAction({
+            actionCreator: testAction1,
+            listener,
+          })
+        )
+      ).toBe(true)
+    })
+
     test('can subscribe with a string action type', () => {
       const listener = jest.fn((_: AnyAction) => {})
 

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -217,12 +217,10 @@ export type ActionListenerMiddleware<
 > & {
   addListener: AddListenerOverloads<Unsubscribe, S, D>
   removeListener: RemoveListenerOverloads<S, D>
-  addListenerAction: TypedAddListenerAction<S, D>
-  removeListenerAction: TypedRemoveListenerAction<S, D>
   /**
    * Unsubscribes all listeners, cancels running listeners and tasks.
    */
-  clear: () => void
+  clearListeners: () => void
 }
 
 /**

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -218,6 +218,7 @@ export type ActionListenerMiddleware<
   addListener: AddListenerOverloads<Unsubscribe, S, D>
   removeListener: RemoveListenerOverloads<S, D>
   addListenerAction: TypedAddListenerAction<S, D>
+  removeListenerAction: TypedRemoveListenerAction<S, D>
 }
 
 /**
@@ -316,16 +317,10 @@ export interface AddListenerOverloads<
   ): Return
 }
 
-export interface RemoveListenerOverloads<
+export type RemoveListenerOverloads<
   S = unknown,
   D extends Dispatch = ThunkDispatch<S, unknown, AnyAction>
-> {
-  <C extends TypedActionCreator<any>>(
-    actionCreator: C,
-    listener: ActionListener<ReturnType<C>, S, D>
-  ): boolean
-  (type: string, listener: ActionListener<AnyAction, S, D>): boolean
-}
+> = AddListenerOverloads<boolean, S, D>
 
 export interface RemoveListenerAction<
   A extends AnyAction,
@@ -348,11 +343,26 @@ export type TypedAddListenerAction<
 > = BaseActionCreator<Payload, T> &
   AddListenerOverloads<PayloadAction<Payload, T>, S, D>
 
+/** A "pre-typed" version of `removeListenerAction`, so the listener args are well-typed */
+export type TypedRemoveListenerAction<
+  S,
+  D extends Dispatch<AnyAction> = ThunkDispatch<S, unknown, AnyAction>,
+  Payload = ListenerEntry<S, D>,
+  T extends string = 'actionListenerMiddleware/remove'
+> = BaseActionCreator<Payload, T> &
+  AddListenerOverloads<PayloadAction<Payload, T>, S, D>
+
 /** A "pre-typed" version of `middleware.addListener`, so the listener args are well-typed */
 export type TypedAddListener<
   S,
   D extends Dispatch<AnyAction> = ThunkDispatch<S, unknown, AnyAction>
 > = AddListenerOverloads<Unsubscribe, S, D>
+
+/** A "pre-typed" version of `middleware.removeListener`, so the listener args are well-typed */
+export type TypedRemoveListener<
+  S,
+  D extends Dispatch<AnyAction> = ThunkDispatch<S, unknown, AnyAction>
+> = RemoveListenerOverloads<S, D>
 
 /** A "pre-typed" version of `createListenerEntry`, so the listener args are well-typed */
 export type TypedCreateListenerEntry<


### PR DESCRIPTION
### Description

`removeListener` & `removeListener` action accept the same arguments of `addListener`.

### Why

It is now possible to remove entries created with
`addListener({ predicate, listener })` or `addListener({ matcher, listener })` using `removeListener` or `removeListenerAction`.

Discussion: https://github.com/reduxjs/redux-toolkit/discussions/1648#discussioncomment-2011133

### Breaking changes

- Synchronously throw error, if listener is not a function
instead of throwing when the predicate matches the action dispatched.

- `removeListener(type, listener)` is not longer a valid function signature.

### Test log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run test --coverage
 PASS  src/tests/listenerMiddleware.test.ts
 PASS  src/tests/effectScenarios.test.ts
 PASS  src/tests/fork.test.ts
 PASS  src/tests/useCases.test.ts
---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-------------------
All files      |   97.37 |    94.23 |      94 |   97.16 |
 exceptions.ts |     100 |      100 |     100 |     100 |
 index.ts      |   97.16 |    97.37 |   91.43 |   97.06 | 178,202,226-227
 task.ts       |   97.06 |       80 |     100 |    96.3 | 31
 utils.ts      |     100 |      100 |     100 |     100 |
---------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       66 passed, 66 total
Snapshots:   0 total
Time:        5.928 s
Ran all test suites.
```

### Build log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run build
Build "actionListenerMiddleware" to dist/esm:
       1596 B: index.modern.js.gz
       1439 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.27 kB: index.js.gz
      2.02 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
      2.27 kB: index.js.gz
      2.02 kB: index.js.br
```