### PR TITLE
docs – it's → its (two spots); slight wording tweak

### DIFF
--- a/docs/rtk-query/usage/manual-cache-updates.mdx
+++ b/docs/rtk-query/usage/manual-cache-updates.mdx
@@ -14,9 +14,9 @@ description: 'RTK Query > Usage > Manual Cache Updates: Updating cached data man
 
 For most cases, in order to receive up to date data after a triggering a change in the backend,
 you can take advantage of `cache tag invalidation` to perform
-[automated re-fetching](./automated-refetching), which will cause a query to re-fetch it's data
-when it has been told that a mutation has occurred which would cause it's data to become out of date.
-In most cases, we recommend to use `automated re-fetching` as a preference over `manual cache updates`,
+[automated re-fetching](./automated-refetching), which will cause a query to re-fetch its data
+when it has been told that a mutation has occurred which would cause its data to become out of date.
+In most cases, we recommend using `automated re-fetching` as a preference over `manual cache updates`,
 unless you encounter the need to do so.
 
 However, in some cases, you may want to update the cache manually. When you wish to update cache


### PR DESCRIPTION
- `it's` always expands to `it is` … meaning `re-fetch it's data` can expand to `re-fetch it is data` which is obviously incorrect
- `we recommend to use` → `we recommend using` (grammar tweak)