### PR TITLE
Batch RTKQ "subscribe on reject" actions, and improve cache collection timer handling

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
@@ -1,0 +1,57 @@
+import type { QueryThunk, RejectedAction } from '../buildThunks'
+import type { SubMiddlewareBuilder } from './types'
+
+// Copied from https://github.com/feross/queue-microtask
+let promise: Promise<any>
+const queueMicrotaskShim =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask.bind(typeof window !== 'undefined' ? window : global)
+    : // reuse resolved promise, and allocate it lazily
+      (cb: () => void) =>
+        (promise || (promise = Promise.resolve())).then(cb).catch((err: any) =>
+          setTimeout(() => {
+            throw err
+          }, 0)
+        )
+
+export const build: SubMiddlewareBuilder = ({
+  api,
+  context: { apiUid },
+  queryThunk,
+  reducerPath,
+}) => {
+  return (mwApi) => {
+    let abortedQueryActionsQueue: RejectedAction<QueryThunk, any>[] = []
+    let dispatchQueued = false
+
+    return (next) => (action) => {
+      if (queryThunk.rejected.match(action)) {
+        const { condition, arg } = action.meta
+
+        if (condition && arg.subscribe) {
+          // request was aborted due to condition (another query already running)
+          // _Don't_ dispatch right away - queue it for a debounced grouped dispatch
+          abortedQueryActionsQueue.push(action)
+
+          if (!dispatchQueued) {
+            queueMicrotaskShim(() => {
+              mwApi.dispatch(
+                api.internalActions.subscriptionRequestsRejected(
+                  abortedQueryActionsQueue
+                )
+              )
+              abortedQueryActionsQueue = []
+            })
+            dispatchQueued = true
+          }
+          // _Don't_ let the action reach the reducers now!
+          return
+        }
+      }
+
+      const result = next(action)
+
+      return result
+    }
+  }
+}

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -113,6 +113,11 @@ export const build: SubMiddlewareBuilder = ({ reducerPath, api, context }) => {
       ] as QueryDefinition<any, any, any, any>
       const keepUnusedDataFor =
         endpointDefinition?.keepUnusedDataFor ?? config.keepUnusedDataFor
+
+      if (keepUnusedDataFor === Infinity) {
+        // Hey, user said keep this forever!
+        return
+      }
       // Prevent `setTimeout` timers from overflowing a 32-bit internal int, by
       // clamping the max value to be at most 1000ms less than the 32-bit max.
       // Look, a 24.8-day keepalive ought to be enough for anybody, right? :)

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -17,6 +17,7 @@ import { build as buildWindowEventHandling } from './windowEventHandling'
 import { build as buildCacheLifecycle } from './cacheLifecycle'
 import { build as buildQueryLifecycle } from './queryLifecycle'
 import { build as buildDevMiddleware } from './devMiddleware'
+import { build as buildBatchActions } from './batchActions'
 
 export function buildMiddleware<
   Definitions extends EndpointDefinitions,
@@ -38,6 +39,7 @@ export function buildMiddleware<
     buildWindowEventHandling,
     buildCacheLifecycle,
     buildQueryLifecycle,
+    buildBatchActions,
   ].map((build) =>
     build({
       ...(input as any as BuildMiddlewareInput<

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1162,9 +1162,12 @@ describe('hooks tests', () => {
     })
 
     test('useMutation return value contains originalArgs', async () => {
-      const { result } = renderHook(() => api.endpoints.updateUser.useMutation(), {
-        wrapper: storeRef.wrapper,
-      })
+      const { result } = renderHook(
+        () => api.endpoints.updateUser.useMutation(),
+        {
+          wrapper: storeRef.wrapper,
+        }
+      )
       const arg = { name: 'Foo' }
 
       const firstRenderResult = result.current
@@ -1955,13 +1958,13 @@ describe('hooks with createApi defaults set', () => {
 
       const addBtn = screen.getByTestId('addPost')
 
-      await waitFor(() => expect(getRenderCount()).toBe(3))
+      await waitFor(() => expect(getRenderCount()).toBe(4))
 
       fireEvent.click(addBtn)
-      await waitFor(() => expect(getRenderCount()).toBe(5))
+      await waitFor(() => expect(getRenderCount()).toBe(6))
       fireEvent.click(addBtn)
       fireEvent.click(addBtn)
-      await waitFor(() => expect(getRenderCount()).toBe(7))
+      await waitFor(() => expect(getRenderCount()).toBe(8))
     })
 
     test('useQuery with selectFromResult option serves a deeply memoized value and does not rerender unnecessarily', async () => {

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -101,6 +101,10 @@ describe(`query: await cleanup, keepUnusedDataFor set`, () => {
           query: () => '/success',
           keepUnusedDataFor: 0,
         }),
+        query4: build.query<unknown, string>({
+          query: () => '/success',
+          keepUnusedDataFor: Infinity,
+        }),
       }),
       keepUnusedDataFor: 29,
     })
@@ -126,8 +130,17 @@ describe(`query: await cleanup, keepUnusedDataFor set`, () => {
     expect(onCleanup).not.toHaveBeenCalled()
     store.dispatch(api.endpoints.query3.initiate('arg')).unsubscribe()
     expect(onCleanup).not.toHaveBeenCalled()
-    jest.advanceTimersByTime(1), await waitMs()
+    jest.advanceTimersByTime(1)
+    await waitMs()
     expect(onCleanup).toHaveBeenCalled()
+  })
+
+  test('endpoint keepUnusedDataFor: Infinity', async () => {
+    expect(onCleanup).not.toHaveBeenCalled()
+    store.dispatch(api.endpoints.query4.initiate('arg')).unsubscribe()
+    expect(onCleanup).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(THIRTY_TWO_BIT_MAX_INT)
+    expect(onCleanup).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -176,14 +176,16 @@ export function setupApiStore<
 >(
   api: A,
   extraReducers?: R,
-  options: { withoutListeners?: boolean; withoutTestLifecycles?: boolean } = {}
+  options: { withoutListeners?: boolean; withoutTestLifecycles?: boolean, middleware?: Middleware[] } = {}
 ) {
+  const { middleware = [] } = options;
   const getStore = () =>
     configureStore({
       reducer: { api: api.reducer, ...extraReducers },
       middleware: (gdm) =>
         gdm({ serializableCheck: false, immutableCheck: false }).concat(
-          api.middleware
+          api.middleware,
+          ...middleware
         ),
     })
 

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -21,6 +21,10 @@ const { getPosts } = api.endpoints
 
 const storeRef = setupApiStore(api)
 
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 const getSubscribersForQueryCacheKey = (queryCacheKey: string) =>
   storeRef.store.getState()[api.reducerPath].subscriptions[queryCacheKey] || {}
 const createSubscriptionGetter = (queryCacheKey: string) => () =>
@@ -78,6 +82,8 @@ describe('polling tests', () => {
         subscribe: true,
       })
     )
+
+    await delay(10)
 
     const getSubs = createSubscriptionGetter(subscriptionOne.queryCacheKey)
 

--- a/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
+++ b/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
@@ -271,14 +271,14 @@ describe('fixedCacheKey', () => {
   test('a component without `fixedCacheKey` has `originalArgs`', async () => {
     render(<Component name="C1" />, {
       wrapper: storeRef.wrapper,
-      legacyRoot: true,
     })
     let c1 = screen.getByTestId('C1')
     expect(getByTestId(c1, 'status').textContent).toBe('uninitialized')
     expect(getByTestId(c1, 'originalArgs').textContent).toBe('undefined')
 
-    act(() => {
+    await act(async () => {
       getByTestId(c1, 'trigger').click()
+      await Promise.resolve()
     })
 
     expect(getByTestId(c1, 'originalArgs').textContent).toBe('C1')
@@ -312,15 +312,16 @@ describe('fixedCacheKey', () => {
         <Component name="C1" fixedCacheKey="test" value={p1} />
         <Component name="C2" fixedCacheKey="test" value={p2} />
       </>,
-      { wrapper: storeRef.wrapper, legacyRoot: true }
+      { wrapper: storeRef.wrapper }
     )
     const c1 = screen.getByTestId('C1')
     const c2 = screen.getByTestId('C2')
     expect(getByTestId(c1, 'status').textContent).toBe('uninitialized')
     expect(getByTestId(c2, 'status').textContent).toBe('uninitialized')
 
-    act(() => {
+    await act(async () => {
       getByTestId(c1, 'trigger').click()
+      await Promise.resolve()
     })
 
     expect(getByTestId(c1, 'status').textContent).toBe('pending')
@@ -333,8 +334,9 @@ describe('fixedCacheKey', () => {
     expect(getByTestId(c1, 'status').textContent).toBe('pending')
     expect(getByTestId(c1, 'data').textContent).toBe('')
 
-    act(() => {
+    await act(async () => {
       resolve1!('this should not show up any more')
+      await Promise.resolve()
     })
 
     await waitMs()
@@ -342,8 +344,9 @@ describe('fixedCacheKey', () => {
     expect(getByTestId(c1, 'status').textContent).toBe('pending')
     expect(getByTestId(c1, 'data').textContent).toBe('')
 
-    act(() => {
+    await act(async () => {
       resolve2!('this should be visible')
+      await Promise.resolve()
     })
 
     await waitMs()


### PR DESCRIPTION
This PR:

- Rewrites the handling of subscriptions to batch all `rejected` actions (from components subscribing when a cache entry already exists) into a single larger action, for perf
- Fixes some React warnings in tests
- Rewrites `keepUnusedDataFor` and `cacheCollection` handling to only clear timers when subscription counts hit 0, and also accept `keepUnusedDataFor: Infinity`

## Subscription Batching Perf Optimization

When a component mounts and tries to subscribe, it dispatches a thunk. The first thunk dispatched for a given cache entry makes the actual request. Later thunks for the same cache entry will see that the cache entry exists, return `false` from `condition()`, and bail out.  That dispatches a `rejected` action, and the reducer logic listened for that to add the additional subscription entry.

However, this meant that adding N subscriptions to a cache entry would dispatch N + 1 actions: `pending` + `fulfilled` from the first thunk, and N-1 `rejected` actions from all others.

We've had reports that this led to slow perf when rendering large lists of components with query hooks inside.

I've rewritten the logic to catch all `query/rejected` subscription actions within an event loop tick, and dispatch them as a single batched action at the end of the tick with `queueMicrotask`. This drastically minimizes the number of dispatched actions - **for a list of 1000 components all using the same query hook, it went from 1002 actions to 4, and 6.5s to 1s**.

This should hopefully resolve the perf issues that were reported.

## Cache Collection Timers

I was always under the impression that we only set a "no more subscriptions, check to see if we should remove the cache data" time when there are... y'know.... no more subscriptions :)  But turns out we _always_ reset that timer _every_ time a subscription was removed.  I'm not sure how expensive `setTimeout/clearTimeout` are, but those timers were probably getting thrashed a bit.  At least one user did a perf trace and reported that "Install/Remove Timers" was showing up noticeably in the trace.

I've reworked that logic so that we only set the timer once the subscription count reaches 0, as I thought it was originally.

Also, since we recently learned that you can't set JS timers more than 24.8 days due to 32-bit overflow, I've updated it to accept `keepUnusedDataFor: Infinity` as a "keep this forever" flag.