### PR TITLE
Update createAsyncThunk example to handle getState typings

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -513,9 +513,11 @@ const fetchUserById = createAsyncThunk(
 
 ```ts no-transpile
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { userAPI } from './userAPI'
+import { userAPI, User } from './userAPI'
 
-const fetchUserById = createAsyncThunk(
+const fetchUserById = createAsyncThunk<User, string, {
+    state: { users: { loading: string, currentRequestId: string } }
+}> (  
   'users/fetchByIdStatus',
   async (userId: string, { getState, requestId }) => {
     const { currentRequestId, loading } = getState().users


### PR DESCRIPTION
Was helping someone on Discord with an issue related to `getState` typings, and noticed that the example here, despite being in Typescript, didn't include the necessary generic parameters to actually compile.