### PR TITLE
Fix wrong extension on docs

### DIFF
--- a/docs/tutorials/quick-start.mdx
+++ b/docs/tutorials/quick-start.mdx
@@ -49,7 +49,7 @@ npm install @reduxjs/toolkit react-redux
 
 Create a file named `src/app/store.js`. Import the `configureStore` API from Redux Toolkit. We'll start by creating an empty Redux store, and exporting it:
 
-```ts title="app/store.js"
+```ts title="app/store.ts"
 import { configureStore } from '@reduxjs/toolkit'
 
 export const store = configureStore({
@@ -68,7 +68,7 @@ This creates a Redux store, and also automatically configure the Redux DevTools 
 
 Once the store is created, we can make it available to our React components by putting a React-Redux `<Provider>` around our application in `src/index.js`. Import the Redux store we just created, put a `<Provider>` around your `<App>`, and pass the store as a prop:
 
-```ts title="index.js"
+```ts title="index.ts"
 // file: App.tsx noEmit
 import React from 'react'
 export default function App() {
@@ -109,7 +109,7 @@ Creating a slice requires a string name to identify the slice, an initial state 
 
 Redux requires that [we write all state updates immutably, by making copies of data and updating the copies](https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow#immutability). However, Redux Toolkit's `createSlice` and `createReducer` APIs use [Immer](https://immerjs.github.io/immer/) inside to allow us to [write "mutating" update logic that becomes correct immutable updates](https://redux.js.org/tutorials/fundamentals/part-8-modern-redux#immutable-updates-with-immer).
 
-```ts title="features/counter/counterSlice.js"
+```ts title="features/counter/counterSlice.ts"
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
 
@@ -151,7 +151,7 @@ export default counterSlice.reducer
 
 Next, we need to import the reducer function from the counter slice and add it to our store. By defining a field inside the `reducer` parameter, we tell the store to use this slice reducer function to handle all updates to that state.
 
-```ts title="app/store.js"
+```ts title="app/store.ts"
 // file: features/counter/counterSlice.ts noEmit
 import { createSlice } from '@reduxjs/toolkit'
 
@@ -185,7 +185,7 @@ export type AppDispatch = typeof store.dispatch
 
 Now we can use the React-Redux hooks to let React components interact with the Redux store. We can read data from the store with `useSelector`, and dispatch actions using `useDispatch`. Create a `src/features/counter/Counter.js` file with a `<Counter>` component inside, then import that component into `App.js` and render it inside of `<App>`.
 
-```ts title="features/counter/Counter.js"
+```ts title="features/counter/Counter.ts"
 // file: features/counter/counterSlice.ts noEmit
 import { createSlice } from '@reduxjs/toolkit'
 const counterSlice = createSlice({


### PR DESCRIPTION
TypeScript examples had .js extension