### PR TITLE
fix(toolkit): take return type should have predicate action type

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -363,7 +363,7 @@ export interface TakePattern<State> {
   <Predicate extends AnyListenerPredicate<State>>(
     predicate: Predicate,
     timeout?: number | undefined
-  ): Promise<[AnyAction, State, State] | null>
+  ): TakePatternOutputWithTimeout<State, Predicate>
 }
 
 /** @public */


### PR DESCRIPTION
When using take with a timeout of type `number | undefined`, the returned action was typed as `AnyAction` despite being able to know its type from the predicate which prevents us from doing something like this:
```typescript
let timeoutMs: number | undefined = undefined;
let takeResult: [PingAction, RootState, RootState] | null = null;
do {
  takeResult = await take(pingActionPredicate, timeoutMs);
  timeoutMs = takeResult?.[0].payload.updatedTimeoutMs;
} while (takeResult !== null);
dispatch(cleanupAction());
```