### PR TITLE
Retry now checks whether potential retry counts are undefined, rather than boolean, in order to avoid filtering out 0's

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -83,7 +83,7 @@ const retryWithBackoff: BaseQueryEnhancer<
     5,
     ((defaultOptions as any) || EMPTY_OPTIONS).maxRetries,
     ((extraOptions as any) || EMPTY_OPTIONS).maxRetries,
-  ].filter(Boolean)
+  ].filter(x => x !== undefined)
   const [maxRetries] = possibleMaxRetries.slice(-1)
 
   const defaultRetryCondition: RetryConditionFunction = (_, __, { attempt }) =>


### PR DESCRIPTION
This will change the filter on possible max retries so that, instead of using `Boolean` (which may unintentionally match against false-y values) to checking that the properties are not undefined.

https://github.com/reduxjs/redux-toolkit/issues/2934