### PR TITLE
fix docs rtk-query/usage/queryies typo

### DIFF
--- a/docs/rtk-query/usage/queries.mdx
+++ b/docs/rtk-query/usage/queries.mdx
@@ -74,7 +74,7 @@ const api = createApi({
           updateCachedData,
         }
       ) {},
-      // The 2nd parameter is the destructured `QueryCacheLifecycleApi`
+      // The 3rd parameter is the destructured `QueryCacheLifecycleApi`
       async onCacheEntryAdded(
         arg,
         {


### PR DESCRIPTION
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/3603431/214611628-b3dca3b6-a6a5-4b07-aa6a-1200b82eef7f.png">
2nd argument has been described