### PR TITLE
Codegen: create an option to "flatten" the queryArg

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -56,6 +56,19 @@ function operationMatches(pattern?: EndpointMatcher) {
   };
 }
 
+function withQueryComment<T extends ts.Node>(node: T, def: QueryArgDefinition, hasTrailingNewLine: boolean): T {
+  const comment = def.origin === 'param' ? def.param.description : def.body.description;
+  if (comment) {
+    return ts.addSyntheticLeadingComment(
+      node,
+      ts.SyntaxKind.MultiLineCommentTrivia,
+      `* ${comment} `,
+      hasTrailingNewLine
+    );
+  }
+  return node;
+}
+
 export function getOverrides(
   operation: OperationDefinition,
   endpointOverrides?: EndpointOverrides[]
@@ -78,6 +91,7 @@ export async function generateApi(
     filterEndpoints,
     endpointOverrides,
     unionUndefined,
+    flattenArg = false,
   }: GenerationOptions
 ) {
   const v3Doc = await getV3Doc(spec);
@@ -290,6 +304,8 @@ export async function generateApi(
 
     const queryArgValues = Object.values(queryArg);
 
+    const isFlatArg = flattenArg && queryArgValues.length === 1;
+
     const QueryArg = factory.createTypeReferenceNode(
       registerInterface(
         factory.createTypeAliasDeclaration(
@@ -298,27 +314,22 @@ export async function generateApi(
           capitalize(operationName + argSuffix),
           undefined,
           queryArgValues.length > 0
-            ? factory.createTypeLiteralNode(
-                queryArgValues.map((def) => {
-                  const comment = def.origin === 'param' ? def.param.description : def.body.description;
-                  const node = factory.createPropertySignature(
-                    undefined,
-                    propertyName(def.name),
-                    createQuestionToken(!def.required),
-                    def.type
-                  );
-
-                  if (comment) {
-                    return ts.addSyntheticLeadingComment(
-                      node,
-                      ts.SyntaxKind.MultiLineCommentTrivia,
-                      `* ${comment} `,
+            ? isFlatArg
+              ? withQueryComment({ ...queryArgValues[0].type }, queryArgValues[0], false)
+              : factory.createTypeLiteralNode(
+                  queryArgValues.map((def) =>
+                    withQueryComment(
+                      factory.createPropertySignature(
+                        undefined,
+                        propertyName(def.name),
+                        createQuestionToken(!def.required),
+                        def.type
+                      ),
+                      def,
                       true
-                    );
-                  }
-                  return node;
-                })
-              )
+                    )
+                  )
+                )
             : factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword)
         )
       ).name
@@ -329,7 +340,7 @@ export async function generateApi(
       type: isQuery ? 'query' : 'mutation',
       Response: ResponseTypeName,
       QueryArg,
-      queryFn: generateQueryFn({ operationDefinition, queryArg, isQuery, tags }),
+      queryFn: generateQueryFn({ operationDefinition, queryArg, isQuery, tags, isFlatArg }),
       extraEndpointsProps: isQuery
         ? generateQueryEndpointProps({ operationDefinition })
         : generateMutationEndpointProps({ operationDefinition }),
@@ -340,13 +351,13 @@ export async function generateApi(
   function generateQueryFn({
     operationDefinition,
     queryArg,
+    isFlatArg,
     isQuery,
-    tags,
   }: {
     operationDefinition: OperationDefinition;
     queryArg: QueryArgDefinitions;
+    isFlatArg: boolean;
     isQuery: boolean;
-    tags: string[];
   }) {
     const { path, verb } = operationDefinition;
 
@@ -365,7 +376,11 @@ export async function generateApi(
             factory.createIdentifier(propertyName),
             factory.createObjectLiteralExpression(
               parameters.map(
-                (param) => createPropertyAssignment(param.originalName, accessProperty(rootObject, param.name)),
+                (param) =>
+                  createPropertyAssignment(
+                    param.originalName,
+                    isFlatArg ? rootObject : accessProperty(rootObject, param.name)
+                  ),
                 true
               )
             )
@@ -395,7 +410,7 @@ export async function generateApi(
           [
             factory.createPropertyAssignment(
               factory.createIdentifier('url'),
-              generatePathExpression(path, pickParams('path'), rootObject)
+              generatePathExpression(path, pickParams('path'), rootObject, isFlatArg)
             ),
             isQuery && verb.toUpperCase() === 'GET'
               ? undefined
@@ -407,7 +422,9 @@ export async function generateApi(
               ? undefined
               : factory.createPropertyAssignment(
                   factory.createIdentifier('body'),
-                  factory.createPropertyAccessExpression(rootObject, factory.createIdentifier(bodyParameter.name))
+                  isFlatArg
+                    ? rootObject
+                    : factory.createPropertyAccessExpression(rootObject, factory.createIdentifier(bodyParameter.name))
                 ),
             createObjectLiteralProperty(pickParams('cookie'), 'cookies'),
             createObjectLiteralProperty(pickParams('header'), 'headers'),
@@ -436,7 +453,12 @@ function accessProperty(rootObject: ts.Identifier, propertyName: string) {
     : factory.createElementAccessExpression(rootObject, factory.createStringLiteral(propertyName));
 }
 
-function generatePathExpression(path: string, pathParameters: QueryArgDefinition[], rootObject: ts.Identifier) {
+function generatePathExpression(
+  path: string,
+  pathParameters: QueryArgDefinition[],
+  rootObject: ts.Identifier,
+  isFlatArg: boolean
+) {
   const expressions: Array<[string, string]> = [];
 
   const head = path.replace(/\{(.*?)\}(.*?)(?=\{|$)/g, (_, expression, literal) => {
@@ -453,7 +475,7 @@ function generatePathExpression(path: string, pathParameters: QueryArgDefinition
         factory.createTemplateHead(head),
         expressions.map(([prop, literal], index) =>
           factory.createTemplateSpan(
-            accessProperty(rootObject, prop),
+            isFlatArg ? rootObject : accessProperty(rootObject, prop),
             index === expressions.length - 1
               ? factory.createTemplateTail(literal)
               : factory.createTemplateMiddle(literal)

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -340,7 +340,7 @@ export async function generateApi(
       type: isQuery ? 'query' : 'mutation',
       Response: ResponseTypeName,
       QueryArg,
-      queryFn: generateQueryFn({ operationDefinition, queryArg, isQuery, tags, isFlatArg }),
+      queryFn: generateQueryFn({ operationDefinition, queryArg, isQuery, isFlatArg }),
       extraEndpointsProps: isQuery
         ? generateQueryEndpointProps({ operationDefinition })
         : generateMutationEndpointProps({ operationDefinition }),

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -59,6 +59,10 @@ export interface CommonOptions {
    * defaults to false
    */
   tag?: boolean;
+  /**
+   * defaults to false
+   */
+  flattenArg?: boolean;
 }
 
 export type TextMatcher = string | RegExp | (string | RegExp)[];

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -53,14 +53,18 @@ export interface CommonOptions {
   hooks?: boolean | { queries: boolean; lazyQueries: boolean; mutations: boolean };
   /**
    * defaults to false
+   * `true` will generate a union type for `undefined` properties like: `{ id?: string | undefined }` instead of `{ id?: string }`
    */
   unionUndefined?: boolean;
   /**
    * defaults to false
+   * `true` will result in all generated endpoints having `providesTags`/`invalidatesTags` declarations for the `tags` of their respective operation definition
+   * @see https://redux-toolkit.js.org/rtk-query/usage/code-generation for more information
    */
   tag?: boolean;
   /**
    * defaults to false
+   * `true` will "flatten" the arg so that you can do things like `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`
    */
   flattenArg?: boolean;
 }

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -424,6 +424,54 @@ export const { useLoginUserMutation } = injectedRtkApi;
 
 `;
 
+exports[`hooks generation: should generate an \`useGetPetByIdQuery\` query hook and an \`useAddPetMutation\` mutation hook 1`] = `
+import { api } from './fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: 'POST',
+        body: queryArg.pet,
+      }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ('available' | 'pending' | 'sold') | undefined;
+};
+export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
+
+`;
+
 exports[`should use brackets in a querystring urls arg, when the arg contains full stops 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -263,54 +263,6 @@ export type User = {
 
 `;
 
-exports[`default hooks generation: should generate an \`useGetPetByIdQuery\` query hook and an \`useAddPetMutation\` mutation hook 1`] = `
-import { api } from './fixtures/emptyApi';
-const injectedRtkApi = api.injectEndpoints({
-  endpoints: (build) => ({
-    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
-      query: (queryArg) => ({
-        url: \`/pet\`,
-        method: 'POST',
-        body: queryArg.pet,
-      }),
-    }),
-    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
-      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
-    }),
-  }),
-  overrideExisting: false,
-});
-export { injectedRtkApi as enhancedApi };
-export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
-export type AddPetApiArg = {
-  /** Create a new pet in the store */
-  pet: Pet;
-};
-export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
-export type GetPetByIdApiArg = {
-  /** ID of pet to return */
-  petId: number;
-};
-export type Category = {
-  id?: number | undefined;
-  name?: string | undefined;
-};
-export type Tag = {
-  id?: number | undefined;
-  name?: string | undefined;
-};
-export type Pet = {
-  id?: number | undefined;
-  name: string;
-  category?: Category | undefined;
-  photoUrls: string[];
-  tags?: Tag[] | undefined;
-  status?: ('available' | 'pending' | 'sold') | undefined;
-};
-export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
-
-`;
-
 exports[`endpoint filtering: should only have endpoints loginUser, placeOrder, getOrderById, deleteOrder 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -73,7 +73,7 @@ test('endpoint overrides', async () => {
   expect(api).toMatchSnapshot('loginUser should be a mutation');
 });
 
-describe('option flattenArg', async () => {
+describe('option flattenArg', () => {
   const config = {
     apiFile: './fixtures/emptyApi.ts',
     schemaFile: resolve(__dirname, 'fixtures/petstore.json'),

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -73,7 +73,50 @@ test('endpoint overrides', async () => {
   expect(api).toMatchSnapshot('loginUser should be a mutation');
 });
 
-test('default hooks generation', async () => {
+describe('option flattenArg', async () => {
+  const config = {
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    flattenArg: true,
+  };
+
+  it('should apply a queryArg directly in the path', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['getOrderById'],
+    });
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(api).toContain('`/store/order/${queryArg}`');
+    expect(api).toMatch(/export type GetOrderByIdApiArg =[\s/*]+ID of order that needs to be fetched[\s/*]+number;/);
+  });
+
+  it('should apply a queryArg directly in the params', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['findPetsByStatus'],
+    });
+    expect(api).toContain('params: { status: queryArg }');
+    expect(api).not.toContain('export type FindPetsByStatusApiArg = {');
+  });
+
+  it('should use the queryArg as the entire body', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['addPet'],
+    });
+    expect(api).toMatch(/body: queryArg[^.]/);
+  });
+
+  it('should not change anything if there are 2+ arguments.', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['uploadFile'],
+    });
+    expect(api).toContain('queryArg.body');
+  });
+});
+
+test('hooks generation', async () => {
   const api = await generateEndpoints({
     unionUndefined: true,
     apiFile: './fixtures/emptyApi.ts',


### PR DESCRIPTION
It has always been a pain point for me that the RTK codegen creates unnecessarily complex arguments, ie. `{ someIdProperty: string }` instead of `string`.

This PR adds an option `flattenArg` (does this name make sense?  It can be changed) to the codegen config which will clean up the `queryArg`.  If the `queryArg` would contain exactly one property, then make that property itself be the `queryArg`.   This works whether the argument is in the path, body, or params.

before:
```
getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
    query: (queryArg) => ({ url: `/store/order/${queryArg.orderId}` }),
})

export type GetOrderByIdApiResponse =
    /** status 200 successful operation */ Order;
export type GetOrderByIdApiArg = {
    /** ID of order that needs to be fetched */
    orderId: number;
};
```
```
const { data } = useGetOrderByIdQuery({ orderId: 99 });
```

after:
```
getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
    query: (queryArg) => ({ url: `/store/order/${queryArg}` }),
})

export type GetOrderByIdApiResponse =
    /** status 200 successful operation */ Order;
export type GetOrderByIdApiArg =
    /** ID of order that needs to be fetched */ number;
```
```
const { data } = useGetOrderByIdQuery(99);
```
