### PR TITLE
docs: fix the link of "enhanceEndpoints"

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -69,7 +69,7 @@ That will result in all generated endpoints having `providesTags`/`invalidatesTa
 
 Note that this will only result in string tags with no ids, so it might lead to scenarios where too much is invalidated and unneccessary requests are made on mutation.
 
-In that case it is still recommended to manually specify tags by using [`enhanceEndpoints`](./code-splitting.mdx) on top of the generated api and manually declare `providesTags`/`invalidatesTags`.
+In that case it is still recommended to manually specify tags by using [`enhanceEndpoints`](../api/created-api/code-splitting.mdx) on top of the generated api and manually declare `providesTags`/`invalidatesTags`.
 
 ### Programmatic usage
 


### PR DESCRIPTION
# [Issue: The link of "enhanceEndpoints" in rtkq document is wrong](https://github.com/reduxjs/redux-toolkit/issues/2679)

In [this page](https://redux-toolkit.js.org/rtk-query/usage/code-generation), the link of "enhanceEndpoints" is wrong.

Currently it's https://redux-toolkit.js.org/rtk-query/usage/code-splitting 
This page contains nothing about `enhanceEndpoints`.

It should be https://redux-toolkit.js.org/rtk-query/api/created-api/code-splitting#enhanceendpoints