### PR TITLE
fix(2448): remove abort controller polyfill

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -553,36 +553,6 @@ export const createAsyncThunk = (() => {
         })
       )
 
-    let displayedWarning = false
-
-    const AC =
-      typeof AbortController !== 'undefined'
-        ? AbortController
-        : class implements AbortController {
-            signal = {
-              aborted: false,
-              addEventListener() {},
-              dispatchEvent() {
-                return false
-              },
-              onabort() {},
-              removeEventListener() {},
-              reason: undefined,
-              throwIfAborted() {},
-            }
-            abort() {
-              if (process.env.NODE_ENV !== 'production') {
-                if (!displayedWarning) {
-                  displayedWarning = true
-                  console.info(
-                    `This platform does not implement AbortController. 
-If you want to use the AbortController to react to \`abort\` events, please consider importing a polyfill like 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'.`
-                  )
-                }
-              }
-            }
-          }
-
     function actionCreator(
       arg: ThunkArg
     ): AsyncThunkAction<Returned, ThunkArg, ThunkApiConfig> {
@@ -591,10 +561,9 @@ If you want to use the AbortController to react to \`abort\` events, please cons
           ? options.idGenerator(arg)
           : nanoid()
 
-        const abortController = new AC()
+        const abortController = new AbortController()
         let abortReason: string | undefined
 
-        let started = false
         function abort(reason?: string) {
           abortReason = reason
           abortController.abort()
@@ -615,7 +584,6 @@ If you want to use the AbortController to react to \`abort\` events, please cons
                 message: 'Aborted due to condition callback returning false.',
               }
             }
-            started = true
 
             const abortedPromise = new Promise<never>((_, reject) =>
               abortController.signal.addEventListener('abort', () =>

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -505,7 +505,7 @@ describe('createAsyncThunk with abortController', () => {
       vi.resetModules()
     })
 
-    test('calling `abort` on an asyncThunk works with a FallbackAbortController if no global abortController is not available', async () => {
+    test('calling a thunk made with createAsyncThunk should fail if no global abortController is not available', async () => {
       const longRunningAsyncThunk = freshlyLoadedModule.createAsyncThunk(
         'longRunning',
         async () => {
@@ -513,14 +513,7 @@ describe('createAsyncThunk with abortController', () => {
         }
       )
 
-      store.dispatch(longRunningAsyncThunk()).abort()
-      // should only log once, even if called twice
-      store.dispatch(longRunningAsyncThunk()).abort()
-
-      expect(getLog().log).toMatchInlineSnapshot(`
-        "This platform does not implement AbortController. 
-        If you want to use the AbortController to react to \`abort\` events, please consider importing a polyfill like 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'."
-      `)
+      expect(longRunningAsyncThunk()).toThrow("AbortController is not defined")
     })
   })
 })


### PR DESCRIPTION
# Description 

In this PR we remove abort controller https://github.com/reduxjs/redux-toolkit/issues/2448 

Where should I add in the docs that ?
- For people that are using redux with a node.js server they:
    - need node.js 15 or have to polyfill `AbortController`

I'll update specs and add docs if we are ok 