### PR TITLE
Downgrade msw to v40.2 in some usage examples

### DIFF
--- a/examples/query/react/authentication-with-extrareducers/package.json
+++ b/examples/query/react/authentication-with-extrareducers/package.json
@@ -11,7 +11,7 @@
     "@emotion/styled": "^11.3.0",
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/authentication/package.json
+++ b/examples/query/react/authentication/package.json
@@ -11,7 +11,7 @@
     "@emotion/styled": "^11.3.0",
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/kitchen-sink/package.json
+++ b/examples/query/react/kitchen-sink/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.tsx",
   "dependencies": {
     "@reduxjs/toolkit": "1.8.1",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-redux": "^8.0.2",

--- a/examples/query/react/mutations/package.json
+++ b/examples/query/react/mutations/package.json
@@ -12,7 +12,7 @@
     "@mswjs/data": "^0.3.0",
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/optimistic-update/package.json
+++ b/examples/query/react/optimistic-update/package.json
@@ -12,7 +12,7 @@
     "@mswjs/data": "^0.3.0",
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/pagination/package.json
+++ b/examples/query/react/pagination/package.json
@@ -13,7 +13,7 @@
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "faker": "^5.5.3",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/prefetching-automatic-waterfall/package.json
+++ b/examples/query/react/prefetching-automatic-waterfall/package.json
@@ -13,7 +13,7 @@
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "faker": "^5.5.3",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/prefetching-automatic/package.json
+++ b/examples/query/react/prefetching-automatic/package.json
@@ -13,7 +13,7 @@
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "faker": "^5.5.3",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/examples/query/react/prefetching/package.json
+++ b/examples/query/react/prefetching/package.json
@@ -13,7 +13,7 @@
     "@reduxjs/toolkit": "^1.6.0-rc.1",
     "faker": "^5.5.3",
     "framer-motion": "^2.9.5",
-    "msw": "^0.41.1",
+    "msw": "^0.40.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3720,7 +3720,7 @@ __metadata:
     "@types/react": ^18.0.5
     "@types/react-dom": ^18.0.5
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -3742,7 +3742,7 @@ __metadata:
     "@types/react": ^18.0.5
     "@types/react-dom": ^18.0.5
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -3881,7 +3881,7 @@ __metadata:
     "@types/node": ^14.14.6
     "@types/react": ^18.0.5
     "@types/react-dom": ^18.0.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-redux: ^8.0.2
@@ -3927,7 +3927,7 @@ __metadata:
     "@types/react": ^18.0.5
     "@types/react-dom": ^18.0.5
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -18949,6 +18949,40 @@ fsevents@^1.2.7:
   bin:
     msw: cli/index.js
   checksum: bfcac14831d88ebee0375933a84294696410a2f93a8dd0cf0d37fb8f641ce93e9d2d840253fb5755003ea8bd7126dc83bd6844066bf5073f0a264cd8c768dec7
+  languageName: node
+  linkType: hard
+
+"msw@npm:^0.40.2":
+  version: 0.40.2
+  resolution: "msw@npm:0.40.2"
+  dependencies:
+    "@mswjs/cookies": ^0.2.0
+    "@mswjs/interceptors": ^0.15.1
+    "@open-draft/until": ^1.0.3
+    "@types/cookie": ^0.4.1
+    "@types/js-levenshtein": ^1.1.1
+    chalk: 4.1.1
+    chokidar: ^3.4.2
+    cookie: ^0.4.2
+    graphql: ^16.3.0
+    headers-polyfill: ^3.0.4
+    inquirer: ^8.2.0
+    is-node-process: ^1.0.1
+    js-levenshtein: ^1.1.6
+    node-fetch: ^2.6.7
+    path-to-regexp: ^6.2.0
+    statuses: ^2.0.0
+    strict-event-emitter: ^0.2.0
+    type-fest: ^1.2.2
+    yargs: ^17.3.1
+  peerDependencies:
+    typescript: ">= 4.2.x <= 4.6.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: a37c3aa79c0fc86499dab70d02942040ce34f16cc7db003c334b2c65b4e5e8236a2a992aa8507b4156188e9ad637c912ff7c02732132278eb6b266ef9982fbf5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3904,7 +3904,7 @@ __metadata:
     "@types/react": ^18.0.5
     "@types/react-dom": ^18.0.5
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -3954,7 +3954,7 @@ __metadata:
     "@types/react-dom": ^18.0.5
     faker: ^5.5.3
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -3994,7 +3994,7 @@ __metadata:
     "@types/react-dom": ^18.0.5
     faker: ^5.5.3
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -4019,7 +4019,7 @@ __metadata:
     "@types/react-dom": ^18.0.5
     faker: ^5.5.3
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0
@@ -4044,7 +4044,7 @@ __metadata:
     "@types/react-dom": ^18.0.5
     faker: ^5.5.3
     framer-motion: ^2.9.5
-    msw: ^0.41.1
+    msw: ^0.40.2
     react: ^18.1.0
     react-dom: ^18.1.0
     react-icons: 3.11.0


### PR DESCRIPTION
While I was going through Redux Toolkit Query documentation, I encountered some errors in some of the usage examples (kitchen sink, optimistic updates, authentication, authentication with extraReducers, mutations, pagination, prefetching, prefetching automatic, prefetching automatic waterfall). After some investigation, I realized that it's because of the version of msw. You can find related issue [here](https://github.com/mswjs/msw/issues/1252). After I downgraded the msw version to 40.2, the problem seems to be solved. You can find the screenshot of one of the broken examples below: 

<img width="715" alt="Screenshot 2022-07-14 at 16 47 08" src="https://user-images.githubusercontent.com/45823795/179011460-1324894b-0338-468c-bc08-9d3b114c8cb3.png">

