### PR TITLE
Rewrite `updateMany` to ensure stable sorting order

### DIFF
--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -343,6 +343,34 @@ describe('Sorted State Adapter', () => {
     })
   })
 
+  it('should maintain a stable sorting order when updating items', () => {
+    interface OrderedEntity {
+      id: string
+      order: number
+      ts: number
+    }
+    const sortedItemsAdapter = createEntityAdapter<OrderedEntity>({
+      sortComparer: (a, b) => a.order - b.order,
+    })
+    const withInitialItems = sortedItemsAdapter.setAll(
+      sortedItemsAdapter.getInitialState(),
+      [
+        { id: 'A', order: 1, ts: 0 },
+        { id: 'B', order: 2, ts: 0 },
+        { id: 'C', order: 3, ts: 0 },
+        { id: 'D', order: 3, ts: 0 },
+        { id: 'E', order: 3, ts: 0 },
+      ]
+    )
+
+    const updated = sortedItemsAdapter.updateOne(withInitialItems, {
+      id: 'C',
+      changes: { ts: 5 },
+    })
+
+    expect(updated.ids).toEqual(['A', 'B', 'C', 'D', 'E'])
+  })
+
   it('should let you update many entities by id in the state', () => {
     const firstChange = { title: 'Zack' }
     const secondChange = { title: 'Aaron' }

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -680,12 +680,20 @@ describe('Sorted State Adapter', () => {
     test('updateMany', () => {
       const firstChange = { title: 'First Change' }
       const secondChange = { title: 'Second Change' }
-      const withMany = adapter.setAll(state, [TheGreatGatsby, AClockworkOrange])
+      const thirdChange = { title: 'Third Change' }
+      const fourthChange = { author: 'Fourth Change' }
+      const withMany = adapter.setAll(state, [
+        TheGreatGatsby,
+        AClockworkOrange,
+        TheHobbit,
+      ])
 
       const result = createNextState(withMany, (draft) => {
         adapter.updateMany(draft, [
-          { id: TheGreatGatsby.id, changes: firstChange },
-          { id: AClockworkOrange.id, changes: secondChange },
+          { id: TheHobbit.id, changes: firstChange },
+          { id: TheGreatGatsby.id, changes: secondChange },
+          { id: AClockworkOrange.id, changes: thirdChange },
+          { id: TheHobbit.id, changes: fourthChange },
         ])
       })
 
@@ -694,14 +702,20 @@ describe('Sorted State Adapter', () => {
           "entities": Object {
             "aco": Object {
               "id": "aco",
-              "title": "Second Change",
+              "title": "Third Change",
             },
             "tgg": Object {
               "id": "tgg",
+              "title": "Second Change",
+            },
+            "th": Object {
+              "author": "Fourth Change",
+              "id": "th",
               "title": "First Change",
             },
           },
           "ids": Array [
+            "th",
             "tgg",
             "aco",
           ],


### PR DESCRIPTION
This PR:

- Rewrites the `updateMany` implementation in `sorted_state_adapter` to ensure that applying updates to fields unrelated to the sort comparator leaves the sorting order unchanged
- Adds a test to verify that applying multiple updates to one item by ID are all applied

Fixes #1853 , fixes #2297

There was also a previous PR at #1860 , but I tackled this fresh and ended up fixing both issues with a simpler rewrite.

The core problem is that the old code always did `delete state.entities[update.id]`, and later re-added it.  Later, the sorting code does `const entities = Object.values(state.entities)`.  Since JS engines mostly use insertion order for key iteration, deleting an re-adding an item to `state.entities` caused it to sort after other items that have the same comparator values.

Also, deleting the item meant that additional updates for that ID weren't actually applied.

I dropped the somewhat confusing `takeUpdatedModel()` function, and opted to just directly mutate the existing item instead, only deleting it if the ID changed.  (This means there's a very minor limitation that if you're trying to apply multiple updates to the same item in one shot, and one of those updates in the middle changes the ID, the later ones won't apply... but that seems like a rare enough edge case to not worry about here.)