### PR TITLE
Add caching to serializableStateInvariantMiddleware

### DIFF
--- a/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
@@ -598,11 +598,6 @@ describe('serializableStateInvariantMiddleware', () => {
   })
 
   it('Should cache its results', () => {
-    const reducer: Reducer<[], AnyAction> = (state = [], action) => {
-      if (action.type === 'SET_STATE') return action.payload
-      return state
-    }
-
     let numPlainChecks = 0
     const countPlainChecks = (x: any) => {
       numPlainChecks++
@@ -615,8 +610,9 @@ describe('serializableStateInvariantMiddleware', () => {
       })
 
     const store = configureStore({
-      reducer: {
-        testSlice: reducer,
+      reducer: (state = [], action) => {
+        if (action.type === 'SET_STATE') return action.payload
+        return state
       },
       middleware: [serializableStateInvariantMiddleware],
     })

--- a/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
@@ -3,13 +3,15 @@ import {
   createConsole,
   getLog,
 } from 'console-testing-library/pure'
-import type { Reducer } from '@reduxjs/toolkit'
+import type { AnyAction, Reducer } from '@reduxjs/toolkit'
 import {
+  createNextState,
   configureStore,
   createSerializableStateInvariantMiddleware,
   findNonSerializableValue,
   isPlain,
 } from '@reduxjs/toolkit'
+import { isNestedFrozen } from '@internal/serializableStateInvariantMiddleware'
 
 // Mocking console
 let restore = () => {}
@@ -593,5 +595,45 @@ describe('serializableStateInvariantMiddleware', () => {
 
     store.dispatch({ type: 'SOME_ACTION' })
     expect(getLog().log).toMatch('')
+  })
+
+  it('Should cache its results', () => {
+    const reducer: Reducer<[], AnyAction> = (state = [], action) => {
+      if (action.type === 'SET_STATE') return action.payload
+      return state
+    }
+
+    let numPlainChecks = 0
+    const countPlainChecks = (x: any) => {
+      numPlainChecks++
+      return isPlain(x)
+    }
+
+    const serializableStateInvariantMiddleware =
+      createSerializableStateInvariantMiddleware({
+        isSerializable: countPlainChecks,
+      })
+
+    const store = configureStore({
+      reducer: {
+        testSlice: reducer,
+      },
+      middleware: [serializableStateInvariantMiddleware],
+    })
+
+    const state = createNextState([], () =>
+      new Array(50).fill(0).map((x, i) => ({ i }))
+    )
+    expect(isNestedFrozen(state)).toBe(true)
+
+    store.dispatch({
+      type: 'SET_STATE',
+      payload: state,
+    })
+    expect(numPlainChecks).toBeGreaterThan(state.length)
+
+    numPlainChecks = 0
+    store.dispatch({ type: 'NOOP' })
+    expect(numPlainChecks).toBeLessThan(10)
   })
 })


### PR DESCRIPTION
The serializableStateInvariantMiddleware is currently scanning the entire state for non-serializable values whenever an action is dispatched. Dispatching a bunch of actions thus takes about `O(numDispatchedActions * stateSize)` time once the state is populated, independent of the size of the action or the complexity of the reducer. This massively slows down the application performance in dev mode for big state trees. Such trees can quickly occur when downloading a bunch of data and putting it into the store, e.g. using rtk-query.

In #885, it was discussed to not check the serializability of the state at all (and only the actions) as an optional addition, which was implemented in #943. It has the disadvantage of giving up detecting non-serializable objects created in a reducer, and I suppose that that's the reason it isn't enabled by default. It can also be avoided by excluding some parts of the store from the middleware using `ignoredPaths`. All of these options, however, require profiling and googling to realize why rtk/rtk-query is slow and what to do about it.

This PR introduces `WeakSet`-based caching to the middleware, making the performance independent of the state size as long as the state is frozen, which happens automatically when using the toolkit-provided functions for creating slices.

When enabled by default, developers should experience the same time complexity in dev and prod, and they would need to profile/google much less.

## Open questions

- [ ] How should we determine the frozen-ness of an object? Can we assume that all descendants of an object are frozen if the object itself is frozen? Do we need to imitate the `getEntries`-based method of finding descendants of `findNonSerializableValue`?