### PR TITLE
fix: incorrect import name for postsApi in authSlice

### DIFF
--- a/examples/query/react/kitchen-sink/src/features/auth/authSlice.ts
+++ b/examples/query/react/kitchen-sink/src/features/auth/authSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { postApi } from '../../app/services/posts'
+import { postsApi } from '../../app/services/posts'
 import type { User } from '../../app/services/posts'
 import type { RootState } from '../../app/store'
 


### PR DESCRIPTION
This PR fixes a typo error for an import name in the kitchen sink example as described in [this issue](https://github.com/reduxjs/redux-toolkit/issues/2456).

