### PR TITLE
docs: add flattenArg option to code-generation.mdx

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -107,6 +107,7 @@ interface SimpleUsage {
     | EndpointMatcherFunction
     | Array<string | RegExp | EndpointMatcherFunction>
   endpointOverrides?: EndpointOverrides[]
+  flattenArg?: boolean
 }
 
 export type EndpointMatcherFunction = (


### PR DESCRIPTION
Add the `flattenArg` option to `code-generation.mdx`.