### PR TITLE
Generate .mjs file to allow importing from Node.js in ESM mode (#1960)

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -24,6 +24,21 @@
   },
   "main": "dist/index.js",
   "module": "dist/redux-toolkit.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/redux-toolkit.esm.mjs",
+      "require": "./dist/index.js"
+    },
+    "./query": {
+      "import": "./dist/query/rtk-query.esm.mjs",
+      "require": "./dist/query/index.js"
+    },
+    "./query/react": {
+      "import": "./dist/query/react/rtk-query-react.esm.mjs",
+      "require": "./dist/query/react/index.js"
+    },
+    "./*": "./*"
+  },
   "unpkg": "dist/redux-toolkit.umd.min.js",
   "types": "dist/index.d.ts",
   "devDependencies": {

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -53,6 +53,14 @@ const buildTargets: BuildOptions[] = [
     minify: false,
     env: '',
   },
+  // ESM, embedded `process`, ES5 syntax: typical Webpack dev, mjs extension
+  {
+    format: 'esm',
+    name: 'esm',
+    minify: false,
+    env: '',
+    extension: 'mjs',
+  },
   // ESM, embedded `process`, ES2017 syntax: modern Webpack dev
   {
     format: 'esm',
@@ -134,10 +142,11 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     name,
     target = 'es2015',
     entryPoint,
+    extension = 'js',
   } = options
 
   const outputFolder = path.join('dist', folder)
-  const outputFilename = `${prefix}.${name}.js`
+  const outputFilename = `${prefix}.${name}.${extension}`
   const outputFilePath = path.join(outputFolder, outputFilename)
 
   const result = await build({

--- a/packages/toolkit/scripts/types.ts
+++ b/packages/toolkit/scripts/types.ts
@@ -12,6 +12,7 @@ export interface BuildOptions {
   minify: boolean
   env: 'development' | 'production' | ''
   target?: 'es2017'
+  extension?: 'js' | 'mjs'
 }
 
 export interface EntryPointOptions {


### PR DESCRIPTION
This pull request fixes #1960 while attempting to not introduce any breaking changes.

In addition to each existing `*.esm.js` bundle, an identical `*.esm.mjs` bundle is created. This makes sure that existing apps/libraries that for some reason import the existing bundle by its filename don't break.

An `exports` map is added to the main `package.json` of redux-toolkit. This map makes sure that Node.js will use the CommonJS bundle in CommonJS mode and the ESM bundle in ESM mode. To not break any projects that import redux-toolkit in an unconventional way, a wildcard export `"./*": "./*"` is added to allow importing any sub paths as before.

Items for `/query` and `/query/react` are also added to the exports map. So far these have been their own directories with their own `package.json`. However, according to my research, the current layout is not supported by Node.js in ESM mode, because modules are required to live in `node_modules/<package>` or in `node_modules/@<org>/<package>`. Importing a package from a sub directory such as `node_modules/@reduxjs/toolkit/query` will raise an `ERR_UNSUPPORTED_DIR_IMPORT` error in Node.js. Adding these items to the exports map fixes these imports.

Unless I made some mistake, this pull request should not introduce any breaking changes, so it can be published with the next patch or minor release.

For the next major release, I think the `*.esm.js` bundles can be removed. It would also be worth to consider relying exclusively on the export map and removing the `query` and `query/react` sub packages.