### PR TITLE
General pre-1.9-beta cleanup

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
@@ -18,7 +18,7 @@ const queueMicrotaskShim =
 
 export const buildBatchedActionsHandler: InternalHandlerBuilder<
   [actionShouldContinue: boolean, subscriptionExists: boolean]
-> = ({ api, queryThunk }) => {
+> = ({ api, queryThunk, internalState }) => {
   const { actuallyMutateSubscriptions } = api.internalActions
   const subscriptionsPrefix = `${api.reducerPath}/subscriptions`
 
@@ -27,7 +27,7 @@ export const buildBatchedActionsHandler: InternalHandlerBuilder<
 
   let dispatchQueued = false
 
-  return (action, mwApi, internalState) => {
+  return (action, mwApi) => {
     if (!previousSubscriptions) {
       // Initialize it the first time this handler runs
       previousSubscriptions = JSON.parse(

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -50,13 +50,11 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
   reducerPath,
   api,
   context,
+  internalState,
 }) => {
   const { removeQueryResult, unsubscribeQueryResult } = api.internalActions
 
-  function anySubscriptionsRemainingForKey(
-    queryCacheKey: string,
-    internalState: InternalMiddlewareState
-  ) {
+  function anySubscriptionsRemainingForKey(queryCacheKey: string) {
     const subscriptions = internalState.currentSubscriptions[queryCacheKey]
     return !!subscriptions && !isObjectEmpty(subscriptions)
   }
@@ -76,7 +74,6 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
         queryCacheKey,
         state.queries[queryCacheKey]?.endpointName,
         mwApi,
-        internalState,
         state.config
       )
     }
@@ -99,7 +96,6 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
           queryCacheKey as QueryCacheKey,
           queryState?.endpointName,
           mwApi,
-          internalState,
           state.config
         )
       }
@@ -110,7 +106,6 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
     queryCacheKey: QueryCacheKey,
     endpointName: string | undefined,
     api: SubMiddlewareApi,
-    internalState: InternalMiddlewareState,
     config: ConfigState<string>
   ) {
     const endpointDefinition = context.endpointDefinitions[
@@ -132,13 +127,13 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
       Math.min(keepUnusedDataFor, THIRTY_TWO_BIT_MAX_TIMER_SECONDS)
     )
 
-    if (!anySubscriptionsRemainingForKey(queryCacheKey, internalState)) {
+    if (!anySubscriptionsRemainingForKey(queryCacheKey)) {
       const currentTimeout = currentRemovalTimeouts[queryCacheKey]
       if (currentTimeout) {
         clearTimeout(currentTimeout)
       }
       currentRemovalTimeouts[queryCacheKey] = setTimeout(() => {
-        if (!anySubscriptionsRemainingForKey(queryCacheKey, internalState)) {
+        if (!anySubscriptionsRemainingForKey(queryCacheKey)) {
           api.dispatch(removeQueryResult({ queryCacheKey }))
         }
         delete currentRemovalTimeouts![queryCacheKey]

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -183,6 +183,7 @@ export const buildCacheLifecycleHandler: InternalHandlerBuilder = ({
   context,
   queryThunk,
   mutationThunk,
+  internalState,
 }) => {
   const isQueryThunk = isAsyncThunkAction(queryThunk)
   const isMutationThunk = isAsyncThunkAction(mutationThunk)
@@ -197,7 +198,6 @@ export const buildCacheLifecycleHandler: InternalHandlerBuilder = ({
   const handler: ApiMiddlewareInternalHandler = (
     action,
     mwApi,
-    internalState,
     stateBefore
   ) => {
     const cacheKey = getCacheKey(action)

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -52,6 +52,7 @@ export type SubMiddlewareApi = MiddlewareAPI<
 
 export interface BuildSubMiddlewareInput
   extends BuildMiddlewareInput<EndpointDefinitions, string, string> {
+  internalState: InternalMiddlewareState
   refetchQuery(
     querySubState: Exclude<
       QuerySubState<any>,
@@ -73,7 +74,6 @@ export type SubMiddlewareBuilder = (
 export type ApiMiddlewareInternalHandler<ReturnType = void> = (
   action: AnyAction,
   mwApi: SubMiddlewareApi & { next: Dispatch<AnyAction> },
-  internalState: InternalMiddlewareState,
   prevState: RootState<EndpointDefinitions, string, string>
 ) => ReturnType
 

--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -4,7 +4,6 @@ import { onFocus, onOnline } from '../setupListeners'
 import type {
   ApiMiddlewareInternalHandler,
   InternalHandlerBuilder,
-  InternalMiddlewareState,
   SubMiddlewareApi,
 } from './types'
 
@@ -13,26 +12,22 @@ export const buildWindowEventHandler: InternalHandlerBuilder = ({
   context,
   api,
   refetchQuery,
+  internalState,
 }) => {
   const { removeQueryResult } = api.internalActions
 
-  const handler: ApiMiddlewareInternalHandler = (
-    action,
-    mwApi,
-    internalState
-  ) => {
+  const handler: ApiMiddlewareInternalHandler = (action, mwApi) => {
     if (onFocus.match(action)) {
-      refetchValidQueries(mwApi, 'refetchOnFocus', internalState)
+      refetchValidQueries(mwApi, 'refetchOnFocus')
     }
     if (onOnline.match(action)) {
-      refetchValidQueries(mwApi, 'refetchOnReconnect', internalState)
+      refetchValidQueries(mwApi, 'refetchOnReconnect')
     }
   }
 
   function refetchValidQueries(
     api: SubMiddlewareApi,
-    type: 'refetchOnFocus' | 'refetchOnReconnect',
-    internalState: InternalMiddlewareState
+    type: 'refetchOnFocus' | 'refetchOnReconnect'
   ) {
     const state = api.getState()[reducerPath]
     const queries = state.queries

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -486,8 +486,6 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
       const endpointDefinition =
         endpointDefinitions[queryThunkArgs.endpointName]
 
-      // console.trace('Query thunk: ', currentArg)
-
       // Order of these checks matters.
       // In order for `upsertQueryData` to successfully run while an existing request is in flight,
       /// we have to check for that first, otherwise `queryThunk` will bail out and not run at all.

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -715,7 +715,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
             requestId,
           })
         )
-        // console.log('Probe subscription check: ', returnedValue)
+
         currentRenderHasSubscription = !!returnedValue
       }
 

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -89,11 +89,7 @@ let actions: AnyAction[] = []
 
 const storeRef = setupApiStore(
   api,
-  {
-    // actions(state: AnyAction[] = [], action: AnyAction) {
-    //   return [...state, action]
-    // },
-  },
+  {},
   {
     middleware: {
       prepend: [listenerMiddleware.middleware],
@@ -133,7 +129,9 @@ describe('hooks tests', () => {
       }
 
       render(<User />, { wrapper: storeRef.wrapper })
-      expect(getRenderCount()).toBe(2) // By the time this runs, the initial render will happen, and the query will start immediately running by the time we can expect this
+      // By the time this runs, the initial render will happen, and the query
+      //  will start immediately running by the time we can expect this
+      expect(getRenderCount()).toBe(2)
 
       await waitFor(() =>
         expect(screen.getByTestId('isFetching').textContent).toBe('false')

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -162,21 +162,6 @@ test('Minimizes the number of subscription dispatches when multiple components a
     withoutTestLifecycles: true,
   })
 
-  const onProfile: ProfilerOnRenderCallback = (
-    id,
-    phase,
-    actualDuration,
-    baseDuration,
-    startTime,
-    commitTime
-  ) => {
-    console.table({
-      phase,
-      actualDuration,
-      baseDuration,
-    })
-  }
-
   let getSubscriptionsA = () =>
     storeRef.store.getState().api.subscriptions['a(undefined)']
 
@@ -199,50 +184,19 @@ test('Minimizes the number of subscription dispatches when multiple components a
     return <>{listItems}</>
   }
 
-  const start = Date.now()
-
-  render(
-    // <Profiler id="a" onRender={onProfile}>
-    <ParentComponent />,
-    // </Profiler>,
-    {
-      wrapper: storeRef.wrapper,
-    }
-  )
-
-  const afterRender = Date.now()
+  render(<ParentComponent />, {
+    wrapper: storeRef.wrapper,
+  })
 
   jest.advanceTimersByTime(10)
-
-  const afterTimers1 = Date.now()
 
   await waitFor(() => {
     return screen.getAllByText(/42/).length > 0
   })
 
-  const afterScreen = Date.now()
-
   await runAllTimers()
 
-  const end = Date.now()
-
-  const timeElapsed = end - start
-  // const renderTime = afterRender - start
-  // const timer1Time = afterTimers1 - afterRender
-  // const screenTime = afterScreen - afterTimers1
-  // const timer2Time = end - afterScreen
-
-  // console.table({
-  //   timeElapsed,
-  //   renderTime,
-  //   timer1Time,
-  //   screenTime,
-  //   timer2Time,
-  // })
-
-  // console.log('Getting final subscriptions')
   const subscriptions = getSubscriptionsA()
-  // console.log(actionTypes)
 
   expect(Object.keys(subscriptions!).length).toBe(NUM_LIST_ITEMS)
 
@@ -252,9 +206,4 @@ test('Minimizes the number of subscription dispatches when multiple components a
     'api/internalSubscriptions/subscriptionsUpdated',
     'api/executeQuery/fulfilled',
   ])
-
-  // Could be flaky in CI, but we'll see.
-  // Currently seeing 800ms in local dev, 6300 without the batching fixes
-  // console.log('Elapsed subscription time: ', timeElapsed)
-  expect(timeElapsed).toBeLessThan(1500)
 }, 25000)


### PR DESCRIPTION
- Rearranged the RTKQ middleware internals one more time to simplify passing around `internalState`
- Removed dead code