### PR TITLE
Add `jsonContentType` to `fetchBaseQuery` options

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -38,7 +38,7 @@ const defaultValidateStatus = (response: Response) =>
   response.status >= 200 && response.status <= 299
 
 const defaultIsJsonContentType = (headers: Headers) =>
-  /*applicat*/ /ion\/(vnd\.api\+)?json/.test(headers.get('content-type') || '')
+  /*applicat*//ion\/(vnd\.api\+)?json/.test(headers.get('content-type') || '')
 
 const handleResponse = async (
   response: Response,

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -38,7 +38,7 @@ const defaultValidateStatus = (response: Response) =>
   response.status >= 200 && response.status <= 299
 
 const defaultIsJsonContentType = (headers: Headers) =>
-  /*applicat*//ion\/(vnd\.api\+)?json/.test(headers.get('content-type') || '')
+  /*applicat*/ /ion\/(vnd\.api\+)?json/.test(headers.get('content-type') || '')
 
 const handleResponse = async (
   response: Response,
@@ -132,6 +132,10 @@ export type FetchBaseQueryArgs = {
    * ```
    */
   isJsonContentType?: (headers: Headers) => boolean
+  /**
+   * Defaults to `application/json`;
+   */
+  jsonContentType?: string
 } & RequestInit
 
 export type FetchBaseQueryMeta = { request: Request; response?: Response }
@@ -171,10 +175,11 @@ export type FetchBaseQueryMeta = { request: Request; response?: Response }
  *
  * @param {(params: Record<string, unknown>) => string} paramsSerializer
  * An optional function that can be used to stringify querystring parameters.
- * 
+ *
  * @param {(headers: Headers) => boolean} isJsonContentType
  * An optional predicate function to determine if `JSON.stringify()` should be called on the `body` arg of `FetchArgs`
- 
+ *
+ * @param {string} jsonContentType Defaults to `application/json`. Used when automatically setting the content-type header for a request with a jsonifiable body that does not have an explicit content-type header.
  */
 export function fetchBaseQuery({
   baseUrl,
@@ -182,6 +187,7 @@ export function fetchBaseQuery({
   fetchFn = defaultFetchFn,
   paramsSerializer,
   isJsonContentType = defaultIsJsonContentType,
+  jsonContentType = 'application/json',
   ...baseFetchOptions
 }: FetchBaseQueryArgs = {}): BaseQueryFn<
   string | FetchArgs,
@@ -229,7 +235,7 @@ export function fetchBaseQuery({
         typeof body.toJSON === 'function')
 
     if (!config.headers.has('content-type') && isJsonifiable(body)) {
-      config.headers.set('content-type', 'application/json')
+      config.headers.set('content-type', jsonContentType)
     }
 
     if (body && isJsonContentType(config.headers)) {

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -292,6 +292,27 @@ describe('fetchBaseQuery', () => {
       expect(request.headers['content-type']).toBe('text/html')
       expect(request.body).toEqual(data.join(','))
     })
+
+    it('supports a custom jsonContentType', async () => {
+      const baseQuery = fetchBaseQuery({
+        baseUrl,
+        fetchFn: fetchFn as any,
+        jsonContentType: 'application/vnd.api+json',
+      })
+
+      let request: any
+      ;({ data: request } = await baseQuery(
+        {
+          url: '/echo',
+          body: {},
+          method: 'POST',
+        },
+        commonBaseQueryApi,
+        {}
+      ))
+
+      expect(request.headers['content-type']).toBe('application/vnd.api+json')
+    })
   })
 
   describe('arg.params', () => {
@@ -408,9 +429,11 @@ describe('fetchBaseQuery', () => {
         baseUrl,
         fetchFn: fetchFn as any,
         isJsonContentType: (headers) =>
-          ['application/vnd.api+json', 'application/json', 'application/vnd.hal+json'].includes(
-            headers.get('content-type') ?? ''
-          ),
+          [
+            'application/vnd.api+json',
+            'application/json',
+            'application/vnd.hal+json',
+          ].includes(headers.get('content-type') ?? ''),
       })
 
       let request: any


### PR DESCRIPTION
Adds support for `jsonContentType` to `fetchBaseQuery`. Useful for consumers that want to default to JSONAPI content-types or something other than `application/json`