### PR TITLE
Add ThunkMiddleware to the re-exported types from redux-thunk

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -16,7 +16,7 @@ export type {
   ParametricSelector,
 } from 'reselect'
 export { createDraftSafeSelector } from './createDraftSafeSelector'
-export type { ThunkAction, ThunkDispatch } from 'redux-thunk'
+export type { ThunkAction, ThunkDispatch, ThunkMiddleware } from 'redux-thunk'
 
 // We deliberately enable Immer's ES5 support, on the grounds that
 // we assume RTK will be used with React Native and other Proxy-less


### PR DESCRIPTION
:wave: hi folks, I have just updated to the latest redux toolkit and found myself reaching into some of my transitive dependencies in order to accurately describe the types inside my app.  

( The code is some shared code across many redux stores which needs to send dispatches to stores, and sets a generic shape constraint on the state's type )

### Old Code (1.5.1)

```ts
import type { EnhancedStore } from "@reduxjs/toolkit"

export const setupHostConfig = (config: GameConfig) => <State extends ObjWithSession, Props extends {}>(
  store: EnhancedStore<State>
) => { ... } 
```

### New Code (1.8.2)

`yarn add redux-thunk`

```ts
import type { AnyAction, EnhancedStore } from "@reduxjs/toolkit"
import type { ThunkMiddleware } from "redux-thunk"

export const setupHostConfig = (config: GameConfig) => <State extends ObjWithSession, Props extends {}>(
  store: EnhancedStore<State, AnyAction, [ThunkMiddleware<State, AnyAction, undefined>]>
) => { ... } 
```

Given that ThunkMiddleware is effectively vendored from an API perspective, and there's already some vendored type exports - I just added it to the list.

### After this PR


```ts
import type { AnyAction, EnhancedStore, ThunkMiddleware } from "@reduxjs/toolkit"

export const setupHostConfig = (config: GameConfig) => <State extends ObjWithSession, Props extends {}>(
  store: EnhancedStore<State, AnyAction, [ThunkMiddleware<State, AnyAction, undefined>]>
) => { ... } 
```