### PR TITLE
Use useDebugValue in useQuery and useMutation hooks

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -4,6 +4,7 @@ import type { Selector } from '@reduxjs/toolkit'
 import type { DependencyList } from 'react'
 import {
   useCallback,
+  useDebugValue,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -856,6 +857,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
               : noPendingQueryStateSelector,
           ...options,
         })
+
+        const { data, status, isLoading, isSuccess, isError, error } = queryStateResults;
+        useDebugValue({ data, status, isLoading, isSuccess, isError, error });
+
         return useMemo(
           () => ({ ...queryStateResults, ...querySubscriptionResults }),
           [queryStateResults, querySubscriptionResults]
@@ -922,6 +927,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           }
         })
       }, [dispatch, fixedCacheKey, promise, requestId])
+
+      const { endpointName, data, status, isLoading, isSuccess, isError, error } = currentState;
+      useDebugValue({ endpointName, data, status, isLoading, isSuccess, isError, error });
+
       const finalState = useMemo(
         () => ({ ...currentState, originalArgs, reset }),
         [currentState, originalArgs, reset]


### PR DESCRIPTION
Fixes #2492
This PR uses `useDebugValue` for better debugging in React DevTools.

This is how a `DebugValue` is shown for a useQuery hook in React DevTools:
![image](https://user-images.githubusercontent.com/11148471/177885712-d57cc304-ebd0-4296-994f-9e9caab614e3.png)

and this is how a `DebugValue` is shown for a useMutation hook in React DevTools:
![image](https://user-images.githubusercontent.com/11148471/177887229-6057b6c5-7df9-4d56-a84c-a7dfb1fd9ad2.png)