### PR TITLE
docs: Updated references for redux-devtools to the correct github repo

### DIFF
--- a/docs/api/configureStore.mdx
+++ b/docs/api/configureStore.mdx
@@ -98,16 +98,17 @@ For more details on how the `middleware` parameter works and the list of middlew
 
 ### `devTools`
 
-If this is a boolean, it will be used to indicate whether `configureStore` should automatically enable support for [the Redux DevTools browser extension](https://github.com/zalmoxisus/redux-devtools-extension).
+If this is a boolean, it will be used to indicate whether `configureStore` should automatically enable support for [the Redux DevTools browser extension](https://github.com/reduxjs/redux-devtools).
 
 If it is an object, then the DevTools Extension will be enabled, and the options object will be passed to `composeWithDevtools()`. See
-the DevTools Extension docs for [`EnhancerOptions`](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#windowdevtoolsextensionconfig) for
+the DevTools Extension docs for [`EnhancerOptions`](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md) for
 a list of the specific options that are available.
 
 Defaults to `true`.
 
-The Redux DevTools Extension recently added [support for showing action stack traces](https://github.com/zalmoxisus/redux-devtools-extension/blob/d4ef75691ad294646f74bca38b973b19850a37cf/docs/Features/Trace.md) that show exactly where each action was dispatched. Capturing the traces can add a bit of overhead, so the DevTools Extension allows users to configure whether action stack traces are captured.
-
+#### `trace`
+The Redux DevTools Extension recently added [support for showing action stack traces](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/Features/Trace.md) that show exactly where each action was dispatched. 
+Capturing the traces can add a bit of overhead, so the DevTools Extension allows users to configure whether action stack traces are captured by [setting the 'trace' argument](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#trace).
 If the DevTools are enabled by passing `true` or an object, then `configureStore` will default to enabling capturing action stack traces in development mode only.
 
 ### `preloadedState`

--- a/docs/rtk-query/usage/cache-behavior.mdx
+++ b/docs/rtk-query/usage/cache-behavior.mdx
@@ -414,7 +414,7 @@ There are a couple additional points that can help here:
 
 ### Cache Subscription Lifetime Demo
 
-This example is a live demo of how the subscriber reference count and the value of `keepUnusedDataFor` interact with each other. The `Subscriptions` and `Queries` (including the cached data) are shown in the demo for you to visualize (note that this can also be viewed in the [Redux Devtools Extension](https://github.com/zalmoxisus/redux-devtools-extension)).
+This example is a live demo of how the subscriber reference count and the value of `keepUnusedDataFor` interact with each other. The `Subscriptions` and `Queries` (including the cached data) are shown in the demo for you to visualize (note that this can also be viewed in the [Redux Devtools Extension](https://github.com/reduxjs/redux-devtools)).
 
 Two components are mounted, each with the same endpoints query (`useGetUsersQuery(2)`). You will be able to observe that when toggling off the components, the subscriber reference count will be reduced. After toggling off both components such that the subscriber reference count reaches zero, you will observe the cached data under the `Queries` section will persist for 5 seconds (the value of `keepUnusedDataFor` provided for the endpoint in this demo). If the subscriber reference count remains at 0 for the full duration, the cached data will then be removed from the store.
 


### PR DESCRIPTION
The docs currently point to https://github.com/zalmoxisus/redux-devtools-extension for the devtools extension. But that repo is no longer the actively maintained one, the correct repo is https://github.com/reduxjs/redux-devtools.
This PR updates the references for the same.