### PR TITLE
Additional 1.9.1 fixes

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -181,6 +181,8 @@ export function buildSlice({
 
               if (merge) {
                 if (substate.data !== undefined) {
+                  const { fulfilledTimeStamp, arg, baseQueryMeta, requestId } =
+                    meta
                   // There's existing cache data. Let the user merge it in themselves.
                   // We're already inside an Immer-powered reducer, and the user could just mutate `substate.data`
                   // themselves inside of `merge()`. But, they might also want to return a new value.
@@ -189,7 +191,12 @@ export function buildSlice({
                     substate.data,
                     (draftSubstateData) => {
                       // As usual with Immer, you can mutate _or_ return inside here, but not both
-                      return merge(draftSubstateData, payload)
+                      return merge(draftSubstateData, payload, {
+                        arg: arg.originalArgs,
+                        baseQueryMeta,
+                        fulfilledTimeStamp,
+                        requestId,
+                      })
                     }
                   )
                   substate.data = newData

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -445,7 +445,13 @@ export interface QueryExtraOptions<
    */
   merge?(
     currentCacheData: ResultType,
-    responseData: ResultType
+    responseData: ResultType,
+    otherArgs: {
+      arg: QueryArg
+      baseQueryMeta: BaseQueryMeta<BaseQuery>
+      requestId: string
+      fulfilledTimeStamp: number
+    }
   ): ResultType | void
 
   /**

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -13,6 +13,7 @@ import {
   getLog,
 } from 'console-testing-library/pure'
 import { expectType } from './helpers'
+import { delay } from '../utils'
 
 declare global {
   interface Window {
@@ -621,6 +622,21 @@ describe('conditional skipping of asyncThunks', () => {
     )
   })
 
+  test('async condition with AbortController signal first', async () => {
+    const condition = async () => {
+      await delay(25)
+      return true
+    }
+    const asyncThunk = createAsyncThunk('test', payloadCreator, { condition })
+
+    try {
+      const thunkPromise = asyncThunk(arg)(dispatch, getState, extra)
+      thunkPromise.abort()
+      await thunkPromise
+    } catch (err) {}
+    expect(dispatch).toHaveBeenCalledTimes(0)
+  })
+
   test('rejected action is not dispatched by default', async () => {
     const asyncThunk = createAsyncThunk('test', payloadCreator, { condition })
     await asyncThunk(arg)(dispatch, getState, extra)
@@ -630,7 +646,7 @@ describe('conditional skipping of asyncThunks', () => {
 
   test('does not fail when attempting to abort a canceled promise', async () => {
     const asyncPayloadCreator = jest.fn(async (x: typeof arg) => {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await delay(200)
       return 10
     })
 


### PR DESCRIPTION
- Allow calling `thunkPromise.abort()` prior to an async `condition` resolving to be the same as returning `false` from condition (ie, bail out and do nothing)
- Pass additional metadata into `merge()`

Fixes #2874 
Fixes #2918 