### PR TITLE
Rewrite MiddlewareArray and gDM for better Dispatch inference

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['14.x']
-        ts: ['3.9', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', 'next']
+        ts: ['4.1', '4.2', '4.3', '4.4', '4.5', 'next']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/packages/action-listener-middleware/src/tests/fork.test.ts
+++ b/packages/action-listener-middleware/src/tests/fork.test.ts
@@ -52,8 +52,11 @@ describe('fork', () => {
     },
   })
   const { increment, decrement, incrementByAmount } = counterSlice.actions
-  let middleware: ReturnType<typeof createActionListenerMiddleware>
-  let store: EnhancedStore<CounterSlice>
+  let middleware = createActionListenerMiddleware()
+  let store = configureStore({
+    reducer: counterSlice.reducer,
+    middleware: (gDM) => gDM().prepend(middleware),
+  })
 
   beforeEach(() => {
     middleware = createActionListenerMiddleware()

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -20,7 +20,7 @@ import type {
   CurriedGetDefaultMiddleware,
 } from './getDefaultMiddleware'
 import { curryGetDefaultMiddleware } from './getDefaultMiddleware'
-import type { DispatchForMiddlewares, NoInfer } from './tsHelpers'
+import type { NoInfer, ExtractDispatchExtensions } from './tsHelpers'
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 
@@ -110,7 +110,7 @@ export interface EnhancedStore<
    *
    * @inheritdoc
    */
-  dispatch: Dispatch<A> & DispatchForMiddlewares<M>
+  dispatch: ExtractDispatchExtensions<M> & Dispatch<A>
 }
 
 /**
@@ -160,7 +160,7 @@ export function configureStore<
   }
   if (
     !IS_PRODUCTION &&
-    finalMiddleware.some((item) => typeof item !== 'function')
+    finalMiddleware.some((item: any) => typeof item !== 'function')
   ) {
     throw new Error(
       'each middleware provided to configureStore must be a function'

--- a/packages/toolkit/src/getDefaultMiddleware.ts
+++ b/packages/toolkit/src/getDefaultMiddleware.ts
@@ -8,6 +8,7 @@ import { createImmutableStateInvariantMiddleware } from './immutableStateInvaria
 
 import type { SerializableStateInvariantMiddlewareOptions } from './serializableStateInvariantMiddleware'
 import { createSerializableStateInvariantMiddleware } from './serializableStateInvariantMiddleware'
+import type { ExcludeFromTuple } from './tsHelpers'
 import { MiddlewareArray } from './utils'
 
 function isBoolean(x: any): x is boolean {
@@ -33,9 +34,7 @@ export type ThunkMiddlewareFor<
   ? never
   : O extends { thunk: { extraArgument: infer E } }
   ? ThunkMiddleware<S, AnyAction, E>
-  :
-      | ThunkMiddleware<S, AnyAction, null> //The ThunkMiddleware with a `null` ExtraArgument is here to provide backwards-compatibility.
-      | ThunkMiddleware<S, AnyAction>
+  : ThunkMiddleware<S, AnyAction>
 
 export type CurriedGetDefaultMiddleware<S = any> = <
   O extends Partial<GetDefaultMiddlewareOptions> = {
@@ -45,7 +44,7 @@ export type CurriedGetDefaultMiddleware<S = any> = <
   }
 >(
   options?: O
-) => MiddlewareArray<Middleware<{}, S> | ThunkMiddlewareFor<S, O>>
+) => MiddlewareArray<ExcludeFromTuple<[ThunkMiddlewareFor<S, O>], never>>
 
 export function curryGetDefaultMiddleware<
   S = any
@@ -76,14 +75,14 @@ export function getDefaultMiddleware<
   }
 >(
   options: O = {} as O
-): MiddlewareArray<Middleware<{}, S> | ThunkMiddlewareFor<S, O>> {
+): MiddlewareArray<ExcludeFromTuple<[ThunkMiddlewareFor<S, O>], never>> {
   const {
     thunk = true,
     immutableCheck = true,
     serializableCheck = true,
   } = options
 
-  let middlewareArray: Middleware<{}, S>[] = new MiddlewareArray()
+  let middlewareArray = new MiddlewareArray<Middleware[]>()
 
   if (thunk) {
     if (isBoolean(thunk)) {

--- a/packages/toolkit/src/tests/MiddlewareArray.typetest.ts
+++ b/packages/toolkit/src/tests/MiddlewareArray.typetest.ts
@@ -1,6 +1,8 @@
 import { getDefaultMiddleware } from '@reduxjs/toolkit'
 import type { Middleware } from 'redux'
-import type { DispatchForMiddlewares } from '@internal/tsHelpers'
+import type { ExtractDispatchExtensions } from '@internal/tsHelpers'
+import thunk from 'redux-thunk'
+import { MiddlewareArray } from '../utils'
 
 declare const expectType: <T>(t: T) => T
 
@@ -14,7 +16,7 @@ declare const middleware2: Middleware<{
 
 declare const getDispatch: <M extends Array<Middleware>>(
   m: M
-) => DispatchForMiddlewares<M>
+) => ExtractDispatchExtensions<M>
 
 type ThunkReturn = Promise<'thunk'>
 declare const thunkCreator: () => () => ThunkReturn

--- a/packages/toolkit/src/tests/MiddlewareArray.typetest.ts
+++ b/packages/toolkit/src/tests/MiddlewareArray.typetest.ts
@@ -1,8 +1,5 @@
-import { getDefaultMiddleware } from '@reduxjs/toolkit'
+import { getDefaultMiddleware, configureStore } from '@reduxjs/toolkit'
 import type { Middleware } from 'redux'
-import type { ExtractDispatchExtensions } from '@internal/tsHelpers'
-import thunk from 'redux-thunk'
-import { MiddlewareArray } from '../utils'
 
 declare const expectType: <T>(t: T) => T
 
@@ -14,103 +11,108 @@ declare const middleware2: Middleware<{
   (_: number): string
 }>
 
-declare const getDispatch: <M extends Array<Middleware>>(
-  m: M
-) => ExtractDispatchExtensions<M>
-
 type ThunkReturn = Promise<'thunk'>
 declare const thunkCreator: () => () => ThunkReturn
 
 {
-  const defaultMiddleware = getDefaultMiddleware()
-
   // prepend single element
   {
-    const concatenated = defaultMiddleware.prepend(middleware1)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().prepend(middleware1),
+    })
+    expectType<number>(store.dispatch('foo'))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 
-  // prepepend multiple (rest)
+  // prepend multiple (rest)
   {
-    const concatenated = defaultMiddleware.prepend(middleware1, middleware2)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<string>(dispatch(5))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().prepend(middleware1, middleware2),
+    })
+    expectType<number>(store.dispatch('foo'))
+    expectType<string>(store.dispatch(5))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 
   // prepend multiple (array notation)
   {
-    const concatenated = defaultMiddleware.prepend([
-      middleware1,
-      middleware2,
-    ] as const)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<string>(dispatch(5))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().prepend([middleware1, middleware2] as const),
+    })
+
+    expectType<number>(store.dispatch('foo'))
+    expectType<string>(store.dispatch(5))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 
   // concat single element
   {
-    const concatenated = defaultMiddleware.concat(middleware1)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().concat(middleware1),
+    })
+
+    expectType<number>(store.dispatch('foo'))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 
-  // prepepend multiple (rest)
+  // prepend multiple (rest)
   {
-    const concatenated = defaultMiddleware.concat(middleware1, middleware2)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<string>(dispatch(5))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().concat(middleware1, middleware2),
+    })
+
+    expectType<number>(store.dispatch('foo'))
+    expectType<string>(store.dispatch(5))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 
   // concat multiple (array notation)
   {
-    const concatenated = defaultMiddleware.concat([
-      middleware1,
-      middleware2,
-    ] as const)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<string>(dispatch(5))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().concat([middleware1, middleware2] as const),
+    })
+
+    expectType<number>(store.dispatch('foo'))
+    expectType<string>(store.dispatch(5))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 
   // concat and prepend
   {
-    const concatenated = defaultMiddleware
-      .concat(middleware1)
-      .prepend(middleware2)
-    const dispatch = getDispatch(concatenated)
-    expectType<number>(dispatch('foo'))
-    expectType<string>(dispatch(5))
-    expectType<ThunkReturn>(dispatch(thunkCreator()))
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().concat(middleware1).prepend(middleware2),
+    })
+
+    expectType<number>(store.dispatch('foo'))
+    expectType<string>(store.dispatch(5))
+    expectType<ThunkReturn>(store.dispatch(thunkCreator()))
 
     // @ts-expect-error
-    expectType<string>(dispatch('foo'))
+    expectType<string>(store.dispatch('foo'))
   }
 }

--- a/packages/toolkit/src/utils.ts
+++ b/packages/toolkit/src/utils.ts
@@ -26,10 +26,9 @@ It is disabled in production builds, so you don't need to worry about that.`)
  * @public
  */
 export class MiddlewareArray<
-  Middlewares extends Middleware<any, any>
-> extends Array<Middlewares> {
-  constructor(arrayLength?: number)
-  constructor(...items: Middlewares[])
+  Middlewares extends Middleware<any, any>[]
+> extends Array<Middlewares[number]> {
+  constructor(...items: Middlewares)
   constructor(...args: any[]) {
     super(...args)
     Object.setPrototypeOf(this, MiddlewareArray.prototype)
@@ -41,22 +40,22 @@ export class MiddlewareArray<
 
   concat<AdditionalMiddlewares extends ReadonlyArray<Middleware<any, any>>>(
     items: AdditionalMiddlewares
-  ): MiddlewareArray<Middlewares | AdditionalMiddlewares[number]>
+  ): MiddlewareArray<[...Middlewares, ...AdditionalMiddlewares]>
 
   concat<AdditionalMiddlewares extends ReadonlyArray<Middleware<any, any>>>(
     ...items: AdditionalMiddlewares
-  ): MiddlewareArray<Middlewares | AdditionalMiddlewares[number]>
+  ): MiddlewareArray<[...Middlewares, ...AdditionalMiddlewares]>
   concat(...arr: any[]) {
     return super.concat.apply(this, arr)
   }
 
   prepend<AdditionalMiddlewares extends ReadonlyArray<Middleware<any, any>>>(
     items: AdditionalMiddlewares
-  ): MiddlewareArray<AdditionalMiddlewares[number] | Middlewares>
+  ): MiddlewareArray<[...AdditionalMiddlewares, ...Middlewares]>
 
   prepend<AdditionalMiddlewares extends ReadonlyArray<Middleware<any, any>>>(
     ...items: AdditionalMiddlewares
-  ): MiddlewareArray<AdditionalMiddlewares[number] | Middlewares>
+  ): MiddlewareArray<[...AdditionalMiddlewares, ...Middlewares]>
 
   prepend(...arr: any[]) {
     if (arr.length === 1 && Array.isArray(arr[0])) {


### PR DESCRIPTION
This is an attempt to rewrite the type inference for the `middleware` arg in `configureStore`, to better capture cases where a custom middleware overrides the return type of `dispatch`.

The motivation for this is specifically an issue with the action listener middleware:

```ts
const unsubscribe = store.dispatch(addListenerAction({actionCreator, listener});

// ERROR: _should_ be a void callback, but is typed as `{type: 'alm/add', payload: listenerEntry}`
unsubscribe()
```

Initial investigation shows that part of the issue is with the middleware itself, due to adding fields like `addListener` to the returned function.  Additionally, use of `TypedAddListenerAction` seems to help.

However, separate to that, I can reproduce the problem with a dummy middleware:

```ts
const dummyMiddleware: Middleware<
        {
          (action: Action<'actionListenerMiddleware/add'>): Unsubscribe
        },
        CounterState
      > = (storeApi) => (next) => (action) => {}

      const store1 = configureStore({
        reducer: counterSlice.reducer,
        // PROBLEM:
        middleware: (gDM) => gDM().prepend(dummyMiddleware),

        // WORKS
        //middleware: [dummyMiddleware, thunk]
      })

      const unsubscribe = store1.dispatch(
        addListenerAction({
          actionCreator: testAction1,
          listener: () => {},
        })
      )
```

Given that, it seems that something is wonky with the way `configureStore` infers the extensions to `dispatch` from the middleware types in conjunction with `getDefaultMiddleware`.

While the commit is a mess, the overall approach here is:

- Rewrite the `MiddlewareArray` type so that it tracks a specific _tuple_ of middleware types, rather than "an array that could be any one of these"
- Use some of the same tuple iteration and intersection techniques we used on Reselect to extract the actual dispatch extension types and intersect them
- Get a more exact final type for `dispatch` using that intersected type

~~What I have here _mostly_ works, except for the "null extraArg in ThunkAction" case.  This is because the `ThunkMiddlewareFor` type previously returned a union of two `ThunkMiddleware` types with different values for `ExtraArgument`, one `undefined` and one `null`.  This was okay when the middleware types were all getting unioned, but now that I've converted them to be a tuple, that doesn't work.~~

~~I'd prefer to drop the `null` case if possible.  The comment says "this is back-compat, since it was shown in the docs", but I don't know where/when the docs showed that.  Unfortunately this seems to be something that is actually used in the wild:~~

~~https://sourcegraph.com/search?q=context:global+lang:typescript+ThunkAction%3C.%2B%2C.%2B%2C.*null.*%3E&patternType=regexp~~

~~Granted, several of the hits I looked at are still using the core `createStore` instead of RTK, but that's still some potential breakage I'd like to avoid if possible.~~

### Update

Lenz and I have worked through the original implementation issues.  Current status:

- We've gotten seemingly correct inference working for middleware, and I've cleaned up the code
- Given that the `extraArg: null` pattern is not something we _want_ people to use (`unknown` would be correct today), and that there's only a couple of examples using it with RTK in the wild, we're comfortable treating that as a bug that needs to be fixed rather than a breaking change and just dropping support for that case
- The `MiddlewareArray.typetests.ts` file began failing in this PR. It appears to have been somehow related to the way we do a "package + install" step in our CI builds, while that file also tried to do an import of some local types. The workaround was to rewrite it to actually call `configureStore` for real instead of faking it at the type level.
- The types changes here now fail in TS 4.0 and earlier.  Given that Reselect now requires TS 4.1 anyway, and 4.6 is right around the corner, it's time to drop 3.9 and 4.0 from our support matrix
- We plan to release the middleware in RTK 1.8, but there's a chance we might need to do a 1.7.x patch release before then.  So, I've created a new `v1.8.0-integration` branch, and will merge these changes into there
- The middleware itself will need additional API changes, per [#1648 (comment)](https://github.com/reduxjs/redux-toolkit/discussions/1648?sort=new#discussioncomment-2118259) , and I'll do those as a separate branch + PR