### PR TITLE
docs(rtk-query): update axios base query example

### DIFF
--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -252,13 +252,13 @@ const axiosBaseQuery =
     {
       url: string
       method: AxiosRequestConfig['method']
-      data?: AxiosRequestConfig['data']
+      body?: AxiosRequestConfig['data']
       params?: AxiosRequestConfig['params']
     },
     unknown,
     unknown
   > =>
-  async ({ url, method, data, params }) => {
+  async ({ url, method, body: data, params }) => {
     try {
       const result = await axios({ url: baseUrl + url, method, data, params })
       return { data: result.data }


### PR DESCRIPTION
It seems that actually, the params that are being sent to `axiosBaseQuery ` do not have a `data` but rather a `body`. This is at least happening in the project I'm working on which is using `@rtk-query/codegen-openapi`. Such change in `axiosBaseQuery` fixed problems I faced. Previous to that axios would send requests without any payload.

Anyone using axios can confirm that?

The example generated code looks like this for me:
```typescript
examplePostRequest: build.mutation<ExamplePostRequestApiResponse, ExamplePostRequestApiArg>({
  query: (queryArg) => ({
    url: `/example-post-request`,
    method: 'POST',
    body: queryArg.examplePostRequest,
  }),
}),
```

So when the `axiosBaseQuery` function is being used it receives `body` not `data`. Am I missing something here?