### PR TITLE
fix: export ToolkitStore interface from configureStore

### DIFF
--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -78,7 +78,7 @@ export interface ConfigureStoreOptions<
    * function (either directly or indirectly by passing an object as `reducer`),
    * this must be an object with the same shape as the reducer map keys.
    */
-  /* 
+  /*
   Not 100% correct but the best approximation we can get:
   - if S is a `CombinedState` applying a second `CombinedState` on it does not change anything.
   - if it is not, there could be two cases:
@@ -104,7 +104,7 @@ type Middlewares<S> = ReadonlyArray<Middleware<{}, S>>
 
 type Enhancers = ReadonlyArray<StoreEnhancer>
 
-interface ToolkitStore<
+export interface ToolkitStore<
   S = any,
   A extends Action = AnyAction,
   M extends Middlewares<S> = Middlewares<S>,


### PR DESCRIPTION
Hello,

Similar to https://github.com/reduxjs/redux-toolkit/pull/473, this PR is aiming to solve the following type issue with the `1.9.0-alpha.1`:

`Exported variable 'createPersistableReduxStore' has or is using name 'ToolkitStore' from external module ".../node_modules/@reduxjs/toolkit/dist/configureStore" but cannot be named.`

This addresses a regression in my codebase where the following lines were ok with `1.8.5` and have this problem with `1.9.0-alpha.1`:

```
import { configureStore, Middleware, Reducer } from '@reduxjs/toolkit';
import { persistReducer } from 'redux-persist';
import AsyncStorage from '@react-native-async-storage/async-storage';
import slices from './slices';

export const createPersistableReduxStore = <T>(slices: Reducer<T>, middleware?: Middleware[]) => {
  const reducer = persistReducer(
    {
      key: 'root',
      storage: AsyncStorage,
      whitelist: [],
    },
    slices,
  );

  const store = configureStore({
    reducer,
    middleware: getDefaultMiddleware => {
      return getDefaultMiddleware({
        serializableCheck: false,
      }).concat(middleware ?? []);
    },
  });

  return {
    reducer,
    store,
  };
};

export const createGenericReduxStore = () => createPersistableReduxStore(slices);
```
