### PR TITLE
Remove legacy object syntax for reducers

### DIFF
--- a/packages/toolkit/.size-limit.js
+++ b/packages/toolkit/.size-limit.js
@@ -19,30 +19,30 @@ function withRtkPath(suffix) {
         join(__dirname)
       ),
       new webpack.NormalModuleReplacementPlugin(
-        /rtk-query-react.esm.js/,
+        /rtk-query-react.modern.js/,
         (r) => {
           const old = r.request
           r.request = r.request.replace(
-            /rtk-query-react.esm.js$/,
+            /rtk-query-react.modern.js$/,
             `rtk-query-react.${suffix}`
           )
           // console.log(old, '=>', r.request)
         }
       ),
-      new webpack.NormalModuleReplacementPlugin(/rtk-query.esm.js/, (r) => {
+      new webpack.NormalModuleReplacementPlugin(/rtk-query.modern.js/, (r) => {
         const old = r.request
         r.request = r.request.replace(
-          /rtk-query.esm.js$/,
+          /rtk-query.modern.js$/,
           `rtk-query.${suffix}`
         )
         // console.log(old, '=>', r.request)
       }),
       new webpack.NormalModuleReplacementPlugin(
-        /redux-toolkit.esm.js$/,
+        /redux-toolkit.modern.js$/,
         (r) => {
           const old = r.request
           r.request = r.request.replace(
-            /redux-toolkit.esm.js$/,
+            /redux-toolkit.modern.js$/,
             `redux-toolkit.${suffix}`
           )
           // console.log(old, '=>', r.request)
@@ -69,29 +69,29 @@ const ignoreAll = [
 module.exports = [
   {
     name: `1. entry point: @reduxjs/toolkit`,
-    path: 'dist/redux-toolkit.esm.js',
+    path: 'dist/redux-toolkit.modern.js',
   },
   {
     name: `1. entry point: @reduxjs/toolkit/query`,
-    path: 'dist/query/rtk-query.esm.js',
+    path: 'dist/query/rtk-query.modern.js',
   },
   {
     name: `1. entry point: @reduxjs/toolkit/query/react`,
-    path: 'dist/query/react/rtk-query-react.esm.js',
+    path: 'dist/query/react/rtk-query-react.modern.js',
   },
   {
     name: `2. entry point: @reduxjs/toolkit (without dependencies)`,
-    path: 'dist/redux-toolkit.esm.js',
+    path: 'dist/redux-toolkit.modern.js',
     ignore: ignoreAll,
   },
   {
     name: `2. entry point: @reduxjs/toolkit/query (without dependencies)`,
-    path: 'dist/query/rtk-query.esm.js',
+    path: 'dist/query/rtk-query.modern.js',
     ignore: ignoreAll,
   },
   {
     name: `2. entry point: @reduxjs/toolkit/query/react (without dependencies)`,
-    path: 'dist/query/react/rtk-query-react.esm.js',
+    path: 'dist/query/react/rtk-query-react.modern.js',
     ignore: ignoreAll,
   },
 ]

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "main": "dist/index.js",
-  "module": "dist/redux-toolkit.esm.js",
+  "module": "dist/redux-toolkit.modern.js",
   "unpkg": "dist/redux-toolkit.umd.min.js",
   "types": "dist/index.d.ts",
   "devDependencies": {

--- a/packages/toolkit/query/package.json
+++ b/packages/toolkit/query/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "../dist/query/index.js",
-  "module": "../dist/query/rtk-query.esm.js",
+  "module": "../dist/query/rtk-query.modern.js",
   "unpkg": "../dist/query/rtk-query.umd.min.js",
   "types": "../dist/query/index.d.ts",
   "author": "Mark Erikson <mark@isquaredsoftware.com>",

--- a/packages/toolkit/query/react/package.json
+++ b/packages/toolkit/query/react/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "../../dist/query/react/index.js",
-  "module": "../../dist/query/react/rtk-query-react.esm.js",
+  "module": "../../dist/query/react/rtk-query-react.modern.js",
   "unpkg": "../../dist/query/react/rtk-query-react.umd.min.js",
   "author": "Mark Erikson <mark@isquaredsoftware.com>",
   "license": "MIT",

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -36,28 +36,22 @@ const buildTargets: BuildOptions[] = [
   {
     format: 'cjs',
     name: 'cjs.development',
+    target: 'es2018',
     minify: false,
     env: 'development',
   },
-
   {
     format: 'cjs',
     name: 'cjs.production.min',
+    target: 'es2018',
     minify: true,
     env: 'production',
-  },
-  // ESM, embedded `process`, ES5 syntax: typical Webpack dev
-  {
-    format: 'esm',
-    name: 'esm',
-    minify: false,
-    env: '',
   },
   // ESM, embedded `process`, ES2017 syntax: modern Webpack dev
   {
     format: 'esm',
     name: 'modern',
-    target: 'es2017',
+    target: 'es2018',
     minify: false,
     env: '',
   },
@@ -65,7 +59,7 @@ const buildTargets: BuildOptions[] = [
   {
     format: 'esm',
     name: 'modern.development',
-    target: 'es2017',
+    target: 'es2018',
     minify: false,
     env: 'development',
   },
@@ -73,19 +67,21 @@ const buildTargets: BuildOptions[] = [
   {
     format: 'esm',
     name: 'modern.production.min',
-    target: 'es2017',
+    target: 'es2018',
     minify: true,
     env: 'production',
   },
   {
     format: 'umd',
     name: 'umd',
+    target: 'es2018',
     minify: false,
     env: 'development',
   },
   {
     format: 'umd',
     name: 'umd.min',
+    target: 'es2018',
     minify: true,
     env: 'production',
   },
@@ -197,7 +193,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     const esVersion =
       target in esVersionMappings
         ? esVersionMappings[target]
-        : ts.ScriptTarget.ES5
+        : ts.ScriptTarget.ES2017
 
     const origin = chunk.text
     const sourcemap = extractInlineSourcemap(origin)

--- a/packages/toolkit/scripts/types.ts
+++ b/packages/toolkit/scripts/types.ts
@@ -11,7 +11,7 @@ export interface BuildOptions {
     | 'umd.min'
   minify: boolean
   env: 'development' | 'production' | ''
-  target?: 'es2017'
+  target?: 'es2017' | 'es2018' | 'es2019' | 'es2020'
 }
 
 export interface EntryPointOptions {

--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -151,91 +151,20 @@ export function createReducer<S extends NotFunction<any>>(
   builderCallback: (builder: ActionReducerMapBuilder<S>) => void
 ): ReducerWithInitialState<S>
 
-/**
- * A utility function that allows defining a reducer as a mapping from action
- * type to *case reducer* functions that handle these action types. The
- * reducer's initial state is passed as the first argument.
- *
- * The body of every case reducer is implicitly wrapped with a call to
- * `produce()` from the [immer](https://github.com/mweststrate/immer) library.
- * This means that rather than returning a new state object, you can also
- * mutate the passed-in state object directly; these mutations will then be
- * automatically and efficiently translated into copies, giving you both
- * convenience and immutability.
- * 
- * @overloadSummary
- * This overload accepts an object where the keys are string action types, and the values
- * are case reducer functions to handle those action types.
- *
- * @param initialState - `State | (() => State)`: The initial state that should be used when the reducer is called the first time. This may also be a "lazy initializer" function, which should return an initial state value when called. This will be used whenever the reducer is called with `undefined` as its state value, and is primarily useful for cases like reading initial state from `localStorage`.
- * @param actionsMap - An object mapping from action types to _case reducers_, each of which handles one specific action type.
- * @param actionMatchers - An array of matcher definitions in the form `{matcher, reducer}`.
- *   All matching reducers will be executed in order, independently if a case reducer matched or not.
- * @param defaultCaseReducer - A "default case" reducer that is executed if no case reducer and no matcher
- *   reducer was executed for this action.
- *
- * @example
-```js
-const counterReducer = createReducer(0, {
-  increment: (state, action) => state + action.payload,
-  decrement: (state, action) => state - action.payload
-})
-
-// Alternately, use a "lazy initializer" to provide the initial state
-// (works with either form of createReducer)
-const initialState = () => 0
-const counterReducer = createReducer(initialState, {
-  increment: (state, action) => state + action.payload,
-  decrement: (state, action) => state - action.payload
-})
-```
- 
- * Action creators that were generated using [`createAction`](./createAction) may be used directly as the keys here, using computed property syntax:
-
-```js
-const increment = createAction('increment')
-const decrement = createAction('decrement')
-
-const counterReducer = createReducer(0, {
-  [increment]: (state, action) => state + action.payload,
-  [decrement.type]: (state, action) => state - action.payload
-})
-```
- * @public
- */
-export function createReducer<
-  S extends NotFunction<any>,
-  CR extends CaseReducers<S, any> = CaseReducers<S, any>
->(
-  initialState: S | (() => S),
-  actionsMap: CR,
-  actionMatchers?: ActionMatcherDescriptionCollection<S>,
-  defaultCaseReducer?: CaseReducer<S>
-): ReducerWithInitialState<S>
-
 export function createReducer<S extends NotFunction<any>>(
   initialState: S | (() => S),
-  mapOrBuilderCallback:
-    | CaseReducers<S, any>
-    | ((builder: ActionReducerMapBuilder<S>) => void),
-  actionMatchers: ReadonlyActionMatcherDescriptionCollection<S> = [],
-  defaultCaseReducer?: CaseReducer<S>
+  mapOrBuilderCallback: (builder: ActionReducerMapBuilder<S>) => void
 ): ReducerWithInitialState<S> {
   if (process.env.NODE_ENV !== 'production') {
     if (typeof mapOrBuilderCallback === 'object') {
-      if (!hasWarnedAboutObjectNotation) {
-        hasWarnedAboutObjectNotation = true
-        console.warn(
-          "The object notation for `createReducer` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createReducer"
-        )
-      }
+      throw new Error(
+        "The object notation for `createReducer` has been removed. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createReducer"
+      )
     }
   }
 
   let [actionsMap, finalActionMatchers, finalDefaultCaseReducer] =
-    typeof mapOrBuilderCallback === 'function'
-      ? executeReducerBuilderCallback(mapOrBuilderCallback)
-      : [mapOrBuilderCallback, actionMatchers, defaultCaseReducer]
+    executeReducerBuilderCallback(mapOrBuilderCallback)
 
   // Ensure the initial state gets frozen either way (if draftable)
   let getInitialState: () => S

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -141,9 +141,7 @@ createSlice({
 })
 ```
    */
-  extraReducers?:
-    | CaseReducers<NoInfer<State>, any>
-    | ((builder: ActionReducerMapBuilder<NoInfer<State>>) => void)
+  extraReducers?: (builder: ActionReducerMapBuilder<NoInfer<State>>) => void
 }
 
 /**
@@ -330,12 +328,9 @@ export function createSlice<
   function buildReducer() {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof options.extraReducers === 'object') {
-        if (!hasWarnedAboutObjectNotation) {
-          hasWarnedAboutObjectNotation = true
-          console.warn(
-            "The object notation for `createSlice.extraReducers` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createSlice"
-          )
-        }
+        throw new Error(
+          "The object notation for `createSlice.extraReducers` has been removed. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createSlice"
+        )
       }
     }
     const [

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,4 +1,3 @@
-import { enableES5 } from 'immer'
 export * from 'redux'
 export {
   default as createNextState,
@@ -17,12 +16,6 @@ export type {
 } from 'reselect'
 export { createDraftSafeSelector } from './createDraftSafeSelector'
 export type { ThunkAction, ThunkDispatch, ThunkMiddleware } from 'redux-thunk'
-
-// We deliberately enable Immer's ES5 support, on the grounds that
-// we assume RTK will be used with React Native and other Proxy-less
-// environments.  In addition, that's how Immer 4 behaved, and since
-// we want to ship this in an RTK minor, we should keep the same behavior.
-enableES5()
 
 export {
   // js

--- a/packages/toolkit/src/tests/createReducer.typetest.ts
+++ b/packages/toolkit/src/tests/createReducer.typetest.ts
@@ -7,16 +7,19 @@ import { expectType } from './helpers'
  * Test: createReducer() infers type of returned reducer.
  */
 {
-  type CounterAction =
-    | { type: 'increment'; payload: number }
-    | { type: 'decrement'; payload: number }
+  const incrementHandler = (
+    state: number,
+    action: { type: 'increment'; payload: number }
+  ) => state + 1
+  const decrementHandler = (
+    state: number,
+    action: { type: 'decrement'; payload: number }
+  ) => state - 1
 
-  const incrementHandler = (state: number, action: CounterAction) => state + 1
-  const decrementHandler = (state: number, action: CounterAction) => state - 1
-
-  const reducer = createReducer(0 as number, {
-    increment: incrementHandler,
-    decrement: decrementHandler,
+  const reducer = createReducer(0 as number, (builder) => {
+    builder
+      .addCase('increment', incrementHandler)
+      .addCase('decrement', decrementHandler)
   })
 
   const numberReducer: Reducer<number> = reducer
@@ -29,25 +32,28 @@ import { expectType } from './helpers'
  * Test: createReducer() state type can be specified expliclity.
  */
 {
-  type CounterAction =
-    | { type: 'increment'; payload: number }
-    | { type: 'decrement'; payload: number }
+  const incrementHandler = (
+    state: number,
+    action: { type: 'increment'; payload: number }
+  ) => state + action.payload
 
-  const incrementHandler = (state: number, action: CounterAction) =>
-    state + action.payload
+  const decrementHandler = (
+    state: number,
+    action: { type: 'decrement'; payload: number }
+  ) => state - action.payload
 
-  const decrementHandler = (state: number, action: CounterAction) =>
-    state - action.payload
-
-  createReducer<number>(0, {
-    increment: incrementHandler,
-    decrement: decrementHandler,
+  createReducer(0 as number, (builder) => {
+    builder
+      .addCase('increment', incrementHandler)
+      .addCase('decrement', decrementHandler)
   })
 
   // @ts-expect-error
-  createReducer<string>(0, {
-    increment: incrementHandler,
-    decrement: decrementHandler,
+  createReducer<string>(0 as number, (builder) => {
+    // @ts-expect-error
+    builder
+      .addCase('increment', incrementHandler)
+      .addCase('decrement', decrementHandler)
   })
 }
 
@@ -57,10 +63,10 @@ import { expectType } from './helpers'
 {
   const initialState: { readonly counter: number } = { counter: 0 }
 
-  createReducer(initialState, {
-    increment: (state) => {
+  createReducer(initialState, (builder) => {
+    builder.addCase('increment', (state) => {
       state.counter += 1
-    },
+    })
   })
 }
 


### PR DESCRIPTION
This PR:

- Removes the legacy object syntax for `createReducer` and `createSlice.extraReducers`