### PR TITLE
Add `upsertQueryData` functionality per issue #1720

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -1,4 +1,4 @@
-import type { AnyAction, PayloadAction } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
 import {
   combineReducers,
   createAction,
@@ -22,7 +22,7 @@ import type {
   ConfigState,
 } from './apiState'
 import { QueryStatus } from './apiState'
-import type { MutationThunk, QueryThunk } from './buildThunks'
+import type { MutationThunk, QueryThunk, QueryThunkArg } from './buildThunks'
 import { calculateProvidedByThunk } from './buildThunks'
 import type {
   AssertTagTypes,
@@ -128,6 +128,31 @@ export function buildSlice({
         updateQuerySubstateIfExists(draft, queryCacheKey, (substate) => {
           substate.data = applyPatches(substate.data as any, patches.concat())
         })
+      },
+      insertQueryResult(
+        draft,
+        {
+          payload: {
+            data,
+            arg: { originalArgs, endpointName, queryCacheKey },
+            fulfilledTimeStamp,
+          },
+        }: PayloadAction<{
+          data: any
+          arg: QueryThunkArg
+          fulfilledTimeStamp: number
+        }>
+      ) {
+        draft[queryCacheKey] = {
+          status: QueryStatus.fulfilled,
+          endpointName,
+          requestId: '',
+          originalArgs,
+          startedTimeStamp: fulfilledTimeStamp,
+          fulfilledTimeStamp,
+          data,
+          error: undefined,
+        }
       },
     },
     extraReducers(builder) {

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -1,7 +1,11 @@
 /**
  * Note: this file should import all other files for type discovery and declaration merging
  */
-import type { PatchQueryDataThunk, UpdateQueryDataThunk } from './buildThunks'
+import type {
+  PatchQueryDataThunk,
+  UpdateQueryDataThunk,
+  UpsertQueryDataThunk,
+} from './buildThunks'
 import { buildThunks } from './buildThunks'
 import type {
   ActionCreatorWithPayload,
@@ -211,6 +215,25 @@ declare module '../apiTypes' {
           RootState<Definitions, string, ReducerPath>
         >
         /**
+         * A Redux thunk that manually adds a 'fulfilled' result to the API cache state with the provided data.  Unlike `patchQueryData`, which can only update previously-fetched data, `upsertQueryData` can both update existing results and add completely new entries to the cache.
+         *
+         * The thunk action creator accepts three arguments: the name of the endpoint we are updating (such as `'getPost'`), any relevant query arguments, and the result data for this API call.
+         *
+         * Caution: This is an advanced function which should be avoided unless absolutely necessary.
+         *
+         *  @example
+         *
+         * ```ts
+         * dispatch(
+         *   api.util.updateQueryData('getPosts', '1', { id: 1, name: 'Teddy' })
+         * )
+         * ```
+         */
+        upsertQueryData: UpsertQueryDataThunk<
+          Definitions,
+          RootState<Definitions, string, ReducerPath>
+        >
+        /**
          * A Redux thunk that applies a JSON diff/patch array to the cached data for a given query result. This immediately updates the Redux state with those changes.
          *
          * The thunk accepts three arguments: the name of the endpoint we are updating (such as `'getPost'`), any relevant query arguments, and a JSON diff/patch array as produced by Immer's `produceWithPatches`.
@@ -406,6 +429,7 @@ export const coreModule = (): Module<CoreModule> => ({
       mutationThunk,
       patchQueryData,
       updateQueryData,
+      upsertQueryData,
       prefetch,
       buildMatchThunkActions,
     } = buildThunks({
@@ -434,6 +458,7 @@ export const coreModule = (): Module<CoreModule> => ({
     safeAssign(api.util, {
       patchQueryData,
       updateQueryData,
+      upsertQueryData,
       prefetch,
       resetApiState: sliceActions.resetApiState,
     })


### PR DESCRIPTION
Is this the desired functionality?
- Should a user be allowed to manually insert an error, or just data?
- Should the third argument of the action creator be a function which is called with the previous data, even though that data might be `undefined`?
- Are the returned immer patches correct?  I will need help writing the unit tests on these.