### PR TITLE
Add Missing Else to enhanceEndpoints Function

### DIFF
--- a/docs/rtk-query/api/created-api/code-splitting.mdx
+++ b/docs/rtk-query/api/created-api/code-splitting.mdx
@@ -61,9 +61,20 @@ Returns an updated and enhanced version of the API slice object, containing the 
 
 This is primarily useful for taking an API slice object that was code-generated from an API schema file like OpenAPI, and adding additional specific hand-written configuration for cache invalidation management on top of the generated endpoint definitions.
 
-For example, `enhanceEndpoints` can be used to modify caching behaviour by changing the values of `providesTags`, `invalidatesTags`, and `keepUnusedDataFor`:
+For example, `enhanceEndpoints` can be used to modify caching behavior by changing the values of `providesTags`, `invalidatesTags`, and `keepUnusedDataFor`:
 
 ```ts
+// file: api.ts noEmit
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+export const api = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+  endpoints: (builder) => ({}),
+})
+
+// file: enhanceEndpoints.ts
+import { api } from './api'
+
 const enhancedApi = api.enchanceEndpoints({
   addTagTypes: ['User'],
   endpoints: {
@@ -75,9 +86,9 @@ const enhancedApi = api.enchanceEndpoints({
     },
     // alternatively, define a function which is called with the endpoint definition as an argument
     postUsers(endpoint) {
-      endpoint.invalidatesTags = ['User'];
-      endpoint.keepUnusedDataFor = 120;
+      endpoint.invalidatesTags = ['User']
+      endpoint.keepUnusedDataFor = 120
     }
   }
-});
+})
 ```

--- a/docs/rtk-query/api/created-api/code-splitting.mdx
+++ b/docs/rtk-query/api/created-api/code-splitting.mdx
@@ -60,3 +60,24 @@ Any provided tag types or endpoint definitions will be merged into the existing 
 Returns an updated and enhanced version of the API slice object, containing the combined endpoint definitions.
 
 This is primarily useful for taking an API slice object that was code-generated from an API schema file like OpenAPI, and adding additional specific hand-written configuration for cache invalidation management on top of the generated endpoint definitions.
+
+For example, `enhanceEndpoints` can be used to modify caching behaviour by changing the values of `providesTags`, `invalidatesTags`, and `keepUnusedDataFor`:
+
+```ts
+const enhancedApi = api.enchanceEndpoints({
+  addTagTypes: ['User'],
+  endpoints: {
+    getUserByUserId: {
+      providesTags: ['User'],
+    },
+    patchUserByUserId: {
+      invalidatesTags: ['User'],
+    },
+    // alternatively, define a function which is called with the endpoint definition as an argument
+    postUsers(endpoint) {
+      endpoint.invalidatesTags = ['User'];
+      endpoint.keepUnusedDataFor = 120;
+    }
+  }
+});
+```

--- a/docs/rtk-query/api/created-api/code-splitting.mdx
+++ b/docs/rtk-query/api/created-api/code-splitting.mdx
@@ -75,7 +75,7 @@ export const api = createApi({
 // file: enhanceEndpoints.ts
 import { api } from './api'
 
-const enhancedApi = api.enchanceEndpoints({
+const enhancedApi = api.enhanceEndpoints({
   addTagTypes: ['User'],
   endpoints: {
     getUserByUserId: {
@@ -85,7 +85,7 @@ const enhancedApi = api.enchanceEndpoints({
       invalidatesTags: ['User'],
     },
     // alternatively, define a function which is called with the endpoint definition as an argument
-    postUsers(endpoint) {
+    postUsers(endpoint: any) {
       endpoint.invalidatesTags = ['User']
       endpoint.keepUnusedDataFor = 120
     }

--- a/docs/rtk-query/api/created-api/code-splitting.mdx
+++ b/docs/rtk-query/api/created-api/code-splitting.mdx
@@ -69,7 +69,23 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  endpoints: (builder) => ({}),
+  endpoints: (builder) => ({
+    getUserByUserId: builder.query({
+      query() {
+        return ''
+      },
+    }),
+    patchUserByUserId: builder.mutation({
+      query() {
+        return ''
+      },
+    }),
+    getUsers: builder.query({
+      query() {
+        return ''
+      },
+    }),
+  }),
 })
 
 // file: enhanceEndpoints.ts
@@ -85,10 +101,10 @@ const enhancedApi = api.enhanceEndpoints({
       invalidatesTags: ['User'],
     },
     // alternatively, define a function which is called with the endpoint definition as an argument
-    postUsers(endpoint: any) {
-      endpoint.invalidatesTags = ['User']
+    getUsers(endpoint) {
+      endpoint.providesTags = ['User']
       endpoint.keepUnusedDataFor = 120
-    }
-  }
+    },
+  },
 })
 ```

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -277,11 +277,12 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
           )) {
             if (typeof partialDefinition === 'function') {
               partialDefinition(context.endpointDefinitions[endpointName])
+            } else {
+              Object.assign(
+                context.endpointDefinitions[endpointName] || {},
+                partialDefinition
+              )
             }
-            Object.assign(
-              context.endpointDefinitions[endpointName] || {},
-              partialDefinition
-            )
           }
         }
         return api


### PR DESCRIPTION
# Overview

Addresses #2334 .

This pr adds a missing `else` to the `enhanceEndpoints` function to improve the clarity of the function. It also adds an example of using it to the documentation.

Regarding the original issue:

> This needs to be a else or the Object.assign will assign the function to the endpoint.

Based on my understanding of `Object.assign`, passing a function as an assign will return a copy of the original object with no modifications. I created a [codesandbox to demonstrate it](https://codesandbox.io/s/admiring-davinci-6ifsjd?file=/src/index.ts) (forgive me if there is a better template to use for such a simple example). As a result, the function won't affect the endpoint as the code currently is written. Let me know if I am misunderstanding the issue though, or if my premise is incorrect.

Here is the code snippet again for reference:

https://github.com/reduxjs/redux-toolkit/blob/64a30d83384d77bcbc59231fa32aa2f1acd67020/packages/toolkit/src/query/createApi.ts#L275-L285

Even if the lack of an `else` will not cause a bug, it still does not make much sense to call `Object.assign` when a function is passed, because it does not do anything. So, I still added the `else` in this pr for clarity and readability.

The issue asked for tests as well, however when I went to adds tests I realized I was mostly duplicating a test that was already in the test suite:

https://github.com/reduxjs/redux-toolkit/blob/64a30d83384d77bcbc59231fa32aa2f1acd67020/packages/toolkit/src/query/tests/createApi.test.ts#L457-L501

I am happy to add more tests 🤓 , but I wondering what test cases may remain for this. I removed my test change from this pr because I didn't want to add more weight to the codebase without adding any testing value.

~Lastly, is there a way for me to preview the docs changes in the format they are rendered? I wanted to provide a before/after screenshot but I am probably missing a very obvious set of steps to get it up and running!~ CI did it for me 😍 (and I figured out how to do it locally as well)

Thanks for creating this package, and taking the time to read this wall of text ✌🏻 😄 
