### PR TITLE
implemented upsertQueryData functionality per #1720 #2007

### DIFF
--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -13,7 +13,7 @@ import { QueryStatus } from './apiState'
 import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type { Api, ApiContext } from '../apiTypes'
 import type { ApiEndpointQuery } from './module'
-import type { BaseQueryError } from '../baseQueryTypes'
+import type { BaseQueryError, QueryReturnValue } from '../baseQueryTypes'
 import type { QueryResultSelectorResult } from './buildSelectors'
 
 declare module './module' {
@@ -34,10 +34,11 @@ declare module './module' {
   }
 }
 
-export interface StartQueryActionCreatorOptions {
+export interface StartQueryActionCreatorOptions  {
   subscribe?: boolean
   forceRefetch?: boolean | number
   subscriptionOptions?: SubscriptionOptions
+  forceQueryFn?: () => QueryReturnValue
 }
 
 type StartQueryActionCreator<
@@ -179,6 +180,7 @@ export type MutationActionCreatorResult<
   unsubscribe(): void
 }
 
+
 export function buildInitiate({
   serializeQueryArgs,
   queryThunk,
@@ -259,7 +261,7 @@ Features like automatic cache collection, automatic refetching etc. will not be 
     endpointDefinition: QueryDefinition<any, any, any, any>
   ) {
     const queryAction: StartQueryActionCreator<any> =
-      (arg, { subscribe = true, forceRefetch, subscriptionOptions } = {}) =>
+      (arg, { subscribe = true, forceRefetch, subscriptionOptions, forceQueryFn } = {}) =>
       (dispatch, getState) => {
         const queryCacheKey = serializeQueryArgs({
           queryArgs: arg,
@@ -270,6 +272,7 @@ Features like automatic cache collection, automatic refetching etc. will not be 
           type: 'query',
           subscribe,
           forceRefetch,
+          forceQueryFn,
           subscriptionOptions,
           endpointName,
           originalArgs: arg,

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -157,7 +157,14 @@ export function buildSlice({
             draft,
             meta.arg.queryCacheKey,
             (substate) => {
-              if (substate.requestId !== meta.requestId) return
+              if (substate.requestId !== meta.requestId) {
+                if (
+                  substate.fulfilledTimeStamp &&
+                  meta.fulfilledTimeStamp < substate.fulfilledTimeStamp
+                ) {
+                  return
+                }
+              }
               const { merge } = definitions[
                 meta.arg.endpointName
               ] as QueryDefinition<any, any, any, any>

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -183,12 +183,6 @@ export type UpsertQueryDataThunk<
  */
 export type PatchCollection = {
   /**
-   * A boolean stating if there was already data in the query cache
-   *
-   * If there was no data in the cache no update operation is performed
-   */
-  cacheEntryFound: boolean
-  /**
    * An `immer` Patch describing the cache update.
    */
   patches: Patch[]
@@ -242,7 +236,6 @@ export function buildThunks<
         api.endpoints[endpointName] as ApiEndpointQuery<any, any>
       ).select(args)(getState())
       let ret: PatchCollection = {
-        cacheEntryFound: false,
         patches: [],
         inversePatches: [],
         undo: () =>
@@ -254,7 +247,6 @@ export function buildThunks<
         return ret
       }
       if ('data' in currentState) {
-        ret.cacheEntryFound = true
         if (isDraftable(currentState.data)) {
           const [, patches, inversePatches] = produceWithPatches(
             currentState.data,

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -278,9 +278,6 @@ export function buildThunks<
             api.util.patchQueryData(endpointName, args, ret.inversePatches)
           ),
       }
-      if (currentState.status === QueryStatus.uninitialized) {
-        return ret
-      }
       if ('data' in currentState) {
         if (isDraftable(currentState.data)) {
           const [, patches, inversePatches] = produceWithPatches(
@@ -305,9 +302,21 @@ export function buildThunks<
           path: [],
           value: undefined,
         })
-        dispatch(api.endpoints[endpointName].initiate(args, {subscribe: false, forceRefetch: true, }))
+        dispatch(
+          (
+            api.endpoints[endpointName] as ApiEndpointQuery<
+              QueryDefinition<any, any, any, any, any>,
+              Definitions
+            >
+          ).initiate(args, {
+            subscribe: false,
+            forceRefetch: true,
+            forceQueryFn: () => ({
+              data: upsertRecipe(undefined),
+            }),
+          })
+        )
       }
-
 
       return ret
     }

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -187,7 +187,7 @@ export type PatchCollection = {
    *
    * If there was no data in the cache no update operation is performed
    */
-  emptyCache: boolean
+  cacheEntryFound: boolean
   /**
    * An `immer` Patch describing the cache update.
    */
@@ -242,7 +242,7 @@ export function buildThunks<
         api.endpoints[endpointName] as ApiEndpointQuery<any, any>
       ).select(args)(getState())
       let ret: PatchCollection = {
-        emptyCache: true,
+        cacheEntryFound: true,
         patches: [],
         inversePatches: [],
         undo: () =>
@@ -254,7 +254,7 @@ export function buildThunks<
         return ret
       }
       if ('data' in currentState) {
-        ret.emptyCache = false
+        ret.cacheEntryFound = false
         if (isDraftable(currentState.data)) {
           const [, patches, inversePatches] = produceWithPatches(
             currentState.data,

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -242,7 +242,7 @@ export function buildThunks<
         api.endpoints[endpointName] as ApiEndpointQuery<any, any>
       ).select(args)(getState())
       let ret: PatchCollection = {
-        cacheEntryFound: true,
+        cacheEntryFound: false,
         patches: [],
         inversePatches: [],
         undo: () =>
@@ -254,7 +254,7 @@ export function buildThunks<
         return ret
       }
       if ('data' in currentState) {
-        ret.cacheEntryFound = false
+        ret.cacheEntryFound = true
         if (isDraftable(currentState.data)) {
           const [, patches, inversePatches] = produceWithPatches(
             currentState.data,

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -178,7 +178,11 @@ export type UpsertQueryDataThunk<
   args: QueryArgFrom<Definitions[EndpointName]>,
   value: ResultTypeFrom<Definitions[EndpointName]>
 ) => ThunkAction<
-  QueryActionCreatorResult<Definitions[EndpointName]>,
+  QueryActionCreatorResult<
+    Definitions[EndpointName] extends QueryDefinition<any, any, any, any>
+      ? Definitions[EndpointName]
+      : never
+  >,
   PartialState,
   any,
   AnyAction
@@ -276,7 +280,7 @@ export function buildThunks<
       return ret
     }
 
-  const upsertQueryData: UpsertQueryDataThunk<EndpointDefinitions, State> =
+  const upsertQueryData: UpsertQueryDataThunk<Definitions, State> =
     (endpointName, args, value) => (dispatch) => {
       return dispatch(
         (

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -1,7 +1,11 @@
 /**
  * Note: this file should import all other files for type discovery and declaration merging
  */
-import type { PatchQueryDataThunk, UpdateQueryDataThunk } from './buildThunks'
+import type {
+  PatchQueryDataThunk,
+  UpdateQueryDataThunk,
+  UpsertQueryDataThunk,
+} from './buildThunks'
 import { buildThunks } from './buildThunks'
 import type {
   ActionCreatorWithPayload,
@@ -207,6 +211,10 @@ declare module '../apiTypes' {
         >
         /** @deprecated renamed to `updateQueryData` */
         updateQueryResult: UpdateQueryDataThunk<
+          Definitions,
+          RootState<Definitions, string, ReducerPath>
+        >
+        upsertQueryData: UpsertQueryDataThunk<
           Definitions,
           RootState<Definitions, string, ReducerPath>
         >
@@ -416,6 +424,7 @@ export const coreModule = (): Module<CoreModule> => ({
       mutationThunk,
       patchQueryData,
       updateQueryData,
+      upsertQueryData,
       prefetch,
       buildMatchThunkActions,
     } = buildThunks({
@@ -444,6 +453,7 @@ export const coreModule = (): Module<CoreModule> => ({
     safeAssign(api.util, {
       patchQueryData,
       updateQueryData,
+      upsertQueryData,
       prefetch,
       resetApiState: sliceActions.resetApiState,
     })

--- a/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
@@ -1,0 +1,385 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { actionsReducer, hookWaitFor, setupApiStore, waitMs } from './helpers'
+import { skipToken } from '../core/buildSelectors'
+import { renderHook, act } from '@testing-library/react-hooks'
+
+interface Post {
+  id: string
+  title: string
+  contents: string
+}
+
+const baseQuery = jest.fn()
+beforeEach(() => baseQuery.mockReset())
+
+const api = createApi({
+  baseQuery: (...args: any[]) => {
+    const result = baseQuery(...args)
+    if (typeof result === 'object' && 'then' in result)
+      return result
+        .then((data: any) => ({ data, meta: 'meta' }))
+        .catch((e: any) => ({ error: e }))
+    return { data: result, meta: 'meta' }
+  },
+  tagTypes: ['Post'],
+  endpoints: (build) => ({
+    post: build.query<Post, string>({
+      query: (id) => `post/${id}`,
+      providesTags: ['Post'],
+    }),
+    updatePost: build.mutation<void, Pick<Post, 'id'> & Partial<Post>>({
+      query: ({ id, ...patch }) => ({
+        url: `post/${id}`,
+        method: 'PATCH',
+        body: patch,
+      }),
+      async onQueryStarted({ id, ...patch }, { dispatch, queryFulfilled }) {
+        const { undo } = dispatch(
+          api.util.upsertQueryData('post', id, (draft) => {
+            Object.assign(draft, patch)
+          })
+        )
+        queryFulfilled.catch(undo)
+      },
+      invalidatesTags: (result) => (result ? ['Post'] : []),
+    }),
+  }),
+})
+
+const storeRef = setupApiStore(api, {
+  ...actionsReducer,
+})
+
+describe('basic lifecycle', () => {
+  let onStart = jest.fn(),
+    onError = jest.fn(),
+    onSuccess = jest.fn()
+
+  const extendedApi = api.injectEndpoints({
+    endpoints: (build) => ({
+      test: build.mutation({
+        query: (x) => x,
+        async onQueryStarted(arg, api) {
+          onStart(arg)
+          try {
+            const result = await api.queryFulfilled
+            onSuccess(result)
+          } catch (e) {
+            onError(e)
+          }
+        },
+      }),
+    }),
+    overrideExisting: true,
+  })
+
+  beforeEach(() => {
+    onStart.mockReset()
+    onError.mockReset()
+    onSuccess.mockReset()
+  })
+
+  test('success', async () => {
+    const { result } = renderHook(
+      () => extendedApi.endpoints.test.useMutation(),
+      {
+        wrapper: storeRef.wrapper,
+      }
+    )
+
+    baseQuery.mockResolvedValue('success')
+
+    expect(onStart).not.toHaveBeenCalled()
+    expect(baseQuery).not.toHaveBeenCalled()
+    act(() => void result.current[0]('arg'))
+    expect(onStart).toHaveBeenCalledWith('arg')
+    expect(baseQuery).toHaveBeenCalledWith('arg', expect.any(Object), undefined)
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+    await act(() => waitMs(5))
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSuccess).toHaveBeenCalledWith({ data: 'success', meta: 'meta' })
+  })
+
+  test('error', async () => {
+    const { result } = renderHook(
+      () => extendedApi.endpoints.test.useMutation(),
+      {
+        wrapper: storeRef.wrapper,
+      }
+    )
+
+    baseQuery.mockRejectedValue('error')
+
+    expect(onStart).not.toHaveBeenCalled()
+    expect(baseQuery).not.toHaveBeenCalled()
+    act(() => void result.current[0]('arg'))
+    expect(onStart).toHaveBeenCalledWith('arg')
+    expect(baseQuery).toHaveBeenCalledWith('arg', expect.any(Object), undefined)
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+    await act(() => waitMs(5))
+    expect(onError).toHaveBeenCalledWith({
+      error: 'error',
+      isUnhandledError: false,
+      meta: undefined,
+    })
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+})
+
+describe('upsertQueryData', () => {
+  test('updates cache values, can apply inverse patch', async () => {
+    baseQuery
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'TODO',
+      })
+      // TODO I have no idea why the query is getting called multiple times,
+      // but passing an additional mocked value (_any_ value)
+      // seems to silence some annoying "got an undefined result" logging
+      .mockResolvedValueOnce(42)
+    const { result } = renderHook(() => api.endpoints.post.useQuery('3'), {
+      wrapper: storeRef.wrapper,
+    })
+    await hookWaitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    const dataBefore = result.current.data
+    expect(dataBefore).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'TODO',
+    })
+
+    let returnValue!: ReturnType<ReturnType<typeof api.util.upsertQueryData>>
+    act(() => {
+      returnValue = storeRef.store.dispatch(
+        api.util.upsertQueryData('post', '3', (draft) => {
+          if (draft) {
+            draft.contents = 'I love cheese!'
+          }
+        })
+      )
+    })
+
+    expect(result.current.data).not.toBe(dataBefore)
+    expect(result.current.data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'I love cheese!',
+    })
+
+    expect(returnValue).toEqual({
+      inversePatches: [{ op: 'replace', path: ['contents'], value: 'TODO' }],
+      patches: [{ op: 'replace', path: ['contents'], value: 'I love cheese!' }],
+      undo: expect.any(Function),
+    })
+
+    act(() => {
+      storeRef.store.dispatch(
+        api.util.patchQueryData('post', '3', returnValue.inversePatches)
+      )
+    })
+
+    expect(result.current.data).toEqual(dataBefore)
+  })
+
+  test('does update non-existing values', async () => {
+    baseQuery
+      // throw an error to make sure there is no cached data
+      .mockImplementationOnce(async () => {
+        throw new Error('failed to load')
+      })
+      .mockResolvedValueOnce(42)
+
+    // a subscriber is needed to have the data stay in the cache
+    // Not sure if this is the wanted behaviour, I would have liked
+    // it to stay in the cache for the x amount of time the cache
+    // is preserved normally after the last subscriber was unmounted
+    const { result, rerender } = renderHook(
+      () => api.endpoints.post.useQuery('4'),
+      {
+        wrapper: storeRef.wrapper,
+      }
+    )
+    await hookWaitFor(() => expect(result.current.isError).toBeTruthy())
+
+    let returnValue!: ReturnType<ReturnType<typeof api.util.upsertQueryData>>
+    // upsert the data
+    act(() => {
+      returnValue = storeRef.store.dispatch(
+        api.util.upsertQueryData('post', '4', (draft) => {
+          if (draft) {
+            draft.contents = 'I love cheese!'
+          } else {
+            return {
+              id: '4',
+              title: 'All about cheese',
+              contents: 'I love cheese!',
+            }
+          }
+        })
+      )
+    })
+
+    // the patch would remove the result again
+    // maybe this needs to be implemented differently in order
+    // for the whole thing to work correctly, I suppose that
+    // this would only revert the data but would not invalidate it
+    expect(returnValue).toEqual({
+      inversePatches: [{ op: 'replace', path: [], value: undefined }],
+      patches: [],
+      undo: expect.any(Function),
+    })
+
+    // rerender the hook
+    rerender()
+    // wait until everything has settled
+    await hookWaitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    // the cached data is returned as the result
+    expect(result.current.data).toStrictEqual({
+      id: '4',
+      title: 'All about cheese',
+      contents: 'I love cheese!',
+    })
+  })
+})
+
+describe('full integration', () => {
+  test('success case', async () => {
+    baseQuery
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'TODO',
+      })
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'Meanwhile, this changed server-side.',
+        contents: 'Delicious cheese!',
+      })
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'Meanwhile, this changed server-side.',
+        contents: 'Delicious cheese!',
+      })
+      .mockResolvedValueOnce(42)
+    const { result } = renderHook(
+      () => ({
+        query: api.endpoints.post.useQuery('3'),
+        mutation: api.endpoints.updatePost.useMutation(),
+      }),
+      {
+        wrapper: storeRef.wrapper,
+      }
+    )
+    await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
+
+    expect(result.current.query.data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'TODO',
+    })
+
+    act(() => {
+      result.current.mutation[0]({ id: '3', contents: 'Delicious cheese!' })
+    })
+
+    expect(result.current.query.data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'Delicious cheese!',
+    })
+
+    await hookWaitFor(() =>
+      expect(result.current.query.data).toEqual({
+        id: '3',
+        title: 'Meanwhile, this changed server-side.',
+        contents: 'Delicious cheese!',
+      })
+    )
+  })
+
+  test('error case', async () => {
+    baseQuery
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'TODO',
+      })
+      .mockRejectedValueOnce('some error!')
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'Meanwhile, this changed server-side.',
+        contents: 'TODO',
+      })
+      .mockResolvedValueOnce(42)
+
+    const { result } = renderHook(
+      () => ({
+        query: api.endpoints.post.useQuery('3'),
+        mutation: api.endpoints.updatePost.useMutation(),
+      }),
+      {
+        wrapper: storeRef.wrapper,
+      }
+    )
+    await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
+
+    expect(result.current.query.data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'TODO',
+    })
+
+    act(() => {
+      result.current.mutation[0]({ id: '3', contents: 'Delicious cheese!' })
+    })
+
+    // optimistic update
+    expect(result.current.query.data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'Delicious cheese!',
+    })
+
+    // rollback
+    await hookWaitFor(() =>
+      expect(result.current.query.data).toEqual({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'TODO',
+      })
+    )
+
+    // mutation failed - will not invalidate query and not refetch data from the server
+    await expect(() =>
+      hookWaitFor(
+        () =>
+          expect(result.current.query.data).toEqual({
+            id: '3',
+            title: 'Meanwhile, this changed server-side.',
+            contents: 'TODO',
+          }),
+        50
+      )
+    ).rejects.toBeTruthy()
+
+    act(() => void result.current.query.refetch())
+
+    // manually refetching gives up-to-date data
+    await hookWaitFor(
+      () =>
+        expect(result.current.query.data).toEqual({
+          id: '3',
+          title: 'Meanwhile, this changed server-side.',
+          contents: 'TODO',
+        }),
+      50
+    )
+  })
+})


### PR DESCRIPTION
I used the comments in PR #2007 to implement a proof of concept for the upsertQueryData functionality. 

I copied and adapted the optimisticUpdate test code to test this. 

I added some comments to the `does update non existing values` test.

* I'm not sure about the behaviour if there are currently no active subscribers.
* The undo might not work as expected.

Please let me know what you think of this