### PR TITLE
Fix assorted issues with the RTKQ middleware refactor

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -91,8 +91,12 @@ export function buildMiddleware<
           // This looks for actions that aren't specific to the API slice
           windowEventsHandler(action, mwApi, stateBefore)
 
-          if (isThisApiSliceAction(action)) {
-            // Only run these additional checks if the actions are part of the API slice
+          if (
+            isThisApiSliceAction(action) ||
+            context.hasRehydrationInfo(action)
+          ) {
+            // Only run these additional checks if the actions are part of the API slice,
+            // or the action has hydration-related data
             for (let handler of handlers) {
               handler(action, mwApi, stateBefore)
             }

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -480,15 +480,17 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
       const fulfilledVal = requestState?.fulfilledTimeStamp
 
       // Order of these checks matters.
-      // In order for `upsertQueryData` to successfully run while an existing request is
-      /// in flight, we have to check `isForcedQuery` before `status === 'pending'`,
-      // otherwise `queryThunk` will bail out and not run at all.
-
-      // if this is forced, continue
-      if (isForcedQuery(arg, state)) return true
+      // In order for `upsertQueryData` to successfully run while an existing request is in flight,
+      /// we have to check for that first, otherwise `queryThunk` will bail out and not run at all.
+      const isUpsertQuery =
+        typeof arg[forceQueryFnSymbol] === 'function' && arg.forceRefetch
+      if (isUpsertQuery) return true
 
       // Don't retry a request that's currently in-flight
       if (requestState?.status === 'pending') return false
+
+      // if this is forced, continue
+      if (isForcedQuery(arg, state)) return true
 
       // Pull from the cache unless we explicitly force refetch or qualify based on time
       if (fulfilledVal)


### PR DESCRIPTION
- Use a more accurate check when deciding if the query thunk should bail out early for `upsert` uses
- Also run RTKQ middleware handlers if the action has hydration info (since it could be _any_ action)