### PR TITLE
Delayed tag invalidations

### DIFF
--- a/packages/toolkit/src/query/apiTypes.ts
+++ b/packages/toolkit/src/query/apiTypes.ts
@@ -45,7 +45,7 @@ export type Module<Name extends ModuleName> = {
       | 'refetchOnMountOrArgChange'
       | 'refetchOnFocus'
       | 'refetchOnReconnect'
-      | 'invalidateImmediately'
+      | 'invalidationBehavior'
       | 'tagTypes'
     >,
     context: ApiContext<Definitions>

--- a/packages/toolkit/src/query/apiTypes.ts
+++ b/packages/toolkit/src/query/apiTypes.ts
@@ -45,6 +45,7 @@ export type Module<Name extends ModuleName> = {
       | 'refetchOnMountOrArgChange'
       | 'refetchOnFocus'
       | 'refetchOnReconnect'
+      | 'invalidateImmediately'
       | 'tagTypes'
     >,
     context: ApiContext<Definitions>

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -7,6 +7,7 @@ import type {
   BaseEndpointDefinition,
   ResultTypeFrom,
   QueryArgFrom,
+  FullTagDescription,
 } from '../endpointDefinitions'
 import type { Id, WithRequiredProp } from '../tsHelpers'
 
@@ -228,6 +229,7 @@ export type CombinedState<
   provided: InvalidationState<E>
   subscriptions: SubscriptionState
   config: ConfigState<ReducerPath>
+  pendingTagInvalidations: FullTagDescription<string>[]
 }
 
 export type InvalidationState<TagTypes extends string> = {

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -7,7 +7,6 @@ import type {
   BaseEndpointDefinition,
   ResultTypeFrom,
   QueryArgFrom,
-  FullTagDescription,
 } from '../endpointDefinitions'
 import type { Id, WithRequiredProp } from '../tsHelpers'
 
@@ -255,7 +254,7 @@ export type ConfigState<ReducerPath> = RefetchConfigOptions & {
 
 export type ModifiableConfigState = {
   keepUnusedDataFor: number
-  invalidateImmediately: boolean
+  invalidationBehavior: 'delayed' | 'immediately'
 } & RefetchConfigOptions
 
 export type MutationState<D extends EndpointDefinitions> = {

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -167,7 +167,6 @@ export type QuerySubState<D extends BaseEndpointDefinition<any, any, any>> = Id<
     > & { error: undefined })
   | ({
       status: QueryStatus.pending
-      pendingTagInvalidations: FullTagDescription<string>[]
     } & BaseQuerySubState<D>)
   | ({
       status: QueryStatus.rejected
@@ -230,7 +229,6 @@ export type CombinedState<
   provided: InvalidationState<E>
   subscriptions: SubscriptionState
   config: ConfigState<ReducerPath>
-  pendingTagInvalidations: FullTagDescription<string>[]
 }
 
 export type InvalidationState<TagTypes extends string> = {

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -167,6 +167,7 @@ export type QuerySubState<D extends BaseEndpointDefinition<any, any, any>> = Id<
     > & { error: undefined })
   | ({
       status: QueryStatus.pending
+      pendingTagInvalidations: FullTagDescription<string>[]
     } & BaseQuerySubState<D>)
   | ({
       status: QueryStatus.rejected
@@ -256,6 +257,7 @@ export type ConfigState<ReducerPath> = RefetchConfigOptions & {
 
 export type ModifiableConfigState = {
   keepUnusedDataFor: number
+  invalidateImmediately: boolean
 } & RefetchConfigOptions
 
 export type MutationState<D extends EndpointDefinitions> = {

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -85,6 +85,11 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
 
     const state = rootState[reducerPath]
 
+    if (state.config.invalidateImmediately) {
+      handleInvalidatedTags(tags, mwApi)
+      return
+    }
+
     const hasPendingQueries = Object.values(state.queries).some(
       (x) => x?.status === QueryStatus.pending
     )

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -108,6 +108,7 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
     const state = rootState[reducerPath]
 
     const tags = [...state.pendingTagInvalidations, ...newTags]
+    if (tags.length === 0) return
 
     const toInvalidate = api.util.selectInvalidatedBy(rootState, tags)
 

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -39,10 +39,8 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
   )
 
   const isQueryEnd = isAnyOf(
-    isFulfilled(mutationThunk),
-    isRejected(mutationThunk),
-    isFulfilled(queryThunk),
-    isRejected(queryThunk)
+    isFulfilled(mutationThunk, queryThunk),
+    isRejected(mutationThunk, queryThunk)
   )
 
   let pendingTagInvalidations: FullTagDescription<string>[] = []

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -84,11 +84,11 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
 
     pendingTagInvalidations.push(...newTags)
 
-    if (!state.config.invalidateImmediately) {
-      const hasPendingRequests = Object.values({
-        ...state.queries,
-        ...state.mutations,
-      }).some((x) => x?.status === QueryStatus.pending)
+    if (state.config.invalidationBehavior === 'delayed') {
+      const hasPendingRequests = [
+        ...Object.values(state.queries),
+        ...Object.values(state.mutations),
+      ].some((x) => x?.status === QueryStatus.pending)
 
       if (hasPendingRequests) return
     }

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -75,15 +75,6 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
     }
   }
 
-  function hasPendingRequests(
-    state: CombinedState<EndpointDefinitions, string, string>
-  ) {
-    return Object.values({
-      ...state.queries,
-      ...state.mutations,
-    }).some((x) => x?.status === QueryStatus.pending)
-  }
-
   function invalidateTags(
     newTags: readonly FullTagDescription<string>[],
     mwApi: SubMiddlewareApi
@@ -93,8 +84,13 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
 
     pendingTagInvalidations.push(...newTags)
 
-    if (!state.config.invalidateImmediately && hasPendingRequests(state)) {
-      return
+    if (!state.config.invalidateImmediately) {
+      const hasPendingRequests = Object.values({
+        ...state.queries,
+        ...state.mutations,
+      }).some((x) => x?.status === QueryStatus.pending)
+
+      if (hasPendingRequests) return
     }
 
     const tags = pendingTagInvalidations

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -420,20 +420,6 @@ export function buildSlice({
     },
   })
 
-  const pendingTagInvalidationsSlice = createSlice({
-    name: `${reducerPath}/pendingTagInvalidations`,
-    initialState: [] as FullTagDescription<string>[],
-    reducers: {
-      addPendingTagInvalidations: (
-        state,
-        action: PayloadAction<readonly FullTagDescription<string>[]>
-      ) => {
-        state.push(...action.payload)
-      },
-      clearPendingTagInvalidations: () => [],
-    },
-  })
-
   // Dummy slice to generate actions
   const subscriptionSlice = createSlice({
     name: `${reducerPath}/subscriptions`,
@@ -516,7 +502,6 @@ export function buildSlice({
     provided: invalidationSlice.reducer,
     subscriptions: internalSubscriptionsSlice.reducer,
     config: configSlice.reducer,
-    pendingTagInvalidations: pendingTagInvalidationsSlice.reducer,
   })
 
   const reducer: typeof combinedReducer = (state, action) =>
@@ -529,7 +514,6 @@ export function buildSlice({
     ...internalSubscriptionsSlice.actions,
     ...mutationSlice.actions,
     ...invalidationSlice.actions,
-    ...pendingTagInvalidationsSlice.actions,
     resetApiState,
   }
 

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -28,6 +28,7 @@ import { calculateProvidedByThunk } from './buildThunks'
 import type {
   AssertTagTypes,
   EndpointDefinitions,
+  FullTagDescription,
   QueryDefinition,
 } from '../endpointDefinitions'
 import type { Patch } from 'immer'

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -420,6 +420,20 @@ export function buildSlice({
     },
   })
 
+  const pendingTagInvalidationsSlice = createSlice({
+    name: `${reducerPath}/pendingTagInvalidations`,
+    initialState: [] as FullTagDescription<string>[],
+    reducers: {
+      addPendingTagInvalidations: (
+        state,
+        action: PayloadAction<readonly FullTagDescription<string>[]>
+      ) => {
+        state.push(...action.payload)
+      },
+      clearPendingTagInvalidations: () => [],
+    },
+  })
+
   // Dummy slice to generate actions
   const subscriptionSlice = createSlice({
     name: `${reducerPath}/subscriptions`,
@@ -502,6 +516,7 @@ export function buildSlice({
     provided: invalidationSlice.reducer,
     subscriptions: internalSubscriptionsSlice.reducer,
     config: configSlice.reducer,
+    pendingTagInvalidations: pendingTagInvalidationsSlice.reducer,
   })
 
   const reducer: typeof combinedReducer = (state, action) =>
@@ -514,6 +529,7 @@ export function buildSlice({
     ...internalSubscriptionsSlice.actions,
     ...mutationSlice.actions,
     ...invalidationSlice.actions,
+    ...pendingTagInvalidationsSlice.actions,
     resetApiState,
   }
 

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -28,7 +28,6 @@ import { calculateProvidedByThunk } from './buildThunks'
 import type {
   AssertTagTypes,
   EndpointDefinitions,
-  FullTagDescription,
   QueryDefinition,
 } from '../endpointDefinitions'
 import type { Patch } from 'immer'

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -452,7 +452,7 @@ export const coreModule = (): Module<CoreModule> => ({
       refetchOnMountOrArgChange,
       refetchOnFocus,
       refetchOnReconnect,
-      invalidateImmediately,
+      invalidationBehavior,
     },
     context
   ) {
@@ -515,7 +515,7 @@ export const coreModule = (): Module<CoreModule> => ({
         refetchOnMountOrArgChange,
         keepUnusedDataFor,
         reducerPath,
-        invalidateImmediately,
+        invalidationBehavior,
       },
     })
 

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -452,6 +452,7 @@ export const coreModule = (): Module<CoreModule> => ({
       refetchOnMountOrArgChange,
       refetchOnFocus,
       refetchOnReconnect,
+      invalidateImmediately,
     },
     context
   ) {
@@ -514,6 +515,7 @@ export const coreModule = (): Module<CoreModule> => ({
         refetchOnMountOrArgChange,
         keepUnusedDataFor,
         reducerPath,
+        invalidateImmediately,
       },
     })
 

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -265,7 +265,7 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
       refetchOnMountOrArgChange: false,
       refetchOnFocus: false,
       refetchOnReconnect: false,
-      invalidationBehavior: 'immediately',
+      invalidationBehavior: 'delayed',
       ...options,
       extractRehydrationInfo,
       serializeQueryArgs(queryArgsApi) {

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -152,14 +152,15 @@ export interface CreateApiOptions<
    */
   refetchOnReconnect?: boolean
   /**
-   * Defaults to `false`. This setting allows you to disable a consistency measure that delay tag invalidations until all pending queries and mutations are settled.
+   * Defaults to `'immediately'`. This setting allows you to control when tags are invalidated after a mutation.
    *
-   * Context: If a mutation finishes while a query is pending, then RTK-query has to wait until the query is finished until it can invalidate any tags, since the query itself could provide a tag that the mutation will invalidate.
-   * RTK-query also waits with the tag invalidations if another mutation is pending, to "batch" the tag invalidations if two mutations invalidate the same tag, avoiding unnecessary re-fetching.
-   *
-   * If you constantly have some queries running, this can delay the tag invalidations. In this case, you can enable this setting to opt-out of the "correct" behavior and refetch immediately when a mutation finishes instead.
+   * - `'immediately'`: Queries are invalidated instantly after the mutation finished, even if they are running.
+   *   If the query provides tags that were invalidated while it ran, it won't be re-fetched.
+   * - `'delayed'`: Invalidation only happens after all queries and mutations are settled.
+   *   This ensures that queries are always invalidated correctly and automatically "batches" invalidations of concurrent mutations.
+   *   Note that if you constantly have some queries (or mutations) running, this can delay tag invalidations indefinitely.
    */
-  invalidateImmediately?: boolean
+  invalidationBehavior?: 'delayed' | 'immediately'
   /**
    * A function that is passed every dispatched action. If this returns something other than `undefined`,
    * that return value will be used to rehydrate fulfilled & errored queries.
@@ -264,7 +265,7 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
       refetchOnMountOrArgChange: false,
       refetchOnFocus: false,
       refetchOnReconnect: false,
-      invalidateImmediately: false,
+      invalidationBehavior: 'delayed',
       ...options,
       extractRehydrationInfo,
       serializeQueryArgs(queryArgsApi) {

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -265,7 +265,7 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
       refetchOnMountOrArgChange: false,
       refetchOnFocus: false,
       refetchOnReconnect: false,
-      invalidationBehavior: 'delayed',
+      invalidationBehavior: 'immediately',
       ...options,
       extractRehydrationInfo,
       serializeQueryArgs(queryArgsApi) {

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -152,6 +152,15 @@ export interface CreateApiOptions<
    */
   refetchOnReconnect?: boolean
   /**
+   * Defaults to `false`. This setting allows you to disable a consistency measure that delay tag invalidations until all pending queries and mutations are settled.
+   *
+   * Context: If a mutation finishes while a query is pending, then RTK-query has to wait until the query is finished until it can invalidate any tags, since the query itself could provide a tag that the mutation will invalidate.
+   * RTK-query also waits with the tag invalidations if another mutation is pending, to "batch" the tag invalidations if two mutations invalidate the same tag, avoiding unnecessary re-fetching.
+   *
+   * If you constantly have some queries running, this can delay the tag invalidations. In this case, you can enable this setting to opt-out of the "correct" behavior and refetch immediately when a mutation finishes instead.
+   */
+  invalidateImmediately?: boolean
+  /**
    * A function that is passed every dispatched action. If this returns something other than `undefined`,
    * that return value will be used to rehydrate fulfilled & errored queries.
    *
@@ -255,6 +264,7 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
       refetchOnMountOrArgChange: false,
       refetchOnFocus: false,
       refetchOnReconnect: false,
+      invalidateImmediately: false,
       ...options,
       extractRehydrationInfo,
       serializeQueryArgs(queryArgsApi) {

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -51,7 +51,7 @@ describe('buildSlice', () => {
       api: {
         config: {
           focused: true,
-          invalidateImmediately: false,
+          invalidationBehavior: "delayed",
           keepUnusedDataFor: 60,
           middlewareRegistered: true,
           online: true,

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -51,7 +51,7 @@ describe('buildSlice', () => {
       api: {
         config: {
           focused: true,
-          invalidationBehavior: "delayed",
+          invalidationBehavior: "immediately",
           keepUnusedDataFor: 60,
           middlewareRegistered: true,
           online: true,

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -61,7 +61,6 @@ describe('buildSlice', () => {
           refetchOnReconnect: false,
         },
         mutations: {},
-        pendingTagInvalidations: [],
         provided: expect.any(Object),
         queries: {
           'getUser(1)': {

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -51,7 +51,7 @@ describe('buildSlice', () => {
       api: {
         config: {
           focused: true,
-          invalidationBehavior: "immediately",
+          invalidationBehavior: 'delayed',
           keepUnusedDataFor: 60,
           middlewareRegistered: true,
           online: true,

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -60,6 +60,7 @@ describe('buildSlice', () => {
           refetchOnReconnect: false,
         },
         mutations: {},
+        pendingTagInvalidations: [],
         provided: expect.any(Object),
         queries: {
           'getUser(1)': {

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -51,6 +51,7 @@ describe('buildSlice', () => {
       api: {
         config: {
           focused: true,
+          invalidateImmediately: false,
           keepUnusedDataFor: 60,
           middlewareRegistered: true,
           online: true,

--- a/packages/toolkit/src/query/tests/raceConditions.test.ts
+++ b/packages/toolkit/src/query/tests/raceConditions.test.ts
@@ -21,6 +21,7 @@ const eatBananaPromises = createPromiseFactory()
 
 let eatenBananas = 0
 const api = createApi({
+  invalidationBehavior: 'delayed',
   baseQuery: () => undefined as any,
   tagTypes: ['Banana'],
   endpoints: (build) => ({

--- a/packages/toolkit/src/query/tests/raceConditions.test.ts
+++ b/packages/toolkit/src/query/tests/raceConditions.test.ts
@@ -1,0 +1,108 @@
+import { createApi, QueryStatus } from '@reduxjs/toolkit/query'
+import { getLog } from 'console-testing-library'
+import { actionsReducer, setupApiStore, waitMs } from './helpers'
+
+// We need to be able to control when which query resolves to simulate race
+// conditions properly, that's the purpose of this factory.
+const createPromiseFactory = () => {
+  const resolveQueue: (() => void)[] = []
+  const createPromise = () =>
+    new Promise<void>((resolve) => {
+      resolveQueue.push(resolve)
+    })
+  const resolveOldest = () => {
+    resolveQueue.shift()?.()
+  }
+  return { createPromise, resolveOldest }
+}
+
+const getEatenBananaPromises = createPromiseFactory()
+const eatBananaPromises = createPromiseFactory()
+
+let eatenBananas = 0
+const api = createApi({
+  baseQuery: () => undefined as any,
+  tagTypes: ['Banana'],
+  endpoints: (build) => ({
+    // Eat a banana.
+    eatBanana: build.mutation<unknown, void>({
+      queryFn: async () => {
+        await eatBananaPromises.createPromise()
+        eatenBananas += 1
+        return { data: null, meta: {} }
+      },
+      invalidatesTags: ['Banana'],
+    }),
+
+    // Get the number of eaten bananas.
+    getEatenBananas: build.query<number, void>({
+      queryFn: async (arg, arg1, arg2, arg3) => {
+        const result = eatenBananas
+        await getEatenBananaPromises.createPromise()
+        return { data: result }
+      },
+      providesTags: ['Banana'],
+    }),
+  }),
+})
+const { getEatenBananas, eatBanana } = api.endpoints
+
+const storeRef = setupApiStore(api, {
+  ...actionsReducer,
+})
+
+it('invalidates a query after a corresponding mutation', async () => {
+  eatenBananas = 0
+
+  const query = storeRef.store.dispatch(getEatenBananas.initiate())
+  const getQueryState = () =>
+    storeRef.store.getState().api.queries[query.queryCacheKey]
+  getEatenBananaPromises.resolveOldest()
+  await waitMs(2)
+
+  expect(getQueryState()?.data).toBe(0)
+  expect(getQueryState()?.status).toBe(QueryStatus.fulfilled)
+
+  const mutation = storeRef.store.dispatch(eatBanana.initiate())
+  const getMutationState = () =>
+    storeRef.store.getState().api.mutations[mutation.requestId]
+  eatBananaPromises.resolveOldest()
+  await waitMs(2)
+
+  expect(getMutationState()?.status).toBe(QueryStatus.fulfilled)
+  expect(getQueryState()?.data).toBe(0)
+  expect(getQueryState()?.status).toBe(QueryStatus.pending)
+
+  getEatenBananaPromises.resolveOldest()
+  await waitMs(2)
+
+  expect(getQueryState()?.data).toBe(1)
+  expect(getQueryState()?.status).toBe(QueryStatus.fulfilled)
+})
+
+it('invalidates a query whose corresponding mutation finished while the query was in flight', async () => {
+  eatenBananas = 0
+
+  const query = storeRef.store.dispatch(getEatenBananas.initiate())
+  const getQueryState = () =>
+    storeRef.store.getState().api.queries[query.queryCacheKey]
+
+  const mutation = storeRef.store.dispatch(eatBanana.initiate())
+  const getMutationState = () =>
+    storeRef.store.getState().api.mutations[mutation.requestId]
+  eatBananaPromises.resolveOldest()
+  await waitMs(2)
+  expect(getMutationState()?.status).toBe(QueryStatus.fulfilled)
+
+  getEatenBananaPromises.resolveOldest()
+  await waitMs(2)
+  expect(getQueryState()?.data).toBe(0)
+  expect(getQueryState()?.status).toBe(QueryStatus.pending)
+
+  // should already be refetching
+  getEatenBananaPromises.resolveOldest()
+  await waitMs(2)
+
+  expect(getQueryState()?.status).toBe(QueryStatus.fulfilled)
+  expect(getQueryState()?.data).toBe(1)
+})

--- a/packages/toolkit/src/tests/combineSlices.test.ts
+++ b/packages/toolkit/src/tests/combineSlices.test.ts
@@ -33,6 +33,7 @@ const api = {
       subscriptions: {},
       config: {
         reducerPath: 'api',
+        invalidationBehavior: 'delayed',
         online: false,
         focused: false,
         keepUnusedDataFor: 60,


### PR DESCRIPTION
I've described the approach in this PR earlier in #3105.
Resolves #2203, #3105

## Problem

There are race conditions when a mutation is finishing while a query is running. More concretely, this happens:

1. The query Q starts.
2. Mutation M finishes. It invalidates the tag T. There is currently no query that provides the tag T, so no query is invalidated.
3. The query Q finishes. It provides the tag T.

If the data from Q was generated before M arrived on the server, then the data is outdated. This is rare in normal circumstances, but when many mutations/queries are being started within a short time frame, it becomes likely.

## Solution

If a mutation finishes while another query or mutation is running, don't invalidate tags. Instead, invalidate them later after all queries/mutations are settled. 

In the much more common case that the mutation isn't running at the same time as a query, this won't change anything.

For the bug described above, it would be sufficient if the tag invalidation would only be delayed until all queries are settled (as opposed to queries + mutations). However, waiting for the mutations as well has the advantage of solving issue #2203 on the go: when multiple mutations are fired at the same time, queries will only start after all the mutations settled. In a way, they are batched automatically.

## Open Questions

- [ ] Does this change require an update to the documentation?
- [ ] Should the purpose of `pendingTagInvalidations` be documented somewhere in the code? If yes, where?
- [ ] I'm not sure whether I've put my code in the right places. Feel free to request changes :-)