### PR TITLE
[breaking fix]  replace `getRunningOperationPromise(s)` with `getRunning(Query|Queries|Mutation|Mutations)Thunk`

### DIFF
--- a/docs/rtk-query/api/created-api/api-slice-utils.mdx
+++ b/docs/rtk-query/api/created-api/api-slice-utils.mdx
@@ -249,53 +249,59 @@ Note that [hooks](./hooks.mdx) also track state in local component state and mig
 dispatch(api.util.resetApiState())
 ```
 
-## `getRunningOperationPromises`
+## `getRunningQueriesThunk` and `getRunningMutationsThunk`
 
 #### Signature
 
 ```ts no-transpile
-getRunningOperationPromises: () => Array<Promise<unknown>>
+getRunningQueriesThunk(): ThunkWithReturnValue<Array<QueryActionCreatorResult<any>>>
+getRunningMutationsThunk(): ThunkWithReturnValue<Array<MutationActionCreatorResult<any>>>
 ```
 
 #### Description
 
-A function that returns all promises for running queries and mutations.
+Thunks that (if dispatched) return either all running queries or mutations.
+These returned values can be awaited like promises.
 
-This is useful for SSR scenarios to await everything triggered in any way, including via hook calls,
+This is useful for SSR scenarios to await all queries (or mutations) triggered in any way, including via hook calls
 or manually dispatching `initiate` actions.
 
-```ts no-transpile title="Awaiting all currently running queries & mutations example"
-await Promise.all(api.util.getRunningOperationPromises())
+```ts no-transpile title="Awaiting all currently running queries example"
+await Promise.all(dispatch(api.util.getRunningQueriesThunk()))
 ```
 
-## `getRunningOperationPromise`
+## `getRunningQueryThunk` and `getRunningMutationThunk`
 
 #### Signature
 
 ```ts no-transpile
-getRunningOperationPromise: <EndpointName extends QueryKeys<Definitions>>(
+getRunningQueryThunk<EndpointName extends QueryKeys<Definitions>>(
   endpointName: EndpointName,
   args: QueryArgFrom<Definitions[EndpointName]>
-) =>
-  | QueryActionCreatorResult<Definitions[EndpointName]>
+): ThunkWithReturnValue<
+  | QueryActionCreatorResult<
+      Definitions[EndpointName] & { type: 'query' }
+    >
   | undefined
+>
 
-getRunningOperationPromise: <EndpointName extends MutationKeys<Definitions>>(
+getRunningMutationThunk<EndpointName extends MutationKeys<Definitions>>(
   endpointName: EndpointName,
   fixedCacheKeyOrRequestId: string
-) =>
-  | MutationActionCreatorResult<Definitions[EndpointName]>
+): ThunkWithReturnValue<
+  | MutationActionCreatorResult<
+      Definitions[EndpointName] & { type: 'mutation' }
+    >
   | undefined
+>
 ```
 
 #### Description
 
-A function that returns a single promise for a given endpoint name + argument combination,
-if it is currently running. If it is not currently running, the function returns `undefined`.
+Thunks that (if dispatched) return a single running query (or mutation) for a given
+endpoint name + argument (or requestId/fixedCacheKey) combination, if it is currently running.
+If it is not currently running, the function returns `undefined`.
 
-When used with mutation endpoints, it accepts a [fixed cache key](./hooks.mdx#signature-1)
-or request ID rather than the argument.
-
-This is primarily added to add experimental support for suspense in the future.
-It enables writing custom hooks that look up if RTK Query has already got a running promise
-for a certain endpoint/argument combination, and retrieving that promise to `throw` it.
+These thunks are primarily added to add experimental support for suspense in the future.
+They enable writing custom hooks that look up if RTK Query has already got a running query/mutation
+for a certain endpoint/argument combination, and retrieving that to `throw` it as a promise.

--- a/docs/rtk-query/api/created-api/overview.mdx
+++ b/docs/rtk-query/api/created-api/overview.mdx
@@ -53,20 +53,29 @@ type Api = {
       Array<TagTypes | FullTagDescription<TagTypes>>,
       string
     >
-    resetApiState: SliceActions['resetApiState']
-    getRunningOperationPromises: () => Array<Promise<unknown>>
-    getRunningOperationPromise: <EndpointName extends QueryKeys<Definitions>>(
+    selectInvalidatedBy: (
+      state: FullState,
+      tags: Array<TagTypes | FullTagDescription<TagTypes>>
+    ) => Array<{
+      endpointName: string
+      originalArgs: any
+      queryCacheKey: string
+    }>
+    resetApiState: ActionCreator<ResetAction>
+    getRunningQueryThunk(
       endpointName: EndpointName,
-      args: QueryArgFrom<Definitions[EndpointName]>
-    ) =>
-      | QueryActionCreatorResult<Definitions[EndpointName]>
-      | undefined
-    getRunningOperationPromise: <EndpointName extends MutationKeys<Definitions>>(
+      args: QueryArg
+    ): ThunkWithReturnValue<QueryActionCreatorResult | undefined>
+    getRunningMutationThunk(
       endpointName: EndpointName,
       fixedCacheKeyOrRequestId: string
-    ) =>
-      | MutationActionCreatorResult<Definitions[EndpointName]>
-      | undefined
+    ): ThunkWithReturnValue<MutationActionCreatorResult | undefined>
+    getRunningQueriesThunk(): ThunkWithReturnValue<
+      Array<QueryActionCreatorResult<any>>
+    >
+    getRunningMutationsThunk(): ThunkWithReturnValue<
+      Array<MutationActionCreatorResult<any>>
+    >
   }
 
   // Internal actions

--- a/docs/rtk-query/usage/server-side-rendering.mdx
+++ b/docs/rtk-query/usage/server-side-rendering.mdx
@@ -21,7 +21,7 @@ The workflow is as follows:
 - Set up `next-redux-wrapper`
 - In `getStaticProps` or `getServerSideProps`:
   - Pre-fetch all queries via the `initiate` actions, e.g. `store.dispatch(api.endpoints.getPokemonByName.initiate(name))`
-  - Wait for each query to finish using `await Promise.all(api.util.getRunningOperationPromises())`
+  - Wait for each query to finish using `await Promise.all(dispatch(api.util.getRunningQueriesThunk()))`
 - In your `createApi` call, configure rehydration using the `extractRehydrationInfo` option:
 
   [examples](docblock://query/createApi.ts?token=CreateApiOptions.extractRehydrationInfo)
@@ -56,4 +56,4 @@ The workflow is as follows:
   [examples](docblock://query/react/module.ts?token=ReactHooksModuleOptions.unstable__sideEffectsInRender)
 
 - Use your custom `createApi` when calling `const api = createApi({...})`
-- Wait for all queries to finish using `await Promise.all(api.util.getRunningOperationPromises())` before performing the next render cycle
+- Wait for all queries to finish using `await Promise.all(dispatch(api.util.getRunningQueriesThunk()))` before performing the next render cycle

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -15,6 +15,7 @@ import type { ApiEndpointQuery } from './module'
 import type { BaseQueryError, QueryReturnValue } from '../baseQueryTypes'
 import type { QueryResultSelectorResult } from './buildSelectors'
 import type { Dispatch } from 'redux'
+import { isNotNullish } from '../utils/isNotNullish'
 
 declare module './module' {
   export interface ApiEndpointQuery<
@@ -218,6 +219,37 @@ export function buildInitiate({
     getRunningMutationThunk,
     getRunningQueriesThunk,
     getRunningMutationsThunk,
+    getRunningOperationPromises,
+    removalWarning,
+  }
+
+  /** @deprecated to be removed in 2.0 */
+  function removalWarning(): never {
+    throw new Error(
+      `This method had to be removed due to a conceptual bug in RTK.
+       Please see https://github.com/reduxjs/redux-toolkit/pull/2481 for details.
+       See https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering for new guidance on SSR.`
+    )
+  }
+
+  /** @deprecated to be removed in 2.0 */
+  function getRunningOperationPromises() {
+    if (
+      typeof process !== 'undefined' &&
+      process.env.NODE_ENV === 'development'
+    ) {
+      removalWarning()
+    } else {
+      const extract = <T>(
+        v: Map<Dispatch<AnyAction>, Record<string, T | undefined>>
+      ) =>
+        Array.from(v.values()).flatMap((queriesForStore) =>
+          queriesForStore ? Object.values(queriesForStore) : []
+        )
+      return [...extract(runningQueries), ...extract(runningMutations)].filter(
+        isNotNullish
+      )
+    }
   }
 
   function getRunningQueryThunk(endpointName: string, queryArgs: any) {
@@ -251,16 +283,12 @@ export function buildInitiate({
 
   function getRunningQueriesThunk() {
     return (dispatch: Dispatch) =>
-      Object.values(runningQueries.get(dispatch) || {}).filter(
-        <T>(t: T | undefined): t is T => !!t
-      )
+      Object.values(runningQueries.get(dispatch) || {}).filter(isNotNullish)
   }
 
   function getRunningMutationsThunk() {
     return (dispatch: Dispatch) =>
-      Object.values(runningMutations.get(dispatch) || {}).filter(
-        <T>(t: T | undefined): t is T => !!t
-      )
+      Object.values(runningMutations.get(dispatch) || {}).filter(isNotNullish)
   }
 
   function middlewareWarning(getState: () => RootState<{}, string, string>) {

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -142,7 +142,12 @@ declare module '../apiTypes' {
          * Useful for SSR scenarios to await everything triggered in any way,
          * including via hook calls, or manually dispatching `initiate` actions.
          */
-        getRunningOperationPromises: () => Array<Promise<unknown>>
+        getRunningOperationPromises: () => ThunkAction<
+          Array<Promise<unknown>>,
+          any,
+          any,
+          AnyAction
+        >
         /**
          * If a promise is running for a given endpoint name + argument combination,
          * returns that promise. Otherwise, returns `undefined`.
@@ -152,21 +157,29 @@ declare module '../apiTypes' {
         getRunningOperationPromise<EndpointName extends QueryKeys<Definitions>>(
           endpointName: EndpointName,
           args: QueryArgFrom<Definitions[EndpointName]>
-        ):
+        ): ThunkAction<
           | QueryActionCreatorResult<
               Definitions[EndpointName] & { type: 'query' }
             >
-          | undefined
+          | undefined,
+          any,
+          any,
+          AnyAction
+        >
         getRunningOperationPromise<
           EndpointName extends MutationKeys<Definitions>
         >(
           endpointName: EndpointName,
           fixedCacheKeyOrRequestId: string
-        ):
+        ): ThunkAction<
           | MutationActionCreatorResult<
               Definitions[EndpointName] & { type: 'mutation' }
             >
-          | undefined
+          | undefined,
+          any,
+          any,
+          AnyAction
+        >
 
         /**
          * A Redux thunk that can be used to manually trigger pre-fetching of data.

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -142,14 +142,22 @@ declare module '../apiTypes' {
       util: {
         /**
          * This method had to be removed due to a conceptual bug in RTK.
-         * Please see https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering for details.
+         *
+         * Despite TypeScript errors, it will continue working in the "buggy" way it did
+         * before in production builds and will be removed in the next major release.
+         *
+         * Nonetheless, you should immediately replace it with the new recommended approach.
+         * See https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering for new guidance on SSR.
+         *
+         * Please see https://github.com/reduxjs/redux-toolkit/pull/2481 for details.
          * @deprecated
          */
         getRunningOperationPromises: never // this is now types as `never` to immediately throw TS errors on use, but still allow for a comment
 
         /**
          * This method had to be removed due to a conceptual bug in RTK.
-         * Please see https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering for details.
+         * It has been replaced by `api.util.getRunningQueryThunk` and `api.util.getRunningMutationThunk`.
+         * Please see https://github.com/reduxjs/redux-toolkit/pull/2481 for details.
          * @deprecated
          */
         getRunningOperationPromise: never // this is now types as `never` to immediately throw TS errors on use, but still allow for a comment
@@ -541,6 +549,8 @@ export const coreModule = (): Module<CoreModule> => ({
       getRunningMutationsThunk,
       getRunningQueriesThunk,
       getRunningQueryThunk,
+      getRunningOperationPromises,
+      removalWarning,
     } = buildInitiate({
       queryThunk,
       mutationThunk,
@@ -549,16 +559,9 @@ export const coreModule = (): Module<CoreModule> => ({
       context,
     })
 
-    function removedSSRHelper(): never {
-      throw new Error(
-        `This method had to be removed due to a conceptual bug in RTK.
-         Please see https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering for details.`
-      )
-    }
-
     safeAssign(api.util, {
-      getRunningOperationPromises: removedSSRHelper as any,
-      getRunningOperationPromise: removedSSRHelper as any,
+      getRunningOperationPromises: getRunningOperationPromises as any,
+      getRunningOperationPromise: removalWarning as any,
       getRunningMutationThunk,
       getRunningMutationsThunk,
       getRunningQueryThunk,

--- a/packages/toolkit/src/query/utils/isNotNullish.ts
+++ b/packages/toolkit/src/query/utils/isNotNullish.ts
@@ -1,0 +1,3 @@
+export function isNotNullish<T>(v: T | null | undefined): v is T {
+  return v != null
+}

--- a/packages/toolkit/src/tests/injectableCombineReducers.example.ts
+++ b/packages/toolkit/src/tests/injectableCombineReducers.example.ts
@@ -1,0 +1,63 @@
+/* eslint-disable import/first */
+// @ts-nocheck
+
+// reducer.ts or whatever
+
+import { combineSlices } from '@reduxjs/toolkit'
+
+import { sliceA } from 'fileA'
+import { sliceB } from 'fileB'
+import { lazySliceC } from 'fileC'
+import type { lazySliceD } from 'fileD'
+
+import { anotherReducer } from 'somewhere'
+
+export interface LazyLoadedSlices {}
+
+export const rootReducer = combineSlices(sliceA, sliceB, {
+  another: anotherReducer,
+}).withLazyLoadedSlices<LazyLoadedSlices>()
+/*
+ results in a return type of
+ {
+    [sliceA.name]: SliceAState,
+    [sliceB.name]: SliceBState,
+    another: AnotherState,
+    [lazySliceC.name]?: SliceCState, // see fileC.ts to understand why this appears here
+    [lazySliceD.name]?: SliceDState, // see fileD.ts to understand why this appears here
+ }
+ */
+
+// fileC.ts
+// "naive" approach
+
+import { rootReducer, RootState } from './reducer'
+import { createSlice } from '@reduxjs/toolkit'
+
+interface SliceCState {
+  foo: string
+}
+
+declare module './reducer' {
+  export interface LazyLoadedSlices {
+    [lazySliceC.name]: SliceCState
+  }
+}
+
+export const lazySliceC = createSlice({
+  /* ... */
+})
+/**
+ * Synchronously call `injectSlice` in file.
+ */
+rootReducer.injectSlice(lazySliceC)
+
+// might want to add code for HMR as well here
+
+// this will still error - `lazySliceC` is optional here
+const naiveSelectFoo = (state: RootState) => state.lazySliceC.foo
+
+const selectFoo = rootReducer.withSlice(lazySliceC).selector((state) => {
+  // `lazySlice` is guaranteed to not be `undefined` here.
+  return state.lazySlice.foo
+})


### PR DESCRIPTION
# Motivation

As reported in #2477, currently doing `await api.util.getRunningOperationsPromise()` in a SSR environment will not only await for queries and mutations of the page currently being rendered, but of all other pages being SSRed at the same time. When designing the api, I forgot that multiple SSR renders will likely share the same api instance, but use different stores for that.

Unforunately, with the existing api there is no way fixing this.
The only way of scoping these functions to a certain store is to change the way they are called:

```diff
-await Promise.all(api.util.getRunningOperationPromises())
+await Promise.all(dispatch(api.util.getRunningOperationPromises()))
```

We essentially need to do a "breaking fix", as much as it hurts me.

If doing this change directly on the original methods, old code (without `dispatch`) would keep running without any errors, but get even worse behaviour: all those `await` statements would immediately continue, resolving to the thunk and not waiting for any running queries and mutations.

As this is too much of a foot gun, this PR needs to introduce even bigger changes.

# Changes

* replace `getRunningOperationPromise` and `getRunningOperationsPromise` with stubs that immediately `throw` with a link to the documentation.
* change the type of `getRunningOperationPromise` and `getRunningOperationsPromise` to `never`, but keep them in the types so we can add a link to the documentation there as well (and mark them as @deprecated).
* create four new functions:
  * api.util.getRunningQueryThunk(endpointName, queryArgs)
  * api.util.getRunningMutationThunk(endpointName, fixedCacheKeyOrRequestId)
  * api.util.getRunningQueriesThunk()
  * api.util.getRunningMutationsThunk()

So both functions are split up into two separate functions for queries and mutations, and the word `Promise` has been replaced by `Thunk`.

That changes the usage like this:

```diff
-await Promise.all(api.util.getRunningOperationPromises())
+await Promise.all([
  ...dispatch(api.util.getRunningQueriesThunk()),
  ...dispatch(api.util.getRunningQueriesThunk()),
])
```
or more realistically like this
```diff
-await Promise.all(api.util.getRunningOperationPromises())
+await Promise.all(dispatch(api.util.getRunningQueriesThunk()))
```
as it should almost never happen that a mutation is initiated during SSR.

# The "breaking fix" compromise

I kept in `getRunningOperationPromises` for now. 
**The function will `throw` in development**, but keep it's old faulty behaviour in production builds so things will not immediately break beyond the state it was already broken before.

I could not create a version of `getRunningOperationPromise` that kept the old behaviour, so it throws in both development and production.
Luckily, that function was documented as "primarily added to add experimental support for suspense", so the impact of removing it should be quite low.

# Todos

* [ ] tests
* [ ] update the example SSR repo at https://github.com/phryneas/ssr-experiments (this has to be coordinated with the release of the next RTK version)
* [ ] maybe provide a codemod (that allows to choose between both refactorings above) - could you take a stab at that @markerikson ?