### PR TITLE
feat(website): respect prefers dark mode

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -69,6 +69,9 @@ module.exports = {
       theme: require('./src/js/monokaiTheme.js'),
     },
     image: 'img/redux-logo-landscape.png',
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     navbar: {
       title: 'Redux Toolkit',
       logo: {


### PR DESCRIPTION
Adds docusaurus config to respect the user's prefered color scheme on the documentation site.