### PR TITLE
`prepareHeaders` does not need to return `headers` any more

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -110,7 +110,7 @@ export type FetchBaseQueryArgs = {
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
     >
-  ) => MaybePromise<Headers>
+  ) => MaybePromise<Headers> | void
   fetchFn?: (
     input: RequestInfo,
     init?: RequestInit | undefined
@@ -224,10 +224,15 @@ export function fetchBaseQuery({
       ...rest,
     }
 
-    config.headers = await prepareHeaders(
-      new Headers(stripUndefined(headers)),
-      { getState, extra, endpoint, forced, type }
-    )
+    headers = new Headers(stripUndefined(headers))
+    config.headers =
+      (await prepareHeaders(headers, {
+        getState,
+        extra,
+        endpoint,
+        forced,
+        type,
+      })) || headers
 
     // Only set the content-type to json if appropriate. Will not be true for FormData, ArrayBuffer, Blob, etc.
     const isJsonifiable = (body: any) =>

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -110,7 +110,7 @@ export type FetchBaseQueryArgs = {
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
     >
-  ) => MaybePromise<Headers> | void
+  ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
     init?: RequestInit | undefined

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -657,6 +657,26 @@ describe('fetchBaseQuery', () => {
       expect(request.headers['delete2']).toBeUndefined()
     })
 
+    test('prepareHeaders can return undefined', async () => {
+      let request: any
+
+      const token = 'accessToken'
+
+      const _baseQuery = fetchBaseQuery({
+        baseUrl,
+        prepareHeaders: (headers) => {
+          headers.set('authorization', `Bearer ${token}`)
+        },
+      })
+
+      const doRequest = async () =>
+        _baseQuery({ url: '/echo' }, commonBaseQueryApi, {})
+
+      ;({ data: request } = await doRequest())
+
+      expect(request.headers['authorization']).toBe(`Bearer ${token}`)
+    })
+
     test('prepareHeaders is able to be an async function', async () => {
       let request: any
 
@@ -668,6 +688,27 @@ describe('fetchBaseQuery', () => {
         prepareHeaders: async (headers) => {
           headers.set('authorization', `Bearer ${await getAccessTokenAsync()}`)
           return headers
+        },
+      })
+
+      const doRequest = async () =>
+        _baseQuery({ url: '/echo' }, commonBaseQueryApi, {})
+
+      ;({ data: request } = await doRequest())
+
+      expect(request.headers['authorization']).toBe(`Bearer ${token}`)
+    })
+
+    test('prepareHeaders is able to be an async function returning undefined', async () => {
+      let request: any
+
+      const token = 'accessToken'
+      const getAccessTokenAsync = async () => token
+
+      const _baseQuery = fetchBaseQuery({
+        baseUrl,
+        prepareHeaders: async (headers) => {
+          headers.set('authorization', `Bearer ${await getAccessTokenAsync()}`)
         },
       })
 


### PR DESCRIPTION
alternative suggestion to resolve #2774 