### PR TITLE
Migrate the RTK package to be full ESM

### DIFF
--- a/packages/toolkit/jest.config.js
+++ b/packages/toolkit/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['./jest.setup.js'],
   testMatch: ['<rootDir>/src/**/*.(spec|test).[jt]s?(x)'],

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -22,10 +22,28 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/index.js",
+  "type": "module",
   "module": "dist/redux-toolkit.modern.js",
-  "unpkg": "dist/redux-toolkit.umd.min.js",
+  "main": "dist/cjs/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/redux-toolkit.modern.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./query": {
+      "types": "./dist/query/index.d.ts",
+      "import": "./dist/query/rtk-query.modern.js",
+      "default": "./dist/query/cjs/index.js"
+    },
+    "./query/react": {
+      "types": "./dist/query/react/index.d.ts",
+      "import": "./dist/query/react/rtk-query-react.modern.js",
+      "default": "./dist/query/react/cjs/index.js"
+    }
+  },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.13.2",
     "@size-limit/preset-small-lib": "^4.11.0",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -119,7 +119,7 @@
   "dependencies": {
     "immer": "^9.0.16",
     "redux": "^4.2.0",
-    "redux-thunk": "^2.4.2",
+    "redux-thunk": "3.0.0-alpha.1",
     "reselect": "^4.1.7"
   },
   "peerDependencies": {

--- a/packages/toolkit/query/package.json
+++ b/packages/toolkit/query/package.json
@@ -2,10 +2,18 @@
   "name": "@reduxjs/toolkit-query",
   "version": "1.0.0",
   "description": "",
-  "main": "../dist/query/index.js",
+  "type": "module",
   "module": "../dist/query/rtk-query.modern.js",
-  "unpkg": "../dist/query/rtk-query.umd.min.js",
-  "types": "../dist/query/index.d.ts",
+  "main": "../dist/query/cjs/index.js",
+  "types": "./../dist/query/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./../dist/query/index.d.ts",
+      "import": "./../dist/query/rtk-query.modern.js",
+      "default": "./../dist/query/cjs/index.js"
+    }
+  },
   "author": "Mark Erikson <mark@isquaredsoftware.com>",
   "license": "MIT",
   "sideEffects": false

--- a/packages/toolkit/query/react/package.json
+++ b/packages/toolkit/query/react/package.json
@@ -2,11 +2,19 @@
   "name": "@reduxjs/toolkit-query-react",
   "version": "1.0.0",
   "description": "",
-  "main": "../../dist/query/react/index.js",
+  "type": "module",
   "module": "../../dist/query/react/rtk-query-react.modern.js",
-  "unpkg": "../../dist/query/react/rtk-query-react.umd.min.js",
+  "main": "../../dist/query/react/cjs/index.js",
+  "types": "./../../dist/query/react/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./../../dist/query/react/index.d.ts",
+      "import": "./../../dist/query/react/rtk-query-react.modern.js",
+      "default": "./../../dist/query/react/cjs/index.js"
+    }
+  },
   "author": "Mark Erikson <mark@isquaredsoftware.com>",
   "license": "MIT",
-  "types": "../../dist/query/react/index.d.ts",
   "sideEffects": false
 }

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -139,7 +139,7 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
     entryPoint,
   } = options
 
-  const folderSegments = ['dist', folder]
+  const folderSegments = [outputDir, folder]
 
   if (format === 'cjs') {
     folderSegments.push('cjs')

--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -148,7 +148,8 @@ async function bundle(options: BuildOptions & EntryPointOptions) {
   const outputFolder = path.join(...folderSegments)
   const outputFilename = `${prefix}.${name}.js`
 
-  fs.mkdirs(outputFolder)
+  await fs.ensureDir(outputFolder)
+
   const outputFilePath = path.join(outputFolder, outputFilename)
 
   if (format === 'cjs') {

--- a/packages/toolkit/scripts/types.ts
+++ b/packages/toolkit/scripts/types.ts
@@ -11,7 +11,14 @@ export interface BuildOptions {
     | 'umd.min'
   minify: boolean
   env: 'development' | 'production' | ''
-  target?: 'es2017' | 'es2018' | 'es2019' | 'es2020'
+  target?:
+    | 'es2017'
+    | 'es2018'
+    | 'es2019'
+    | 'es2020'
+    | 'es2021'
+    | 'es2022'
+    | 'esnext'
 }
 
 export interface EntryPointOptions {

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -34,7 +34,7 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production'
  * @public
  */
 export type ConfigureEnhancersCallback<E extends Enhancers = Enhancers> = (
-    defaultEnhancers: readonly StoreEnhancer[]
+  defaultEnhancers: readonly StoreEnhancer[]
 ) => [...E]
 
 /**
@@ -107,7 +107,7 @@ type Enhancers = ReadonlyArray<StoreEnhancer>
 export interface ToolkitStore<
   S = any,
   A extends Action = AnyAction,
-  M extends Middlewares<S> = Middlewares<S>,
+  M extends Middlewares<S> = Middlewares<S>
 > extends Store<S, A> {
   /**
    * The `dispatch` method of your store, enhanced by all its middlewares.

--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -1,5 +1,5 @@
 import type { Draft } from 'immer'
-import createNextState, { isDraft, isDraftable } from 'immer'
+import { produce as createNextState, isDraft, isDraftable } from 'immer'
 import type { AnyAction, Action, Reducer } from 'redux'
 import type { ActionReducerMapBuilder } from './mapBuilders'
 import { executeReducerBuilderCallback } from './mapBuilders'

--- a/packages/toolkit/src/entities/state_adapter.ts
+++ b/packages/toolkit/src/entities/state_adapter.ts
@@ -1,4 +1,4 @@
-import createNextState, { isDraft } from 'immer'
+import { produce as createNextState, isDraft } from 'immer'
 import type { EntityState, PreventAny } from './models'
 import type { PayloadAction } from '../createAction'
 import { isFSA } from '../createAction'

--- a/packages/toolkit/src/getDefaultMiddleware.ts
+++ b/packages/toolkit/src/getDefaultMiddleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware, AnyAction } from 'redux'
 import type { ThunkMiddleware } from 'redux-thunk'
-import thunkMiddleware from 'redux-thunk'
+import { thunk as thunkMiddleware, withExtraArgument } from 'redux-thunk'
 import type { ImmutableStateInvariantMiddlewareOptions } from './immutableStateInvariantMiddleware'
 /* PROD_START_REMOVE_UMD */
 import { createImmutableStateInvariantMiddleware } from './immutableStateInvariantMiddleware'
@@ -88,9 +88,7 @@ export function getDefaultMiddleware<
     if (isBoolean(thunk)) {
       middlewareArray.push(thunkMiddleware)
     } else {
-      middlewareArray.push(
-        thunkMiddleware.withExtraArgument(thunk.extraArgument)
-      )
+      middlewareArray.push(withExtraArgument(thunk.extraArgument))
     }
   }
 

--- a/packages/toolkit/src/tests/configureStore.typetest.ts
+++ b/packages/toolkit/src/tests/configureStore.typetest.ts
@@ -6,7 +6,7 @@ import type {
   Reducer,
   Store,
   Action,
-  StoreEnhancer
+  StoreEnhancer,
 } from 'redux'
 import { applyMiddleware } from 'redux'
 import type { PayloadAction } from '@reduxjs/toolkit'
@@ -17,7 +17,7 @@ import {
   ConfigureStoreOptions,
 } from '@reduxjs/toolkit'
 import type { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
-import thunk from 'redux-thunk'
+import { thunk } from 'redux-thunk'
 import { expectNotAny, expectType } from './helpers'
 
 const _anyMiddleware: any = () => () => () => {}
@@ -144,10 +144,12 @@ const _anyMiddleware: any = () => () => () => {}
   {
     const store = configureStore({
       reducer: () => 0,
-      enhancers: [applyMiddleware(() => next => next)]
+      enhancers: [applyMiddleware(() => (next) => next)],
     })
 
-    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(store.dispatch)
+    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(
+      store.dispatch
+    )
   }
 
   configureStore({
@@ -159,7 +161,7 @@ const _anyMiddleware: any = () => () => () => {}
   {
     type SomePropertyStoreEnhancer = StoreEnhancer<{ someProperty: string }>
 
-    const somePropertyStoreEnhancer: SomePropertyStoreEnhancer = next => {
+    const somePropertyStoreEnhancer: SomePropertyStoreEnhancer = (next) => {
       return (reducer, preloadedState) => {
         return {
           ...next(reducer, preloadedState),
@@ -168,9 +170,13 @@ const _anyMiddleware: any = () => () => () => {}
       }
     }
 
-    type AnotherPropertyStoreEnhancer = StoreEnhancer<{ anotherProperty: number }>
+    type AnotherPropertyStoreEnhancer = StoreEnhancer<{
+      anotherProperty: number
+    }>
 
-    const anotherPropertyStoreEnhancer: AnotherPropertyStoreEnhancer = next => {
+    const anotherPropertyStoreEnhancer: AnotherPropertyStoreEnhancer = (
+      next
+    ) => {
       return (reducer, preloadedState) => {
         return {
           ...next(reducer, preloadedState),
@@ -184,7 +190,9 @@ const _anyMiddleware: any = () => () => () => {}
       enhancers: [somePropertyStoreEnhancer, anotherPropertyStoreEnhancer],
     })
 
-    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(store.dispatch)
+    expectType<Dispatch & ThunkDispatch<number, undefined, AnyAction>>(
+      store.dispatch
+    )
     expectType<string>(store.someProperty)
     expectType<number>(store.anotherProperty)
   }
@@ -348,7 +356,9 @@ const _anyMiddleware: any = () => () => () => {}
   {
     const store = configureStore({
       reducer: reducerA,
-      middleware: [] as any as readonly [Middleware<(a: StateA) => boolean, StateA>],
+      middleware: [] as any as readonly [
+        Middleware<(a: StateA) => boolean, StateA>
+      ],
     })
     const result: boolean = store.dispatch(5)
     // @ts-expect-error
@@ -532,21 +542,23 @@ const _anyMiddleware: any = () => () => () => {}
       initialState: null as any,
       reducers: {
         set(state) {
-          return state;
+          return state
         },
       },
-    });
+    })
 
-    function configureMyStore<S>(options: Omit<ConfigureStoreOptions<S>, 'reducer'>) {
+    function configureMyStore<S>(
+      options: Omit<ConfigureStoreOptions<S>, 'reducer'>
+    ) {
       return configureStore({
         ...options,
         reducer: someSlice.reducer,
-      });
+      })
     }
 
-    const store = configureMyStore({});
+    const store = configureMyStore({})
 
-    expectType<Function>(store.dispatch);
+    expectType<Function>(store.dispatch)
   }
 
   {

--- a/packages/toolkit/src/tests/getDefaultMiddleware.test.ts
+++ b/packages/toolkit/src/tests/getDefaultMiddleware.test.ts
@@ -11,7 +11,7 @@ import {
   MiddlewareArray,
   configureStore,
 } from '@reduxjs/toolkit'
-import thunk from 'redux-thunk'
+import { thunk } from 'redux-thunk'
 import type { ThunkMiddleware } from 'redux-thunk'
 
 import { expectType } from './helpers'
@@ -23,10 +23,20 @@ describe('getDefaultMiddleware', () => {
     process.env.NODE_ENV = ORIGINAL_NODE_ENV
   })
 
-  it('returns an array with only redux-thunk in production', () => {
-    process.env.NODE_ENV = 'production'
+  describe('Production behavior', () => {
+    beforeEach(() => {
+      jest.resetModules()
+    })
 
-    expect(getDefaultMiddleware()).toEqual([thunk]) // @remap-prod-remove-line
+    it('returns an array with only redux-thunk in production', () => {
+      process.env.NODE_ENV = 'production'
+      const { thunk } = require('redux-thunk')
+      const { getDefaultMiddleware } = require('@reduxjs/toolkit')
+
+      const middleware = getDefaultMiddleware()
+      expect(middleware).toContain(thunk)
+      expect(middleware.length).toBe(1)
+    })
   })
 
   it('returns an array with additional middleware in development', () => {

--- a/packages/toolkit/src/utils.ts
+++ b/packages/toolkit/src/utils.ts
@@ -1,4 +1,4 @@
-import createNextState, { isDraftable } from 'immer'
+import { produce as createNextState, isDraftable } from 'immer'
 import type { Middleware } from 'redux'
 
 export function getTimeMeasureUtils(maxDelay: number, fnName: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6596,7 +6596,7 @@ __metadata:
     prettier: ^2.2.1
     query-string: ^7.0.1
     redux: ^4.2.0
-    redux-thunk: ^2.4.2
+    redux-thunk: 3.0.0-alpha.1
     reselect: ^4.1.7
     rimraf: ^3.0.2
     rollup: ^2.47.0
@@ -23548,6 +23548,15 @@ fsevents@^1.2.7:
   peerDependencies:
     redux: ">4.0.0"
   checksum: edaf10dbf17351ce8058d0802357adae8665b3a1ff39371834e37838ddbe1a79cccbc717b8ba54acb5307651ccf51d0f7dc1cbc8dbae0726ff952d11ef61c6b8
+  languageName: node
+  linkType: hard
+
+"redux-thunk@npm:3.0.0-alpha.1":
+  version: 3.0.0-alpha.1
+  resolution: "redux-thunk@npm:3.0.0-alpha.1"
+  peerDependencies:
+    redux: ^4
+  checksum: 280e0d399c96d071030f6dfa5bdb0b05b9f228dd0b840ffbb213e778b773efc25e6ba24f7ed13818696ea54a359ecc06a9e5e718e07d960a772101b14c0dd8c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR attempts to convert the RTK package from its existing "contains ESM and CJS modules, but not _fully_ ESM", to be fully ESM with `{type: "module"}` and still support CJS:

- **BREAKING**: Sets the main RTK `package.json` file to be `{type: "module"}`
- **BREAKING**: Updates all entry point `package.json` files to use `exports` to point to the types, ESM file, and CJS file
  - I still have `main` and `module` in there because WHO KNOWS WHETHER THOSE STILL END UP GETTING USED BY SOME TOOLS OR NOT 🤷‍♂️ 
- Updates the build script:
  - Fixed ESM compat on execution by replacing use of `__dirname` and fixing the Terser import
  - Switched all build targets to be `"esnext"`, to ensure the output is untouched other than TS transpilation
  - Moved all CJS build artifacts to be nested a level deeper in each entry point in a `./cjs/` folder, ie, `./dist/query/cjs/`
  - Added `{type: "commonjs"}` package files to those folders
  - Turned off the UMD build artifacts for now




I've done some hand-testing of a locally-built version of this.  I set up an example project that used all three entry points ( `@reduxjs/toolkit`, `/query`, and `/query/react`), then  that ported it to several different build tools and ran both dev and prod builds for each:

- Vite 4: worked
- CRA 4 and 5: worked
- Next 13: needs `redux-thunk` to be converted over to ESM as well, as the middleware array ended up as `[ {default: thunk()}, api1.middleware, api2.middleware]`. Installing a local build of `redux-thunk` with similar ESM changes made that work
- Parcel: worked
- RN Expo: it found the correct file ( `rtk-query-modern.js` ), but choked on the optional chaining syntax inside, and I don't feel like messing with RN further. Important thing is it found the right file.

I also tested this with a tiny Node script that imported all three entry points in both a CJS and an ESM file, and got that running without errors.

Finally, I tested this with the https://publint.dev/ CLI run against all three entry point `package.json` files, and it gave me a ✅ for each.

Given that, I'm tentatively hopeful that the `exports` configuration is actually sufficient.