### PR TITLE
Adding sandbox with creds includes, but from my own account

### DIFF
--- a/docs/rtk-query/usage/examples.mdx
+++ b/docs/rtk-query/usage/examples.mdx
@@ -76,6 +76,22 @@ The example has some intentionally wonky behavior... when editing the name of a 
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
+## React with GraphQL with custom client
+
+<iframe
+  src="https://codesandbox.io/s/determined-shannon-iv2p5x"
+  style={{
+    width: '100%',
+    height: '800px',
+    border: 0,
+    borderRadius: '4px',
+    overflow: 'hidden',
+  }}
+  title="RTK Query GraphQL Example with custom client"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
 ## Authentication
 
 There are several ways to handle authentication with RTK Query. This is a very basic example of taking a JWT from a login mutation, then setting that in our store. We then use `prepareHeaders` to inject the authentication headers into every subsequent request.


### PR DESCRIPTION
Hey,
I added to docs example of using graphql-request but with your own client. Unfortunately I cannot create codesandbox example from the same account as the all other examples. Could you guys help out with that?