### PR TITLE
Add 'content-type' ResponseHandler

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -54,16 +54,12 @@ const handleResponse = async (
     responseHandler = isJsonContentType(response.headers) ? 'json' : 'text'
   }
 
-  if (responseHandler === 'text') {
-    return response.text()
-  }
-
   if (responseHandler === 'json') {
     const text = await response.text()
     return text.length ? JSON.parse(text) : null
   }
 
-  return responseHandler
+  return response.text()
 }
 
 export type FetchBaseQueryError =

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -46,6 +46,7 @@ const handleResponse = async (
   response: Response,
   responseHandler: ResponseHandler
 ) => {
+  let x: never
   if (typeof responseHandler === 'function') {
     return responseHandler(response)
   }
@@ -62,6 +63,9 @@ const handleResponse = async (
     const text = await response.text()
     return text.length ? JSON.parse(text) : null
   }
+
+  x = responseHandler
+  return x
 }
 
 export type FetchBaseQueryError =

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -46,7 +46,6 @@ const handleResponse = async (
   response: Response,
   responseHandler: ResponseHandler
 ) => {
-  let x: never
   if (typeof responseHandler === 'function') {
     return responseHandler(response)
   }
@@ -64,8 +63,7 @@ const handleResponse = async (
     return text.length ? JSON.parse(text) : null
   }
 
-  x = responseHandler
-  return x
+  return responseHandler
 }
 
 export type FetchBaseQueryError =

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -4,6 +4,7 @@ import type { BaseQueryApi, BaseQueryFn } from './baseQueryTypes'
 import type { MaybePromise, Override } from './tsHelpers'
 
 export type ResponseHandler =
+  | 'content-type'
   | 'json'
   | 'text'
   | ((response: Response) => Promise<any>)
@@ -47,6 +48,10 @@ const handleResponse = async (
 ) => {
   if (typeof responseHandler === 'function') {
     return responseHandler(response)
+  }
+
+  if (responseHandler === 'content-type') {
+    responseHandler = isJsonContentType(response.headers) ? 'json' : 'text'
   }
 
   if (responseHandler === 'text') {

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -42,26 +42,6 @@ const defaultValidateStatus = (response: Response) =>
 const defaultIsJsonContentType = (headers: Headers) =>
   /*applicat*/ /ion\/(vnd\.api\+)?json/.test(headers.get('content-type') || '')
 
-const handleResponse = async (
-  response: Response,
-  responseHandler: ResponseHandler
-) => {
-  if (typeof responseHandler === 'function') {
-    return responseHandler(response)
-  }
-
-  if (responseHandler === 'content-type') {
-    responseHandler = isJsonContentType(response.headers) ? 'json' : 'text'
-  }
-
-  if (responseHandler === 'json') {
-    const text = await response.text()
-    return text.length ? JSON.parse(text) : null
-  }
-
-  return response.text()
-}
-
 export type FetchBaseQueryError =
   | {
       /**
@@ -344,5 +324,25 @@ export function fetchBaseQuery({
           },
           meta,
         }
+  }
+
+  async function handleResponse(
+    response: Response,
+    responseHandler: ResponseHandler
+  ) {
+    if (typeof responseHandler === 'function') {
+      return responseHandler(response)
+    }
+
+    if (responseHandler === 'content-type') {
+      responseHandler = isJsonContentType(response.headers) ? 'json' : 'text'
+    }
+
+    if (responseHandler === 'json') {
+      const text = await response.text()
+      return text.length ? JSON.parse(text) : null
+    }
+
+    return response.text()
   }
 }

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -262,6 +262,62 @@ describe('fetchBaseQuery', () => {
       })
     })
 
+    it('server error: should fail normally with a 500 status as text ("content-type" responseHandler)', async () => {
+      const serverResponse = 'Internal Server Error'
+      server.use(
+        rest.get('https://example.com/error', (_, res, ctx) =>
+          res(ctx.status(500), ctx.text(serverResponse))
+        )
+      )
+
+      const req = baseQuery(
+        { url: '/error', responseHandler: 'content-type' },
+        commonBaseQueryApi,
+        {}
+      )
+      expect(req).toBeInstanceOf(Promise)
+      const res = await req
+      expect(res).toBeInstanceOf(Object)
+      expect(res.meta?.request).toBeInstanceOf(Request)
+      expect(res.meta?.response).toBeInstanceOf(Object)
+      expect(res.meta?.response?.headers.get('content-type')).toEqual(
+        'text/plain'
+      )
+      expect(res.error).toEqual({
+        status: 500,
+        data: serverResponse,
+      })
+    })
+
+    it('server error: should fail normally with a 500 status as json ("content-type" responseHandler)', async () => {
+      const serverResponse = {
+        errors: { field1: "Password cannot be 'password'" },
+      }
+      server.use(
+        rest.get('https://example.com/error', (_, res, ctx) =>
+          res(ctx.status(500), ctx.json(serverResponse))
+        )
+      )
+
+      const req = baseQuery(
+        { url: '/error', responseHandler: 'content-type' },
+        commonBaseQueryApi,
+        {}
+      )
+      expect(req).toBeInstanceOf(Promise)
+      const res = await req
+      expect(res).toBeInstanceOf(Object)
+      expect(res.meta?.request).toBeInstanceOf(Request)
+      expect(res.meta?.response).toBeInstanceOf(Object)
+      expect(res.meta?.response?.headers.get('content-type')).toEqual(
+        'application/json'
+      )
+      expect(res.error).toEqual({
+        status: 500,
+        data: serverResponse,
+      })
+    })
+
     it('server error: should fail gracefully (default="json" responseHandler)', async () => {
       server.use(
         rest.get('https://example.com/error', (_, res, ctx) =>


### PR DESCRIPTION
Please let me know:

- If this PR is welcome, I can edit the docs as well before merge.
- Would you be open to a follow-up PR to make `content-type` the default for `responseHandler`?

Closes #2354.