### PR TITLE
Elaborate on refreshToken examples

### DIFF
--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -380,7 +380,7 @@ const baseQueryWithReauth: BaseQueryFn<
   let result = await baseQuery(args, api, extraOptions)
   if (result.error && result.error.status === 401) {
     // try to get a new token
-    const refreshResult = await baseQuery('/refreshToken', api, extraOptions)
+    const refreshResult = await baseQuery({ url: '/refreshToken', method: 'POST', body: { refresh_token: "exampleRefreshToken" } }, api, extraOptions)
     if (refreshResult.data) {
       // store the new token
       api.dispatch(tokenReceived(refreshResult.data))
@@ -439,7 +439,7 @@ const baseQueryWithReauth: BaseQueryFn<
       // highlight-end
       try {
         const refreshResult = await baseQuery(
-          '/refreshToken',
+          { url: '/refreshToken', method: 'POST', body: { refresh_token: "exampleRefreshToken" } },
           api,
           extraOptions
         )


### PR DESCRIPTION
I was silly and it took me a bit to realize that, just as with mutations and queries, the first argument to `baseQuery` can be a `string` in short form but a more verbose object argument may be provided. I think a longer form example will help people to realize how a custom baseQuery can work.