### PR TITLE
Update quick-start.mdx

### DIFF
--- a/docs/tutorials/quick-start.mdx
+++ b/docs/tutorials/quick-start.mdx
@@ -58,7 +58,6 @@ export const store = configureStore({
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>
-// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
 export type AppDispatch = typeof store.dispatch
 ```
 


### PR DESCRIPTION
remove confusing comment since `posts`, `comments` and `users` are not registered