### PR TITLE
Fix Conversion of incompatible types

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -263,7 +263,7 @@ const safelyNotifyError = (
  */
 export const addListener = createAction(
   `${alm}/add`
-) as TypedAddListener<unknown>
+) as unknown as TypedAddListener<unknown>
 
 /**
  * @public
@@ -275,7 +275,7 @@ export const clearAllListeners = createAction(`${alm}/removeAll`)
  */
 export const removeListener = createAction(
   `${alm}/remove`
-) as TypedRemoveListener<unknown>
+) as unknown as TypedRemoveListener<unknown>
 
 const defaultErrorHandler: ListenerErrorHandler = (...args: unknown[]) => {
   console.error(`${alm}/error`, ...args)


### PR DESCRIPTION
Fix Conversion of incompatible types PayloadActionCreator to TypedAddListener. Force type to unknown first.

```
ERROR in node_modules/@reduxjs/toolkit/src/listenerMiddleware/index.ts:276:31
TS2352: Conversion of type 'ActionCreatorWithOptionalPayload<{ actionCreator?: never; type?: never; matcher?: never; predicate: AnyListenerPredicate<unknown>; effect: ListenerEffect<AnyAction, unknown, ThunkDispatch<unknown, unknown, AnyAction>, any>; } & UnsubscribeListenerOptions, "listenerMiddleware/remove">' to type 'TypedRemoveListener<unknown, ThunkDispatch<unknown, unknown, AnyAction>, ListenerEntry<unknown, ThunkDispatch<unknown, unknown, AnyAction>>, "listenerMiddleware/remove">' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Type 'ActionCreatorWithOptionalPayload<{ actionCreator?: never; type?: never; matcher?: never; predicate: AnyListenerPredicate<unknown>; effect: ListenerEffect<AnyAction, unknown, ThunkDispatch<unknown, unknown, AnyAction>, any>; } & UnsubscribeListenerOptions, "listenerMiddleware/remove">' is not comparable to type 'BaseActionCreator<ListenerEntry<unknown, ThunkDispatch<unknown, unknown, AnyAction>>, "listenerMiddleware/remove", never, never>'.
    Types of property 'match' are incompatible.
      Type '(action: Action<unknown>) => action is { payload: { actionCreator?: never; type?: never; matcher?: never; predicate: AnyListenerPredicate<unknown>; effect: ListenerEffect<AnyAction, unknown, ThunkDispatch<...>, any>; } & UnsubscribeListenerOptions; type: "listenerMiddleware/remove"; }' is not comparable to type '(action: Action<unknown>) => action is { payload: ListenerEntry<unknown, ThunkDispatch<unknown, unknown, AnyAction>>; type: "listenerMiddleware/remove"; }'.
        Type predicate 'action is { payload: { actionCreator?: never; type?: never; matcher?: never; predicate: AnyListenerPredicate<unknown>; effect: ListenerEffect<AnyAction, unknown, ThunkDispatch<unknown, unknown, AnyAction>, any>; } & UnsubscribeListenerOptions; type: "listenerMiddleware/remove"; }' is not assignable to 'action is { payload: ListenerEntry<unknown, ThunkDispatch<unknown, unknown, AnyAction>>; type: "listenerMiddleware/remove"; }'.
          Type '{ payload: { actionCreator?: never; type?: never; matcher?: never; predicate: AnyListenerPredicate<unknown>; effect: ListenerEffect<AnyAction, unknown, ThunkDispatch<unknown, unknown, AnyAction>, any>; } & UnsubscribeListenerOptions; type: "listenerMiddleware/remove"; }' is not comparable to type '{ payload: ListenerEntry<unknown, ThunkDispatch<unknown, unknown, AnyAction>>; type: "listenerMiddleware/remove"; }'.
            Types of property 'payload' are incompatible.
              Type '{ actionCreator?: never; type?: never; matcher?: never; predicate: AnyListenerPredicate<unknown>; effect: ListenerEffect<AnyAction, unknown, ThunkDispatch<unknown, unknown, AnyAction>, any>; } & UnsubscribeListenerOptions' is missing the following properties from type 'ListenerEntry<unknown, ThunkDispatch<unknown, unknown, AnyAction>>': id, unsubscribe, pending
    274 |  * @public
    275 |  */
  > 276 | export const removeListener = createAction(
        |                               ^^^^^^^^^^^^^
  > 277 |   `${alm}/remove`
        | ^^^^^^^^^^^^^^^^^
  > 278 | ) as TypedRemoveListener<unknown>
        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    279 |
    280 | const defaultErrorHandler: ListenerErrorHandler = (...args: unknown[]) => {
    281 |   console.error(`${alm}/error`, ...args)
```