### PR TITLE
fix: abort controller fallback

### DIFF
--- a/packages/toolkit/src/abortController.ts
+++ b/packages/toolkit/src/abortController.ts
@@ -1,0 +1,28 @@
+let displayedWarning = false
+export const AC =
+    typeof AbortController !== 'undefined'
+        ? AbortController
+        : class implements AbortController {
+            signal = {
+                aborted: false,
+                addEventListener() {},
+                dispatchEvent() {
+                    return false
+                },
+                onabort() {},
+                removeEventListener() {},
+                reason: undefined,
+                throwIfAborted() {},
+            }
+            abort() {
+                if (process.env.NODE_ENV !== 'production') {
+                    if (!displayedWarning) {
+                        displayedWarning = true
+                        console.info(
+                            `This platform does not implement AbortController. 
+If you want to use the AbortController to react to \`abort\` events, please consider importing a polyfill like 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'.`
+                        )
+                    }
+                }
+            }
+        }

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -7,6 +7,7 @@ import { createAction } from './createAction'
 import type { ThunkDispatch } from 'redux-thunk'
 import type { FallbackIfUnknown, IsAny, IsUnknown } from './tsHelpers'
 import { nanoid } from './nanoid'
+import { AC } from "./abortController";
 
 // @ts-ignore we need the import of these types due to a bundling issue.
 type _Keep = PayloadAction | ActionCreatorWithPreparedPayload<any, unknown>
@@ -523,36 +524,6 @@ export function createAsyncThunk<
         },
       })
     )
-
-  let displayedWarning = false
-
-  const AC =
-    typeof AbortController !== 'undefined'
-      ? AbortController
-      : class implements AbortController {
-          signal = {
-            aborted: false,
-            addEventListener() {},
-            dispatchEvent() {
-              return false
-            },
-            onabort() {},
-            removeEventListener() {},
-            reason: undefined,
-            throwIfAborted() {},
-          }
-          abort() {
-            if (process.env.NODE_ENV !== 'production') {
-              if (!displayedWarning) {
-                displayedWarning = true
-                console.info(
-                  `This platform does not implement AbortController. 
-If you want to use the AbortController to react to \`abort\` events, please consider importing a polyfill like 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'.`
-                )
-              }
-            }
-          }
-        }
 
   function actionCreator(
     arg: ThunkArg

--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -44,6 +44,7 @@ import {
   createPause,
   createDelay,
 } from './task'
+import { AC } from "../abortController";
 export { TaskAbortError } from './exceptions'
 export type {
   ListenerEffect,
@@ -86,7 +87,7 @@ const createFork = (parentAbortSignal: AbortSignalWithReason<unknown>) => {
 
   return <T>(taskExecutor: ForkedTaskExecutor<T>): ForkedTask<T> => {
     assertFunction(taskExecutor, 'taskExecutor')
-    const childAbortController = new AbortController()
+    const childAbortController = new AC()
 
     linkControllers(childAbortController)
 
@@ -368,7 +369,7 @@ export function createListenerMiddleware<
     api: MiddlewareAPI,
     getOriginalState: () => S
   ) => {
-    const internalTaskController = new AbortController()
+    const internalTaskController = new AC()
     const take = createTakePattern(
       startListening,
       internalTaskController.signal


### PR DESCRIPTION
# Description 

Inside `createAsyncThunk` currently RTK have a fallback in case `AbortController` is not declared. https://github.com/reduxjs/redux-toolkit/blob/e307245e8e78868353c746531331257ea69ccab2/packages/toolkit/src/createAsyncThunk.ts#L530

This seems not the case for the `listenerMiddleware` https://github.com/reduxjs/redux-toolkit/blob/3d7bd2246df35a668a25d60a757f1f0b6df62798/packages/toolkit/src/listenerMiddleware/index.ts#L89

## How to reproduce the issue ? 

- Create a next.js project with node 14
- use listener middleware on server side 
- see the reference error of `AbortController`


