### PR TITLE
Fix Identifier/MemberExpression values in createReducerBuilder

### DIFF
--- a/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic-ts.input.ts
+++ b/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic-ts.input.ts
@@ -1,7 +1,9 @@
 createReducer(initialState, {
-  [todoAdded]: (state: SliceState, action: PayloadAction<string>) => {
+  [todoAdded1a]: (state: SliceState, action: PayloadAction<string>) => {
     // stuff
   },
+  [todoAdded1b]: someFunc,
+  todoAdded1c: adapter.someFunc,
 });
 
 createReducer(initialState, {

--- a/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic-ts.output.ts
+++ b/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic-ts.output.ts
@@ -1,7 +1,10 @@
 createReducer(initialState, (builder) => {
-  builder.addCase(todoAdded, (state: SliceState, action: PayloadAction<string>) => {
+  builder.addCase(todoAdded1a, (state: SliceState, action: PayloadAction<string>) => {
     // stuff
   });
+
+  builder.addCase(todoAdded1b, someFunc);
+  builder.addCase(todoAdded1c, adapter.someFunc);
 });
 
 createReducer(initialState, (builder) => {

--- a/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic.input.js
+++ b/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic.input.js
@@ -14,7 +14,9 @@ createReducer(initialState, {
   },
   todoAdded1f: (state, action) => {
     //stuff
-  }
+  },
+  [todoAdded1g]: someFunc,
+  todoAdded1h: adapter.someFunc
 });
 
 

--- a/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic.output.js
+++ b/packages/rtk-codemods/transforms/createReducerBuilder/__testfixtures__/basic.output.js
@@ -20,6 +20,9 @@ createReducer(initialState, (builder) => {
   builder.addCase(todoAdded1f, (state, action) => {
     //stuff
   });
+
+  builder.addCase(todoAdded1g, someFunc);
+  builder.addCase(todoAdded1h, adapter.someFunc);
 });
 
 


### PR DESCRIPTION
Follow-up to #2881.

Applies the same fixes to `createReducerBuilder` so the reducers are not deleted.