### PR TITLE
Add `forceRefetch` to `QueryExtraOptions`

### DIFF
--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -279,20 +279,10 @@ Features like automatic cache collection, automatic refetching etc. will not be 
           endpointName,
         })
 
-        const endpointContext = context.endpointDefinitions[endpointName]
-        const sideEffectForced =
-          isQueryDefinition(endpointContext) &&
-          endpointContext.sideEffectForced?.({
-            getState,
-            endpointState: (
-              api.endpoints[endpointName] as ApiEndpointQuery<any, any>
-            ).select(arg)(getState()),
-          })
-
         const thunk = queryThunk({
           type: 'query',
           subscribe,
-          forceRefetch: forceRefetch || sideEffectForced,
+          forceRefetch: forceRefetch,
           subscriptionOptions,
           endpointName,
           originalArgs: arg,

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -5,11 +5,10 @@ import type {
   QueryArgFrom,
   ResultTypeFrom,
 } from '../endpointDefinitions'
-import { DefinitionType } from '../endpointDefinitions'
+import { DefinitionType, isQueryDefinition } from '../endpointDefinitions'
 import type { QueryThunk, MutationThunk, QueryThunkArg } from './buildThunks'
 import type { AnyAction, ThunkAction, SerializedError } from '@reduxjs/toolkit'
 import type { SubscriptionOptions, RootState } from './apiState'
-import { QueryStatus } from './apiState'
 import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type { Api, ApiContext } from '../apiTypes'
 import type { ApiEndpointQuery } from './module'
@@ -279,10 +278,21 @@ Features like automatic cache collection, automatic refetching etc. will not be 
           endpointDefinition,
           endpointName,
         })
+
+        const endpointContext = context.endpointDefinitions[endpointName]
+        const sideEffectForced =
+          isQueryDefinition(endpointContext) &&
+          endpointContext.sideEffectForced?.({
+            getState,
+            endpointState: (
+              api.endpoints[endpointName] as ApiEndpointQuery<any, any>
+            ).select(arg)(getState()),
+          })
+
         const thunk = queryThunk({
           type: 'query',
           subscribe,
-          forceRefetch,
+          forceRefetch: forceRefetch || sideEffectForced,
           subscriptionOptions,
           endpointName,
           originalArgs: arg,

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -339,14 +339,15 @@ export interface QueryExtraOptions<
     responseData: ResultType
   ): ResultType | void
 
+  forceRefetch?(params: {
+    state: RootState<any, any, string>
+    endpointState?: QuerySubState<any>
+  }): boolean
+
   /**
    * All of these are `undefined` at runtime, purely to be used in TypeScript declarations!
    */
   Types?: QueryTypes<QueryArg, BaseQuery, TagTypes, ResultType, ReducerPath>
-  sideEffectForced?: (params: {
-    getState(): RootState<any, any, string>
-    endpointState: QuerySubState<any>
-  }) => boolean
 }
 
 export type QueryDefinition<

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -339,7 +339,32 @@ export interface QueryExtraOptions<
     responseData: ResultType
   ): ResultType | void
 
+  /**
+   * Check to see if the endpoint should force a refetch in cases where it normally wouldn't.
+   * This is primarily useful for "infinite scroll" / pagination use cases where
+   * RTKQ is keeping a single cache entry that is added to over time, in combination
+   * with `serializeQueryArgs` returning a fixed cache key and a `merge` callback
+   * set to add incoming data to the cache entry each time.
+   *
+   * Example:
+   *
+   * ```ts
+   * forceRefetch({currentArg, previousArg}) {
+   *   // Assume these are page numbers
+   *   return currentArg !== previousArg
+   * },
+   * serializeQueryArgs({endpointName}) {
+   *   return endpointName
+   * },
+   * merge(currentCacheData, responseData) {
+   *   currentCacheData.push(...responseData)
+   * }
+   *
+   * ```
+   */
   forceRefetch?(params: {
+    currentArg: QueryArg | undefined
+    previousArg: QueryArg | undefined
     state: RootState<any, any, string>
     endpointState?: QuerySubState<any>
   }): boolean

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -1,6 +1,6 @@
 import type { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
 import { SerializeQueryArgs } from './defaultSerializeQueryArgs'
-import type { RootState } from './core/apiState'
+import type { QuerySubState, RootState } from './core/apiState'
 import type {
   BaseQueryExtraOptions,
   BaseQueryFn,
@@ -343,6 +343,10 @@ export interface QueryExtraOptions<
    * All of these are `undefined` at runtime, purely to be used in TypeScript declarations!
    */
   Types?: QueryTypes<QueryArg, BaseQuery, TagTypes, ResultType, ReducerPath>
+  sideEffectForced?: (params: {
+    getState(): RootState<any, any, string>
+    endpointState: QuerySubState<any>
+  }) => boolean
 }
 
 export type QueryDefinition<


### PR DESCRIPTION
Resolves: #2389 

This PR is to further explain our use-case. We check for a timestamp of the last time a side-effect handled and if the timestamp is newer than the last time the endpoint was called (which means something that'll change the return of the query has happened in the meantime), then the call will be forced.

This still needs some testing and docs, but I wanted to make sure that the concept is something you could imagine being valuable.