### PR TITLE
fix(alm): cancel forkApi.delay and forkApi.pause if listener is cancelled or completed

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/exceptions.ts
+++ b/packages/toolkit/src/listenerMiddleware/exceptions.ts
@@ -6,15 +6,15 @@ const completed = 'completed'
 const cancelled = 'cancelled'
 
 /* TaskAbortError error codes  */
-export const taskCancelled = `${task}-${cancelled}` as const
-export const taskCompleted = `${task}-${completed}` as const
+export const taskCancelled = `task-${cancelled}` as const
+export const taskCompleted = `task-${completed}` as const
 export const listenerCancelled = `${listener}-${cancelled}` as const
 export const listenerCompleted = `${listener}-${completed}` as const
 
 export class TaskAbortError implements SerializedError {
   name = 'TaskAbortError'
-  message = ''
-  constructor(public code = 'unknown') {
-    this.message = `task cancelled (reason: ${code})`
+  message: string
+  constructor(public code: string | undefined) {
+    this.message = `${task} ${cancelled} (reason: ${code})`
   }
 }

--- a/packages/toolkit/src/listenerMiddleware/task.ts
+++ b/packages/toolkit/src/listenerMiddleware/task.ts
@@ -1,6 +1,6 @@
 import { TaskAbortError } from './exceptions'
 import type { AbortSignalWithReason, TaskResult } from './types'
-import { catchRejection } from './utils'
+import { addAbortSignalListener, catchRejection } from './utils'
 
 /**
  * Synchronously raises {@link TaskAbortError} if the task tied to the input `signal` has been cancelled.
@@ -29,7 +29,7 @@ export const promisifyAbortSignal = (
       if (signal.aborted) {
         notifyRejection()
       } else {
-        signal.addEventListener('abort', notifyRejection, { once: true })
+        addAbortSignalListener(signal, notifyRejection)
       }
     })
   )

--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -54,12 +54,12 @@ export type MatchFunction<T> = (v: any) => v is T
 export interface ForkedTaskAPI {
   /**
    * Returns a promise that resolves when `waitFor` resolves or
-   * rejects if the task has been cancelled or completed.
+   * rejects if the task or the parent listener has been cancelled or is completed.
    */
   pause<W>(waitFor: Promise<W>): Promise<W>
   /**
    * Returns a promise resolves after `timeoutMs` or
-   * rejects if the task has been cancelled or is completed.
+   * rejects if the task or the parent listener has been cancelled or is completed.
    * @param timeoutMs
    */
   delay(timeoutMs: number): Promise<void>

--- a/packages/toolkit/src/listenerMiddleware/utils.ts
+++ b/packages/toolkit/src/listenerMiddleware/utils.ts
@@ -23,6 +23,13 @@ export const catchRejection = <T>(
   return promise
 }
 
+export const addAbortSignalListener = (
+  abortSignal: AbortSignal,
+  callback: (evt: Event) => void
+) => {
+  abortSignal.addEventListener('abort', callback, { once: true })
+}
+
 /**
  * Calls `abortController.abort(reason)` and patches `signal.reason`.
  * if it is not supported.


### PR DESCRIPTION
This is a repeat of #2073 , which accidentally got closed automatically because it was targeted at another PR branch.

Original description:

Follow up of https://github.com/reduxjs/redux-toolkit/pull/2070

Changes

-`forkApi.delay` and `forkApi.pause` rejects if listener is cancelled or completed.
- `forkApi.signal` notifies the task as aborted if parent listener is cancelled or completed.
- Byte shaving