### PR TITLE
[fix][1.8.0-integration][alm]: missing type export

### DIFF
--- a/packages/action-listener-middleware/src/index.ts
+++ b/packages/action-listener-middleware/src/index.ts
@@ -53,6 +53,7 @@ export type {
   ListenerEffect,
   ListenerMiddleware,
   ListenerEffectAPI,
+  ListenerMiddlewareInstance,
   CreateListenerMiddlewareOptions,
   ListenerErrorHandler,
   TypedStartListening,


### PR DESCRIPTION
### Description

`ListenerMiddlewareInstance` is not exported.