### PR TITLE
docs: Clarify documentation about the overrideExisting flag in injectEndpoints

### DIFF
--- a/docs/rtk-query/api/created-api/code-splitting.mdx
+++ b/docs/rtk-query/api/created-api/code-splitting.mdx
@@ -35,7 +35,7 @@ Accepts an options object containing the same `endpoints` builder callback you w
 
 Returns an updated and enhanced version of the API slice object, containing the combined endpoint definitions.
 
-The `overrideExisting` flag controls a development-only warning that notifies you if there is a name clash between endpoint definitions. When set to `true`, the warning will not be printed.
+In development, endpoints will not be overridden unless `overrideExisting` is set to `true`. If not, a warning will be shown to notify you if there is a name clash between endpoint definitions.
 
 This method is primarily useful for code splitting and hot reloading.
 

--- a/docs/rtk-query/usage/code-splitting.mdx
+++ b/docs/rtk-query/usage/code-splitting.mdx
@@ -56,5 +56,5 @@ export const { useExampleQuery } = extendedApi
 ```
 
 :::tip
-You will get a warning if you inject an endpoint that already exists in development mode when you don't explicitly specify `overrideExisting: true`. You **will not see this in production** and the existing endpoint will just be overriden, so make sure to account for this in your tests.
+In development mode, if you inject an endpoint that already exists and don't explicitly specify `overrideExisting: true`, the endpoint will not be overridden and you will get a warning about it. You **will not see the warning in production** and the existing endpoint will just be overriden, so make sure to account for this in your tests.
 :::


### PR DESCRIPTION
# Proposed changes

Clarify in the `injectEndpoints` docs that the `overrideExisting` flag actually controls whether endpoints are overridden or not in development.

Closes #2694