### PR TITLE
Initial RTK 2.0 build configuration changes

### DIFF
--- a/packages/toolkit/.size-limit.js
+++ b/packages/toolkit/.size-limit.js
@@ -19,30 +19,30 @@ function withRtkPath(suffix) {
         join(__dirname)
       ),
       new webpack.NormalModuleReplacementPlugin(
-        /rtk-query-react.esm.js/,
+        /rtk-query-react.modern.js/,
         (r) => {
           const old = r.request
           r.request = r.request.replace(
-            /rtk-query-react.esm.js$/,
+            /rtk-query-react.modern.js$/,
             `rtk-query-react.${suffix}`
           )
           // console.log(old, '=>', r.request)
         }
       ),
-      new webpack.NormalModuleReplacementPlugin(/rtk-query.esm.js/, (r) => {
+      new webpack.NormalModuleReplacementPlugin(/rtk-query.modern.js/, (r) => {
         const old = r.request
         r.request = r.request.replace(
-          /rtk-query.esm.js$/,
+          /rtk-query.modern.js$/,
           `rtk-query.${suffix}`
         )
         // console.log(old, '=>', r.request)
       }),
       new webpack.NormalModuleReplacementPlugin(
-        /redux-toolkit.esm.js$/,
+        /redux-toolkit.modern.js$/,
         (r) => {
           const old = r.request
           r.request = r.request.replace(
-            /redux-toolkit.esm.js$/,
+            /redux-toolkit.modern.js$/,
             `redux-toolkit.${suffix}`
           )
           // console.log(old, '=>', r.request)
@@ -69,29 +69,29 @@ const ignoreAll = [
 module.exports = [
   {
     name: `1. entry point: @reduxjs/toolkit`,
-    path: 'dist/redux-toolkit.esm.js',
+    path: 'dist/redux-toolkit.modern.js',
   },
   {
     name: `1. entry point: @reduxjs/toolkit/query`,
-    path: 'dist/query/rtk-query.esm.js',
+    path: 'dist/query/rtk-query.modern.js',
   },
   {
     name: `1. entry point: @reduxjs/toolkit/query/react`,
-    path: 'dist/query/react/rtk-query-react.esm.js',
+    path: 'dist/query/react/rtk-query-react.modern.js',
   },
   {
     name: `2. entry point: @reduxjs/toolkit (without dependencies)`,
-    path: 'dist/redux-toolkit.esm.js',
+    path: 'dist/redux-toolkit.modern.js',
     ignore: ignoreAll,
   },
   {
     name: `2. entry point: @reduxjs/toolkit/query (without dependencies)`,
-    path: 'dist/query/rtk-query.esm.js',
+    path: 'dist/query/rtk-query.modern.js',
     ignore: ignoreAll,
   },
   {
     name: `2. entry point: @reduxjs/toolkit/query/react (without dependencies)`,
-    path: 'dist/query/react/rtk-query-react.esm.js',
+    path: 'dist/query/react/rtk-query-react.modern.js',
     ignore: ignoreAll,
   },
 ]

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "main": "dist/index.js",
-  "module": "dist/redux-toolkit.esm.js",
+  "module": "dist/redux-toolkit.modern.js",
   "unpkg": "dist/redux-toolkit.umd.min.js",
   "types": "dist/index.d.ts",
   "devDependencies": {

--- a/packages/toolkit/query/package.json
+++ b/packages/toolkit/query/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "../dist/query/index.js",
-  "module": "../dist/query/rtk-query.esm.js",
+  "module": "../dist/query/rtk-query.modern.js",
   "unpkg": "../dist/query/rtk-query.umd.min.js",
   "types": "../dist/query/index.d.ts",
   "author": "Mark Erikson <mark@isquaredsoftware.com>",

--- a/packages/toolkit/query/react/package.json
+++ b/packages/toolkit/query/react/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "../../dist/query/react/index.js",
-  "module": "../../dist/query/react/rtk-query-react.esm.js",
+  "module": "../../dist/query/react/rtk-query-react.modern.js",
   "unpkg": "../../dist/query/react/rtk-query-react.umd.min.js",
   "author": "Mark Erikson <mark@isquaredsoftware.com>",
   "license": "MIT",

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -36,28 +36,22 @@ const buildTargets: BuildOptions[] = [
   {
     format: 'cjs',
     name: 'cjs.development',
+    target: 'es2018',
     minify: false,
     env: 'development',
   },
-
   {
     format: 'cjs',
     name: 'cjs.production.min',
+    target: 'es2018',
     minify: true,
     env: 'production',
-  },
-  // ESM, embedded `process`, ES5 syntax: typical Webpack dev
-  {
-    format: 'esm',
-    name: 'esm',
-    minify: false,
-    env: '',
   },
   // ESM, embedded `process`, ES2017 syntax: modern Webpack dev
   {
     format: 'esm',
     name: 'modern',
-    target: 'es2017',
+    target: 'es2018',
     minify: false,
     env: '',
   },
@@ -65,7 +59,7 @@ const buildTargets: BuildOptions[] = [
   {
     format: 'esm',
     name: 'modern.development',
-    target: 'es2017',
+    target: 'es2018',
     minify: false,
     env: 'development',
   },
@@ -73,19 +67,21 @@ const buildTargets: BuildOptions[] = [
   {
     format: 'esm',
     name: 'modern.production.min',
-    target: 'es2017',
+    target: 'es2018',
     minify: true,
     env: 'production',
   },
   {
     format: 'umd',
     name: 'umd',
+    target: 'es2018',
     minify: false,
     env: 'development',
   },
   {
     format: 'umd',
     name: 'umd.min',
+    target: 'es2018',
     minify: true,
     env: 'production',
   },
@@ -197,7 +193,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     const esVersion =
       target in esVersionMappings
         ? esVersionMappings[target]
-        : ts.ScriptTarget.ES5
+        : ts.ScriptTarget.ES2017
 
     const origin = chunk.text
     const sourcemap = extractInlineSourcemap(origin)

--- a/packages/toolkit/scripts/types.ts
+++ b/packages/toolkit/scripts/types.ts
@@ -11,7 +11,7 @@ export interface BuildOptions {
     | 'umd.min'
   minify: boolean
   env: 'development' | 'production' | ''
-  target?: 'es2017'
+  target?: 'es2017' | 'es2018' | 'es2019' | 'es2020'
 }
 
 export interface EntryPointOptions {

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,4 +1,3 @@
-import { enableES5 } from 'immer'
 export * from 'redux'
 export {
   default as createNextState,
@@ -17,12 +16,6 @@ export type {
 } from 'reselect'
 export { createDraftSafeSelector } from './createDraftSafeSelector'
 export type { ThunkAction, ThunkDispatch, ThunkMiddleware } from 'redux-thunk'
-
-// We deliberately enable Immer's ES5 support, on the grounds that
-// we assume RTK will be used with React Native and other Proxy-less
-// environments.  In addition, that's how Immer 4 behaved, and since
-// we want to ship this in an RTK minor, we should keep the same behavior.
-enableES5()
 
 export {
   // js


### PR DESCRIPTION
This PR:

- Updates the build config to remove ES5 compilation output and use the "modern" build as the default
- Removes the Immer ES5 plugin usage