### PR TITLE
Add `ignoreActions` flag to serializable state middleware

### DIFF
--- a/docs/api/serializabilityMiddleware.mdx
+++ b/docs/api/serializabilityMiddleware.mdx
@@ -57,9 +57,14 @@ interface SerializableStateInvariantMiddlewareOptions {
   warnAfter?: number
 
   /**
-   * Opt out of checking state, but continue checking actions
+   * Opt out of checking state. When set to `true`, other state-related params will be ignored.
    */
   ignoreState?: boolean
+
+  /**
+   * Opt out of checking actions. When set to `true`, other action-related params will be ignored.
+   */
+  ignoreActions?: boolean
 }
 ```
 

--- a/packages/toolkit/src/serializableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/serializableStateInvariantMiddleware.ts
@@ -132,9 +132,14 @@ export interface SerializableStateInvariantMiddlewareOptions {
   warnAfter?: number
 
   /**
-   * Opt out of checking state, but continue checking actions
+   * Opt out of checking state. When set to `true`, other state-related params will be ignored.
    */
   ignoreState?: boolean
+
+  /**
+   * Opt out of checking actions. When set to `true`, other action-related params will be ignored.
+   */
+  ignoreActions?: boolean
 }
 
 /**
@@ -160,10 +165,14 @@ export function createSerializableStateInvariantMiddleware(
     ignoredPaths = [],
     warnAfter = 32,
     ignoreState = false,
+    ignoreActions = false,
   } = options
 
   return (storeAPI) => (next) => (action) => {
-    if (ignoredActions.length && ignoredActions.indexOf(action.type) !== -1) {
+    if (
+      ignoreActions ||
+      (ignoredActions.length && ignoredActions.indexOf(action.type) !== -1)
+    ) {
       return next(action)
     }
 

--- a/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
@@ -389,6 +389,30 @@ describe('serializableStateInvariantMiddleware', () => {
     })
   })
 
+  it('allows ignoring actions entirely', () => {
+    let numTimesCalled = 0
+
+    const serializableStateMiddleware =
+      createSerializableStateInvariantMiddleware({
+        isSerializable: () => {
+          numTimesCalled++
+          return true
+        },
+        ignoreActions: true,
+      })
+
+    const store = configureStore({
+      reducer: () => ({}),
+      middleware: [serializableStateMiddleware],
+    })
+
+    expect(numTimesCalled).toBe(0)
+
+    store.dispatch({ type: 'THIS_DOESNT_MATTER' })
+
+    expect(numTimesCalled).toBe(0)
+  })
+
   it('should not check serializability for ignored slice names', () => {
     const ACTION_TYPE = 'TEST_ACTION'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5513,7 +5513,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rtk-incubator/action-listener-middleware@^0.6.0, @rtk-incubator/action-listener-middleware@workspace:packages/action-listener-middleware":
+"@rtk-incubator/action-listener-middleware@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@rtk-incubator/action-listener-middleware@npm:0.6.0"
+  peerDependencies:
+    "@reduxjs/toolkit": ^1.6.0
+  checksum: 01e600a9e513f883e4c6d02cbe4565b9691d6b43ebff432a9ad7f4f96d07c3164c3a0c14fde4391e3d3f65e18753e567b67d9645a2af27daba6b0aadd5fa2066
+  languageName: node
+  linkType: hard
+
+"@rtk-incubator/action-listener-middleware@workspace:packages/action-listener-middleware":
   version: 0.0.0-use.local
   resolution: "@rtk-incubator/action-listener-middleware@workspace:packages/action-listener-middleware"
   dependencies:


### PR DESCRIPTION
Adds an `ignoreActions` flag to `serializableCheck` to balance out the `ignoreState` flag. Also re-ran api-extractor.

Fixes #1967 