### PR TITLE
Remove Unused Import

### DIFF
--- a/packages/toolkit/src/tsHelpers.ts
+++ b/packages/toolkit/src/tsHelpers.ts
@@ -1,4 +1,4 @@
-import type { Middleware, Dispatch } from 'redux'
+import type { Middleware } from 'redux'
 import type { MiddlewareArray } from './utils'
 
 /**


### PR DESCRIPTION
Removes an unused import from `tsHelpers.ts` that causes a `tsc` warning when `--noUnusedLocals` is enabled:

```
node_modules/@reduxjs/toolkit/src/tsHelpers.ts:1:27 - error TS6196: 'Dispatch' is declared but never used.

1 import type { Middleware, Dispatch } from 'redux'
```