### PR TITLE
remove unnecessary 'debugger' statement

### DIFF
--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -436,7 +436,6 @@ describe('endpoint definition typings', () => {
 
       storeRef.store.dispatch(api.endpoints.query2.initiate('in2'))
       await waitMs(1)
-      debugger
       expect(spy).toHaveBeenCalledWith(
         "Tag type 'missing' was used, but not specified in `tagTypes`!"
       )


### PR DESCRIPTION
found this unnecessary `debugger` statement; think it should be removed