### PR TITLE
docs(alm): add missing ts docs of ListenerEffectAPI

### DIFF
--- a/examples/action-listener/counter/package.json
+++ b/examples/action-listener/counter/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@reduxjs/toolkit": "^1.8.0-rc.0",
+    "@reduxjs/toolkit": "^1.8.0",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build"
+    "build": "react-scripts build",
+    "lint:ts": "tsc --noEmit"
   },
   "eslintConfig": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,7 +3672,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples-action-listener/counter@workspace:examples/action-listener/counter"
   dependencies:
-    "@reduxjs/toolkit": ^1.8.0-rc.0
+    "@reduxjs/toolkit": ^1.8.0
     "@types/node": ^12.0.0
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
@@ -5462,7 +5462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@^1.6.0, @reduxjs/toolkit@^1.6.0-rc.1, @reduxjs/toolkit@^1.8.0-rc.0, @reduxjs/toolkit@workspace:packages/toolkit":
+"@reduxjs/toolkit@^1.6.0, @reduxjs/toolkit@^1.6.0-rc.1, @reduxjs/toolkit@^1.8.0, @reduxjs/toolkit@workspace:packages/toolkit":
   version: 0.0.0-use.local
   resolution: "@reduxjs/toolkit@workspace:packages/toolkit"
   dependencies:


### PR DESCRIPTION
### Description
adds missing ts docs of `ListenerEffectAPI`

### Other changes

- update toolkit version in @examples-action-listener/counter
- add lint:ts script in @examples-action-listener/counter