### PR TITLE
Fix manually initiate()d rtk-query promises

### DIFF
--- a/packages/toolkit/src/query/tests/buildInitiate.test.tsx
+++ b/packages/toolkit/src/query/tests/buildInitiate.test.tsx
@@ -1,0 +1,54 @@
+import { createApi } from '../core'
+import { fakeBaseQuery } from '../fakeBaseQuery'
+import { setupApiStore } from './helpers'
+
+let calls = 0
+const api = createApi({
+  baseQuery: fakeBaseQuery(),
+  endpoints: (build) => ({
+    increment: build.query<number, void>({
+      async queryFn() {
+        const data = calls++
+        await Promise.resolve()
+        return { data }
+      },
+    }),
+  }),
+})
+
+const storeRef = setupApiStore(api)
+
+test('multiple synchonrous initiate calls with pre-existing cache entry', async () => {
+  const { store, api } = storeRef
+  // seed the store
+  const firstValue = await store.dispatch(api.endpoints.increment.initiate())
+
+  expect(firstValue).toMatchObject({ data: 0, status: 'fulfilled' })
+
+  // dispatch another increment
+  const secondValuePromise = store.dispatch(api.endpoints.increment.initiate())
+  // and one with a forced refresh
+  const thirdValuePromise = store.dispatch(
+    api.endpoints.increment.initiate(undefined, { forceRefetch: true })
+  )
+  // and another increment
+  const fourthValuePromise = store.dispatch(api.endpoints.increment.initiate())
+
+  const secondValue = await secondValuePromise
+  const thirdValue = await thirdValuePromise
+  const fourthValue = await fourthValuePromise
+
+  expect(secondValue).toMatchObject({
+    data: firstValue.data,
+    status: 'fulfilled',
+    requestId: firstValue.requestId,
+  })
+
+  expect(thirdValue).toMatchObject({ data: 1, status: 'fulfilled' })
+  expect(thirdValue.requestId).not.toBe(firstValue.requestId)
+  expect(fourthValue).toMatchObject({
+    data: thirdValue.data,
+    status: 'fulfilled',
+    requestId: thirdValue.requestId,
+  })
+})


### PR DESCRIPTION
This PR keeps track of `runningQueries` in `buildInitiate`
by using a `Record<queryCacheKey, Record<requestId, Promise>>` type for
`runningQueries` instead of tracking a single request per cache key.

That way, when multiple queries are actually in flight for the same cache key,
we now call `Promise.all` on all of them, and thus get the proper store 
result once a `forceRefetch` query finishes.

This is a bit problematic in that the call `getRunningOperationPromise` doesn't
really fit its name. Arguably, this was already not the case before, as it
was returning `runningQueries[cacheKey]`, yet the actual promises handed out
to callers were already `Promise.all(...)` variants.

I also couldn't figure out how to write a proper unit test (this was a bit too much
for me at once).

This addresses #2186 