### PR TITLE
feat(alm): add cancellation message to TaskAbortError, listenerApi.signal & forkApi.signal.

### DIFF
--- a/packages/action-listener-middleware/src/exceptions.ts
+++ b/packages/action-listener-middleware/src/exceptions.ts
@@ -1,7 +1,20 @@
-export class TaskAbortError implements Error {
+import type { SerializedError } from '@reduxjs/toolkit'
+
+const task = 'task'
+const listener = 'listener'
+const completed = 'completed'
+const cancelled = 'cancelled'
+
+/* TaskAbortError error codes  */
+export const taskCancelled = `${task}-${cancelled}` as const
+export const taskCompleted = `${task}-${completed}` as const
+export const listenerCancelled = `${listener}-${cancelled}` as const
+export const listenerCompleted = `${listener}-${completed}` as const
+
+export class TaskAbortError implements SerializedError {
   name = 'TaskAbortError'
   message = ''
-  constructor(public reason = 'unknown') {
-    this.message = `task cancelled (reason: ${reason})`
+  constructor(public code = 'unknown') {
+    this.message = `task cancelled (reason: ${code})`
   }
 }

--- a/packages/action-listener-middleware/src/task.ts
+++ b/packages/action-listener-middleware/src/task.ts
@@ -1,6 +1,6 @@
 import { TaskAbortError } from './exceptions'
-import type { TaskResult } from './types'
-import { noop, catchRejection } from './utils'
+import type { AbortSignalWithReason, TaskResult } from './types'
+import { catchRejection } from './utils'
 
 /**
  * Synchronously raises {@link TaskAbortError} if the task tied to the input `signal` has been cancelled.
@@ -8,9 +8,9 @@ import { noop, catchRejection } from './utils'
  * @param reason
  * @see {TaskAbortError}
  */
-export const validateActive = (signal: AbortSignal, reason?: string): void => {
+export const validateActive = (signal: AbortSignal): void => {
   if (signal.aborted) {
-    throw new TaskAbortError(reason)
+    throw new TaskAbortError((signal as AbortSignalWithReason<string>).reason)
   }
 }
 
@@ -20,12 +20,11 @@ export const validateActive = (signal: AbortSignal, reason?: string): void => {
  * @returns
  */
 export const promisifyAbortSignal = (
-  signal: AbortSignal,
-  reason?: string
+  signal: AbortSignalWithReason<string>
 ): Promise<never> => {
   return catchRejection(
     new Promise<never>((_, reject) => {
-      const notifyRejection = () => reject(new TaskAbortError(reason))
+      const notifyRejection = () => reject(new TaskAbortError(signal.reason))
 
       if (signal.aborted) {
         notifyRejection()

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -10,6 +10,12 @@ import type {
 import type { TaskAbortError } from './exceptions'
 
 /**
+ * @internal
+ * At the time of writing `lib.dom.ts` does not provide `abortSignal.reason`.
+ */
+export type AbortSignalWithReason<T> = AbortSignal & { reason?: T }
+
+/**
  * Types copied from RTK
  */
 

--- a/packages/action-listener-middleware/src/utils.ts
+++ b/packages/action-listener-middleware/src/utils.ts
@@ -1,3 +1,5 @@
+import type { AbortSignalWithReason } from './types'
+
 export const assertFunction: (
   func: unknown,
   expected: string
@@ -19,4 +21,42 @@ export const catchRejection = <T>(
   promise.catch(onError)
 
   return promise
+}
+
+/**
+ * Calls `abortController.abort(reason)` and patches `signal.reason`.
+ * if it is not supported.
+ *
+ * At the time of writing `signal.reason` is available in FF chrome, edge node 17 and deno.
+ * @param abortController
+ * @param reason
+ * @returns
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason
+ */
+export const abortControllerWithReason = <T>(
+  abortController: AbortController,
+  reason: T
+): void => {
+  type Consumer<T> = (val: T) => void
+
+  const signal = abortController.signal as AbortSignalWithReason<T>
+
+  if (signal.aborted) {
+    return
+  }
+
+  // Patch `reason` if necessary.
+  // - We use defineProperty here because reason is a getter of `AbortSignal.__proto__`.
+  // - We need to patch 'reason' before calling `.abort()` because listeners to the 'abort'
+  // event are are notified immediately.
+  if (!('reason' in signal)) {
+    Object.defineProperty(signal, 'reason', {
+      enumerable: true,
+      value: reason,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  ;(abortController.abort as Consumer<typeof reason>)(reason)
 }


### PR DESCRIPTION
### Description

adds meaningful cancellation message to TaskAbortError, listenerApi.signal & forkApi.signal.

listenerApi.signal.reason can be one of

- 'listener-cancelled'
- 'listener-completed'

forkApi.signal.reason & TaskAbortError.code can be one of

- 'listener-cancelled'
- 'listener-completed'
- 'task-cancelled'
- 'task-completed'

### Usage

```ts
startListening({ 
  predicate: () => true,
  async effect({ payload }, { signal }) {
    signal.addEventListener('abort', () => { 
        console.log(signal.reason)  // prints either "listener-completed" or "listener-cancelled"
    })
  },
})
```
---

###  Build log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run build
Build "actionListenerMiddleware" to dist/esm:
       1739 B: index.modern.js.gz
       1566 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      2.41 kB: index.js.gz
      2.15 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
       2.4 kB: index.js.gz
      2.15 kB: index.js.br
```

### Test log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run test --coverage
 PASS  src/tests/listenerMiddleware.test.ts (5.738 s)
 PASS  src/tests/effectScenarios.test.ts
 PASS  src/tests/fork.test.ts
 PASS  src/tests/useCases.test.ts
---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-------------------
All files      |   97.72 |    91.38 |   94.64 |   97.55 |
 exceptions.ts |     100 |        0 |     100 |     100 | 17
 index.ts      |    97.4 |     97.5 |    92.5 |   97.32 | 190,214,252-253
 task.ts       |   97.06 |       80 |     100 |    96.3 | 30
 utils.ts      |     100 |    85.71 |     100 |     100 | 52
---------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       72 passed, 72 total
Snapshots:   0 total
Time:        6.796 s
Ran all test suites.
```