### PR TITLE
Add runtime deprecation warning for reducer object notation

### DIFF
--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -80,6 +80,8 @@ export type ReducerWithInitialState<S extends NotFunction<any>> = Reducer<S> & {
   getInitialState: () => S
 }
 
+let hasWarnedAboutObjectNotation = false
+
 /**
  * A utility function that allows defining a reducer as a mapping from action
  * type to *case reducer* functions that handle these action types. The
@@ -219,6 +221,17 @@ export function createReducer<S extends NotFunction<any>>(
   actionMatchers: ReadonlyActionMatcherDescriptionCollection<S> = [],
   defaultCaseReducer?: CaseReducer<S>
 ): ReducerWithInitialState<S> {
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof mapOrBuilderCallback === 'object') {
+      if (!hasWarnedAboutObjectNotation) {
+        hasWarnedAboutObjectNotation = true
+        console.warn(
+          "The object notation for `createReducer` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createReducer"
+        )
+      }
+    }
+  }
+
   let [actionsMap, finalActionMatchers, finalDefaultCaseReducer] =
     typeof mapOrBuilderCallback === 'function'
       ? executeReducerBuilderCallback(mapOrBuilderCallback)

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -19,6 +19,8 @@ import { executeReducerBuilderCallback } from './mapBuilders'
 import type { NoInfer } from './tsHelpers'
 import { freezeDraftable } from './utils'
 
+let hasWarnedAboutObjectNotation = false
+
 /**
  * An action creator attached to a slice.
  *
@@ -243,15 +245,16 @@ type SliceDefinedCaseReducers<CaseReducers extends SliceCaseReducers<any>> = {
 export type ValidateSliceCaseReducers<
   S,
   ACR extends SliceCaseReducers<S>
-> = ACR & {
-  [T in keyof ACR]: ACR[T] extends {
-    reducer(s: S, action?: infer A): any
+> = ACR &
+  {
+    [T in keyof ACR]: ACR[T] extends {
+      reducer(s: S, action?: infer A): any
+    }
+      ? {
+          prepare(...a: never[]): Omit<A, 'type'>
+        }
+      : {}
   }
-    ? {
-        prepare(...a: never[]): Omit<A, 'type'>
-      }
-    : {}
-}
 
 function getType(slice: string, actionKey: string): string {
   return `${slice}/${actionKey}`
@@ -283,8 +286,10 @@ export function createSlice<
     typeof process !== 'undefined' &&
     process.env.NODE_ENV === 'development'
   ) {
-    if(options.initialState === undefined) {
-      console.error('You must provide an `initialState` value that is not `undefined`. You may have misspelled `initialState`')
+    if (options.initialState === undefined) {
+      console.error(
+        'You must provide an `initialState` value that is not `undefined`. You may have misspelled `initialState`'
+      )
     }
   }
 
@@ -323,6 +328,16 @@ export function createSlice<
   })
 
   function buildReducer() {
+    if (process.env.NODE_ENV !== 'production') {
+      if (typeof options.extraReducers === 'object') {
+        if (!hasWarnedAboutObjectNotation) {
+          hasWarnedAboutObjectNotation = true
+          console.warn(
+            "The object notation for `createSlice.extraReducers` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createSlice"
+          )
+        }
+      }
+    }
     const [
       extraReducers = {},
       actionMatchers = [],
@@ -333,12 +348,18 @@ export function createSlice<
         : [options.extraReducers]
 
     const finalCaseReducers = { ...extraReducers, ...sliceCaseReducersByType }
-    return createReducer(
-      initialState,
-      finalCaseReducers as any,
-      actionMatchers,
-      defaultCaseReducer
-    )
+
+    return createReducer(initialState, (builder) => {
+      for (let key in finalCaseReducers) {
+        builder.addCase(key, finalCaseReducers[key] as CaseReducer<any>)
+      }
+      for (let m of actionMatchers) {
+        builder.addMatcher(m.matcher, m.reducer)
+      }
+      if (defaultCaseReducer) {
+        builder.addDefaultCase(defaultCaseReducer)
+      }
+    })
   }
 
   let _reducer: ReducerWithInitialState<State>


### PR DESCRIPTION
The initial prototype of RTK started out with `createReducer`, and accepted an object with string action type keys, like `{"ADD_TODO": (state, action) => {})`.  This was based on other existing libraries like `redux-actions`, the "Reducing Boilerplate" example in the docs, and the five gazillion other reducer lookup table utils.

In 0.4.1, we added the `extraReducers` field to let `createSlice` respond to other actions defined outside the slice.  That again was originally just an object.

We later [added the "builder callback" notation](https://github.com/reduxjs/redux-toolkit/pull/262) ([API docs ref](https://redux-toolkit.js.org/api/createReducer#usage-with-the-builder-callback-notation)) to both `createReducer` and `createSlice` to address a few major weaknesses with the object form:

- When you define an object with string type keys, TS cannot infer what the right TS type is for the action object, so you end up having to supply that manually.  That's repetitive, especially given that you probably defined that TS type with `createAction` or `createSlice`
- There was no way to add a default case to `createReducer`
- We also wanted the ability to add arbitrary matching logic, beyond exact action type string matching

At first the builder notation was secondary. But, over time, we switched our docs to show the builder as primary in both the API reference and the "Essentials" tutorial, especially as we continued to see more users trying to use RTK with TS and struggle with getting the TS types for the actions right.

**We intend to remove the object form in RTK 2.0, so that the "builder callback" is the _only_ way to add cases to `createReducer` and `createSlice.extraReducers`** (the `createSlice.reducers` object will stay the same).  So, we're adding a once-per-load runtime warning to both `createReducer` and `createSlice.extraReducers` if you pass in an object for either of those.

Code-wise, the "builder" form is essentially the same number of LOC as the object form.  It's clearer, more flexible, and vastly better with TS.

We've got codemods over in #2303 that we'll release alongside RTK 2.0 to make that transition easier.  (Actually, we probably oughta release them alongside 1.9 now that I think about it...