### PR TITLE
fix(types): export `ThunkWithReturnValue` interface

### DIFF
--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -71,7 +71,7 @@ export type CoreModule =
   | ReferenceQueryLifecycle
   | ReferenceCacheCollection
 
-interface ThunkWithReturnValue<T> extends ThunkAction<T, any, any, AnyAction> {}
+export interface ThunkWithReturnValue<T> extends ThunkAction<T, any, any, AnyAction> {}
 
 declare module '../apiTypes' {
   export interface ApiModules<


### PR DESCRIPTION
Closes #3107 

Export `ThunkWithReturnValue` interface to fix errors like the one below when trying to emit declarations of api types.

```
Exported variable 'authApi' has or is using name 'ThunkWithReturnValue' from external module "/node_modules/@reduxjs/toolkit/dist/query/core/module" but cannot be named.
```