### PR TITLE
Make autobatching notification queueing configurable

### DIFF
--- a/docs/api/autoBatchEnhancer.mdx
+++ b/docs/api/autoBatchEnhancer.mdx
@@ -65,17 +65,30 @@ const store = configureStore({
 
 ```ts title="autoBatchEnhancer signature" no-transpile
 export type SHOULD_AUTOBATCH = string
-export type autoBatchEnhancer = () => StoreEnhancer
+type AutoBatchOptions =
+  | { type: 'tick' }
+  | { type: 'timer'; timeout: number }
+  | { type: 'raf' }
+  | { type: 'callback'; queueNotification: (notify: () => void) => void }
+
+export type autoBatchEnhancer = (options?: AutoBatchOptions) => StoreEnhancer
 ```
 
 Creates a new instance of the autobatch store enhancer.
 
-Any action that is tagged with `action.meta[SHOULD_AUTOBATCH] = true` will be treated as "low-priority", and the enhancer will delay notifying subscribers until either:
+Any action that is tagged with `action.meta[SHOULD_AUTOBATCH] = true` will be treated as "low-priority", and a notification callback will be queued. The enhancer will delay notifying subscribers until either:
 
-- The end of the current event loop tick happens, and a queued microtask runs the notifications
+- The queued callback runs and triggers the notifications
 - A "normal-priority" action (any action _without_ `action.meta[SHOULD_AUTOBATCH] = true`) is dispatched in the same tick
 
-This method currently does not accept any options. We may consider allowing customization of the delay behavior in the future.
+`autoBatchEnhancer` accepts options to configure how the notification callback is queued:
+
+- `{type: 'tick'}: queues using `queueMicrotask` (default)
+- `{type: 'timer, timeout: number}`: queues using `setTimeout`
+- `{type: 'raf'}`: queues using `requestAnimationFrame`
+- `{type: 'callback', queueNotification: (notify: () => void) => void}: lets you provide your own callback
+
+The default behavior is to queue the notifications at the end of the current event loop using `queueMicrotask`.
 
 The `SHOULD_AUTOBATCH` value is meant to be opaque - it's currently a string for simplicity, but could be a `Symbol` in the future.
 
@@ -117,7 +130,7 @@ This enhancer is a variation of the "debounce" approach, but with a twist.
 
 Instead of _just_ debouncing _all_ subscriber notifications, it watches for any actions with a specific `action.meta[SHOULD_AUTOBATCH]: true` field attached.
 
-When it sees an action with that field, it queues a microtask. The reducer is updated immediately, but the enhancer does _not_ notify subscribers right way. If other actions with the same field are dispatched in succession, the enhancer will continue to _not_ notify subscribers. Then, when the queued microtask runs at the end of the event loop tick, it finally notifies all subscribers, similar to how React batches re-renders.
+When it sees an action with that field, it queues a callback. The reducer is updated immediately, but the enhancer does _not_ notify subscribers right way. If other actions with the same field are dispatched in succession, the enhancer will continue to _not_ notify subscribers. Then, when the queued callback runs, it finally notifies all subscribers, similar to how React batches re-renders.
 
 The additional twist is also inspired by React's separation of updates into "low-priority" and "immediate" behavior (such as a render queued by an AJAX request vs a render queued by a user input that should be handled synchronously).
 

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -189,4 +189,5 @@ export {
   SHOULD_AUTOBATCH,
   prepareAutoBatched,
   autoBatchEnhancer,
+  AutoBatchOptions,
 } from './autoBatchEnhancer'


### PR DESCRIPTION
This PR:

- Updates the `autoBatchEnhancer` to accept four options for queueing the notification callback:
  - `queueMicrotask` (default)
  - `setTimeout` (with timer)
  - `requestAnimationFrame`
  - user-provided callback

The user-provided option makes it more similar to https://github.com/tappleby/redux-batched-subscribe , although this still only runs against specifically-tagged actions rather than _all_ actions.  There's also some similar/related issues there:

- https://github.com/tappleby/redux-batched-subscribe/issues/24
- https://github.com/tappleby/redux-batched-subscribe/issues/4

(Hypothetically, maybe down the road we'd allow passing in a "batch this action?" predicate or something.)

In practice, what I'm seeing in a local benchmark copy of https://github.com/phryneas/rtkq-performance-testbench and capturing "1000 children, individual queries" is that:

- `queueMicrotask`: keeps the UI updated as each promise resolves, but forces a full render each time because each promise resolve is its own microtask.  (992 renders total)
- `setTimeout`: gets delayed until after _all_ the promises have resolved, because each promise is a microtask, and those all expire and line up to run before the timer task ever gets a chance to run. That causes the UI to freeze for several seconds.  (3 renders total)
- `requestAnimationFrame`: a good balance. Seems to have higher priority than the microtask queue, so it runs after 5-6 promises have resolved (makes sense, 2.5ms dispatch, 16.6ms frame).  That keeps the UI updating more freely, and the renders are small. (39 renders total)

So, having these options built in, plus a bring-your-own, seems to cover the bases pretty well.