### PR TITLE
Fix lint problems and enable linting on CI

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -77,13 +77,13 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "build-ci": "yarn rimraf dist && yarn tsc && node scripts/cli.js --skipExtraction",
+    "build-ci": "yarn rimraf dist && yarn tsc && yarn lint && node scripts/cli.js --skipExtraction",
     "build-prepare": "npm run build-ci",
     "build": "yarn rimraf dist && yarn tsc && node scripts/cli.js --local --skipExtraction",
     "build-only": "yarn rimraf dist && yarn tsc && node scripts/cli.js --skipExtraction",
     "format": "prettier --write \"(src|examples)/**/*.{ts,tsx}\" \"**/*.md\"",
     "format:check": "prettier --list-different \"(src|examples)/**/*.{ts,tsx}\" \"docs/*/**.md\"",
-    "lint": "eslint src examples",
+    "lint": "eslint src",
     "test": "jest --runInBand",
     "type-tests": "yarn tsc -p src/tests/tsconfig.typetests.json && yarn tsc -p src/query/tests/tsconfig.typetests.json",
     "prepack": "npm run build-prepare"

--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -225,6 +225,14 @@ export const createListenerEntry: TypedCreateListenerEntry<unknown> = (
   return entry
 }
 
+const cancelActiveListeners = (
+  entry: ListenerEntry<unknown, Dispatch<AnyAction>>
+) => {
+  entry.pending.forEach((controller) => {
+    abortControllerWithReason(controller, listenerCancelled)
+  })
+}
+
 const createClearListenerMiddleware = (
   listenerMap: Map<string, ListenerEntry>
 ) => {
@@ -279,14 +287,6 @@ export const removeListener = createAction(
 
 const defaultErrorHandler: ListenerErrorHandler = (...args: unknown[]) => {
   console.error(`${alm}/error`, ...args)
-}
-
-const cancelActiveListeners = (
-  entry: ListenerEntry<unknown, Dispatch<AnyAction>>
-) => {
-  entry.pending.forEach((controller) => {
-    abortControllerWithReason(controller, listenerCancelled)
-  })
 }
 
 /**

--- a/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
@@ -6,7 +6,8 @@ import type {
   Subscribers,
 } from '../apiState'
 import { produceWithPatches } from 'immer'
-import { createSlice, PayloadAction, AnyAction } from '@reduxjs/toolkit'
+import type { AnyAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 // Copied from https://github.com/feross/queue-microtask
 let promise: Promise<any>

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -12,15 +12,16 @@ import type {
   QueryActionCreatorResult,
 } from './buildInitiate'
 import { forceQueryFnSymbol, isUpsertQuery } from './buildInitiate'
-import {
+import type {
   AssertTagTypes,
   EndpointDefinition,
   EndpointDefinitions,
-  isQueryDefinition,
   MutationDefinition,
   QueryArgFrom,
   QueryDefinition,
-  ResultTypeFrom,
+  ResultTypeFrom} from '../endpointDefinitions';
+import {
+  isQueryDefinition
 } from '../endpointDefinitions'
 import { calculateProvidedBy } from '../endpointDefinitions'
 import type { AsyncThunkPayloadCreator, Draft } from '@reduxjs/toolkit'

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -19,10 +19,9 @@ import type {
   MutationDefinition,
   QueryArgFrom,
   QueryDefinition,
-  ResultTypeFrom} from '../endpointDefinitions';
-import {
-  isQueryDefinition
+  ResultTypeFrom,
 } from '../endpointDefinitions'
+import { isQueryDefinition } from '../endpointDefinitions'
 import { calculateProvidedBy } from '../endpointDefinitions'
 import type { AsyncThunkPayloadCreator, Draft } from '@reduxjs/toolkit'
 import {

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -1,9 +1,10 @@
 import type { Api, ApiContext, Module, ModuleName } from './apiTypes'
 import type { CombinedState } from './core/apiState'
 import type { BaseQueryArg, BaseQueryFn } from './baseQueryTypes'
+import type {
+  SerializeQueryArgs} from './defaultSerializeQueryArgs';
 import {
-  defaultSerializeQueryArgs,
-  SerializeQueryArgs,
+  defaultSerializeQueryArgs
 } from './defaultSerializeQueryArgs'
 import type {
   EndpointBuilder,

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -1,11 +1,8 @@
 import type { Api, ApiContext, Module, ModuleName } from './apiTypes'
 import type { CombinedState } from './core/apiState'
 import type { BaseQueryArg, BaseQueryFn } from './baseQueryTypes'
-import type {
-  SerializeQueryArgs} from './defaultSerializeQueryArgs';
-import {
-  defaultSerializeQueryArgs
-} from './defaultSerializeQueryArgs'
+import type { SerializeQueryArgs } from './defaultSerializeQueryArgs'
+import { defaultSerializeQueryArgs } from './defaultSerializeQueryArgs'
 import type {
   EndpointBuilder,
   EndpointDefinitions,

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -1,5 +1,5 @@
 import type { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
-import { SerializeQueryArgs } from './defaultSerializeQueryArgs'
+import type { SerializeQueryArgs } from './defaultSerializeQueryArgs'
 import type { QuerySubState, RootState } from './core/apiState'
 import type {
   BaseQueryExtraOptions,

--- a/packages/toolkit/src/query/react/ApiProvider.tsx
+++ b/packages/toolkit/src/query/react/ApiProvider.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { Context, useEffect } from 'react'
+import type { Context } from 'react'
+import { useEffect } from 'react'
 import React from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import { Provider } from 'react-redux'
@@ -50,7 +51,7 @@ export function ApiProvider<A extends Api<any, {}, any, any>>(props: {
       props.setupListeners === false
         ? undefined
         : setupListeners(store.dispatch, props.setupListeners),
-    [props.setupListeners]
+    [props.setupListeners, store.dispatch]
   )
 
   return (

--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -5,7 +5,7 @@ import type {
   BaseQueryExtraOptions,
   BaseQueryFn,
 } from './baseQueryTypes'
-import { FetchBaseQueryError } from './fetchBaseQuery'
+import type { FetchBaseQueryError } from './fetchBaseQuery'
 import { HandledError } from './HandledError'
 
 /**

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -25,9 +25,10 @@ import {
 import { server } from './mocks/server'
 import type { AnyAction } from 'redux'
 import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiState'
+import type {
+  SerializedError} from '@reduxjs/toolkit';
 import {
   createListenerMiddleware,
-  SerializedError,
   configureStore,
 } from '@reduxjs/toolkit'
 import { renderHook } from '@testing-library/react'

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -25,12 +25,8 @@ import {
 import { server } from './mocks/server'
 import type { AnyAction } from 'redux'
 import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiState'
-import type {
-  SerializedError} from '@reduxjs/toolkit';
-import {
-  createListenerMiddleware,
-  configureStore,
-} from '@reduxjs/toolkit'
+import type { SerializedError } from '@reduxjs/toolkit'
+import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
 import { renderHook } from '@testing-library/react'
 import { delay } from '../../utils'
 

--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -17,7 +17,7 @@ import {
 } from './helpers'
 import { server } from './mocks/server'
 import { rest } from 'msw'
-import { SerializeQueryArgs } from '../defaultSerializeQueryArgs'
+import type { SerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import { string } from 'yargs'
 
 const originalEnv = process.env.NODE_ENV

--- a/packages/toolkit/src/tests/autoBatchEnhancer.test.ts
+++ b/packages/toolkit/src/tests/autoBatchEnhancer.test.ts
@@ -1,9 +1,10 @@
 import { configureStore } from '../configureStore'
 import { createSlice } from '../createSlice'
+import type {
+  AutoBatchOptions} from '../autoBatchEnhancer';
 import {
   autoBatchEnhancer,
-  prepareAutoBatched,
-  AutoBatchOptions,
+  prepareAutoBatched
 } from '../autoBatchEnhancer'
 import { delay } from '../utils'
 import { debounce } from 'lodash'

--- a/packages/toolkit/src/tests/autoBatchEnhancer.test.ts
+++ b/packages/toolkit/src/tests/autoBatchEnhancer.test.ts
@@ -1,11 +1,7 @@
 import { configureStore } from '../configureStore'
 import { createSlice } from '../createSlice'
-import type {
-  AutoBatchOptions} from '../autoBatchEnhancer';
-import {
-  autoBatchEnhancer,
-  prepareAutoBatched
-} from '../autoBatchEnhancer'
+import type { AutoBatchOptions } from '../autoBatchEnhancer'
+import { autoBatchEnhancer, prepareAutoBatched } from '../autoBatchEnhancer'
 import { delay } from '../utils'
 import { debounce } from 'lodash'
 

--- a/packages/toolkit/src/tests/configureStore.typetest.ts
+++ b/packages/toolkit/src/tests/configureStore.typetest.ts
@@ -6,15 +6,14 @@ import type {
   Reducer,
   Store,
   Action,
-  StoreEnhancer
+  StoreEnhancer,
 } from 'redux'
 import { applyMiddleware } from 'redux'
-import type { PayloadAction ,
-  ConfigureStoreOptions} from '@reduxjs/toolkit'
+import type { PayloadAction, ConfigureStoreOptions } from '@reduxjs/toolkit'
 import {
   configureStore,
   getDefaultMiddleware,
-  createSlice
+  createSlice,
 } from '@reduxjs/toolkit'
 import type { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
 import thunk from 'redux-thunk'
@@ -144,10 +143,12 @@ const _anyMiddleware: any = () => () => () => {}
   {
     const store = configureStore({
       reducer: () => 0,
-      enhancers: [applyMiddleware(() => next => next)]
+      enhancers: [applyMiddleware(() => (next) => next)],
     })
 
-    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(store.dispatch)
+    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(
+      store.dispatch
+    )
   }
 
   configureStore({
@@ -159,7 +160,7 @@ const _anyMiddleware: any = () => () => () => {}
   {
     type SomePropertyStoreEnhancer = StoreEnhancer<{ someProperty: string }>
 
-    const somePropertyStoreEnhancer: SomePropertyStoreEnhancer = next => {
+    const somePropertyStoreEnhancer: SomePropertyStoreEnhancer = (next) => {
       return (reducer, preloadedState) => {
         return {
           ...next(reducer, preloadedState),
@@ -168,9 +169,13 @@ const _anyMiddleware: any = () => () => () => {}
       }
     }
 
-    type AnotherPropertyStoreEnhancer = StoreEnhancer<{ anotherProperty: number }>
+    type AnotherPropertyStoreEnhancer = StoreEnhancer<{
+      anotherProperty: number
+    }>
 
-    const anotherPropertyStoreEnhancer: AnotherPropertyStoreEnhancer = next => {
+    const anotherPropertyStoreEnhancer: AnotherPropertyStoreEnhancer = (
+      next
+    ) => {
       return (reducer, preloadedState) => {
         return {
           ...next(reducer, preloadedState),
@@ -184,7 +189,9 @@ const _anyMiddleware: any = () => () => () => {}
       enhancers: [somePropertyStoreEnhancer, anotherPropertyStoreEnhancer],
     })
 
-    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(store.dispatch)
+    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(
+      store.dispatch
+    )
     expectType<string>(store.someProperty)
     expectType<number>(store.anotherProperty)
   }
@@ -348,7 +355,9 @@ const _anyMiddleware: any = () => () => () => {}
   {
     const store = configureStore({
       reducer: reducerA,
-      middleware: [] as any as readonly [Middleware<(a: StateA) => boolean, StateA>],
+      middleware: [] as any as readonly [
+        Middleware<(a: StateA) => boolean, StateA>
+      ],
     })
     const result: boolean = store.dispatch(5)
     // @ts-expect-error
@@ -532,21 +541,23 @@ const _anyMiddleware: any = () => () => () => {}
       initialState: null as any,
       reducers: {
         set(state) {
-          return state;
+          return state
         },
       },
-    });
+    })
 
-    function configureMyStore<S>(options: Omit<ConfigureStoreOptions<S>, 'reducer'>) {
+    function configureMyStore<S>(
+      options: Omit<ConfigureStoreOptions<S>, 'reducer'>
+    ) {
       return configureStore({
         ...options,
         reducer: someSlice.reducer,
-      });
+      })
     }
 
-    const store = configureMyStore({});
+    const store = configureMyStore({})
 
-    expectType<Function>(store.dispatch);
+    expectType<Function>(store.dispatch)
   }
 
   {

--- a/packages/toolkit/src/tests/configureStore.typetest.ts
+++ b/packages/toolkit/src/tests/configureStore.typetest.ts
@@ -9,12 +9,12 @@ import type {
   StoreEnhancer
 } from 'redux'
 import { applyMiddleware } from 'redux'
-import type { PayloadAction } from '@reduxjs/toolkit'
+import type { PayloadAction ,
+  ConfigureStoreOptions} from '@reduxjs/toolkit'
 import {
   configureStore,
   getDefaultMiddleware,
-  createSlice,
-  ConfigureStoreOptions,
+  createSlice
 } from '@reduxjs/toolkit'
 import type { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
 import thunk from 'redux-thunk'

--- a/packages/toolkit/src/tests/injectableCombineReducers.example.ts
+++ b/packages/toolkit/src/tests/injectableCombineReducers.example.ts
@@ -31,7 +31,8 @@ export const rootReducer = combineSlices(sliceA, sliceB, {
 // fileC.ts
 // "naive" approach
 
-import { rootReducer, RootState } from './reducer'
+import type { RootState } from './reducer';
+import { rootReducer } from './reducer'
 import { createSlice } from '@reduxjs/toolkit'
 
 interface SliceCState {


### PR DESCRIPTION
Even though ESLint is configured in this project, it isn't called on CI, so the rules aren't enforced. Whenever I open the source code in my IDE, I see ESLint warnings and they're really distracting. This PR fixes the existing ESLint warnings and adds `yarn lint` to `build-ci` to enforce the rules in the future.

After fixing the lint issues (`yarn lint --fix`), I didn't run `yarn format` to reformat the code. Prettier is another tool that's configured but not enforced. Should I reformat the code and add `yarn format:check` to `build-ci` in this PR as well?

upd: I did reformat the code, but only in the files where lint issues have been fixed.