### PR TITLE
fix `reducerPath` for query definitions

### DIFF
--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -390,10 +390,10 @@ export type EndpointBuilder<
    */
   query<ResultType, QueryArg>(
     definition: OmitFromUnion<
-      QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType>,
+      QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType, ReducerPath>,
       'type'
     >
-  ): QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType>
+  ): QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType, ReducerPath>
   /**
    * An endpoint definition that alters data on the server or will possibly invalidate the cache.
    *

--- a/packages/toolkit/src/query/tests/buildSelector.test.ts
+++ b/packages/toolkit/src/query/tests/buildSelector.test.ts
@@ -42,6 +42,7 @@ describe('buildSelector', () => {
     const store = configureStore({
       reducer: {
         [exampleApi.reducerPath]: exampleApi.reducer,
+        other: () => 1,
       },
     })
 


### PR DESCRIPTION
Fixes #1879 #1914 #1976 

I really don't know how I could have missed that.