### PR TITLE
RFC: configurable `produce` implementation

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -47,20 +47,26 @@ export type {
 export {
   // js
   createReducer,
+  buildCreateReducer,
 } from './createReducer'
 export type {
   // types
   Actions,
   CaseReducer,
   CaseReducers,
+  CreateReducer,
+  BuildCreateReducerConfiguration,
 } from './createReducer'
 export {
   // js
   createSlice,
+  buildCreateSlice,
 } from './createSlice'
 
 export type {
   // types
+  BuildCreateSliceConfiguration,
+  CreateSlice,
   CreateSliceOptions,
   Slice,
   CaseReducerActions,


### PR DESCRIPTION
With `immer` alternatives like [structura.js](https://giusepperaso.github.io/structura.js/) and [mutative](https://github.com/unadlib/mutative) popping up, it might make sense to allow the configuration of the `produce` implementation used by RTK.

This PR would, by default, still use `immer`, but expose `buildCreateReducer` and `buildCreateSlice` functions to create custom `createReducer` and `createSlice` functions. This should tree-shake well, and if only those other implementations are used, `immer` should not be bundled anymore (as soon as the polyfill in 2.0 is disabled, which is why I base this PR against the v2 version).

This would also theoretically allow `produce` to be swapped out for a stub, so people who *really* want to use RTK without any immutability helper could do so - even though I would highly recommend against that.

It would also prepare for future situations when Records and Tuples are widely available, and an immutability helper will not be necessary anymore.

There are still a few more places where we use `produce`, so additional changes would be required in
* createEntityAdapter
* createApi (here we need to configure with a version allowing for patches)

So far, I just wanted to put this out as a base for discussion - the code changes required for this are pretty small, so I think it might make sense at this point.

PS: we might need to do some docs updates, as, at the moment, the docs directly reference the types of `createSlice` and that has now moved into its own interface definition.

PS2: at this point, `mutative` does not allow for returning a new object, so that one might not work yet. [Let's see if we can convince the author to add that functionality](https://www.reddit.com/r/javascript/comments/100gsnx/comment/j3vpu8k/?utm_source=reddit&utm_medium=web2x&context=3).