### PR TITLE
Fix correct alias of useDispatch function

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -81,7 +81,7 @@ import type { RootState, AppDispatch } from './store'
 
 // highlight-start
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppDispatch: () => useDispatch<AppDispatch>()
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 // highlight-end
 ```


### PR DESCRIPTION
The useDispatch function should be aliased by adding the AppDispatch as a generic type argument