### PR TITLE
Fix multiple small issues with 1.9

### DIFF
--- a/packages/toolkit/src/createAction.ts
+++ b/packages/toolkit/src/createAction.ts
@@ -144,7 +144,7 @@ export interface ActionCreatorWithoutPayload<T extends string = string>
    * Calling this {@link redux#ActionCreator} will
    * return a {@link PayloadAction} of type `T` with a payload of `undefined`
    */
-  (): PayloadAction<undefined, T>
+  (noArgument: void): PayloadAction<undefined, T>
 }
 
 /**

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -412,6 +412,7 @@ export interface ApiEndpointQuery<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Definitions extends EndpointDefinitions
 > {
+  name: string
   /**
    * All of these are `undefined` at runtime, purely to be used in TypeScript declarations!
    */
@@ -425,6 +426,7 @@ export interface ApiEndpointMutation<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Definitions extends EndpointDefinitions
 > {
+  name: string
   /**
    * All of these are `undefined` at runtime, purely to be used in TypeScript declarations!
    */
@@ -603,6 +605,7 @@ export const coreModule = (): Module<CoreModule> => ({
           safeAssign(
             anyApi.endpoints[endpointName],
             {
+              name: endpointName,
               select: buildQuerySelector(endpointName, definition),
               initiate: buildInitiateQuery(endpointName, definition),
             },
@@ -612,6 +615,7 @@ export const coreModule = (): Module<CoreModule> => ({
           safeAssign(
             anyApi.endpoints[endpointName],
             {
+              name: endpointName,
               select: buildMutationSelector(),
               initiate: buildInitiateMutation(endpointName),
             },

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -10,6 +10,7 @@ export type {
   EndpointDefinition,
   QueryDefinition,
   MutationDefinition,
+  TagDescription,
 } from './endpointDefinitions'
 export { fetchBaseQuery } from './fetchBaseQuery'
 export type {

--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -18,6 +18,7 @@ import {
 import { server } from './mocks/server'
 import { rest } from 'msw'
 import { SerializeQueryArgs } from '../defaultSerializeQueryArgs'
+import { string } from 'yargs'
 
 const originalEnv = process.env.NODE_ENV
 beforeAll(() => void ((process.env as any).NODE_ENV = 'development'))
@@ -43,6 +44,9 @@ test('sensible defaults', () => {
           return { url: `user/${id}` }
         },
       }),
+      updateUser: build.mutation<unknown, void>({
+        query: () => '',
+      }),
     }),
   })
   configureStore({
@@ -60,6 +64,9 @@ test('sensible defaults', () => {
   expectType<TagTypes>(ANY as never)
   // @ts-expect-error
   expectType<TagTypes>(0)
+
+  expect(api.endpoints.getUser.name).toBe('getUser')
+  expect(api.endpoints.updateUser.name).toBe('updateUser')
 })
 
 describe('wrong tagTypes log errors', () => {

--- a/packages/toolkit/src/tests/createAction.typetest.tsx
+++ b/packages/toolkit/src/tests/createAction.typetest.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import type { Action, AnyAction, ActionCreator } from 'redux'
 import type {
   PayloadAction,
@@ -343,4 +344,16 @@ import { expectType } from './helpers'
   expectType<ActionCreatorWithPayload<any>>(anyCreator)
   type AnyPayload = ReturnType<typeof anyCreator>['payload']
   expectType<IsAny<AnyPayload, true, false>>(true)
+}
+
+// Verify action creators should not be passed directly as arguments
+// to React event handlers if there shouldn't be a payload
+{
+  const emptyAction = createAction<void>('empty/action')
+  function TestComponent() {
+    // This typically leads to an error like:
+    //  // A non-serializable value was detected in an action, in the path: `payload`.
+    // @ts-expect-error Should error because `void` and `MouseEvent` aren't compatible
+    return <button onClick={emptyAction}>+</button>
+  }
 }


### PR DESCRIPTION
- Exported `TagDescription` type
- Updated `createAction`'s `ActionCreatorWithoutPayload` type to ensure that it can't be called with an argument (such as passing it directly to an `onClick` handler)
- Exposed `api.endpoints.someEndpoint.name` field with the actual name of the endpoint (such as `"getPokemon"`

Fixes #2876
Fixes #2896
Fixes #2940 