### PR TITLE
make isAnyOf friendly for mapped matchers, but making argument optional

### DIFF
--- a/packages/toolkit/src/matchers.ts
+++ b/packages/toolkit/src/matchers.ts
@@ -12,14 +12,12 @@ import type {
 } from './createAsyncThunk'
 
 /** @public */
-export type ActionMatchingAnyOf<
-  Matchers extends [Matcher<any>, ...Matcher<any>[]]
-> = ActionFromMatcher<Matchers[number]>
+export type ActionMatchingAnyOf<Matchers extends [...Matcher<any>[]]> =
+  ActionFromMatcher<Matchers[number]>
 
 /** @public */
-export type ActionMatchingAllOf<
-  Matchers extends [Matcher<any>, ...Matcher<any>[]]
-> = UnionToIntersection<ActionMatchingAnyOf<Matchers>>
+export type ActionMatchingAllOf<Matchers extends [...Matcher<any>[]]> =
+  UnionToIntersection<ActionMatchingAnyOf<Matchers>>
 
 const matches = (matcher: Matcher<any>, action: any) => {
   if (hasMatchFunction(matcher)) {
@@ -38,7 +36,7 @@ const matches = (matcher: Matcher<any>, action: any) => {
  *
  * @public
  */
-export function isAnyOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(
+export function isAnyOf<Matchers extends [...Matcher<any>[]]>(
   ...matchers: Matchers
 ) {
   return (action: any): action is ActionMatchingAnyOf<Matchers> => {
@@ -55,7 +53,7 @@ export function isAnyOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(
  *
  * @public
  */
-export function isAllOf<Matchers extends [Matcher<any>, ...Matcher<any>[]]>(
+export function isAllOf<Matchers extends [...Matcher<any>[]]>(
   ...matchers: Matchers
 ) {
   return (action: any): action is ActionMatchingAllOf<Matchers> => {

--- a/packages/toolkit/src/tests/matchers.typetest.ts
+++ b/packages/toolkit/src/tests/matchers.typetest.ts
@@ -312,3 +312,20 @@ function isRejectedWithValueTest(action: AnyAction) {
     expectExactType<SerializedError>(action.error)
   }
 }
+
+function matchersAcceptSpreadArguments() {
+  const thunk1 = createAsyncThunk('a', () => 'a')
+  const thunk2 = createAsyncThunk('b', () => 'b')
+  const interestingThunks = [thunk1, thunk2]
+  const interestingPendingThunks = interestingThunks.map(
+    (thunk) => thunk.pending
+  )
+  const interestingFulfilledThunks = interestingThunks.map(
+    (thunk) => thunk.fulfilled
+  )
+
+  const isLoading = isAnyOf(...interestingPendingThunks)
+  const isNotLoading = isAnyOf(...interestingFulfilledThunks)
+
+  const isAllLoading = isAllOf(...interestingPendingThunks)
+}


### PR DESCRIPTION
As discussed in the comments - I removed the mandatory parameter for isAnyOf.

For me it feels like making it work with mapped results if more valuable than not accepting zero args

#2209 