### PR TITLE
`raceWithSignal` method instead of `Promise.race`

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -39,10 +39,10 @@ import {
 } from './exceptions'
 import {
   runTask,
-  promisifyAbortSignal,
   validateActive,
   createPause,
   createDelay,
+  raceWithSignal,
 } from './task'
 export { TaskAbortError } from './exceptions'
 export type {
@@ -138,9 +138,9 @@ const createTakePattern = <S>(
     // Placeholder unsubscribe function until the listener is added
     let unsubscribe: UnsubscribeListener = () => {}
 
-    const tuplePromise = new Promise<[AnyAction, S, S]>((resolve) => {
+    const tuplePromise = new Promise<[AnyAction, S, S]>((resolve, reject) => {
       // Inside the Promise, we synchronously add the listener.
-      unsubscribe = startListening({
+      let stopListening = startListening({
         predicate: predicate as any,
         effect: (action, listenerApi): void => {
           // One-shot listener that cleans up as soon as the predicate passes
@@ -153,10 +153,13 @@ const createTakePattern = <S>(
           ])
         },
       })
+      unsubscribe = () => {
+        stopListening()
+        reject()
+      }
     })
 
     const promises: (Promise<null> | Promise<[AnyAction, S, S]>)[] = [
-      promisifyAbortSignal(signal),
       tuplePromise,
     ]
 
@@ -167,7 +170,7 @@ const createTakePattern = <S>(
     }
 
     try {
-      const output = await Promise.race(promises)
+      const output = await raceWithSignal(signal, Promise.race(promises))
 
       validateActive(signal)
       return output

--- a/packages/toolkit/src/listenerMiddleware/utils.ts
+++ b/packages/toolkit/src/listenerMiddleware/utils.ts
@@ -28,6 +28,7 @@ export const addAbortSignalListener = (
   callback: (evt: Event) => void
 ) => {
   abortSignal.addEventListener('abort', callback, { once: true })
+  return () => abortSignal.removeEventListener('abort', callback)
 }
 
 /**


### PR DESCRIPTION
This *should* fix #3020, but I have not tested it. 

@MrSquaare since you found this, could you please test the CodeSandbox CI build of this PR against your reproduction?