### PR TITLE
Update axios example to use body instead of data

### DIFF
--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -303,13 +303,13 @@ const axiosBaseQuery =
     {
       url: string
       method: AxiosRequestConfig['method']
-      data?: AxiosRequestConfig['data']
+      body?: AxiosRequestConfig['data']
       params?: AxiosRequestConfig['params']
     },
     unknown,
     unknown
   > =>
-  async ({ url, method, data, params }) => {
+  async ({ url, method, body: data, params }) => {
     try {
       const result = await axios({ url: baseUrl + url, method, data, params })
       return { data: result.data }


### PR DESCRIPTION
It seems that rtkq passes the data as `body` not `data`. This updates the example to send the body object as the data attribute