### PR TITLE
Fix retryCondition `error`.

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -124,7 +124,7 @@ const retryWithBackoff: BaseQueryEnhancer<
 
       if (
         e instanceof HandledError &&
-        !options.retryCondition(e.value as FetchBaseQueryError, args, {
+        !options.retryCondition(e.value.error as FetchBaseQueryError, args, {
           attempt: retry,
           baseQueryApi: api,
           extraOptions,


### PR DESCRIPTION
Previously, the full baseQueryResult was passed into the `error` argument. This should fix it to only pass `error` in.