### PR TITLE
Update RDT options types, and export those + AnyListenerPredicate

### DIFF
--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -11,7 +11,7 @@ import type {
   CombinedState,
 } from 'redux'
 import { createStore, compose, applyMiddleware, combineReducers } from 'redux'
-import type { EnhancerOptions as DevToolsOptions } from './devtoolsExtension'
+import type { DevToolsEnhancerOptions as DevToolsOptions } from './devtoolsExtension'
 import { composeWithDevTools } from './devtoolsExtension'
 
 import isPlainObject from './isPlainObject'
@@ -52,7 +52,7 @@ export interface ConfigureStoreOptions<
   /**
    * An array of Redux middleware to install. If not supplied, defaults to
    * the set of middleware returned by `getDefaultMiddleware()`.
-   * 
+   *
    * @example `middleware: (gDM) => gDM().concat(logger, apiMiddleware, yourCustomMiddleware)`
    * @see https://redux-toolkit.js.org/api/getDefaultMiddleware#intended-usage
    */

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -34,6 +34,7 @@ export type {
   ConfigureStoreOptions,
   EnhancedStore,
 } from './configureStore'
+export type { DevToolsEnhancerOptions } from './devtoolsExtension'
 export {
   // js
   createAction,
@@ -174,6 +175,7 @@ export type {
   TaskResolved,
   TaskResult,
 } from './listenerMiddleware/index'
+export type { AnyListenerPredicate } from './listenerMiddleware/types'
 
 export {
   createListenerMiddleware,


### PR DESCRIPTION
This PR:

- Copies over the latest-latest changes to the Redux DevTools options types (last updated just a few days ago)
- Exports the `DevToolsEnhancerOptions` type, which I've had to hackily grab out over in Replay
- Exports the `AnyListenerPredicate` type, which is needed for that silly `listenForCondition` hack

Fixes #2515 