### PR TITLE
Auto batch enhancer

### DIFF
--- a/packages/toolkit/src/autoBatchEnhancer.ts
+++ b/packages/toolkit/src/autoBatchEnhancer.ts
@@ -1,6 +1,6 @@
 import type { StoreEnhancer } from 'redux'
 
-export const autoBatch = 'ReduxToolkit_autoBatch'
+export const shouldAutoBatch = 'RTK_autoBatch'
 
 // Copied from https://github.com/feross/queue-microtask
 let promise: Promise<any>
@@ -43,7 +43,7 @@ export const autoBatchEnhancer =
       },
       dispatch(action: any) {
         try {
-          notifying = !action?.meta?.[autoBatch]
+          notifying = !action?.meta?.[shouldAutoBatch]
           if (notifying) {
             notificationQueued = false
             // if (nextNotification) {

--- a/packages/toolkit/src/autoBatchEnhancer.ts
+++ b/packages/toolkit/src/autoBatchEnhancer.ts
@@ -1,0 +1,47 @@
+import type { StoreEnhancer } from 'redux'
+
+export const autoBatch = 'ReduxToolkit_autoBatch'
+
+export const autoBatchEnhancer =
+  (batchTimeout: number = 0): StoreEnhancer =>
+  (next) =>
+  (...args) => {
+    const store = next(...args)
+
+    let notifying = true
+    let nextNotification: NodeJS.Timeout | undefined = undefined
+    const listeners = new Set<() => void>()
+    const notifyListeners = () => {
+      nextNotification = void listeners.forEach((l) => l())
+    }
+
+    return Object.assign({}, store, {
+      subscribe(listener: () => void) {
+        const wrappedListener: typeof listener = () => notifying && listener()
+        const unsubscribe = store.subscribe(wrappedListener)
+        listeners.add(listener)
+        return () => {
+          unsubscribe()
+          listeners.delete(listener)
+        }
+      },
+      dispatch(action: any) {
+        try {
+          notifying = !action?.meta?.[autoBatch]
+          if (notifying) {
+            if (nextNotification) {
+              nextNotification = void clearTimeout(nextNotification)
+            }
+          } else {
+            nextNotification ||= setTimeout(
+              notifyListeners,
+              batchTimeout
+            ) as any
+          }
+          return store.dispatch(action)
+        } finally {
+          notifying = true
+        }
+      },
+    })
+  }

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -34,7 +34,7 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production'
  * @public
  */
 export type ConfigureEnhancersCallback<E extends Enhancers = Enhancers> = (
-    defaultEnhancers: readonly StoreEnhancer[]
+  defaultEnhancers: readonly StoreEnhancer[]
 ) => [...E]
 
 /**
@@ -104,10 +104,10 @@ type Middlewares<S> = ReadonlyArray<Middleware<{}, S>>
 
 type Enhancers = ReadonlyArray<StoreEnhancer>
 
-interface ToolkitStore<
+export interface ToolkitStore<
   S = any,
   A extends Action = AnyAction,
-  M extends Middlewares<S> = Middlewares<S>,
+  M extends Middlewares<S> = Middlewares<S>
 > extends Store<S, A> {
   /**
    * The `dispatch` method of your store, enhanced by all its middlewares.

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -7,6 +7,7 @@ import { createAction } from './createAction'
 import type { ThunkDispatch } from 'redux-thunk'
 import type { FallbackIfUnknown, Id, IsAny, IsUnknown } from './tsHelpers'
 import { nanoid } from './nanoid'
+import { shouldAutoBatch } from './autoBatchEnhancer'
 
 // @ts-ignore we need the import of these types due to a bundling issue.
 type _Keep = PayloadAction | ActionCreatorWithPreparedPayload<any, unknown>
@@ -550,7 +551,7 @@ export const createAsyncThunk = (() => {
             // TODO: this is a hack to showcase the autobatching behaviour
             // currently there is no way to add `meta` to a "condition rejected"
             // action - that would need to be added
-            ReduxToolkit_autoBatch: true,
+            [shouldAutoBatch]: true,
           },
         })
       )

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -547,6 +547,10 @@ export const createAsyncThunk = (() => {
             requestStatus: 'rejected' as const,
             aborted: error?.name === 'AbortError',
             condition: error?.name === 'ConditionError',
+            // TODO: this is a hack to showcase the autobatching behaviour
+            // currently there is no way to add `meta` to a "condition rejected"
+            // action - that would need to be added
+            ReduxToolkit_autoBatch: true,
           },
         })
       )

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -17,6 +17,7 @@ export type {
 } from 'reselect'
 export { createDraftSafeSelector } from './createDraftSafeSelector'
 export type { ThunkAction, ThunkDispatch, ThunkMiddleware } from 'redux-thunk'
+export { autoBatch, autoBatchEnhancer } from './autoBatchEnhancer'
 
 // We deliberately enable Immer's ES5 support, on the grounds that
 // we assume RTK will be used with React Native and other Proxy-less

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -17,7 +17,7 @@ export type {
 } from 'reselect'
 export { createDraftSafeSelector } from './createDraftSafeSelector'
 export type { ThunkAction, ThunkDispatch, ThunkMiddleware } from 'redux-thunk'
-export { autoBatch, autoBatchEnhancer } from './autoBatchEnhancer'
+export { shouldAutoBatch, autoBatchEnhancer } from './autoBatchEnhancer'
 
 // We deliberately enable Immer's ES5 support, on the grounds that
 // we assume RTK will be used with React Native and other Proxy-less

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -79,9 +79,9 @@ export function buildMiddleware<
 
         const stateBefore = mwApi.getState()
 
-        if (!batchedActionsHandler(action, mwApi, stateBefore)) {
-          return
-        }
+        // if (!batchedActionsHandler(action, mwApi, stateBefore)) {
+        //   return
+        // }
 
         const res = next(action)
 

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -79,9 +79,9 @@ export function buildMiddleware<
 
         const stateBefore = mwApi.getState()
 
-        // if (!batchedActionsHandler(action, mwApi, stateBefore)) {
-        //   return
-        // }
+        if (!batchedActionsHandler(action, mwApi, stateBefore)) {
+          return
+        }
 
         const res = next(action)
 

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -1,6 +1,6 @@
 import type { AnyAction, PayloadAction } from '@reduxjs/toolkit'
 import {
-  autoBatch,
+  shouldAutoBatch,
   combineReducers,
   createAction,
   createSlice,
@@ -90,7 +90,7 @@ const prepareAutoBatched =
   <T>() =>
   (payload: T): { payload: T; meta: unknown } => ({
     payload,
-    meta: { [autoBatch]: true },
+    meta: { [shouldAutoBatch]: true },
   })
 
 export function buildSlice({

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -453,17 +453,17 @@ export function buildSlice({
           }
         })
         // original case added back in as otherwise nothing would happen without the batching middleware
-        // .addCase(
-        //   queryThunk.rejected,
-        //   (draft, { meta: { condition, arg, requestId }, error, payload }) => {
-        //     // request was aborted due to condition (another query already running)
-        //     if (condition && arg.subscribe) {
-        //       const substate = (draft[arg.queryCacheKey] ??= {})
-        //       substate[requestId] =
-        //         arg.subscriptionOptions ?? substate[requestId] ?? {}
-        //     }
-        //   }
-        // )
+        .addCase(
+          queryThunk.rejected,
+          (draft, { meta: { condition, arg, requestId }, error, payload }) => {
+            // request was aborted due to condition (another query already running)
+            if (condition && arg.subscribe) {
+              const substate = (draft[arg.queryCacheKey] ??= {})
+              substate[requestId] =
+                arg.subscriptionOptions ?? substate[requestId] ?? {}
+            }
+          }
+        )
         // update the state to be a new object to be picked up as a "state change"
         // by redux-persist's `autoMergeLevel2`
         .addMatcher(hasRehydrationInfo, (draft) => ({ ...draft }))

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -452,6 +452,18 @@ export function buildSlice({
               arg.subscriptionOptions ?? substate[requestId] ?? {}
           }
         })
+        // original case added back in as otherwise nothing would happen without the batching middleware
+        .addCase(
+          queryThunk.rejected,
+          (draft, { meta: { condition, arg, requestId }, error, payload }) => {
+            // request was aborted due to condition (another query already running)
+            if (condition && arg.subscribe) {
+              const substate = (draft[arg.queryCacheKey] ??= {})
+              substate[requestId] =
+                arg.subscriptionOptions ?? substate[requestId] ?? {}
+            }
+          }
+        )
         // update the state to be a new object to be picked up as a "state change"
         // by redux-persist's `autoMergeLevel2`
         .addMatcher(hasRehydrationInfo, (draft) => ({ ...draft }))

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -453,17 +453,17 @@ export function buildSlice({
           }
         })
         // original case added back in as otherwise nothing would happen without the batching middleware
-        .addCase(
-          queryThunk.rejected,
-          (draft, { meta: { condition, arg, requestId }, error, payload }) => {
-            // request was aborted due to condition (another query already running)
-            if (condition && arg.subscribe) {
-              const substate = (draft[arg.queryCacheKey] ??= {})
-              substate[requestId] =
-                arg.subscriptionOptions ?? substate[requestId] ?? {}
-            }
-          }
-        )
+        // .addCase(
+        //   queryThunk.rejected,
+        //   (draft, { meta: { condition, arg, requestId }, error, payload }) => {
+        //     // request was aborted due to condition (another query already running)
+        //     if (condition && arg.subscribe) {
+        //       const substate = (draft[arg.queryCacheKey] ??= {})
+        //       substate[requestId] =
+        //         arg.subscriptionOptions ?? substate[requestId] ?? {}
+        //     }
+        //   }
+        // )
         // update the state to be a new object to be picked up as a "state change"
         // by redux-persist's `autoMergeLevel2`
         .addMatcher(hasRehydrationInfo, (draft) => ({ ...draft }))

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -38,7 +38,7 @@ import type {
   ThunkDispatch,
   AsyncThunk,
 } from '@reduxjs/toolkit'
-import { createAsyncThunk, autoBatch } from '@reduxjs/toolkit'
+import { createAsyncThunk, shouldAutoBatch } from '@reduxjs/toolkit'
 
 import { HandledError } from '../HandledError'
 
@@ -124,16 +124,16 @@ export type ThunkResult = unknown
 export type ThunkApiMetaConfig = {
   pendingMeta: {
     startedTimeStamp: number
-    [autoBatch]: true
+    [shouldAutoBatch]: true
   }
   fulfilledMeta: {
     fulfilledTimeStamp: number
     baseQueryMeta: unknown
-    [autoBatch]: true
+    [shouldAutoBatch]: true
   }
   rejectedMeta: {
     baseQueryMeta: unknown
-    [autoBatch]: true
+    [shouldAutoBatch]: true
   }
 }
 export type QueryThunk = AsyncThunk<
@@ -403,7 +403,7 @@ export function buildThunks<
         {
           fulfilledTimeStamp: Date.now(),
           baseQueryMeta: result.meta,
-          [autoBatch]: true,
+          [shouldAutoBatch]: true,
         }
       )
     } catch (error) {
@@ -428,7 +428,7 @@ export function buildThunks<
               catchedError.meta,
               arg.originalArgs
             ),
-            { baseQueryMeta: catchedError.meta, [autoBatch]: true }
+            { baseQueryMeta: catchedError.meta, [shouldAutoBatch]: true }
           )
         } catch (e) {
           catchedError = e
@@ -478,7 +478,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeQuery`, executeEndpoint, {
     getPendingMeta() {
-      return { startedTimeStamp: Date.now(), [autoBatch]: true }
+      return { startedTimeStamp: Date.now(), [shouldAutoBatch]: true }
     },
     condition(arg, { getState }) {
       const state = getState()
@@ -512,7 +512,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeMutation`, executeEndpoint, {
     getPendingMeta() {
-      return { startedTimeStamp: Date.now(), [autoBatch]: true }
+      return { startedTimeStamp: Date.now(), [shouldAutoBatch]: true }
     },
   })
 

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -38,7 +38,7 @@ import type {
   ThunkDispatch,
   AsyncThunk,
 } from '@reduxjs/toolkit'
-import { createAsyncThunk } from '@reduxjs/toolkit'
+import { createAsyncThunk, autoBatch } from '@reduxjs/toolkit'
 
 import { HandledError } from '../HandledError'
 
@@ -122,13 +122,18 @@ export interface MutationThunkArg {
 export type ThunkResult = unknown
 
 export type ThunkApiMetaConfig = {
-  pendingMeta: { startedTimeStamp: number }
+  pendingMeta: {
+    startedTimeStamp: number
+    [autoBatch]: true
+  }
   fulfilledMeta: {
     fulfilledTimeStamp: number
     baseQueryMeta: unknown
+    [autoBatch]: true
   }
   rejectedMeta: {
     baseQueryMeta: unknown
+    [autoBatch]: true
   }
 }
 export type QueryThunk = AsyncThunk<
@@ -398,6 +403,7 @@ export function buildThunks<
         {
           fulfilledTimeStamp: Date.now(),
           baseQueryMeta: result.meta,
+          [autoBatch]: true,
         }
       )
     } catch (error) {
@@ -422,7 +428,7 @@ export function buildThunks<
               catchedError.meta,
               arg.originalArgs
             ),
-            { baseQueryMeta: catchedError.meta }
+            { baseQueryMeta: catchedError.meta, [autoBatch]: true }
           )
         } catch (e) {
           catchedError = e
@@ -472,7 +478,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeQuery`, executeEndpoint, {
     getPendingMeta() {
-      return { startedTimeStamp: Date.now() }
+      return { startedTimeStamp: Date.now(), [autoBatch]: true }
     },
     condition(arg, { getState }) {
       const state = getState()
@@ -506,7 +512,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeMutation`, executeEndpoint, {
     getPendingMeta() {
-      return { startedTimeStamp: Date.now() }
+      return { startedTimeStamp: Date.now(), [autoBatch]: true }
     },
   })
 

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -151,7 +151,7 @@ export const reactHooksModule = ({
     })
     safeAssign(anyApi, { usePrefetch })
     // even with React batching completely out of the picture, we should get similar results now
-    // safeAssign(context, { batch })
+    safeAssign(context, { batch })
 
     return {
       injectEndpoint(endpointName, definition) {

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -150,7 +150,8 @@ export const reactHooksModule = ({
       context,
     })
     safeAssign(anyApi, { usePrefetch })
-    safeAssign(context, { batch })
+    // even with React batching completely out of the picture, we should get similar results now
+    // safeAssign(context, { batch })
 
     return {
       injectEndpoint(endpointName, definition) {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1277,8 +1277,13 @@ describe('hooks tests', () => {
       )
 
       userEvent.hover(screen.getByTestId('highPriority'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isFetching').textContent).toBe('true')
+      })
+
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         data: { name: 'Timmy' },
         endpointName: 'getUser',
@@ -1299,7 +1304,7 @@ describe('hooks tests', () => {
       )
 
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         data: { name: 'Timmy' },
         endpointName: 'getUser',
@@ -1347,7 +1352,7 @@ describe('hooks tests', () => {
       userEvent.hover(screen.getByTestId('lowPriority'))
 
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         data: { name: 'Timmy' },
         endpointName: 'getUser',
@@ -1365,7 +1370,7 @@ describe('hooks tests', () => {
       await waitMs()
 
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         data: { name: 'Timmy' },
         endpointName: 'getUser',
@@ -1414,8 +1419,13 @@ describe('hooks tests', () => {
 
       // This should run the query being that we're past the threshold
       userEvent.hover(screen.getByTestId('lowPriority'))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('isFetching').textContent).toBe('true')
+      )
+
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         data: { name: 'Timmy' },
         endpointName: 'getUser',
@@ -1435,7 +1445,7 @@ describe('hooks tests', () => {
       )
 
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         data: { name: 'Timmy' },
         endpointName: 'getUser',
@@ -1482,13 +1492,13 @@ describe('hooks tests', () => {
 
       // Get a snapshot of the last result
       const latestQueryData = api.endpoints.getUser.select(USER_ID)(
-        storeRef.store.getState() as any
+        storeRef.store.getState()
       )
 
       userEvent.hover(screen.getByTestId('lowPriority'))
       //  Serve up the result from the cache being that the condition wasn't met
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual(latestQueryData)
     })
 
@@ -1516,7 +1526,7 @@ describe('hooks tests', () => {
       userEvent.hover(screen.getByTestId('lowPriority'))
 
       expect(
-        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState() as any)
+        api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())
       ).toEqual({
         endpointName: 'getUser',
         isError: false,
@@ -1984,13 +1994,13 @@ describe('hooks with createApi defaults set', () => {
 
       const addBtn = screen.getByTestId('addPost')
 
-      await waitFor(() => expect(getRenderCount()).toBe(4))
+      await waitFor(() => expect(getRenderCount()).toBe(3))
 
       fireEvent.click(addBtn)
-      await waitFor(() => expect(getRenderCount()).toBe(6))
+      await waitFor(() => expect(getRenderCount()).toBe(5))
       fireEvent.click(addBtn)
       fireEvent.click(addBtn)
-      await waitFor(() => expect(getRenderCount()).toBe(8))
+      await waitFor(() => expect(getRenderCount()).toBe(7))
     })
 
     test('useQuery with selectFromResult option serves a deeply memoized value and does not rerender unnecessarily', async () => {
@@ -2355,13 +2365,19 @@ describe('skip behaviour', () => {
     expect(result.current).toEqual(uninitialized)
     expect(subscriptionCount('getUser(1)')).toBe(0)
 
-    rerender([1])
+    act(() => {
+      rerender([1])
+    })
     expect(result.current).toMatchObject({ status: QueryStatus.pending })
     expect(subscriptionCount('getUser(1)')).toBe(1)
 
-    rerender([1, { skip: true }])
+    act(() => {
+      rerender([1, { skip: true }])
+    })
     expect(result.current).toEqual(uninitialized)
     expect(subscriptionCount('getUser(1)')).toBe(0)
+
+    await act(async () => {})
   })
 
   test('skipToken', async () => {
@@ -2379,14 +2395,20 @@ describe('skip behaviour', () => {
     // also no subscription on `getUser(skipToken)` or similar:
     expect(storeRef.store.getState().api.subscriptions).toEqual({})
 
-    rerender([1])
+    act(() => {
+      rerender([1])
+    })
     expect(result.current).toMatchObject({ status: QueryStatus.pending })
     expect(subscriptionCount('getUser(1)')).toBe(1)
     expect(storeRef.store.getState().api.subscriptions).not.toEqual({})
 
-    rerender([skipToken])
+    act(() => {
+      rerender([skipToken])
+    })
     expect(result.current).toEqual(uninitialized)
     expect(subscriptionCount('getUser(1)')).toBe(0)
+
+    await act(async () => {})
   })
 })
 

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -82,7 +82,7 @@ it('only resets the api state when resetApiState is dispatched', async () => {
   expect(storeRef.store.getState()).toEqual(initialState)
 })
 
-describe.only('`merge` callback', () => {
+describe('`merge` callback', () => {
   const baseQuery = (args?: any) => ({ data: args })
 
   interface Todo {

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -157,6 +157,7 @@ test('Minimizes the number of subscription dispatches when multiple components a
   const storeRef = setupApiStore(api, undefined, {
     middleware: [listenerMiddleware.middleware],
     withoutTestLifecycles: true,
+    addAutoBatchEnhancer: true,
   })
 
   let subscribersTriggered = 0

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -152,7 +152,7 @@ test('data stays in store when one component requiring the data stays in the sto
   expect(getSubStateB()).toEqual(statusB)
 })
 
-test.only('Minimizes the number of subscription dispatches when multiple components ask for the same data', async () => {
+test('Minimizes the number of subscription dispatches when multiple components ask for the same data', async () => {
   const listenerMiddleware = createListenerMiddleware()
   const storeRef = setupApiStore(api, undefined, {
     middleware: [listenerMiddleware.middleware],

--- a/packages/toolkit/src/query/tests/errorHandling.test.tsx
+++ b/packages/toolkit/src/query/tests/errorHandling.test.tsx
@@ -6,7 +6,14 @@ import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import axios from 'axios'
 import { expectExactType, hookWaitFor, setupApiStore } from './helpers'
 import { server } from './mocks/server'
-import { fireEvent, render, waitFor, screen, act, renderHook } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  waitFor,
+  screen,
+  act,
+  renderHook,
+} from '@testing-library/react'
 import { useDispatch } from 'react-redux'
 import type { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
 import type { BaseQueryApi } from '../baseQueryTypes'
@@ -131,7 +138,7 @@ describe('query error handling', () => {
       wrapper: storeRef.wrapper,
     })
 
-    await hookWaitFor(() => expect(result.current.isFetching).toBeFalsy())
+    await hookWaitFor(() => expect(result.current.isFetching).toBe(false))
     expect(result.current).toEqual(
       expect.objectContaining({
         isLoading: false,
@@ -147,9 +154,10 @@ describe('query error handling', () => {
       )
     )
 
-    act(() => void result.current.refetch())
+    await act(async () => {
+      await result.current.refetch()
+    })
 
-    await hookWaitFor(() => expect(result.current.isFetching).toBeFalsy())
     expect(result.current).toEqual(
       expect.objectContaining({
         isLoading: false,
@@ -193,9 +201,10 @@ describe('query error handling', () => {
       })
     )
 
-    act(() => void result.current.refetch())
+    await act(async () => {
+      await result.current.refetch()
+    })
 
-    await hookWaitFor(() => expect(result.current.isFetching).toBeFalsy())
     expect(result.current).toEqual(
       expect.objectContaining({
         isLoading: false,

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -179,10 +179,11 @@ export function setupApiStore<
   options: {
     withoutListeners?: boolean
     withoutTestLifecycles?: boolean
+    addAutoBatchEnhancer?: boolean
     middleware?: Middleware[]
   } = {}
 ) {
-  const { middleware = [] } = options
+  const { middleware = [], addAutoBatchEnhancer = true } = options
   const getStore = () =>
     configureStore({
       reducer: { api: api.reducer, ...extraReducers },
@@ -191,7 +192,13 @@ export function setupApiStore<
           api.middleware,
           ...middleware
         ),
-      enhancers: (e) => e.concat(autoBatchEnhancer()),
+      enhancers: (e) => {
+        if (addAutoBatchEnhancer) {
+          return e.concat(autoBatchEnhancer())
+        }
+        // stupid TS `readonly` error if we `return e`
+        return e.concat()
+      },
     })
 
   type StoreType = EnhancedStore<

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -4,7 +4,7 @@ import type {
   Middleware,
   Store,
 } from '@reduxjs/toolkit'
-import { configureStore } from '@reduxjs/toolkit'
+import { configureStore, autoBatchEnhancer } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query'
 import type { Reducer } from 'react'
 import React, { useCallback } from 'react'
@@ -176,9 +176,13 @@ export function setupApiStore<
 >(
   api: A,
   extraReducers?: R,
-  options: { withoutListeners?: boolean; withoutTestLifecycles?: boolean, middleware?: Middleware[] } = {}
+  options: {
+    withoutListeners?: boolean
+    withoutTestLifecycles?: boolean
+    middleware?: Middleware[]
+  } = {}
 ) {
-  const { middleware = [] } = options;
+  const { middleware = [] } = options
   const getStore = () =>
     configureStore({
       reducer: { api: api.reducer, ...extraReducers },
@@ -187,6 +191,7 @@ export function setupApiStore<
           api.middleware,
           ...middleware
         ),
+      enhancers: (e) => e.concat(autoBatchEnhancer(0)),
     })
 
   type StoreType = EnhancedStore<

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -191,7 +191,7 @@ export function setupApiStore<
           api.middleware,
           ...middleware
         ),
-      // enhancers: (e) => e.concat(autoBatchEnhancer(0)),
+      enhancers: (e) => e.concat(autoBatchEnhancer(0)),
     })
 
   type StoreType = EnhancedStore<

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -191,7 +191,7 @@ export function setupApiStore<
           api.middleware,
           ...middleware
         ),
-      enhancers: (e) => e.concat(autoBatchEnhancer(0)),
+      // enhancers: (e) => e.concat(autoBatchEnhancer(0)),
     })
 
   type StoreType = EnhancedStore<

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -191,7 +191,7 @@ export function setupApiStore<
           api.middleware,
           ...middleware
         ),
-      enhancers: (e) => e.concat(autoBatchEnhancer(0)),
+      enhancers: (e) => e.concat(autoBatchEnhancer()),
     })
 
   type StoreType = EnhancedStore<

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -6,6 +6,7 @@ import {
   createReducer,
 } from '@reduxjs/toolkit'
 import { miniSerializeError } from '@internal/createAsyncThunk'
+import { shouldAutoBatch } from '@internal/autoBatchEnhancer'
 
 import {
   mockConsole,
@@ -664,6 +665,7 @@ describe('conditional skipping of asyncThunks', () => {
           condition: true,
           requestId: expect.stringContaining(''),
           requestStatus: 'rejected',
+          [shouldAutoBatch]: true,
         },
         payload: undefined,
         type: 'test/rejected',
@@ -939,6 +941,7 @@ describe('meta', () => {
         rejectedWithValue: true,
         aborted: false,
         condition: false,
+        [shouldAutoBatch]: true,
       },
       error: { message: 'Rejected' },
       payload: 'damn!',

--- a/packages/toolkit/src/tests/createSlice.test.ts
+++ b/packages/toolkit/src/tests/createSlice.test.ts
@@ -372,7 +372,7 @@ describe('createSlice', () => {
     })
   })
 
-  describe.only('Deprecation warnings', () => {
+  describe('Deprecation warnings', () => {
     let originalNodeEnv = process.env.NODE_ENV
 
     beforeEach(() => {


### PR DESCRIPTION
Mostly for discussion:

This would be my alternative approach to #2599

Downside:
* it's an enhancer - we would need to add that to the docs and probably have to add it to `defaultEnhancers`
* it would be extra code (~470 bytes) to be shipped

Upsides:
* it could be used by everyone outside of RTKQ
* this batches a lot more things
* it could even be made to batch with a larger "batching window"
* it does not change the shape of existing actions (the alternative approach needs new actions and I'm a bit hesitant towards that as that will break `api.endpoint.foo.matchRejected` etc.
* we could remove all references to react-redux `batch` with a similar result -  or all batch-related code in general - for RTKQ users it would probably even mean less overall bundle size, not more.