### PR TITLE
fix: prevent duplicate ids when updating id of an element with the id of an existing element

### DIFF
--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -1,6 +1,6 @@
-import type { EntityStateAdapter, EntityState } from '../models'
+import type { EntityAdapter, EntityState } from '../models'
 import { createEntityAdapter } from '../create_adapter'
-import { createAction } from '../../createAction'
+import { createAction, createSlice, configureStore } from '@reduxjs/toolkit'
 import type { BookModel } from './fixtures/book'
 import {
   TheGreatGatsby,
@@ -11,7 +11,7 @@ import {
 import { createNextState } from '../..'
 
 describe('Sorted State Adapter', () => {
-  let adapter: EntityStateAdapter<BookModel>
+  let adapter: EntityAdapter<BookModel>
   let state: EntityState<BookModel>
 
   beforeAll(() => {
@@ -566,6 +566,22 @@ describe('Sorted State Adapter', () => {
         [AClockworkOrange.id]: AClockworkOrange,
       },
     })
+  })
+
+  it("only returns one entry for that id in the id's array", () => {
+    const book1: BookModel = { id: 'a', title: 'First' }
+    const book2: BookModel = { id: 'b', title: 'Second' }
+    const initialState = adapter.getInitialState()
+    const withItems = adapter.addMany(initialState, [book1, book2])
+
+    expect(withItems.ids).toEqual(['a', 'b'])
+    const withUpdate = adapter.updateOne(withItems, {
+      id: 'a',
+      changes: { id: 'b' },
+    })
+
+    expect(withUpdate.ids).toEqual(['b'])
+    expect(withUpdate.entities['b']!.title).toBe(book1.title)
   })
 
   describe('can be used mutably when wrapped in createNextState', () => {

--- a/packages/toolkit/src/entities/tests/state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/state_adapter.test.ts
@@ -58,39 +58,4 @@ describe('createStateOperator', () => {
     expect(state2.books.ids.length).toBe(2)
     expect(state2.books.entities['b']).toBe(book2)
   })
-
-  describe("when an id is updated to an existing id's value", () => {
-    it("only returns one entry for that id in the id's array", () => {
-      const booksSlice = createSlice({
-        name: 'books',
-        initialState: adapter.getInitialState(),
-        reducers: {
-          addOne: adapter.addOne,
-          updateOne: adapter.updateOne,
-        },
-      })
-
-      const { addOne, updateOne } = booksSlice.actions
-
-      const store = configureStore({
-        reducer: {
-          books: booksSlice.reducer,
-        },
-      })
-
-      const book1: BookModel = { id: 'a', title: 'First' }
-      const book2: BookModel = { id: 'b', title: 'Second' }
-      store.dispatch(addOne(book1))
-      store.dispatch(addOne(book2))
-
-      const state = store.getState()
-      expect(state.books.ids).toEqual(['a', 'b'])
-
-      store.dispatch(updateOne({ id: 'a', changes: { id: 'b' } }))
-
-      const updatedState = store.getState()
-      expect(updatedState.books.ids).toEqual(['b'])
-      expect(updatedState.books.entities['b'].title).toBe(book1.title)
-    })
-  })
 })

--- a/packages/toolkit/src/entities/tests/state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/state_adapter.test.ts
@@ -58,4 +58,39 @@ describe('createStateOperator', () => {
     expect(state2.books.ids.length).toBe(2)
     expect(state2.books.entities['b']).toBe(book2)
   })
+
+  describe("when an id is updated to an existing id's value", () => {
+    it("only returns one entry for that id in the id's array", () => {
+      const booksSlice = createSlice({
+        name: 'books',
+        initialState: adapter.getInitialState(),
+        reducers: {
+          addOne: adapter.addOne,
+          updateOne: adapter.updateOne,
+        },
+      })
+
+      const { addOne, updateOne } = booksSlice.actions
+
+      const store = configureStore({
+        reducer: {
+          books: booksSlice.reducer,
+        },
+      })
+
+      const book1: BookModel = { id: 'a', title: 'First' }
+      const book2: BookModel = { id: 'b', title: 'Second' }
+      store.dispatch(addOne(book1))
+      store.dispatch(addOne(book2))
+
+      const state = store.getState()
+      expect(state.books.ids).toEqual(['a', 'b'])
+
+      store.dispatch(updateOne({ id: 'a', changes: { id: 'b' } }))
+
+      const updatedState = store.getState()
+      expect(updatedState.books.ids).toEqual(['b'])
+      expect(updatedState.books.entities['b'].title).toBe(book1.title)
+    })
+  })
 })

--- a/packages/toolkit/src/entities/tests/unsorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/unsorted_state_adapter.test.ts
@@ -1,4 +1,4 @@
-import type { EntityStateAdapter, EntityState } from '../models'
+import type { EntityAdapter, EntityState } from '../models'
 import { createEntityAdapter } from '../create_adapter'
 import type { BookModel } from './fixtures/book'
 import {
@@ -10,7 +10,7 @@ import {
 import { createNextState } from '../..'
 
 describe('Unsorted State Adapter', () => {
-  let adapter: EntityStateAdapter<BookModel>
+  let adapter: EntityAdapter<BookModel>
   let state: EntityState<BookModel>
 
   beforeAll(() => {
@@ -412,6 +412,21 @@ describe('Unsorted State Adapter', () => {
         [AClockworkOrange.id]: AClockworkOrange,
       },
     })
+  })
+  it("only returns one entry for that id in the id's array", () => {
+    const book1: BookModel = { id: 'a', title: 'First' }
+    const book2: BookModel = { id: 'b', title: 'Second' }
+    const initialState = adapter.getInitialState()
+    const withItems = adapter.addMany(initialState, [book1, book2])
+
+    expect(withItems.ids).toEqual(['a', 'b'])
+    const withUpdate = adapter.updateOne(withItems, {
+      id: 'a',
+      changes: { id: 'b' },
+    })
+
+    expect(withUpdate.ids).toEqual(['b'])
+    expect(withUpdate.entities['b']!.title).toBe(book1.title)
   })
 
   describe('can be used mutably when wrapped in createNextState', () => {

--- a/packages/toolkit/src/entities/unsorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/unsorted_state_adapter.ts
@@ -158,7 +158,9 @@ export function createUnsortedStateAdapter<T>(
         0
 
       if (didMutateIds) {
-        state.ids = state.ids.map((id) => newKeys[id] || id)
+        state.ids = Array.from(
+          new Set(state.ids.map((id) => newKeys[id] || id))
+        )
       }
     }
   }

--- a/packages/toolkit/src/entities/unsorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/unsorted_state_adapter.ts
@@ -158,9 +158,7 @@ export function createUnsortedStateAdapter<T>(
         0
 
       if (didMutateIds) {
-        state.ids = Array.from(
-          new Set(state.ids.map((id) => newKeys[id] || id))
-        )
+        state.ids = Object.keys(state.entities)
       }
     }
   }


### PR DESCRIPTION
Fixes #2018

Think I'll probably have to update the sorted_state adapter too, but I'm unfamiliar with redux-toolkit and will need to take a closer look. Any pointers would be great 😛. Also let me know if it's too "expensive" to create a set from the array of ids and then changing it back to an array again. 