### PR TITLE
Fix the `dispatch` type inference to correctly handle read-only middleware arrays

### DIFF
--- a/packages/toolkit/src/tests/configureStore.typetest.ts
+++ b/packages/toolkit/src/tests/configureStore.typetest.ts
@@ -13,6 +13,7 @@ import {
   configureStore,
   getDefaultMiddleware,
   createSlice,
+  ConfigureStoreOptions,
 } from '@reduxjs/toolkit'
 import type { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
 import thunk from 'redux-thunk'
@@ -305,6 +306,18 @@ const _anyMiddleware: any = () => () => () => {}
     const result2: string = store.dispatch(5)
   }
   /**
+   * Test: read-only middleware tuple
+   */
+  {
+    const store = configureStore({
+      reducer: reducerA,
+      middleware: [] as any as readonly [Middleware<(a: StateA) => boolean, StateA>],
+    })
+    const result: boolean = store.dispatch(5)
+    // @ts-expect-error
+    const result2: string = store.dispatch(5)
+  }
+  /**
    * Test: multiple custom middleware
    */
   {
@@ -471,6 +484,32 @@ const _anyMiddleware: any = () => () => () => {}
     })
 
     expectNotAny(store.dispatch)
+  }
+
+  /**
+   * Test: decorated `configureStore` won't make `dispatch` `never`
+   */
+  {
+    const someSlice = createSlice({
+      name: 'something',
+      initialState: null as any,
+      reducers: {
+        set(state) {
+          return state;
+        },
+      },
+    });
+
+    function configureMyStore<S>(options: Omit<ConfigureStoreOptions<S>, 'reducer'>) {
+      return configureStore({
+        ...options,
+        reducer: someSlice.reducer,
+      });
+    }
+
+    const store = configureMyStore({});
+
+    expectType<Function>(store.dispatch);
   }
 
   {

--- a/packages/toolkit/src/tsHelpers.ts
+++ b/packages/toolkit/src/tsHelpers.ts
@@ -88,7 +88,7 @@ export type ExtractDispatchExtensions<M> = M extends MiddlewareArray<
   infer MiddlewareTuple
 >
   ? ExtractDispatchFromMiddlewareTuple<MiddlewareTuple, {}>
-  : M extends Middleware[]
+  : M extends ReadonlyArray<Middleware>
   ? ExtractDispatchFromMiddlewareTuple<[...M], {}>
   : never
 


### PR DESCRIPTION
Resolves #2628.

All the details are in the linked issue.

The solution fixes the TypeScript helper to use a more generic array type to align with the `ConfigureStoreOptions` interface.