### PR TITLE
rtk-query-codegen-openapi: use patched oazapfts for intersection type gen

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/index.ts
+++ b/packages/rtk-query-codegen-openapi/src/index.ts
@@ -42,7 +42,7 @@ export function parseConfig(fullConfig: ConfigFile) {
 }
 
 /**
- * Enforces `oazapfts` to use the same TypeScript version as this module itself uses.
+ * Enforces `@rtk-query/oazapfts-patched` to use the same TypeScript version as this module itself uses.
  * That should prevent enums from running out of sync if both libraries use different TS versions.
  */
 function enforceOazapftsTsVersion<T>(cb: () => T): T {

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -445,6 +445,40 @@ export type PatchApiV1ListByItemIdApiArg = {
 
 `;
 
+exports[`tests from issues issue #2002: should be able to generate proper intersection types 1`] = `
+import { api } from './tmp/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getApiV1Animals: build.query<GetApiV1AnimalsApiResponse, GetApiV1AnimalsApiArg>({
+      query: (queryArg) => ({
+        url: \`/api/v1/animals\`,
+        params: { type: queryArg['type'] },
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetApiV1AnimalsApiResponse = /** status 200 Success */ (Dog | Cat)[];
+export type GetApiV1AnimalsApiArg = {
+  type?: AnimalType;
+};
+export type AnimalType = 'All' | 'Cats' | 'Dogs';
+export type Animal = {
+  type: AnimalType;
+  id?: number;
+  name?: string | null;
+};
+export type Dog = Animal & {
+  dogUniqueProp?: string | null;
+};
+export type Cat = Animal & {
+  catUniqueProp?: string | null;
+};
+export const { useGetApiV1AnimalsQuery } = injectedRtkApi;
+
+`;
+
 exports[`yaml parsing should be able to use read a yaml file 1`] = `
 import { api } from './tmp/emptyApi';
 const injectedRtkApi = api.injectEndpoints({

--- a/packages/rtk-query-codegen-openapi/test/fixtures/issue-2002.json
+++ b/packages/rtk-query-codegen-openapi/test/fixtures/issue-2002.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Animals API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://localhost:8000"
+    }
+  ],
+  "paths": {
+    "/api/v1/animals": {
+      "get": {
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/AnimalType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/Dog"
+                      },
+                      {
+                        "$ref": "#/components/schemas/Cat"
+                      }
+                    ],
+                    "description": "Base animal type."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AnimalType": {
+        "type": "string",
+        "enum": ["All", "Cats", "Dogs"]
+      },
+      "Animal": {
+        "required": ["type"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "$ref": "#/components/schemas/AnimalType"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Base animal type.",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "Dog": "#/components/schemas/Dog",
+            "Cat": "#/components/schemas/Cat"
+          }
+        }
+      },
+      "Dog": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          }
+        ],
+        "properties": {
+          "dogUniqueProp": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Dog animal"
+      },
+      "Cat": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          }
+        ],
+        "properties": {
+          "catUniqueProp": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Cat animal"
+      }
+    }
+  }
+}

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -211,3 +211,14 @@ describe('yaml parsing', () => {
     expect(output).toContain('"foo:bar-foo.bar/foo": queryArg["foo:bar-foo.bar/foo"],');
   });
 });
+
+describe('tests from issues', () => {
+  it('issue #2002: should be able to generate proper intersection types', async () => {
+    const result = await generateEndpoints({
+      apiFile: './tmp/emptyApi.ts',
+      schemaFile: `./fixtures/issue-2002.json`,
+      hooks: true,
+    });
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
~~I opened a PR over in oazapfts here: https://github.com/cellular/oazapfts/pull/207. I'd prefer to not be blocked on them merging that PR or a similar one that is referenced in the linked PR. So this would allow us to patch this behavior for our users in the short term.~~

## Update
This now uses a patched version of oazapfts (@rtk-query/oazapfts-patched) located at https://github.com/rtk-incubator/oazapfts

- Adds test for intersection types

Fixes #2002 #1940 