### PR TITLE
fix `skipToken`  behaviour in `useQueryState`

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -428,15 +428,19 @@ export function buildSlice({
         draft[queryCacheKey]![requestId] = options
       }
       return true
-    } else if (unsubscribeQueryResult.match(action)) {
+    }
+    if (unsubscribeQueryResult.match(action)) {
       const { queryCacheKey, requestId } = action.payload
       if (draft[queryCacheKey]) {
         delete draft[queryCacheKey]![requestId]
       }
       return true
-    } else if (querySlice.actions.removeQueryResult.match(action)) {
+    }
+    if (querySlice.actions.removeQueryResult.match(action)) {
       delete draft[action.payload.queryCacheKey]
-    } else if (queryThunk.pending.match(action)) {
+      return true
+    }
+    if (queryThunk.pending.match(action)) {
       const {
         meta: { arg, requestId },
       } = action
@@ -447,7 +451,8 @@ export function buildSlice({
 
         return true
       }
-    } else if (queryThunk.rejected.match(action)) {
+    }
+    if (queryThunk.rejected.match(action)) {
       const {
         meta: { condition, arg, requestId },
       } = action

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -625,7 +625,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       )
         lastResult = undefined
     }
-
+    if (queryArgs === skipToken) {
+      lastResult = undefined
+    }
     // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
     let data = currentState.isSuccess ? currentState.data : lastResult?.data
     if (data === undefined) data = currentState.data

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -2379,11 +2379,7 @@ describe('skip behaviour', () => {
     await act(async () => {
       rerender([1, { skip: true }])
     })
-    expect(result.current).toEqual({
-      ...uninitialized,
-      currentData: undefined,
-      data: { name: 'Timmy' },
-    })
+    expect(result.current).toEqual(uninitialized)
     await delay(1)
     expect(subscriptionCount('getUser(1)')).toBe(0)
   })
@@ -2415,11 +2411,7 @@ describe('skip behaviour', () => {
     await act(async () => {
       rerender([skipToken])
     })
-    expect(result.current).toEqual({
-      ...uninitialized,
-      currentData: undefined,
-      data: { name: 'Timmy' },
-    })
+    expect(result.current).toEqual(uninitialized)
     await delay(1)
     expect(subscriptionCount('getUser(1)')).toBe(0)
   })


### PR DESCRIPTION
This reverts a test change that I identified as problematic over in https://github.com/reduxjs/redux-toolkit/pull/2759/files/6975282e87ce98f9a548043c15a82aacf3c384fc#r990775186 and fixes the underlying bug.

When calling `useQueryState(skipToken)`, the result should always be a pristine `uninitialized` result and not contain previous data.

My theory: that only worked before because of a double-render, so during the first render the result changed a bit and during the second render it completely reset.
#2759 removed that additional render and so the behaviour broke.

This PR reintroduces that expected behaviour (and fixes some minor nitpicks I had over in #2759 - there is still stuff open over there though).