### PR TITLE
Check initial state is draftable before using immer to freeze it.

### DIFF
--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -75,6 +75,10 @@ function isStateFunction<S>(x: unknown): x is () => S {
   return typeof x === 'function'
 }
 
+function freezeDraftable<T>(val: T) {
+  return isDraftable(val) ? createNextState(val, () => {}) : val
+}
+
 export type ReducerWithInitialState<S extends NotFunction<any>> = Reducer<S> & {
   getInitialState: () => S
 }
@@ -223,12 +227,12 @@ export function createReducer<S extends NotFunction<any>>(
       ? executeReducerBuilderCallback(mapOrBuilderCallback)
       : [mapOrBuilderCallback, actionMatchers, defaultCaseReducer]
 
-  // Ensure the initial state gets frozen either way
+  // Ensure the initial state gets frozen either way (if draftable)
   let getInitialState: () => S
   if (isStateFunction(initialState)) {
-    getInitialState = () => createNextState(initialState(), () => {})
+    getInitialState = () => freezeDraftable(initialState())
   } else {
-    const frozenInitialState = createNextState(initialState, () => {})
+    const frozenInitialState = freezeDraftable(initialState)
     getInitialState = () => frozenInitialState
   }
 

--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -4,6 +4,7 @@ import type { AnyAction, Action, Reducer } from 'redux'
 import type { ActionReducerMapBuilder } from './mapBuilders'
 import { executeReducerBuilderCallback } from './mapBuilders'
 import type { NoInfer } from './tsHelpers'
+import { freezeDraftable } from './utils'
 
 /**
  * Defines a mapping from action types to corresponding action object shapes.
@@ -73,10 +74,6 @@ export type NotFunction<T> = T extends Function ? never : T
 
 function isStateFunction<S>(x: unknown): x is () => S {
   return typeof x === 'function'
-}
-
-function freezeDraftable<T>(val: T) {
-  return isDraftable(val) ? createNextState(val, () => {}) : val
 }
 
 export type ReducerWithInitialState<S extends NotFunction<any>> = Reducer<S> & {

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -17,6 +17,7 @@ import { createReducer, NotFunction } from './createReducer'
 import type { ActionReducerMapBuilder } from './mapBuilders'
 import { executeReducerBuilderCallback } from './mapBuilders'
 import type { NoInfer } from './tsHelpers'
+import { freezeDraftable } from './utils'
 
 /**
  * An action creator attached to a slice.
@@ -226,16 +227,15 @@ type SliceDefinedCaseReducers<CaseReducers extends SliceCaseReducers<any>> = {
 export type ValidateSliceCaseReducers<
   S,
   ACR extends SliceCaseReducers<S>
-> = ACR &
-  {
-    [T in keyof ACR]: ACR[T] extends {
-      reducer(s: S, action?: infer A): any
-    }
-      ? {
-          prepare(...a: never[]): Omit<A, 'type'>
-        }
-      : {}
+> = ACR & {
+  [T in keyof ACR]: ACR[T] extends {
+    reducer(s: S, action?: infer A): any
   }
+    ? {
+        prepare(...a: never[]): Omit<A, 'type'>
+      }
+    : {}
+}
 
 function getType(slice: string, actionKey: string): string {
   return `${slice}/${actionKey}`
@@ -265,7 +265,7 @@ export function createSlice<
   const initialState =
     typeof options.initialState == 'function'
       ? options.initialState
-      : createNextState(options.initialState, () => {})
+      : freezeDraftable(options.initialState)
 
   const reducers = options.reducers || {}
 

--- a/packages/toolkit/src/tests/createReducer.test.ts
+++ b/packages/toolkit/src/tests/createReducer.test.ts
@@ -106,6 +106,9 @@ describe('createReducer', () => {
         /Cannot assign to read only property/
       )
     })
+    test('does not throw error if initial state is not draftable', () => {
+      expect(() => createReducer(new URLSearchParams(), {})).not.toThrowError()
+    })
   })
 
   describe('given pure reducers with immutable updates', () => {

--- a/packages/toolkit/src/tests/createSlice.test.ts
+++ b/packages/toolkit/src/tests/createSlice.test.ts
@@ -74,6 +74,16 @@ describe('createSlice', () => {
 
       expect(slice.getInitialState()).toBe(initialState)
     })
+
+    it('should allow non-draftable initial state', () => {
+      expect(() =>
+        createSlice({
+          name: 'params',
+          initialState: new URLSearchParams(),
+          reducers: {},
+        })
+      ).not.toThrowError()
+    })
   })
 
   describe('when initialState is a function', () => {
@@ -104,6 +114,16 @@ describe('createSlice', () => {
       })
 
       expect(slice.getInitialState()).toBe(42)
+    })
+
+    it('should allow non-draftable initial state', () => {
+      expect(() =>
+        createSlice({
+          name: 'params',
+          initialState: () => new URLSearchParams(),
+          reducers: {},
+        })
+      ).not.toThrowError()
     })
   })
 

--- a/packages/toolkit/src/utils.ts
+++ b/packages/toolkit/src/utils.ts
@@ -1,3 +1,4 @@
+import createNextState, { isDraftable } from 'immer'
 import type { Middleware } from 'redux'
 
 export function getTimeMeasureUtils(maxDelay: number, fnName: string) {
@@ -63,4 +64,8 @@ export class MiddlewareArray<
     }
     return new MiddlewareArray(...arr.concat(this))
   }
+}
+
+export function freezeDraftable<T>(val: T) {
+  return isDraftable(val) ? createNextState(val, () => {}) : val
 }


### PR DESCRIPTION
Fixes #2377.