### PR TITLE
`fetchBaseQuery`: allow `headers` option

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -208,7 +208,7 @@ export function fetchBaseQuery({
     let {
       url,
       method = 'GET' as const,
-      headers = new Headers({}),
+      headers = new Headers(baseFetchOptions.headers),
       body = undefined,
       params = undefined,
       responseHandler = 'json' as const,

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -808,6 +808,24 @@ describe('fetchBaseQuery', () => {
     })
   })
 
+  test('can pass `headers` into `fetchBaseQuery`', async () => {
+    let request: any
+
+    const token = 'accessToken'
+
+    const _baseQuery = fetchBaseQuery({
+      baseUrl,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    const doRequest = async () =>
+      _baseQuery({ url: '/echo' }, commonBaseQueryApi, {})
+
+    ;({ data: request } = await doRequest())
+
+    expect(request.headers['authorization']).toBe(`Bearer ${token}`)
+  })
+
   test('lets a header be undefined', async () => {
     let request: any
     ;({ data: request } = await baseQuery(


### PR DESCRIPTION
This came up in https://github.com/am-miracle/crypto-news-site/issues/1

From the types, this should always have been possible (and up until now I also assumed that it would be possible) to pass `headers` as an object into the options of `fetchBaseQuery`.

These `headers` will - just like any other option passed in that way - not be merged with `headers` passed in from an endpoint, but overridden. As such, this is less useful than `prepareHeaders` - but it should definitely work.