### PR TITLE
Consolidate RTKQ middleware to simplify stack size

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -11,9 +11,10 @@ import type {
 import { getMutationCacheKey } from '../buildSlice'
 import type { PatchCollection, Recipe } from '../buildThunks'
 import type {
+  ApiMiddlewareInternalHandler,
+  InternalHandlerBuilder,
   PromiseWithKnownReason,
   SubMiddlewareApi,
-  SubMiddlewareBuilder,
 } from './types'
 
 export type ReferenceCacheLifecycle = never
@@ -176,7 +177,7 @@ const neverResolvedError = new Error(
   message: 'Promise never resolved before cacheEntryRemoved.'
 }
 
-export const build: SubMiddlewareBuilder = ({
+export const buildCacheLifecycleHandler: InternalHandlerBuilder = ({
   api,
   reducerPath,
   context,
@@ -185,148 +186,145 @@ export const build: SubMiddlewareBuilder = ({
 }) => {
   const isQueryThunk = isAsyncThunkAction(queryThunk)
   const isMutationThunk = isAsyncThunkAction(mutationThunk)
-  const isFullfilledThunk = isFulfilled(queryThunk, mutationThunk)
+  const isFulfilledThunk = isFulfilled(queryThunk, mutationThunk)
 
-  return (mwApi) => {
-    type CacheLifecycle = {
-      valueResolved?(value: { data: unknown; meta: unknown }): unknown
-      cacheEntryRemoved(): void
-    }
-    const lifecycleMap: Record<string, CacheLifecycle> = {}
+  type CacheLifecycle = {
+    valueResolved?(value: { data: unknown; meta: unknown }): unknown
+    cacheEntryRemoved(): void
+  }
+  const lifecycleMap: Record<string, CacheLifecycle> = {}
 
-    return (next) =>
-      (action): any => {
-        const stateBefore = mwApi.getState()
+  const handler: ApiMiddlewareInternalHandler = (
+    action,
+    mwApi,
+    stateBefore
+  ) => {
+    const cacheKey = getCacheKey(action)
 
-        const result = next(action)
-
-        const cacheKey = getCacheKey(action)
-
-        if (queryThunk.pending.match(action)) {
-          const oldState = stateBefore[reducerPath].queries[cacheKey]
-          const state = mwApi.getState()[reducerPath].queries[cacheKey]
-          if (!oldState && state) {
-            handleNewKey(
-              action.meta.arg.endpointName,
-              action.meta.arg.originalArgs,
-              cacheKey,
-              mwApi,
-              action.meta.requestId
-            )
-          }
-        } else if (mutationThunk.pending.match(action)) {
-          const state = mwApi.getState()[reducerPath].mutations[cacheKey]
-          if (state) {
-            handleNewKey(
-              action.meta.arg.endpointName,
-              action.meta.arg.originalArgs,
-              cacheKey,
-              mwApi,
-              action.meta.requestId
-            )
-          }
-        } else if (isFullfilledThunk(action)) {
-          const lifecycle = lifecycleMap[cacheKey]
-          if (lifecycle?.valueResolved) {
-            lifecycle.valueResolved({
-              data: action.payload,
-              meta: action.meta.baseQueryMeta,
-            })
-            delete lifecycle.valueResolved
-          }
-        } else if (
-          api.internalActions.removeQueryResult.match(action) ||
-          api.internalActions.removeMutationResult.match(action)
-        ) {
-          const lifecycle = lifecycleMap[cacheKey]
-          if (lifecycle) {
-            delete lifecycleMap[cacheKey]
-            lifecycle.cacheEntryRemoved()
-          }
-        } else if (api.util.resetApiState.match(action)) {
-          for (const [cacheKey, lifecycle] of Object.entries(lifecycleMap)) {
-            delete lifecycleMap[cacheKey]
-            lifecycle.cacheEntryRemoved()
-          }
-        }
-
-        return result
+    if (queryThunk.pending.match(action)) {
+      const oldState = stateBefore[reducerPath].queries[cacheKey]
+      const state = mwApi.getState()[reducerPath].queries[cacheKey]
+      if (!oldState && state) {
+        handleNewKey(
+          action.meta.arg.endpointName,
+          action.meta.arg.originalArgs,
+          cacheKey,
+          mwApi,
+          action.meta.requestId
+        )
       }
-
-    function getCacheKey(action: any) {
-      if (isQueryThunk(action)) return action.meta.arg.queryCacheKey
-      if (isMutationThunk(action)) return action.meta.requestId
-      if (api.internalActions.removeQueryResult.match(action))
-        return action.payload.queryCacheKey
-      if (api.internalActions.removeMutationResult.match(action))
-        return getMutationCacheKey(action.payload)
-      return ''
-    }
-
-    function handleNewKey(
-      endpointName: string,
-      originalArgs: any,
-      queryCacheKey: string,
-      mwApi: SubMiddlewareApi,
-      requestId: string
+    } else if (mutationThunk.pending.match(action)) {
+      const state = mwApi.getState()[reducerPath].mutations[cacheKey]
+      if (state) {
+        handleNewKey(
+          action.meta.arg.endpointName,
+          action.meta.arg.originalArgs,
+          cacheKey,
+          mwApi,
+          action.meta.requestId
+        )
+      }
+    } else if (isFulfilledThunk(action)) {
+      const lifecycle = lifecycleMap[cacheKey]
+      if (lifecycle?.valueResolved) {
+        lifecycle.valueResolved({
+          data: action.payload,
+          meta: action.meta.baseQueryMeta,
+        })
+        delete lifecycle.valueResolved
+      }
+    } else if (
+      api.internalActions.removeQueryResult.match(action) ||
+      api.internalActions.removeMutationResult.match(action)
     ) {
-      const endpointDefinition = context.endpointDefinitions[endpointName]
-      const onCacheEntryAdded = endpointDefinition?.onCacheEntryAdded
-      if (!onCacheEntryAdded) return
-
-      let lifecycle = {} as CacheLifecycle
-
-      const cacheEntryRemoved = new Promise<void>((resolve) => {
-        lifecycle.cacheEntryRemoved = resolve
-      })
-      const cacheDataLoaded: PromiseWithKnownReason<
-        { data: unknown; meta: unknown },
-        typeof neverResolvedError
-      > = Promise.race([
-        new Promise<{ data: unknown; meta: unknown }>((resolve) => {
-          lifecycle.valueResolved = resolve
-        }),
-        cacheEntryRemoved.then(() => {
-          throw neverResolvedError
-        }),
-      ])
-      // prevent uncaught promise rejections from happening.
-      // if the original promise is used in any way, that will create a new promise that will throw again
-      cacheDataLoaded.catch(() => {})
-      lifecycleMap[queryCacheKey] = lifecycle
-      const selector = (api.endpoints[endpointName] as any).select(
-        endpointDefinition.type === DefinitionType.query
-          ? originalArgs
-          : queryCacheKey
-      )
-
-      const extra = mwApi.dispatch((_, __, extra) => extra)
-      const lifecycleApi = {
-        ...mwApi,
-        getCacheEntry: () => selector(mwApi.getState()),
-        requestId,
-        extra,
-        updateCachedData: (endpointDefinition.type === DefinitionType.query
-          ? (updateRecipe: Recipe<any>) =>
-              mwApi.dispatch(
-                api.util.updateQueryData(
-                  endpointName as never,
-                  originalArgs,
-                  updateRecipe
-                )
-              )
-          : undefined) as any,
-
-        cacheDataLoaded,
-        cacheEntryRemoved,
+      const lifecycle = lifecycleMap[cacheKey]
+      if (lifecycle) {
+        delete lifecycleMap[cacheKey]
+        lifecycle.cacheEntryRemoved()
       }
-
-      const runningHandler = onCacheEntryAdded(originalArgs, lifecycleApi)
-      // if a `neverResolvedError` was thrown, but not handled in the running handler, do not let it leak out further
-      Promise.resolve(runningHandler).catch((e) => {
-        if (e === neverResolvedError) return
-        throw e
-      })
+    } else if (api.util.resetApiState.match(action)) {
+      for (const [cacheKey, lifecycle] of Object.entries(lifecycleMap)) {
+        delete lifecycleMap[cacheKey]
+        lifecycle.cacheEntryRemoved()
+      }
     }
   }
+
+  function getCacheKey(action: any) {
+    if (isQueryThunk(action)) return action.meta.arg.queryCacheKey
+    if (isMutationThunk(action)) return action.meta.requestId
+    if (api.internalActions.removeQueryResult.match(action))
+      return action.payload.queryCacheKey
+    if (api.internalActions.removeMutationResult.match(action))
+      return getMutationCacheKey(action.payload)
+    return ''
+  }
+
+  function handleNewKey(
+    endpointName: string,
+    originalArgs: any,
+    queryCacheKey: string,
+    mwApi: SubMiddlewareApi,
+    requestId: string
+  ) {
+    const endpointDefinition = context.endpointDefinitions[endpointName]
+    const onCacheEntryAdded = endpointDefinition?.onCacheEntryAdded
+    if (!onCacheEntryAdded) return
+
+    let lifecycle = {} as CacheLifecycle
+
+    const cacheEntryRemoved = new Promise<void>((resolve) => {
+      lifecycle.cacheEntryRemoved = resolve
+    })
+    const cacheDataLoaded: PromiseWithKnownReason<
+      { data: unknown; meta: unknown },
+      typeof neverResolvedError
+    > = Promise.race([
+      new Promise<{ data: unknown; meta: unknown }>((resolve) => {
+        lifecycle.valueResolved = resolve
+      }),
+      cacheEntryRemoved.then(() => {
+        throw neverResolvedError
+      }),
+    ])
+    // prevent uncaught promise rejections from happening.
+    // if the original promise is used in any way, that will create a new promise that will throw again
+    cacheDataLoaded.catch(() => {})
+    lifecycleMap[queryCacheKey] = lifecycle
+    const selector = (api.endpoints[endpointName] as any).select(
+      endpointDefinition.type === DefinitionType.query
+        ? originalArgs
+        : queryCacheKey
+    )
+
+    const extra = mwApi.dispatch((_, __, extra) => extra)
+    const lifecycleApi = {
+      ...mwApi,
+      getCacheEntry: () => selector(mwApi.getState()),
+      requestId,
+      extra,
+      updateCachedData: (endpointDefinition.type === DefinitionType.query
+        ? (updateRecipe: Recipe<any>) =>
+            mwApi.dispatch(
+              api.util.updateQueryData(
+                endpointName as never,
+                originalArgs,
+                updateRecipe
+              )
+            )
+        : undefined) as any,
+
+      cacheDataLoaded,
+      cacheEntryRemoved,
+    }
+
+    const runningHandler = onCacheEntryAdded(originalArgs, lifecycleApi)
+    // if a `neverResolvedError` was thrown, but not handled in the running handler, do not let it leak out further
+    Promise.resolve(runningHandler).catch((e) => {
+      if (e === neverResolvedError) return
+      throw e
+    })
+  }
+
+  return handler
 }

--- a/packages/toolkit/src/query/core/buildMiddleware/devMiddleware.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/devMiddleware.ts
@@ -1,47 +1,34 @@
-import type { SubMiddlewareBuilder } from './types'
+import type { InternalHandlerBuilder } from './types'
 
-export const build: SubMiddlewareBuilder = ({
+export const buildDevCheckHandler: InternalHandlerBuilder = ({
   api,
   context: { apiUid },
   reducerPath,
 }) => {
-  return (mwApi) => {
-    let initialized = false
-    return (next) => (action) => {
-      if (!initialized) {
-        initialized = true
-        // dispatch before any other action
-        mwApi.dispatch(api.internalActions.middlewareRegistered(apiUid))
-      }
+  return (action, mwApi) => {
+    if (api.util.resetApiState.match(action)) {
+      // dispatch after api reset
+      mwApi.dispatch(api.internalActions.middlewareRegistered(apiUid))
+    }
 
-      const result = next(action)
-
-      if (api.util.resetApiState.match(action)) {
-        // dispatch after api reset
-        mwApi.dispatch(api.internalActions.middlewareRegistered(apiUid))
-      }
-
+    if (
+      typeof process !== 'undefined' &&
+      process.env.NODE_ENV === 'development'
+    ) {
       if (
-        typeof process !== 'undefined' &&
-        process.env.NODE_ENV === 'development'
+        api.internalActions.middlewareRegistered.match(action) &&
+        action.payload === apiUid &&
+        mwApi.getState()[reducerPath]?.config?.middlewareRegistered ===
+          'conflict'
       ) {
-        if (
-          api.internalActions.middlewareRegistered.match(action) &&
-          action.payload === apiUid &&
-          mwApi.getState()[reducerPath]?.config?.middlewareRegistered ===
-            'conflict'
-        ) {
-          console.warn(`There is a mismatch between slice and middleware for the reducerPath "${reducerPath}".
+        console.warn(`There is a mismatch between slice and middleware for the reducerPath "${reducerPath}".
 You can only have one api per reducer path, this will lead to crashes in various situations!${
-            reducerPath === 'api'
-              ? `
+          reducerPath === 'api'
+            ? `
 If you have multiple apis, you *have* to specify the reducerPath option when using createApi!`
-              : ''
-          }`)
-        }
+            : ''
+        }`)
       }
-
-      return result
     }
   }
 }

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -1,5 +1,3 @@
-import { compose } from 'redux'
-
 import type { AnyAction, Middleware, ThunkDispatch } from '@reduxjs/toolkit'
 import { createAction } from '@reduxjs/toolkit'
 
@@ -9,60 +7,100 @@ import type {
 } from '../../endpointDefinitions'
 import type { QueryStatus, QuerySubState, RootState } from '../apiState'
 import type { QueryThunkArg } from '../buildThunks'
-import { build as buildCacheCollection } from './cacheCollection'
-import { build as buildInvalidationByTags } from './invalidationByTags'
-import { build as buildPolling } from './polling'
-import type { BuildMiddlewareInput } from './types'
-import { build as buildWindowEventHandling } from './windowEventHandling'
-import { build as buildCacheLifecycle } from './cacheLifecycle'
-import { build as buildQueryLifecycle } from './queryLifecycle'
-import { build as buildDevMiddleware } from './devMiddleware'
-import { build as buildBatchActions } from './batchActions'
+import { buildCacheCollectionHandler } from './cacheCollection'
+import { buildInvalidationByTagsHandler } from './invalidationByTags'
+import { buildPollingHandler } from './polling'
+import type { BuildMiddlewareInput, InternalHandlerBuilder } from './types'
+import { buildWindowEventHandler } from './windowEventHandling'
+import { buildCacheLifecycleHandler } from './cacheLifecycle'
+import { buildQueryLifecycleHandler } from './queryLifecycle'
+import { buildDevCheckHandler } from './devMiddleware'
+import { buildBatchedActionsHandler } from './batchActions'
 
 export function buildMiddleware<
   Definitions extends EndpointDefinitions,
   ReducerPath extends string,
   TagTypes extends string
 >(input: BuildMiddlewareInput<Definitions, ReducerPath, TagTypes>) {
-  const { reducerPath, queryThunk } = input
+  const { reducerPath, queryThunk, api, context } = input
+  const { apiUid } = context
+
   const actions = {
     invalidateTags: createAction<
       Array<TagTypes | FullTagDescription<TagTypes>>
     >(`${reducerPath}/invalidateTags`),
   }
 
-  const middlewares = [
-    buildDevMiddleware,
-    buildCacheCollection,
-    buildInvalidationByTags,
-    buildPolling,
-    buildWindowEventHandling,
-    buildCacheLifecycle,
-    buildQueryLifecycle,
-    buildBatchActions,
-  ].map((build) =>
-    build({
+  const isThisApiSliceAction = (action: AnyAction) => {
+    return (
+      !!action &&
+      typeof action.type === 'string' &&
+      action.type.startsWith(`${reducerPath}/`)
+    )
+  }
+
+  const handlerBuilders: InternalHandlerBuilder[] = [
+    buildDevCheckHandler,
+    buildCacheCollectionHandler,
+    buildInvalidationByTagsHandler,
+    buildPollingHandler,
+    buildCacheLifecycleHandler,
+    buildQueryLifecycleHandler,
+  ]
+
+  const middleware: Middleware<
+    {},
+    RootState<Definitions, string, ReducerPath>,
+    ThunkDispatch<any, any, AnyAction>
+  > = (mwApi) => {
+    let initialized = false
+
+    const builderArgs = {
       ...(input as any as BuildMiddlewareInput<
         EndpointDefinitions,
         string,
         string
       >),
       refetchQuery,
-    })
-  )
-  const middleware: Middleware<
-    {},
-    RootState<Definitions, string, ReducerPath>,
-    ThunkDispatch<any, any, AnyAction>
-  > = (mwApi) => (next) => {
-    const applied = compose<typeof next>(
-      ...middlewares.map((middleware) => middleware(mwApi))
-    )(next)
-    return (action) => {
-      if (mwApi.getState()[reducerPath]) {
-        return applied(action)
+    }
+
+    const handlers = handlerBuilders.map((build) => build(builderArgs))
+
+    const batchedActionsHandler = buildBatchedActionsHandler(builderArgs)
+    const windowEventsHandler = buildWindowEventHandler(builderArgs)
+
+    return (next) => {
+      return (action) => {
+        if (!initialized) {
+          initialized = true
+          // dispatch before any other action
+          mwApi.dispatch(api.internalActions.middlewareRegistered(apiUid))
+        }
+
+        const stateBefore = mwApi.getState()
+
+        if (!batchedActionsHandler(action, mwApi, stateBefore)) {
+          return
+        }
+
+        const res = next(action)
+
+        if (!!mwApi.getState()[reducerPath]) {
+          // Only run these checks if the middleware is registered okay
+
+          // This looks for actions that aren't specific to the API slice
+          windowEventsHandler(action, mwApi, stateBefore)
+
+          if (isThisApiSliceAction(action)) {
+            // Only run these additional checks if the actions are part of the API slice
+            for (let handler of handlers) {
+              handler(action, mwApi, stateBefore)
+            }
+          }
+        }
+
+        return res
       }
-      return next(action)
     }
   }
 

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -3,132 +3,123 @@ import { QueryStatus } from '../apiState'
 import type {
   QueryStateMeta,
   SubMiddlewareApi,
-  SubMiddlewareBuilder,
   TimeoutId,
+  InternalHandlerBuilder,
+  ApiMiddlewareInternalHandler,
 } from './types'
 
-export const build: SubMiddlewareBuilder = ({
+export const buildPollingHandler: InternalHandlerBuilder = ({
   reducerPath,
   queryThunk,
   api,
   refetchQuery,
 }) => {
-  return (mwApi) => {
-    const currentPolls: QueryStateMeta<{
-      nextPollTimestamp: number
-      timeout?: TimeoutId
-      pollingInterval: number
-    }> = {}
+  const currentPolls: QueryStateMeta<{
+    nextPollTimestamp: number
+    timeout?: TimeoutId
+    pollingInterval: number
+  }> = {}
 
-    return (next) =>
-      (action): any => {
-        const result = next(action)
-
-        if (
-          api.internalActions.updateSubscriptionOptions.match(action) ||
-          api.internalActions.unsubscribeQueryResult.match(action)
-        ) {
-          updatePollingInterval(action.payload, mwApi)
-        }
-
-        if (
-          queryThunk.pending.match(action) ||
-          (queryThunk.rejected.match(action) && action.meta.condition)
-        ) {
-          updatePollingInterval(action.meta.arg, mwApi)
-        }
-
-        if (
-          queryThunk.fulfilled.match(action) ||
-          (queryThunk.rejected.match(action) && !action.meta.condition)
-        ) {
-          startNextPoll(action.meta.arg, mwApi)
-        }
-
-        if (api.util.resetApiState.match(action)) {
-          clearPolls()
-        }
-
-        return result
-      }
-
-    function startNextPoll(
-      { queryCacheKey }: QuerySubstateIdentifier,
-      api: SubMiddlewareApi
+  const handler: ApiMiddlewareInternalHandler = (action, mwApi) => {
+    if (
+      api.internalActions.updateSubscriptionOptions.match(action) ||
+      api.internalActions.unsubscribeQueryResult.match(action)
     ) {
-      const state = api.getState()[reducerPath]
-      const querySubState = state.queries[queryCacheKey]
-      const subscriptions = state.subscriptions[queryCacheKey]
-
-      if (!querySubState || querySubState.status === QueryStatus.uninitialized)
-        return
-
-      const lowestPollingInterval = findLowestPollingInterval(subscriptions)
-      if (!Number.isFinite(lowestPollingInterval)) return
-
-      const currentPoll = currentPolls[queryCacheKey]
-
-      if (currentPoll?.timeout) {
-        clearTimeout(currentPoll.timeout)
-        currentPoll.timeout = undefined
-      }
-
-      const nextPollTimestamp = Date.now() + lowestPollingInterval
-
-      const currentInterval: typeof currentPolls[number] = (currentPolls[
-        queryCacheKey
-      ] = {
-        nextPollTimestamp,
-        pollingInterval: lowestPollingInterval,
-        timeout: setTimeout(() => {
-          currentInterval!.timeout = undefined
-          api.dispatch(refetchQuery(querySubState, queryCacheKey))
-        }, lowestPollingInterval),
-      })
+      updatePollingInterval(action.payload, mwApi)
     }
 
-    function updatePollingInterval(
-      { queryCacheKey }: QuerySubstateIdentifier,
-      api: SubMiddlewareApi
+    if (
+      queryThunk.pending.match(action) ||
+      (queryThunk.rejected.match(action) && action.meta.condition)
     ) {
-      const state = api.getState()[reducerPath]
-      const querySubState = state.queries[queryCacheKey]
-      const subscriptions = state.subscriptions[queryCacheKey]
-
-      if (
-        !querySubState ||
-        querySubState.status === QueryStatus.uninitialized
-      ) {
-        return
-      }
-
-      const lowestPollingInterval = findLowestPollingInterval(subscriptions)
-
-      if (!Number.isFinite(lowestPollingInterval)) {
-        cleanupPollForKey(queryCacheKey)
-        return
-      }
-
-      const currentPoll = currentPolls[queryCacheKey]
-      const nextPollTimestamp = Date.now() + lowestPollingInterval
-
-      if (!currentPoll || nextPollTimestamp < currentPoll.nextPollTimestamp) {
-        startNextPoll({ queryCacheKey }, api)
-      }
+      updatePollingInterval(action.meta.arg, mwApi)
     }
 
-    function cleanupPollForKey(key: string) {
-      const existingPoll = currentPolls[key]
-      if (existingPoll?.timeout) {
-        clearTimeout(existingPoll.timeout)
-      }
-      delete currentPolls[key]
+    if (
+      queryThunk.fulfilled.match(action) ||
+      (queryThunk.rejected.match(action) && !action.meta.condition)
+    ) {
+      startNextPoll(action.meta.arg, mwApi)
     }
 
-    function clearPolls() {
-      for (const key of Object.keys(currentPolls)) {
-        cleanupPollForKey(key)
-      }
+    if (api.util.resetApiState.match(action)) {
+      clearPolls()
+    }
+  }
+
+  function startNextPoll(
+    { queryCacheKey }: QuerySubstateIdentifier,
+    api: SubMiddlewareApi
+  ) {
+    const state = api.getState()[reducerPath]
+    const querySubState = state.queries[queryCacheKey]
+    const subscriptions = state.subscriptions[queryCacheKey]
+
+    if (!querySubState || querySubState.status === QueryStatus.uninitialized)
+      return
+
+    const lowestPollingInterval = findLowestPollingInterval(subscriptions)
+    if (!Number.isFinite(lowestPollingInterval)) return
+
+    const currentPoll = currentPolls[queryCacheKey]
+
+    if (currentPoll?.timeout) {
+      clearTimeout(currentPoll.timeout)
+      currentPoll.timeout = undefined
+    }
+
+    const nextPollTimestamp = Date.now() + lowestPollingInterval
+
+    const currentInterval: typeof currentPolls[number] = (currentPolls[
+      queryCacheKey
+    ] = {
+      nextPollTimestamp,
+      pollingInterval: lowestPollingInterval,
+      timeout: setTimeout(() => {
+        currentInterval!.timeout = undefined
+        api.dispatch(refetchQuery(querySubState, queryCacheKey))
+      }, lowestPollingInterval),
+    })
+  }
+
+  function updatePollingInterval(
+    { queryCacheKey }: QuerySubstateIdentifier,
+    api: SubMiddlewareApi
+  ) {
+    const state = api.getState()[reducerPath]
+    const querySubState = state.queries[queryCacheKey]
+    const subscriptions = state.subscriptions[queryCacheKey]
+
+    if (!querySubState || querySubState.status === QueryStatus.uninitialized) {
+      return
+    }
+
+    const lowestPollingInterval = findLowestPollingInterval(subscriptions)
+
+    if (!Number.isFinite(lowestPollingInterval)) {
+      cleanupPollForKey(queryCacheKey)
+      return
+    }
+
+    const currentPoll = currentPolls[queryCacheKey]
+    const nextPollTimestamp = Date.now() + lowestPollingInterval
+
+    if (!currentPoll || nextPollTimestamp < currentPoll.nextPollTimestamp) {
+      startNextPoll({ queryCacheKey }, api)
+    }
+  }
+
+  function cleanupPollForKey(key: string) {
+    const existingPoll = currentPolls[key]
+    if (existingPoll?.timeout) {
+      clearTimeout(existingPoll.timeout)
+    }
+    delete currentPolls[key]
+  }
+
+  function clearPolls() {
+    for (const key of Object.keys(currentPolls)) {
+      cleanupPollForKey(key)
     }
   }
 
@@ -143,4 +134,5 @@ export const build: SubMiddlewareBuilder = ({
     }
     return lowestPollingInterval
   }
+  return handler
 }

--- a/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -8,9 +8,10 @@ import { DefinitionType } from '../../endpointDefinitions'
 import type { QueryFulfilledRejectionReason } from '../../endpointDefinitions'
 import type { Recipe } from '../buildThunks'
 import type {
-  SubMiddlewareBuilder,
   PromiseWithKnownReason,
   PromiseConstructorWithKnownReason,
+  InternalHandlerBuilder,
+  ApiMiddlewareInternalHandler,
 } from './types'
 
 export type ReferenceQueryLifecycle = never
@@ -200,7 +201,7 @@ declare module '../../endpointDefinitions' {
       QueryLifecyclePromises<ResultType, BaseQuery> {}
 }
 
-export const build: SubMiddlewareBuilder = ({
+export const buildQueryLifecycleHandler: InternalHandlerBuilder = ({
   api,
   context,
   queryThunk,
@@ -210,83 +211,77 @@ export const build: SubMiddlewareBuilder = ({
   const isRejectedThunk = isRejected(queryThunk, mutationThunk)
   const isFullfilledThunk = isFulfilled(queryThunk, mutationThunk)
 
-  return (mwApi) => {
-    type CacheLifecycle = {
-      resolve(value: { data: unknown; meta: unknown }): unknown
-      reject(value: QueryFulfilledRejectionReason<any>): unknown
-    }
-    const lifecycleMap: Record<string, CacheLifecycle> = {}
-
-    return (next) =>
-      (action): any => {
-        const result = next(action)
-
-        if (isPendingThunk(action)) {
-          const {
-            requestId,
-            arg: { endpointName, originalArgs },
-          } = action.meta
-          const endpointDefinition = context.endpointDefinitions[endpointName]
-          const onQueryStarted = endpointDefinition?.onQueryStarted
-          if (onQueryStarted) {
-            const lifecycle = {} as CacheLifecycle
-            const queryFulfilled =
-              new (Promise as PromiseConstructorWithKnownReason)<
-                { data: unknown; meta: unknown },
-                QueryFulfilledRejectionReason<any>
-              >((resolve, reject) => {
-                lifecycle.resolve = resolve
-                lifecycle.reject = reject
-              })
-            // prevent uncaught promise rejections from happening.
-            // if the original promise is used in any way, that will create a new promise that will throw again
-            queryFulfilled.catch(() => {})
-            lifecycleMap[requestId] = lifecycle
-            const selector = (api.endpoints[endpointName] as any).select(
-              endpointDefinition.type === DefinitionType.query
-                ? originalArgs
-                : requestId
-            )
-
-            const extra = mwApi.dispatch((_, __, extra) => extra)
-            const lifecycleApi = {
-              ...mwApi,
-              getCacheEntry: () => selector(mwApi.getState()),
-              requestId,
-              extra,
-              updateCachedData: (endpointDefinition.type ===
-              DefinitionType.query
-                ? (updateRecipe: Recipe<any>) =>
-                    mwApi.dispatch(
-                      api.util.updateQueryData(
-                        endpointName as never,
-                        originalArgs,
-                        updateRecipe
-                      )
-                    )
-                : undefined) as any,
-              queryFulfilled,
-            }
-            onQueryStarted(originalArgs, lifecycleApi)
-          }
-        } else if (isFullfilledThunk(action)) {
-          const { requestId, baseQueryMeta } = action.meta
-          lifecycleMap[requestId]?.resolve({
-            data: action.payload,
-            meta: baseQueryMeta,
-          })
-          delete lifecycleMap[requestId]
-        } else if (isRejectedThunk(action)) {
-          const { requestId, rejectedWithValue, baseQueryMeta } = action.meta
-          lifecycleMap[requestId]?.reject({
-            error: action.payload ?? action.error,
-            isUnhandledError: !rejectedWithValue,
-            meta: baseQueryMeta as any,
-          })
-          delete lifecycleMap[requestId]
-        }
-
-        return result
-      }
+  type CacheLifecycle = {
+    resolve(value: { data: unknown; meta: unknown }): unknown
+    reject(value: QueryFulfilledRejectionReason<any>): unknown
   }
+  const lifecycleMap: Record<string, CacheLifecycle> = {}
+
+  const handler: ApiMiddlewareInternalHandler = (action, mwApi) => {
+    if (isPendingThunk(action)) {
+      const {
+        requestId,
+        arg: { endpointName, originalArgs },
+      } = action.meta
+      const endpointDefinition = context.endpointDefinitions[endpointName]
+      const onQueryStarted = endpointDefinition?.onQueryStarted
+      if (onQueryStarted) {
+        const lifecycle = {} as CacheLifecycle
+        const queryFulfilled =
+          new (Promise as PromiseConstructorWithKnownReason)<
+            { data: unknown; meta: unknown },
+            QueryFulfilledRejectionReason<any>
+          >((resolve, reject) => {
+            lifecycle.resolve = resolve
+            lifecycle.reject = reject
+          })
+        // prevent uncaught promise rejections from happening.
+        // if the original promise is used in any way, that will create a new promise that will throw again
+        queryFulfilled.catch(() => {})
+        lifecycleMap[requestId] = lifecycle
+        const selector = (api.endpoints[endpointName] as any).select(
+          endpointDefinition.type === DefinitionType.query
+            ? originalArgs
+            : requestId
+        )
+
+        const extra = mwApi.dispatch((_, __, extra) => extra)
+        const lifecycleApi = {
+          ...mwApi,
+          getCacheEntry: () => selector(mwApi.getState()),
+          requestId,
+          extra,
+          updateCachedData: (endpointDefinition.type === DefinitionType.query
+            ? (updateRecipe: Recipe<any>) =>
+                mwApi.dispatch(
+                  api.util.updateQueryData(
+                    endpointName as never,
+                    originalArgs,
+                    updateRecipe
+                  )
+                )
+            : undefined) as any,
+          queryFulfilled,
+        }
+        onQueryStarted(originalArgs, lifecycleApi)
+      }
+    } else if (isFullfilledThunk(action)) {
+      const { requestId, baseQueryMeta } = action.meta
+      lifecycleMap[requestId]?.resolve({
+        data: action.payload,
+        meta: baseQueryMeta,
+      })
+      delete lifecycleMap[requestId]
+    } else if (isRejectedThunk(action)) {
+      const { requestId, rejectedWithValue, baseQueryMeta } = action.meta
+      lifecycleMap[requestId]?.reject({
+        error: action.payload ?? action.error,
+        isUnhandledError: !rejectedWithValue,
+        meta: baseQueryMeta as any,
+      })
+      delete lifecycleMap[requestId]
+    }
+  }
+
+  return handler
 }

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -1,6 +1,5 @@
 import type {
   AnyAction,
-  AsyncThunk,
   AsyncThunkAction,
   Middleware,
   MiddlewareAPI,
@@ -60,6 +59,16 @@ export type SubMiddlewareBuilder = (
   RootState<EndpointDefinitions, string, string>,
   ThunkDispatch<any, any, AnyAction>
 >
+
+export type ApiMiddlewareInternalHandler<ReturnType = void> = (
+  action: AnyAction,
+  mwApi: SubMiddlewareApi,
+  prevState: RootState<EndpointDefinitions, string, string>
+) => ReturnType
+
+export type InternalHandlerBuilder<ReturnType = void> = (
+  input: BuildSubMiddlewareInput
+) => ApiMiddlewareInternalHandler<ReturnType>
 
 export interface PromiseConstructorWithKnownReason {
   /**

--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -1,9 +1,13 @@
 import { QueryStatus } from '../apiState'
 import type { QueryCacheKey } from '../apiState'
 import { onFocus, onOnline } from '../setupListeners'
-import type { SubMiddlewareApi, SubMiddlewareBuilder } from './types'
+import type {
+  ApiMiddlewareInternalHandler,
+  InternalHandlerBuilder,
+  SubMiddlewareApi,
+} from './types'
 
-export const build: SubMiddlewareBuilder = ({
+export const buildWindowEventHandler: InternalHandlerBuilder = ({
   reducerPath,
   context,
   api,
@@ -11,20 +15,14 @@ export const build: SubMiddlewareBuilder = ({
 }) => {
   const { removeQueryResult } = api.internalActions
 
-  return (mwApi) =>
-    (next) =>
-    (action): any => {
-      const result = next(action)
-
-      if (onFocus.match(action)) {
-        refetchValidQueries(mwApi, 'refetchOnFocus')
-      }
-      if (onOnline.match(action)) {
-        refetchValidQueries(mwApi, 'refetchOnReconnect')
-      }
-
-      return result
+  const handler: ApiMiddlewareInternalHandler = (action, mwApi) => {
+    if (onFocus.match(action)) {
+      refetchValidQueries(mwApi, 'refetchOnFocus')
     }
+    if (onOnline.match(action)) {
+      refetchValidQueries(mwApi, 'refetchOnReconnect')
+    }
+  }
 
   function refetchValidQueries(
     api: SubMiddlewareApi,
@@ -64,4 +62,6 @@ export const build: SubMiddlewareBuilder = ({
       }
     })
   }
+
+  return handler
 }


### PR DESCRIPTION
Previously, the RTKQ middleware was made up of 7 "sub-middleware", each encapsulating a different responsibility (polling, caching, etc).  In practice, these _were_ each a real middleware, just pre-composed into a single middleware internally.

However, that meant that each middleware was called on _every_ action, even if it wasn't RTKQ-related. That adds to call stack size.

Almost all the RTKQ processing logic runs _after_ the action is handled by the reducers. So, I've reworked the files to create "handlers" (conceptually similar to the `(action) => {}` part of a middleware, with a couple extra args), and rewritten the top-level middleware to run those in a loop.  The middleware also only runs those handlers if the action appears to be related to this API slice.

This should speed up perf overall because there's fewer calls per action in all cases, as well as a shallower call stack.  (This will especially help if users are adding multiple API slices+middleware).

Note that much of the diff is just unindenting the body of each middleware/handler - you might want to turn off "Whitespace" in the diffs.

For now, I'm keeping the "batch similar subscription actions" behavior as-is, with an explicit check before the action goes to the reducers.  That may get obsoleted by the batching enhancer proposed over in #2621 .