### PR TITLE
fulfillWithValue should infer return value

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -35,9 +35,7 @@ export type BaseThunkAPI<
   >
   fulfillWithValue: IsUnknown<
     FulfilledMeta,
-    <FulfilledValue>(
-      value: FulfilledValue
-    ) => FulfillWithMeta<FulfilledValue, FulfilledMeta>,
+    <FulfilledValue>(value: FulfilledValue) => FulfilledValue,
     <FulfilledValue>(
       value: FulfilledValue,
       meta: FulfilledMeta
@@ -405,18 +403,16 @@ export type AsyncThunk<
   Returned,
   ThunkArg,
   ThunkApiConfig extends AsyncThunkConfig
-> = [Returned] extends [FulfillWithMeta<infer P, infer M>]
-  ? AsyncThunk<P, ThunkArg, ThunkApiConfig & { fulfilledMeta: M }>
-  : AsyncThunkActionCreator<Returned, ThunkArg, ThunkApiConfig> & {
-      pending: AsyncThunkPendingActionCreator<ThunkArg, ThunkApiConfig>
-      rejected: AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig>
-      fulfilled: AsyncThunkFulfilledActionCreator<
-        Returned,
-        ThunkArg,
-        ThunkApiConfig
-      >
-      typePrefix: string
-    }
+> = AsyncThunkActionCreator<Returned, ThunkArg, ThunkApiConfig> & {
+  pending: AsyncThunkPendingActionCreator<ThunkArg, ThunkApiConfig>
+  rejected: AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig>
+  fulfilled: AsyncThunkFulfilledActionCreator<
+    Returned,
+    ThunkArg,
+    ThunkApiConfig
+  >
+  typePrefix: string
+}
 
 type OverrideThunkApiConfigs<OldConfig, NewConfig> = Id<
   NewConfig & Omit<OldConfig, keyof NewConfig>
@@ -696,12 +692,19 @@ If you want to use the AbortController to react to \`abort\` events, please cons
       }
     }
 
-    return Object.assign(actionCreator as any, {
-      pending,
-      rejected,
-      fulfilled,
-      typePrefix,
-    })
+    return Object.assign(
+      actionCreator as AsyncThunkActionCreator<
+        Returned,
+        ThunkArg,
+        ThunkApiConfig
+      >,
+      {
+        pending,
+        rejected,
+        fulfilled,
+        typePrefix,
+      }
+    )
   }
   createAsyncThunk.withTypes = () => createAsyncThunk
 

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -405,16 +405,18 @@ export type AsyncThunk<
   Returned,
   ThunkArg,
   ThunkApiConfig extends AsyncThunkConfig
-> = AsyncThunkActionCreator<Returned, ThunkArg, ThunkApiConfig> & {
-  pending: AsyncThunkPendingActionCreator<ThunkArg, ThunkApiConfig>
-  rejected: AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig>
-  fulfilled: AsyncThunkFulfilledActionCreator<
-    Returned,
-    ThunkArg,
-    ThunkApiConfig
-  >
-  typePrefix: string
-}
+> = [Returned] extends [FulfillWithMeta<infer P, infer M>]
+  ? AsyncThunk<P, ThunkArg, ThunkApiConfig & { fulfilledMeta: M }>
+  : AsyncThunkActionCreator<Returned, ThunkArg, ThunkApiConfig> & {
+      pending: AsyncThunkPendingActionCreator<ThunkArg, ThunkApiConfig>
+      rejected: AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig>
+      fulfilled: AsyncThunkFulfilledActionCreator<
+        Returned,
+        ThunkArg,
+        ThunkApiConfig
+      >
+      typePrefix: string
+    }
 
 type OverrideThunkApiConfigs<OldConfig, NewConfig> = Id<
   NewConfig & Omit<OldConfig, keyof NewConfig>
@@ -694,19 +696,12 @@ If you want to use the AbortController to react to \`abort\` events, please cons
       }
     }
 
-    return Object.assign(
-      actionCreator as AsyncThunkActionCreator<
-        Returned,
-        ThunkArg,
-        ThunkApiConfig
-      >,
-      {
-        pending,
-        rejected,
-        fulfilled,
-        typePrefix,
-      }
-    )
+    return Object.assign(actionCreator as any, {
+      pending,
+      rejected,
+      fulfilled,
+      typePrefix,
+    })
   }
   createAsyncThunk.withTypes = () => createAsyncThunk
 

--- a/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
@@ -525,6 +525,38 @@ const anyAction = { type: 'foo' } as AnyAction
   })
 }
 
+{
+  // https://github.com/reduxjs/redux-toolkit/issues/2886
+  // fulfillWithValue should infer return value
+
+  const initialState = {
+    loading: false,
+    obj: { magic: '' },
+  }
+
+  const getObj = createAsyncThunk(
+    'slice/getObj',
+    async (_: any, { fulfillWithValue, rejectWithValue }) => {
+      try {
+        return fulfillWithValue({ magic: 'object' })
+      } catch (rejected: any) {
+        return rejectWithValue(rejected?.response?.error || rejected)
+      }
+    }
+  )
+
+  createSlice({
+    name: 'slice',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+      builder.addCase(getObj.fulfilled, (state, action) => {
+        expectExactType<{ magic: string }>(ANY)(action.payload)
+      })
+    },
+  })
+}
+
 // meta return values
 {
   // return values
@@ -621,8 +653,8 @@ const anyAction = { type: 'foo' } as AnyAction
 
     // correct extra type
     const { s, n } = api.extra
-    expectExactType<string>(s)
-    expectExactType<number>(n)
+    expectExactType<string>(ANY)(s)
+    expectExactType<number>(ANY)(n)
 
     if (1 < 2)
       // @ts-expect-error
@@ -646,8 +678,8 @@ const anyAction = { type: 'foo' } as AnyAction
     })
     // correct extra type
     const { s, n } = api.extra
-    expectExactType<string>(s)
-    expectExactType<number>(n)
+    expectExactType<string>(ANY)(s)
+    expectExactType<number>(ANY)(n)
 
     if (1 < 2)
       // @ts-expect-error
@@ -673,8 +705,8 @@ const anyAction = { type: 'foo' } as AnyAction
       })
       // correct extra type
       const { s, n } = api.extra
-      expectExactType<string>(s)
-      expectExactType<number>(n)
+      expectExactType<string>(ANY)(s)
+      expectExactType<number>(ANY)(n)
       if (1 < 2) return api.rejectWithValue(5)
       if (1 < 2)
         // @ts-expect-error


### PR DESCRIPTION
Closes #2886 

This should probably sit for a while to make sure it doesn't break anything or should be done somewhere else. 

So far, this was just not possible to be inferred - it is a bit nonsensical to use `returnWithValue` if no `fulfilledMeta` is declared in the `ThunkConfig` - that makes it impossible to add a `meta` as a second argument and defeats the purpose a bit.