### PR TITLE
Fix "running thunks" types and remove unnecessary RTKQ selectors

### DIFF
--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -71,8 +71,7 @@ export type CoreModule =
   | ReferenceQueryLifecycle
   | ReferenceCacheCollection
 
-interface ThunkWithReturnValue<T>
-  extends ThunkAction<T | undefined, any, any, AnyAction> {}
+interface ThunkWithReturnValue<T> extends ThunkAction<T, any, any, AnyAction> {}
 
 declare module '../apiTypes' {
   export interface ApiModules<

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -885,7 +885,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
     const useQueryState: UseQueryState<any> = (
       arg: any,
-      { skip = false, selectFromResult = defaultQueryStateSelector } = {}
+      { skip = false, selectFromResult } = {}
     ) => {
       const { select } = api.endpoints[name] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
@@ -916,7 +916,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       )
 
       const querySelector: Selector<ApiRootState, any, [any]> = useMemo(
-        () => createSelector([selectDefaultResult], selectFromResult),
+        () =>
+          selectFromResult
+            ? createSelector([selectDefaultResult], selectFromResult)
+            : selectDefaultResult,
         [selectDefaultResult, selectFromResult]
       )
 


### PR DESCRIPTION
This PR:

- Fixes the type used by the "running queries" thunks to remove `| undefined`, since they both return arrays
- Removes some unnecessary `createSelector` calls from the "build selector" logic and the query hooks