### PR TITLE
Reorganize serializable check conditions

### DIFF
--- a/packages/toolkit/src/serializableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/serializableStateInvariantMiddleware.ts
@@ -169,41 +169,40 @@ export function createSerializableStateInvariantMiddleware(
   } = options
 
   return (storeAPI) => (next) => (action) => {
-    if (
-      ignoreActions ||
-      (ignoredActions.length && ignoredActions.indexOf(action.type) !== -1)
-    ) {
-      return next(action)
-    }
+    const result = next(action)
 
     const measureUtils = getTimeMeasureUtils(
       warnAfter,
       'SerializableStateInvariantMiddleware'
     )
-    measureUtils.measureTime(() => {
-      const foundActionNonSerializableValue = findNonSerializableValue(
-        action,
-        '',
-        isSerializable,
-        getEntries,
-        ignoredActionPaths
-      )
 
-      if (foundActionNonSerializableValue) {
-        const { keyPath, value } = foundActionNonSerializableValue
-
-        console.error(
-          `A non-serializable value was detected in an action, in the path: \`${keyPath}\`. Value:`,
-          value,
-          '\nTake a look at the logic that dispatched this action: ',
+    if (
+      !ignoreActions &&
+      !(ignoredActions.length && ignoredActions.indexOf(action.type) !== -1)
+    ) {
+      measureUtils.measureTime(() => {
+        const foundActionNonSerializableValue = findNonSerializableValue(
           action,
-          '\n(See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)',
-          '\n(To allow non-serializable values see: https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data)'
+          '',
+          isSerializable,
+          getEntries,
+          ignoredActionPaths
         )
-      }
-    })
 
-    const result = next(action)
+        if (foundActionNonSerializableValue) {
+          const { keyPath, value } = foundActionNonSerializableValue
+
+          console.error(
+            `A non-serializable value was detected in an action, in the path: \`${keyPath}\`. Value:`,
+            value,
+            '\nTake a look at the logic that dispatched this action: ',
+            action,
+            '\n(See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)',
+            '\n(To allow non-serializable values see: https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data)'
+          )
+        }
+      })
+    }
 
     if (!ignoreState) {
       measureUtils.measureTime(() => {


### PR DESCRIPTION
Fixes #1996 

- `state` and `action` checks behave independently, allowing a user to `ignoreState` and still check actions, or `ignoreActions` and continue to check state