### PR TITLE
[FEAT][AsyncThunk] Pass abort reason of thunk action to AbortController #2395

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -7,6 +7,8 @@ import { createAction } from './createAction'
 import type { ThunkDispatch } from 'redux-thunk'
 import type { FallbackIfUnknown, IsAny, IsUnknown } from './tsHelpers'
 import { nanoid } from './nanoid'
+import type { AbortSignalWithReason } from './function-utils'
+import { abortControllerWithReason } from './function-utils'
 
 // @ts-ignore we need the import of these types due to a bundling issue.
 type _Keep = PayloadAction | ActionCreatorWithPreparedPayload<any, unknown>
@@ -541,7 +543,7 @@ export function createAsyncThunk<
             reason: undefined,
             throwIfAborted() {},
           }
-          abort() {
+          abort(reason?: any) {
             if (process.env.NODE_ENV !== 'production') {
               if (!displayedWarning) {
                 displayedWarning = true
@@ -550,6 +552,12 @@ export function createAsyncThunk<
 If you want to use the AbortController to react to \`abort\` events, please consider importing a polyfill like 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'.`
                 )
               }
+            }
+
+            if (!this.signal.aborted) {
+              this.signal.aborted = true
+              ;(this.signal as AbortSignalWithReason<typeof reason>).reason =
+                reason
             }
           }
         }
@@ -575,7 +583,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
       function abort(reason?: string) {
         if (started) {
           abortReason = reason
-          abortController.abort()
+          abortControllerWithReason(abortController, reason)
         }
       }
 

--- a/packages/toolkit/src/function-utils.ts
+++ b/packages/toolkit/src/function-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * @internal
+ * At the time of writing `lib.dom.ts` does not provide `abortSignal.reason`.
+ */
+export type AbortSignalWithReason<T> = AbortSignal & { reason?: T }
+
+/**
+ * Calls `abortController.abort(reason)` and patches `signal.reason`.
+ * if it is not supported.
+ *
+ * At the time of writing `signal.reason` is available in FF chrome, edge node 17 and deno.
+ * @param abortController
+ * @param reason
+ * @returns
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason
+ */
+export const abortControllerWithReason = <T>(
+  abortController: AbortController,
+  reason: T
+): void => {
+  type Consumer<T> = (val: T) => void
+
+  const signal = abortController.signal as AbortSignalWithReason<T>
+
+  if (signal.aborted) {
+    return
+  }
+
+  // Patch `reason` if necessary.
+  // - We use defineProperty here because reason is a getter of `AbortSignal.__proto__`.
+  // - We need to patch 'reason' before calling `.abort()` because listeners to the 'abort'
+  // event are are notified immediately.
+  if (!('reason' in signal)) {
+    Object.defineProperty(signal, 'reason', {
+      enumerable: true,
+      value: reason,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  ;(abortController.abort as Consumer<typeof reason>)(reason)
+}

--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -2,7 +2,8 @@ import type { Dispatch, AnyAction, MiddlewareAPI } from 'redux'
 import type { ThunkDispatch } from 'redux-thunk'
 import { createAction } from '../createAction'
 import { nanoid } from '../nanoid'
-
+import { abortControllerWithReason } from '../function-utils'
+import type { AbortSignalWithReason } from '../function-utils'
 import type {
   ListenerMiddleware,
   ListenerMiddlewareInstance,
@@ -21,15 +22,9 @@ import type {
   ForkedTask,
   TypedRemoveListener,
   TaskResult,
-  AbortSignalWithReason,
   UnsubscribeListenerOptions,
 } from './types'
-import {
-  abortControllerWithReason,
-  addAbortSignalListener,
-  assertFunction,
-  catchRejection,
-} from './utils'
+import { addAbortSignalListener, assertFunction, catchRejection } from './utils'
 import {
   listenerCancelled,
   listenerCompleted,

--- a/packages/toolkit/src/listenerMiddleware/task.ts
+++ b/packages/toolkit/src/listenerMiddleware/task.ts
@@ -1,5 +1,6 @@
 import { TaskAbortError } from './exceptions'
-import type { AbortSignalWithReason, TaskResult } from './types'
+import type { TaskResult } from './types'
+import type { AbortSignalWithReason } from '../function-utils'
 import { addAbortSignalListener, catchRejection } from './utils'
 
 /**

--- a/packages/toolkit/src/listenerMiddleware/tests/fork.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/fork.test.ts
@@ -1,12 +1,8 @@
 import type { EnhancedStore } from '@reduxjs/toolkit'
 import { configureStore, createSlice, createAction } from '@reduxjs/toolkit'
-
+import type { AbortSignalWithReason } from '../../function-utils'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import type {
-  AbortSignalWithReason,
-  ForkedTaskExecutor,
-  TaskResult,
-} from '../types'
+import type { ForkedTaskExecutor, TaskResult } from '../types'
 import { createListenerMiddleware, TaskAbortError } from '../index'
 import {
   listenerCancelled,

--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
@@ -25,11 +25,8 @@ import type {
   UnsubscribeListener,
   ListenerMiddleware,
 } from '../index'
-import type {
-  AbortSignalWithReason,
-  AddListenerOverloads,
-  TypedRemoveListener,
-} from '../types'
+import type { AbortSignalWithReason } from '../../function-utils'
+import type { AddListenerOverloads, TypedRemoveListener } from '../types'
 import { listenerCancelled, listenerCompleted } from '../exceptions'
 
 const middlewareApi = {
@@ -185,7 +182,7 @@ describe('createListenerMiddleware', () => {
         middleware: (gDM) => gDM().prepend(listenerMiddleware.middleware),
       })
 
-      let foundExtra = null
+      let foundExtra: number | null = null
 
       const typedAddListener =
         listenerMiddleware.startListening as TypedStartListening<
@@ -1122,31 +1119,34 @@ describe('createListenerMiddleware', () => {
       expect(takeResult).toEqual([increment(), stateCurrent, stateBefore])
     })
 
-    test("take resolves to `[A, CurrentState, PreviousState] | null` if a possibly undefined timeout parameter is provided", async () => {
+    test('take resolves to `[A, CurrentState, PreviousState] | null` if a possibly undefined timeout parameter is provided', async () => {
       const store = configureStore({
         reducer: counterSlice.reducer,
         middleware: (gDM) => gDM().prepend(middleware),
       })
 
-      type ExpectedTakeResultType = readonly [ReturnType<typeof increment>, CounterState, CounterState] | null
+      type ExpectedTakeResultType =
+        | readonly [ReturnType<typeof increment>, CounterState, CounterState]
+        | null
 
       let timeout: number | undefined = undefined
       let done = false
 
-      const startAppListening = startListening as TypedStartListening<CounterState>
+      const startAppListening =
+        startListening as TypedStartListening<CounterState>
       startAppListening({
         predicate: incrementByAmount.match,
         effect: async (_, listenerApi) => {
           const stateBefore = listenerApi.getState()
-          
+
           let takeResult = await listenerApi.take(increment.match, timeout)
           const stateCurrent = listenerApi.getState()
           expect(takeResult).toEqual([increment(), stateCurrent, stateBefore])
-          
+
           timeout = 1
           takeResult = await listenerApi.take(increment.match, timeout)
           expect(takeResult).toBeNull()
-          
+
           expectType<ExpectedTakeResultType>(takeResult)
 
           done = true
@@ -1156,7 +1156,7 @@ describe('createListenerMiddleware', () => {
       store.dispatch(increment())
 
       await delay(25)
-      expect(done).toBe(true);
+      expect(done).toBe(true)
     })
 
     test('condition method resolves promise when the predicate succeeds', async () => {

--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -10,12 +10,6 @@ import type { ThunkDispatch } from 'redux-thunk'
 import type { TaskAbortError } from './exceptions'
 
 /**
- * @internal
- * At the time of writing `lib.dom.ts` does not provide `abortSignal.reason`.
- */
-export type AbortSignalWithReason<T> = AbortSignal & { reason?: T }
-
-/**
  * Types copied from RTK
  */
 
@@ -177,9 +171,9 @@ export interface ListenerEffectAPI<
    * rejects if the listener has been cancelled or is completed.
    *
    * The return value is `true` if the predicate succeeds or `false` if a timeout is provided and expires first.
-   * 
+   *
    * ### Example
-   * 
+   *
    * ```ts
    * const updateBy = createAction<number>('counter/updateBy');
    *
@@ -201,7 +195,7 @@ export interface ListenerEffectAPI<
    *
    * The return value is the `[action, currentState, previousState]` combination that the predicate saw as arguments.
    *
-   * The promise resolves to null if a timeout is provided and expires first, 
+   * The promise resolves to null if a timeout is provided and expires first,
    *
    * ### Example
    *

--- a/packages/toolkit/src/listenerMiddleware/utils.ts
+++ b/packages/toolkit/src/listenerMiddleware/utils.ts
@@ -1,5 +1,3 @@
-import type { AbortSignalWithReason } from './types'
-
 export const assertFunction: (
   func: unknown,
   expected: string
@@ -28,42 +26,4 @@ export const addAbortSignalListener = (
   callback: (evt: Event) => void
 ) => {
   abortSignal.addEventListener('abort', callback, { once: true })
-}
-
-/**
- * Calls `abortController.abort(reason)` and patches `signal.reason`.
- * if it is not supported.
- *
- * At the time of writing `signal.reason` is available in FF chrome, edge node 17 and deno.
- * @param abortController
- * @param reason
- * @returns
- * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason
- */
-export const abortControllerWithReason = <T>(
-  abortController: AbortController,
-  reason: T
-): void => {
-  type Consumer<T> = (val: T) => void
-
-  const signal = abortController.signal as AbortSignalWithReason<T>
-
-  if (signal.aborted) {
-    return
-  }
-
-  // Patch `reason` if necessary.
-  // - We use defineProperty here because reason is a getter of `AbortSignal.__proto__`.
-  // - We need to patch 'reason' before calling `.abort()` because listeners to the 'abort'
-  // event are are notified immediately.
-  if (!('reason' in signal)) {
-    Object.defineProperty(signal, 'reason', {
-      enumerable: true,
-      value: reason,
-      configurable: true,
-      writable: true,
-    })
-  }
-
-  ;(abortController.abort as Consumer<typeof reason>)(reason)
 }


### PR DESCRIPTION
Closes #2395

### Description

`asyncThunkApi.signal.reason` is set to the first value provided to `asyncThunkHandle.abort`.

#### Other changes

- fixes `signal.aborted` not being set to `true` in the `AbortController` shim if `abort` is called.

#### Implementation details

It uses a utility function `abortControllerWithReason`, already used within the listenerMiddleware,  that patches reason if it is not available.

