### PR TITLE
[OpenAPI codegen] Use schema.title for body params

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -168,13 +168,13 @@ export async function generateApi(
         ...apiGen.enumAliases,
         ...(hooks
           ? [
-              generateReactHooks({
-                exportName: generatedApiName,
-                operationDefinitions,
-                endpointOverrides,
-                config: hooks,
-              }),
-            ]
+            generateReactHooks({
+              exportName: generatedApiName,
+              operationDefinitions,
+              endpointOverrides,
+              config: hooks,
+            }),
+          ]
           : []),
       ],
       factory.createToken(ts.SyntaxKind.EndOfFileToken),
@@ -294,7 +294,7 @@ export async function generateApi(
       const body = apiGen.resolve(requestBody);
       const schema = apiGen.getSchemaFromContent(body.content);
       const type = apiGen.getTypeFromSchema(schema);
-      const schemaName = camelCase((type as any).name || getReferenceName(schema) || 'body');
+      const schemaName = camelCase((type as any).name || getReferenceName(schema) || ("title" in schema && schema.title) || 'body');
       const name = generateName(schemaName in queryArg ? 'body' : schemaName, 'body');
 
       queryArg[name] = {
@@ -328,19 +328,19 @@ export async function generateApi(
             ? isFlatArg
               ? withQueryComment({ ...queryArgValues[0].type }, queryArgValues[0], false)
               : factory.createTypeLiteralNode(
-                  queryArgValues.map((def) =>
-                    withQueryComment(
-                      factory.createPropertySignature(
-                        undefined,
-                        propertyName(def.name),
-                        createQuestionToken(!def.required),
-                        def.type
-                      ),
-                      def,
-                      true
-                    )
+                queryArgValues.map((def) =>
+                  withQueryComment(
+                    factory.createPropertySignature(
+                      undefined,
+                      propertyName(def.name),
+                      createQuestionToken(!def.required),
+                      def.type
+                    ),
+                    def,
+                    true
                   )
                 )
+              )
             : factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword)
         )
       ).name
@@ -384,18 +384,18 @@ export async function generateApi(
       return parameters.length === 0
         ? undefined
         : factory.createPropertyAssignment(
-            factory.createIdentifier(propertyName),
-            factory.createObjectLiteralExpression(
-              parameters.map(
-                (param) =>
-                  createPropertyAssignment(
-                    param.originalName,
-                    isFlatArg ? rootObject : accessProperty(rootObject, param.name)
-                  ),
-                true
-              )
+          factory.createIdentifier(propertyName),
+          factory.createObjectLiteralExpression(
+            parameters.map(
+              (param) =>
+                createPropertyAssignment(
+                  param.originalName,
+                  isFlatArg ? rootObject : accessProperty(rootObject, param.name)
+                ),
+              true
             )
-          );
+          )
+        );
     }
 
     return factory.createArrowFunction(
@@ -416,17 +416,17 @@ export async function generateApi(
             isQuery && verb.toUpperCase() === 'GET'
               ? undefined
               : factory.createPropertyAssignment(
-                  factory.createIdentifier('method'),
-                  factory.createStringLiteral(verb.toUpperCase())
-                ),
+                factory.createIdentifier('method'),
+                factory.createStringLiteral(verb.toUpperCase())
+              ),
             bodyParameter === undefined
               ? undefined
               : factory.createPropertyAssignment(
-                  factory.createIdentifier('body'),
-                  isFlatArg
-                    ? rootObject
-                    : factory.createPropertyAccessExpression(rootObject, factory.createIdentifier(bodyParameter.name))
-                ),
+                factory.createIdentifier('body'),
+                isFlatArg
+                  ? rootObject
+                  : factory.createPropertyAccessExpression(rootObject, factory.createIdentifier(bodyParameter.name))
+              ),
             createObjectLiteralProperty(pickParams('cookie'), 'cookies'),
             createObjectLiteralProperty(pickParams('header'), 'headers'),
             createObjectLiteralProperty(pickParams('query'), 'params'),
@@ -438,12 +438,12 @@ export async function generateApi(
   }
 
   // eslint-disable-next-line no-empty-pattern
-  function generateQueryEndpointProps({}: { operationDefinition: OperationDefinition }): ObjectPropertyDefinitions {
+  function generateQueryEndpointProps({ }: { operationDefinition: OperationDefinition }): ObjectPropertyDefinitions {
     return {}; /* TODO needs implementation - skip for now */
   }
 
   // eslint-disable-next-line no-empty-pattern
-  function generateMutationEndpointProps({}: { operationDefinition: OperationDefinition }): ObjectPropertyDefinitions {
+  function generateMutationEndpointProps({ }: { operationDefinition: OperationDefinition }): ObjectPropertyDefinitions {
     return {}; /* TODO needs implementation - skip for now */
   }
 }
@@ -473,16 +473,16 @@ function generatePathExpression(
 
   return expressions.length
     ? factory.createTemplateExpression(
-        factory.createTemplateHead(head),
-        expressions.map(([prop, literal], index) =>
-          factory.createTemplateSpan(
-            isFlatArg ? rootObject : accessProperty(rootObject, prop),
-            index === expressions.length - 1
-              ? factory.createTemplateTail(literal)
-              : factory.createTemplateMiddle(literal)
-          )
+      factory.createTemplateHead(head),
+      expressions.map(([prop, literal], index) =>
+        factory.createTemplateSpan(
+          isFlatArg ? rootObject : accessProperty(rootObject, prop),
+          index === expressions.length - 1
+            ? factory.createTemplateTail(literal)
+            : factory.createTemplateMiddle(literal)
         )
       )
+    )
     : factory.createNoSubstitutionTemplateLiteral(head);
 }
 
@@ -493,13 +493,13 @@ type QueryArgDefinition = {
   required?: boolean;
   param?: OpenAPIV3.ParameterObject;
 } & (
-  | {
+    | {
       origin: 'param';
       param: OpenAPIV3.ParameterObject;
     }
-  | {
+    | {
       origin: 'body';
       body: OpenAPIV3.RequestBodyObject;
     }
-);
+  );
 type QueryArgDefinitions = Record<string, QueryArgDefinition>;

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -383,6 +383,40 @@ export type LoginUserApiArg = {
 
 `;
 
+exports[`falls back to the \`title\` parameter for the body parameter name when no other name is available 1`] = `
+import { api } from 'fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    postV1Export: build.mutation<PostV1ExportApiResponse, PostV1ExportApiArg>({
+      query: (queryArg) => ({
+        url: \`/v1/export\`,
+        method: 'POST',
+        body: queryArg.exportedEntityIds,
+      }),
+    }),
+    postV1Import: build.mutation<PostV1ImportApiResponse, PostV1ImportApiArg>({
+      query: (queryArg) => ({
+        url: \`/v1/import\`,
+        method: 'POST',
+        body: queryArg.rawData,
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type PostV1ExportApiResponse = unknown;
+export type PostV1ExportApiArg = {
+  exportedEntityIds: IdList;
+};
+export type PostV1ImportApiResponse = unknown;
+export type PostV1ImportApiArg = {
+  rawData: string;
+};
+export type IdList = number[];
+
+`;
+
 exports[`hooks generation uses overrides: should generate an \`useLoginMutation\` mutation hook 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({

--- a/packages/rtk-query-codegen-openapi/test/fixtures/title-as-param-name.json
+++ b/packages/rtk-query-codegen-openapi/test/fixtures/title-as-param-name.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Title as param name",
+    "version": "0.1"
+  },
+  "paths": {
+    "/v1/export": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "exportedEntityIds",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/IdList"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/import": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "rawData",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IdList": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -198,6 +198,17 @@ it('supports granular hooks generation with only mutations', async () => {
   expect(api).toMatchSnapshot();
 });
 
+it('falls back to the `title` parameter for the body parameter name when no other name is available', async () => {
+  const api = await generateEndpoints({
+    apiFile: 'fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/title-as-param-name.json'),
+  });
+  expect(api).not.toContain('queryArg.body');
+  expect(api).toContain('queryArg.exportedEntityIds');
+  expect(api).toContain('queryArg.rawData');
+  expect(api).toMatchSnapshot();
+});
+
 test('hooks generation uses overrides', async () => {
   const api = await generateEndpoints({
     unionUndefined: true,


### PR DESCRIPTION
Instead of falling back to `body`, request parameters now consider the schema title as an additional source of information.

Since it was not ideal to change the type or reference name to determine the name of the body parameter in my setup, I was lacking an ability to determine its name from the OpenAPI specification. Using the `title` field of the schema for this purpose seemed pretty reasonable to me. 

FastAPI in particular conveniently allows setting the title attribute of the embedded schema, which was what I was using.

While this is technically a breaking change, I believe it's very unlikely to actually break anyone's code, since setting an embedded type with a title different to the type name or ref name seems uncommon to me.