### PR TITLE
split `enhanceEndpoints` into `addTagTypes` and `enhanceEndpoint`

### DIFF
--- a/packages/toolkit/src/query/apiTypes.ts
+++ b/packages/toolkit/src/query/apiTypes.ts
@@ -3,6 +3,9 @@ import type {
   EndpointBuilder,
   EndpointDefinition,
   ReplaceTagTypes,
+  ResultTypeFrom,
+  QueryArgFrom,
+  QueryDefinition,
 } from './endpointDefinitions'
 import type {
   UnionToIntersection,
@@ -12,7 +15,7 @@ import type {
 import type { CoreModule } from './core/module'
 import type { CreateApiOptions } from './createApi'
 import type { BaseQueryFn } from './baseQueryTypes'
-import type { CombinedState } from './core/apiState'
+import type { CombinedState, MutationKeys, QueryKeys } from './core/apiState'
 import type { AnyAction } from '@reduxjs/toolkit'
 
 export interface ApiModules<
@@ -92,6 +95,8 @@ export type Api<
   >
   /**
    *A function to enhance a generated API with additional information. Useful with code-generation.
+
+   @deprecated this will be replaced by `addTagTypes` and `enhanceEndpoint`
    */
   enhanceEndpoints<NewTagTypes extends string = never>(_: {
     addTagTypes?: readonly NewTagTypes[]
@@ -110,6 +115,77 @@ export type Api<
     ReplaceTagTypes<Definitions, TagTypes | NewTagTypes>,
     ReducerPath,
     TagTypes | NewTagTypes,
+    Enhancers
+  >
+
+  /**
+   *A function to enhance a generated API with additional information. Useful with code-generation.
+   */
+  addTagTypes<NewTagTypes extends string = never>(
+    ...addTagTypes: readonly NewTagTypes[]
+  ): Api<
+    BaseQuery,
+    ReplaceTagTypes<Definitions, TagTypes | NewTagTypes>,
+    ReducerPath,
+    TagTypes | NewTagTypes,
+    Enhancers
+  >
+
+  /**
+   *A function to enhance a generated API with additional information. Useful with code-generation.
+   */
+  enhanceEndpoint<
+    QueryName extends QueryKeys<Definitions>,
+    ResultType = ResultTypeFrom<Definitions[QueryName]>,
+    QueryArg = QueryArgFrom<Definitions[QueryName]>
+  >(
+    queryName: QueryName,
+    queryDefinition: Partial<
+      QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType, ReducerPath>
+    >
+  ): Api<
+    BaseQuery,
+    Omit<Definitions, QueryName> &
+      {
+        [Q in QueryName]: QueryDefinition<
+          QueryArg,
+          BaseQuery,
+          TagTypes,
+          ResultType,
+          ReducerPath
+        >
+      },
+    ReducerPath,
+    TagTypes,
+    Enhancers
+  >
+
+  /**
+   *A function to enhance a generated API with additional information. Useful with code-generation.
+   */
+  enhanceEndpoint<
+    MutationName extends MutationKeys<Definitions>,
+    ResultType = ResultTypeFrom<Definitions[MutationName]>,
+    QueryArg = QueryArgFrom<Definitions[MutationName]>
+  >(
+    mutationName: MutationName,
+    mutationDefinition: Partial<
+      QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType, ReducerPath>
+    >
+  ): Api<
+    BaseQuery,
+    Omit<Definitions, MutationName> &
+      {
+        [Q in MutationName]: QueryDefinition<
+          QueryArg,
+          BaseQuery,
+          TagTypes,
+          ResultType,
+          ReducerPath
+        >
+      },
+    ReducerPath,
+    TagTypes,
     Enhancers
   >
 }

--- a/packages/toolkit/src/query/tests/codeSplitting.test.ts
+++ b/packages/toolkit/src/query/tests/codeSplitting.test.ts
@@ -1,0 +1,218 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query'
+import { expectType } from './helpers'
+
+function buildInitialApi() {
+  return createApi({
+    baseQuery: fetchBaseQuery(),
+    endpoints(build) {
+      return {
+        someQuery: build.query<'ReturnedFromQuery', 'QueryArgument'>({
+          query() {
+            return '/'
+          },
+        }),
+        someMutation: build.query<'ReturnedFromMutation', 'MutationArgument'>({
+          query() {
+            return '/'
+          },
+        }),
+      }
+    },
+  })
+}
+let baseApi = buildInitialApi()
+beforeEach(() => {
+  baseApi = buildInitialApi()
+})
+const emptyApiState = {
+  [baseApi.reducerPath]: baseApi.reducer(undefined, { type: 'foo' }),
+}
+
+test('injectTagTypes', () => {
+  const injectedApi = baseApi.addTagTypes('Foo', 'Bar')
+
+  injectedApi.util.selectInvalidatedBy(emptyApiState, ['Foo'])
+  // @ts-expect-error
+  injectedApi.util.selectInvalidatedBy(emptyApiState, ['Baz'])
+})
+
+function getEndpointDetails<
+  E extends {
+    initiate(arg: any): any
+    select: (arg: any) => (state: any) => any
+  }
+>(
+  e: E
+): {
+  arg: Parameters<E['initiate']>[0]
+  returned: NonNullable<ReturnType<ReturnType<E['select']>>['data']>
+} {
+  return {} as any
+}
+
+describe('enhanceEndpoint', () => {
+  describe('query', () => {
+    test('no changes', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someQuery', {})
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someQuery
+      )
+
+      expectType<'QueryArgument'>(arg)
+      expectType<'ReturnedFromQuery'>(returned)
+    })
+
+    test('change return value through `tranformResponse`', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someQuery', {
+        transformResponse(): 'Changed' {
+          return 'Changed'
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someQuery
+      )
+
+      expectType<'QueryArgument'>(arg)
+      expectType<'Changed'>(returned)
+      // @ts-expect-error
+      expectType<'ReturnedFromQuery'>(returned)
+    })
+
+    test('change argument value through new `query` function', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someQuery', {
+        query(arg: 'Changed') {
+          return '/'
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someQuery
+      )
+
+      expectType<'Changed'>(arg)
+      // @ts-expect-error
+      expectType<'QueryArgument'>(arg)
+      expectType<'ReturnedFromQuery'>(returned)
+    })
+
+    test('change argument and return value through new `query` and `transformResponse` functions', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someQuery', {
+        query(arg: 'Changed') {
+          return ''
+        },
+        transformResponse(): 'AlsoChanged' {
+          return 'AlsoChanged'
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someQuery
+      )
+
+      expectType<'Changed'>(arg)
+      // @ts-expect-error
+      expectType<'QueryArgument'>(arg)
+      expectType<'AlsoChanged'>(returned)
+      // @ts-expect-error
+      expectType<'ReturnedFromQuery'>(returned)
+    })
+
+    test('change argument and return value through new `queryFn` function', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someQuery', {
+        queryFn(arg: 'Changed') {
+          return { data: 'AlsoChanged' as const }
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someQuery
+      )
+
+      expectType<'Changed'>(arg)
+      // @ts-expect-error
+      expectType<'QueryArgument'>(arg)
+      expectType<'AlsoChanged'>(returned)
+      // @ts-expect-error
+      expectType<'ReturnedFromQuery'>(returned)
+    })
+  })
+  describe('mutation', () => {
+    test('no changes', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someMutation', {})
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someMutation
+      )
+
+      expectType<'MutationArgument'>(arg)
+      expectType<'ReturnedFromMutation'>(returned)
+    })
+
+    test('change return value through `tranformResponse`', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someMutation', {
+        transformResponse(): 'Changed' {
+          return 'Changed'
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someMutation
+      )
+
+      expectType<'MutationArgument'>(arg)
+      expectType<'Changed'>(returned)
+      // @ts-expect-error
+      expectType<'ReturnedFromMutation'>(returned)
+    })
+
+    test('change argument value through new `query` function', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someMutation', {
+        query(arg: 'Changed') {
+          return '/'
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someMutation
+      )
+
+      expectType<'Changed'>(arg)
+      // @ts-expect-error
+      expectType<'MutationArgument'>(arg)
+      expectType<'ReturnedFromMutation'>(returned)
+    })
+
+    test('change argument and return value through new `queryFn` function', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someMutation', {
+        query(arg: 'Changed') {
+          return ''
+        },
+        transformResponse(): 'AlsoChanged' {
+          return 'AlsoChanged'
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someMutation
+      )
+
+      expectType<'Changed'>(arg)
+      // @ts-expect-error
+      expectType<'MutationArgument'>(arg)
+      expectType<'AlsoChanged'>(returned)
+      // @ts-expect-error
+      expectType<'ReturnedFromMutation'>(returned)
+    })
+
+    test('change argument and return value through new `queryFn` function', () => {
+      const injectedApi = baseApi.enhanceEndpoint('someMutation', {
+        queryFn(arg: 'Changed') {
+          return { data: 'AlsoChanged' as const }
+        },
+      })
+      const { arg, returned } = getEndpointDetails(
+        injectedApi.endpoints.someMutation
+      )
+
+      expectType<'Changed'>(arg)
+      // @ts-expect-error
+      expectType<'MutationArgument'>(arg)
+      expectType<'AlsoChanged'>(returned)
+      // @ts-expect-error
+      expectType<'ReturnedFromMutation'>(returned)
+    })
+  })
+})


### PR DESCRIPTION
(at the moment this is TS only and missing runtime code)

This would deprecate `enhanceEndpoints` and add new methods `addTagTypes` and `enhanceEndpoint`.

These are easier to type from our side and would allow the argument and return type of existing endpoints to be changed.