### PR TITLE
Add documentation section about testing cancellation behavior

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -507,6 +507,36 @@ const fetchUserById = createAsyncThunk(
 )
 ```
 
+### Testing Cancellation Behavior
+
+To test behavior around thunk cancellation, you can check various properties on the `meta` object of the dispatched action.
+If a thunk was cancelled, the result of the promise will be a `rejected` action (regardless of whether that action was actually dispatched to the store).
+
+- If it was cancelled before execution, `meta.condition` will be true.
+- If it was aborted while running, `meta.aborted` will be true.
+- If neither of those is true, the thunk was not cancelled, it was simply rejected, either by a Promise rejection or `rejectWithValue`.
+- If the thunk was not rejected, both `meta.aborted` and `meta.condition` will be `undefined`.
+
+So to test that a thunk was cancelled before executing, you can do the following:
+
+```ts no-transpile
+import { createAsyncThunk, isRejected } from '@reduxjs/toolkit'
+
+test('this thunk should always be skipped', async () => {
+  const thunk = createAsyncThunk(
+    'users/fetchById',
+    async () => 'This promise should never be entered',
+    {
+      condition: () => false,
+    }
+  )
+  const result = await thunk()(dispatch, getState, null)
+
+  expect(result.meta.condition).toBe(true)
+  expect(result.meta.aborted).toBe(false)
+})
+```
+
 ## Examples
 
 - Requesting a user by ID, with loading state, and only one request at a time:


### PR DESCRIPTION
In reference to #2382, this PR adds some clarity about how to test cancellation behavior to the docs.