### PR TITLE
Export the BaseQueryApi interface from rtk-query so it can be used as a type in TypeScript without importing from dist/.

### DIFF
--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -1,6 +1,6 @@
 export { QueryStatus } from './core/apiState'
 export type { Api, Module, ApiModules } from './apiTypes'
-export type { BaseQueryEnhancer, BaseQueryFn } from './baseQueryTypes'
+export type { BaseQueryApi, BaseQueryEnhancer, BaseQueryFn } from './baseQueryTypes'
 export type {
   EndpointDefinitions,
   EndpointDefinition,


### PR DESCRIPTION
This PR adds the `BaseQueryApi` as an export to the public `src/query/index.ts` API from `baseQueryTypes`.