### PR TITLE
Ensures there is no slash in url before query params

### DIFF
--- a/packages/toolkit/src/query/tests/utils.test.ts
+++ b/packages/toolkit/src/query/tests/utils.test.ts
@@ -83,6 +83,8 @@ describe('joinUrls', () => {
 
     expect(joinUrls('', '/banana')).toBe('/banana')
     expect(joinUrls('', 'banana')).toBe('banana')
+
+    expect(joinUrls('/api', '?foo=bar')).toBe('/api?foo=bar')
   })
 
   test('correctly joins variations of absolute urls', () => {
@@ -98,6 +100,10 @@ describe('joinUrls', () => {
     )
     expect(joinUrls('https://example.com/api/', '/banana/')).toBe(
       'https://example.com/api/banana/'
+    )
+
+    expect(joinUrls('https://example.com/api/', '?foo=bar')).toBe(
+      'https://example.com/api?foo=bar'
     )
   })
 })

--- a/packages/toolkit/src/query/utils/joinUrls.ts
+++ b/packages/toolkit/src/query/utils/joinUrls.ts
@@ -20,6 +20,7 @@ export function joinUrls(
 
   base = withoutTrailingSlash(base)
   url = withoutLeadingSlash(url)
+  const delimiter = url.startsWith('?') ? '' : '/'
 
-  return `${base}/${url}`
+  return `${base}${delimiter}${url}`;
 }


### PR DESCRIPTION
Fixes reduxjs/redux-toolkit#2379