### PR TITLE
fix(toolkit): export "ThunkMiddleware" from redux-thunk

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -16,7 +16,7 @@ export type {
   ParametricSelector,
 } from 'reselect'
 export { createDraftSafeSelector } from './createDraftSafeSelector'
-export type { ThunkAction, ThunkDispatch } from 'redux-thunk'
+export type { ThunkAction, ThunkDispatch, ThunkMiddleware } from 'redux-thunk'
 
 // We deliberately enable Immer's ES5 support, on the grounds that
 // we assume RTK will be used with React Native and other Proxy-less


### PR DESCRIPTION
Hi there!

Based on [this initiative](https://github.com/reduxjs/redux-toolkit/pull/473#issuecomment-1266554741) and facing the exact same problem, I would like to expose `ThunkMiddleware` among the types exported by RTK.

See [my comment](https://github.com/reduxjs/redux-toolkit/pull/473#issuecomment-1266554741) for the diagnostic and error logs.

