### PR TITLE
Correct minor spelling mistake in docs for transform error response

### DIFF
--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -177,7 +177,7 @@ See also [Websocket Chat API with a transformed response shape](./streaming-upda
 
 ## Customizing query responses with `transformErrorResponse`
 
-Individual endpoints on [`createApi`](../api/createApi.mdx) accept a [`transformErrorResponse`](../api/createApi.mdx) property which allows manipulation of the errir returned by a query or mutation before it hits the cache.
+Individual endpoints on [`createApi`](../api/createApi.mdx) accept a [`transformErrorResponse`](../api/createApi.mdx) property which allows manipulation of the error returned by a query or mutation before it hits the cache.
 
 `transformErrorResponse` is called with the error that a failed `baseQuery` returns for the corresponding endpoint, and the return value of `transformErrorResponse` is used as the cached error associated with that endpoint call.
 


### PR DESCRIPTION
As per https://github.com/reduxjs/redux-toolkit/issues/2947, this corrects a minor spelling mistake