### PR TITLE
Throw new error when initial state is undefined - #2459

### DIFF
--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -262,6 +262,16 @@ export function createSlice<
   if (!name) {
     throw new Error('`name` is a required option for createSlice')
   }
+
+  if (
+    typeof process !== 'undefined' &&
+    process.env.NODE_ENV === 'development'
+  ) {
+    if(options.initialState === undefined) {
+      throw new Error('initial state must be different of undefined')
+    }
+  }
+
   const initialState =
     typeof options.initialState == 'function'
       ? options.initialState

--- a/packages/toolkit/src/tests/createSlice.test.ts
+++ b/packages/toolkit/src/tests/createSlice.test.ts
@@ -34,6 +34,18 @@ describe('createSlice', () => {
     })
   })
 
+  describe('when initial state is undefined', () => {
+    it('should throw an error', () => {
+      expect(() =>
+        createSlice({
+          name: 'test',
+          reducers: {},
+          initialState: undefined,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(`"initial state must be different of undefined"`)
+    })
+  })
+
   describe('when passing slice', () => {
     const { actions, reducer, caseReducers } = createSlice({
       reducers: {


### PR DESCRIPTION
Add a new error when initial state is undefined on createSlice.ts.

Issue: #2459