### PR TITLE
Revert "Ensures there is no slash in url before query params"

### DIFF
--- a/packages/toolkit/src/query/tests/utils.test.ts
+++ b/packages/toolkit/src/query/tests/utils.test.ts
@@ -83,8 +83,6 @@ describe('joinUrls', () => {
 
     expect(joinUrls('', '/banana')).toBe('/banana')
     expect(joinUrls('', 'banana')).toBe('banana')
-
-    expect(joinUrls('/api', '?foo=bar')).toBe('/api?foo=bar')
   })
 
   test('correctly joins variations of absolute urls', () => {
@@ -100,10 +98,6 @@ describe('joinUrls', () => {
     )
     expect(joinUrls('https://example.com/api/', '/banana/')).toBe(
       'https://example.com/api/banana/'
-    )
-
-    expect(joinUrls('https://example.com/api/', '?foo=bar')).toBe(
-      'https://example.com/api?foo=bar'
     )
   })
 })

--- a/packages/toolkit/src/query/utils/joinUrls.ts
+++ b/packages/toolkit/src/query/utils/joinUrls.ts
@@ -20,7 +20,6 @@ export function joinUrls(
 
   base = withoutTrailingSlash(base)
   url = withoutLeadingSlash(url)
-  const delimiter = url.startsWith('?') ? '' : '/'
 
-  return `${base}${delimiter}${url}`;
+  return `${base}/${url}`
 }


### PR DESCRIPTION
Reverts reduxjs/redux-toolkit#2465