### PR TITLE
fix(alm): prevent zombie listeners caused by forked tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:packages",
     "test": "yarn test:packages",
-    "build:examples": "yarn workspaces foreach --include '@reduxjs/*' --include '@examples-query-react/*' -vtp run build",
+    "build:examples": "yarn workspaces foreach --include '@reduxjs/*' --include '@examples-query-react/*' --include '@examples-action-listener/*' -vtp run build",
     "build:docs": "yarn workspace website run build",
     "build:packages": "yarn workspaces foreach --include '@reduxjs/*' --include '@rtk-query/*' --include '@rtk-incubator/*' --topological-dev run build",
     "test:packages": "yarn workspaces foreach --include '@reduxjs/*' --include '@rtk-query/*'  --include '@rtk-incubator/*' run test",

--- a/packages/action-listener-middleware/README.md
+++ b/packages/action-listener-middleware/README.md
@@ -285,7 +285,7 @@ Both these methods are cancelation-aware, and will throw a `TaskAbortError` if t
 
 - `fork: (executor: (forkApi: ForkApi) => T | Promise<T>) => ForkedTask<T>`: Launches a "child task" that may be used to accomplish additional work. Accepts any sync or async function as its argument, and returns a `{result, cancel}` object that can be used to check the final status and return value of the child task, or cancel it while in-progress.
 
-Child tasks can be launched, and waited on to collect their return values. The provided `executor` function will be called with a `forkApi` object containing `{pause, delay, signal}`, allowing it to pause or check cancelation status. It can also make use of the `listenerApi` from the listener's scope.
+Child tasks can be launched, and waited on to collect their return values. The provided `executor` function will be called asynchronously with a `forkApi` object containing `{pause, delay, signal}`, allowing it to pause or check cancelation status. It can also make use of the `listenerApi` from the listener's scope.
 
 An example of this might be a listener that forks a child task containing an infinite loop that listens for events from a server. The parent then uses `listenerApi.condition()` to wait for a "stop" action, and cancels the child task.
 

--- a/packages/action-listener-middleware/src/task.ts
+++ b/packages/action-listener-middleware/src/task.ts
@@ -37,8 +37,9 @@ export const promisifyAbortSignal = (
 
 /**
  * Runs a task and returns promise that resolves to {@link TaskResult}.
- *
  * Second argument is an optional `cleanUp` function that always runs after task.
+ *
+ * **Note:** `runTask` runs the executor in the next microtask.
  * @returns
  */
 export const runTask = async <T>(

--- a/packages/action-listener-middleware/src/types.ts
+++ b/packages/action-listener-middleware/src/types.ts
@@ -105,6 +105,19 @@ export type TaskResult<Value> =
   | TaskCancelled
 
 export interface ForkedTask<T> {
+  /**
+   * A promise that resolves when the task is either completed or cancelled or rejects
+   * if parent listener execution is cancelled or completed.
+   *
+   * ### Example
+   * ```ts
+   * const result = await fork(async (forkApi) => Promise.resolve(4)).result
+   *
+   * if(result.status === 'ok') {
+   *   console.log(result.value) // logs 4
+   * }}
+   * ```
+   */
   result: Promise<TaskResult<T>>
   /**
    * Cancel task if it is in progress or not yet started,


### PR DESCRIPTION
### Description

Prevents zombie listeners caused by forked tasks.

BREAKING CHANGE: `forkedTask.result` now rejects if parent listener is either completed or cancelled.

Other changes:

1. Improve documentation
2. Add '@examples-action-listener/*' to the 
3. "build:examples" script now builds '@examples-action-listener/*' too

### Build log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run build
Build "actionListenerMiddleware" to dist/esm:
       1744 B: index.modern.js.gz
       1565 B: index.modern.js.br
Build "actionListenerMiddleware" to dist/module:
      5.41 kB: index.js.gz
      2.16 kB: index.js.br
Build "actionListenerMiddleware" to dist/cjs:
       2.4 kB: index.js.gz
      2.16 kB: index.js.br
```

### Test log

```bash
$ yarn workspace @rtk-incubator/action-listener-middleware run test --coverage
 PASS  src/tests/fork.test.ts
 PASS  src/tests/listenerMiddleware.test.ts
 PASS  src/tests/effectScenarios.test.ts
 PASS  src/tests/useCases.test.ts
---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |    97.7 |    91.38 |   94.64 |   97.52 |                   
 exceptions.ts |     100 |        0 |     100 |     100 | 17                
 index.ts      |   97.37 |     97.5 |    92.5 |   97.28 | 190,214,252-253   
 task.ts       |   97.06 |       80 |     100 |    96.3 | 30                
 utils.ts      |     100 |    85.71 |     100 |     100 | 52                
---------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       72 passed, 72 total
Snapshots:   0 total
Time:        6.386 s
Ran all test suites.
```