### PR TITLE
Add support for .cjs and .cts files in codegen cli

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/bin/cli.ts
+++ b/packages/rtk-query-codegen-openapi/src/bin/cli.ts
@@ -43,7 +43,7 @@ program.version(meta.version).usage('</path/to/config.js>').parse(process.argv);
 
 const configFile = program.args[0];
 
-if (program.args.length === 0 || !/\.(jsx?|tsx?|jsonc?)?$/.test(configFile)) {
+if (program.args.length === 0 || !/\.(c?(jsx?|tsx?)|jsonc?)?$/.test(configFile)) {
   program.help();
 } else {
   if (/\.tsx?$/.test(configFile) && !ts) {


### PR DESCRIPTION
In reference to #2437, the regex check for valid configuration files is changed to allow .cjs and .cts files.