### PR TITLE
fix(alm): type error (typescript>=4.6) in counter example #2105

### DIFF
--- a/examples/action-listener/counter/src/store.ts
+++ b/examples/action-listener/counter/src/store.ts
@@ -31,7 +31,7 @@ export type AppDispatch = typeof store.dispatch
 
 export type AppListenerEffectAPI = ListenerEffectAPI<RootState, AppDispatch>
 
-export type AppStartListening = TypedStartListening<RootState>
+export type AppStartListening = TypedStartListening<RootState, AppDispatch>
 export type AppAddListener = TypedAddListener<RootState>
 
 export const startAppListening =


### PR DESCRIPTION
### Description

Adds missing generic parameter in `AppStartListening` declaration.

Closes #2105 
