### PR TITLE
Ensures there is no unexpected slash in url before query params

### DIFF
--- a/packages/toolkit/src/query/tests/utils.test.ts
+++ b/packages/toolkit/src/query/tests/utils.test.ts
@@ -83,6 +83,12 @@ describe('joinUrls', () => {
 
     expect(joinUrls('', '/banana')).toBe('/banana')
     expect(joinUrls('', 'banana')).toBe('banana')
+
+    expect(joinUrls('/api', '?a=1')).toBe('/api?a=1')
+    expect(joinUrls('/api/', '?a=1')).toBe('/api/?a=1')
+
+    expect(joinUrls('/api', 'banana?a=1')).toBe('/api/banana?a=1')
+    expect(joinUrls('/api/', 'banana/?a=1')).toBe('/api/banana/?a=1')
   })
 
   test('correctly joins variations of absolute urls', () => {

--- a/packages/toolkit/src/query/tests/utils.test.ts
+++ b/packages/toolkit/src/query/tests/utils.test.ts
@@ -74,37 +74,25 @@ describe('isDocumentVisible', () => {
 })
 
 describe('joinUrls', () => {
-  test('correctly joins variations of relative urls', () => {
-    expect(joinUrls('/api/', '/banana')).toBe('/api/banana')
-    expect(joinUrls('/api/', 'banana')).toBe('/api/banana')
-
-    expect(joinUrls('/api', 'banana')).toBe('/api/banana')
-    expect(joinUrls('/api', '/banana/')).toBe('/api/banana/')
-
-    expect(joinUrls('', '/banana')).toBe('/banana')
-    expect(joinUrls('', 'banana')).toBe('banana')
-
-    expect(joinUrls('/api', '?a=1')).toBe('/api?a=1')
-    expect(joinUrls('/api/', '?a=1')).toBe('/api/?a=1')
-
-    expect(joinUrls('/api', 'banana?a=1')).toBe('/api/banana?a=1')
-    expect(joinUrls('/api/', 'banana/?a=1')).toBe('/api/banana/?a=1')
-  })
-
-  test('correctly joins variations of absolute urls', () => {
-    expect(joinUrls('https://example.com/api', 'banana')).toBe(
-      'https://example.com/api/banana'
-    )
-    expect(joinUrls('https://example.com/api', '/banana')).toBe(
-      'https://example.com/api/banana'
-    )
-
-    expect(joinUrls('https://example.com/api/', 'banana')).toBe(
-      'https://example.com/api/banana'
-    )
-    expect(joinUrls('https://example.com/api/', '/banana/')).toBe(
-      'https://example.com/api/banana/'
-    )
+  test.each([
+    ['/api/', '/banana', '/api/banana'],
+    ['/api/', 'banana', '/api/banana'],
+    ['/api', '/banana', '/api/banana'],
+    ['/api', 'banana', '/api/banana'],
+    ['', '/banana', '/banana'],
+    ['', 'banana', 'banana'],
+    ['api', '?a=1', 'api?a=1'],
+    ['api/', '?a=1', 'api/?a=1'],
+    ['api', 'banana?a=1', 'api/banana?a=1'],
+    ['api/', 'banana?a=1', 'api/banana?a=1'],
+    ['https://example.com/api', 'banana', 'https://example.com/api/banana'],
+    ['https://example.com/api', '/banana', 'https://example.com/api/banana'],
+    ['https://example.com/api/', 'banana', 'https://example.com/api/banana'],
+    ['https://example.com/api/', '/banana', 'https://example.com/api/banana'],
+    ['https://example.com/api/', 'https://example.org', 'https://example.org'],
+    ['https://example.com/api/', '//example.org', '//example.org'],
+  ])('%s and %s join to %s', (base, url, expected) => {
+    expect(joinUrls(base, url)).toBe(expected)
   })
 })
 

--- a/packages/toolkit/src/query/utils/joinUrls.ts
+++ b/packages/toolkit/src/query/utils/joinUrls.ts
@@ -18,8 +18,9 @@ export function joinUrls(
     return url
   }
 
+  const delimiter = base.endsWith('/') || !url.startsWith('?') ? '/' : ''
   base = withoutTrailingSlash(base)
   url = withoutLeadingSlash(url)
 
-  return `${base}/${url}`
+  return `${base}${delimiter}${url}`;
 }


### PR DESCRIPTION
Fixes reduxjs/redux-toolkit#2379