### PR TITLE
docs(alm): add missing generic parameter in `TypeScript Usage` section

### DIFF
--- a/docs/api/createListenerMiddleware.mdx
+++ b/docs/api/createListenerMiddleware.mdx
@@ -391,13 +391,13 @@ To fix this, the middleware provides types for defining "pre-typed" versions of 
 import { createListenerMiddleware, addListener } from '@reduxjs/toolkit'
 import type { TypedStartListening, TypedAddListener } from '@reduxjs/toolkit'
 
-import type { RootState } from './store'
+import type { RootState, AppDispatch } from './store'
 
 export const listenerMiddleware = createListenerMiddleware()
 
 export const startAppListening =
-  listenerMiddleware.startListening as TypedStartListening<RootState>
-export const addAppListener = addListener as TypedAddListener<RootState>
+  listenerMiddleware.startListening as TypedStartListening<RootState, AppDispatch>
+export const addAppListener = addListener as TypedAddListener<RootState, AppDispatch>
 ```
 
 Then import and use those pre-typed methods in your components.

--- a/examples/action-listener/counter/src/store.ts
+++ b/examples/action-listener/counter/src/store.ts
@@ -26,13 +26,14 @@ export { store }
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>
-// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+// @see https://redux-toolkit.js.org/usage/usage-with-typescript#getting-the-dispatch-type
 export type AppDispatch = typeof store.dispatch
 
 export type AppListenerEffectAPI = ListenerEffectAPI<RootState, AppDispatch>
 
+// @see https://redux-toolkit.js.org/api/createListenerMiddleware#typescript-usage
 export type AppStartListening = TypedStartListening<RootState, AppDispatch>
-export type AppAddListener = TypedAddListener<RootState>
+export type AppAddListener = TypedAddListener<RootState, AppDispatch>
 
 export const startAppListening =
   listenerMiddlewareInstance.startListening as AppStartListening


### PR DESCRIPTION
Other changes:

- add missing generic param in `AppAddListener` of counter example
- clean up store.ts in counter example

Context:

- https://github.com/reduxjs/redux-toolkit/pull/2118
- https://github.com/reduxjs/redux-toolkit/issues/2105