### PR TITLE
Update Examples to use React Router 6.8 Patterns

### DIFF
--- a/examples/query/react/authentication-with-extrareducers/package.json
+++ b/examples/query/react/authentication-with-extrareducers/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/authentication-with-extrareducers/src/App.tsx
+++ b/examples/query/react/authentication-with-extrareducers/src/App.tsx
@@ -1,9 +1,17 @@
-import { Routes, Route } from 'react-router-dom'
+import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
 import { Box, Center, VStack } from '@chakra-ui/react'
 
 import { Login } from './features/auth/Login'
 import { PrivateOutlet } from './utils/PrivateOutlet'
 import { ProtectedComponent } from './features/auth/ProtectedComponent'
+
+function AppLayout() {
+  return (
+    <Box>
+      <Outlet />
+    </Box>
+  )
+}
 
 function Hooray() {
   return (
@@ -18,17 +26,28 @@ function Hooray() {
   )
 }
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [
+      { path: '/login', element: <Login /> },
+      {
+        path: '*',
+        element: <PrivateOutlet />,
+        children: [
+          {
+            index: true,
+            element: <Hooray />,
+          },
+        ],
+      },
+    ],
+  },
+])
+
 function App() {
-  return (
-    <Box>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/" element={<PrivateOutlet />}>
-          <Route index element={<Hooray />} />
-        </Route>
-      </Routes>
-    </Box>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/authentication-with-extrareducers/src/index.tsx
+++ b/examples/query/react/authentication-with-extrareducers/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
 import { ChakraProvider } from '@chakra-ui/react'
 
 import App from './App'
@@ -15,9 +14,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <Provider store={store}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </Provider>
     </React.StrictMode>

--- a/examples/query/react/authentication/package.json
+++ b/examples/query/react/authentication/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/authentication/src/App.tsx
+++ b/examples/query/react/authentication/src/App.tsx
@@ -1,9 +1,17 @@
-import { Routes, Route } from 'react-router-dom'
+import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
 import { Box, Center, VStack } from '@chakra-ui/react'
 
 import { Login } from './features/auth/Login'
 import { PrivateOutlet } from './utils/PrivateOutlet'
 import { ProtectedComponent } from './features/auth/ProtectedComponent'
+
+function AppLayout() {
+  return (
+    <Box>
+      <Outlet />
+    </Box>
+  )
+}
 
 function Hooray() {
   return (
@@ -18,17 +26,27 @@ function Hooray() {
   )
 }
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [
+      { path: '/login', element: <Login /> },
+      {
+        path: '*',
+        element: <PrivateOutlet />,
+        children: [
+          {
+            index: true,
+            element: <Hooray />,
+          },
+        ],
+      },
+    ],
+  },
+])
 function App() {
-  return (
-    <Box>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="*" element={<PrivateOutlet />}>
-          <Route index element={<Hooray />} />
-        </Route>
-      </Routes>
-    </Box>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/authentication/src/index.tsx
+++ b/examples/query/react/authentication/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
 import { ChakraProvider } from '@chakra-ui/react'
 import App from './App'
 import { store } from './app/store'
@@ -19,9 +18,7 @@ worker
       <React.StrictMode>
         <Provider store={store}>
           <ChakraProvider>
-            <BrowserRouter>
-              <App />
-            </BrowserRouter>
+            <App />
           </ChakraProvider>
         </Provider>
       </React.StrictMode>

--- a/examples/query/react/graphql-codegen/package.json
+++ b/examples/query/react/graphql-codegen/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/graphql-codegen/src/App.tsx
+++ b/examples/query/react/graphql-codegen/src/App.tsx
@@ -1,12 +1,15 @@
-import { Route, Routes } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { PostsManager } from './features/posts/PostsManager'
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <PostsManager />,
+  },
+])
+
 function App() {
-  return (
-    <Routes>
-      <Route path="/" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/graphql-codegen/src/index.tsx
+++ b/examples/query/react/graphql-codegen/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/baseApi'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -16,9 +15,7 @@ worker.start({ quiet: true }).then(() => {
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/examples/query/react/graphql/package.json
+++ b/examples/query/react/graphql/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/graphql/src/App.tsx
+++ b/examples/query/react/graphql/src/App.tsx
@@ -1,12 +1,15 @@
-import { Route, Routes } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { PostsManager } from './features/posts/PostsManager'
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <PostsManager />,
+  },
+])
+
 function App() {
-  return (
-    <Routes>
-      <Route path="/" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/graphql/src/index.tsx
+++ b/examples/query/react/graphql/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/posts'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -16,9 +15,7 @@ worker.start({ quiet: true }).then(() => {
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/examples/query/react/kitchen-sink/package.json
+++ b/examples/query/react/kitchen-sink/package.json
@@ -11,7 +11,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/kitchen-sink/src/App.tsx
+++ b/examples/query/react/kitchen-sink/src/App.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { Routes, Route, Link } from 'react-router-dom'
+import {
+  Link,
+  createBrowserRouter,
+  Outlet,
+  RouterProvider,
+} from 'react-router-dom'
 import { PostsManager } from './features/posts/PostsManager'
 import { CounterList } from './features/counter/CounterList'
 import { TimeList } from './features/time/TimeList'
@@ -7,7 +12,7 @@ import { PollingToggles } from './features/polling/PollingToggles'
 import { Lazy } from './features/bundleSplitting'
 import './App.css'
 
-function App() {
+function AppLayout() {
   return (
     <div className="App">
       <div className="row">
@@ -24,15 +29,30 @@ function App() {
       </div>
       <div></div>
       <div>
-        <Routes>
-          <Route path="/" element={<TimeList />} />
-          <Route path="/counters" element={<CounterList />} />
-          <Route path="/posts/*" element={<PostsManager />} />
-          <Route path="/bundleSplitting" element={<Lazy />} />
-        </Routes>
+        <Outlet />
       </div>
     </div>
   )
+}
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [
+      { path: '/', element: <TimeList /> },
+      { path: '/counters', element: <CounterList /> },
+      {
+        path: '/posts/*',
+        element: <PostsManager />,
+      },
+      { path: '/bundleSplitting', element: <Lazy /> },
+    ],
+  },
+])
+
+function App() {
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/kitchen-sink/src/index.tsx
+++ b/examples/query/react/kitchen-sink/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import { store } from './app/store'
 import { Provider } from 'react-redux'
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 
 // Initialize the msw worker, wait for the service worker registration to resolve, then mount
@@ -19,9 +18,7 @@ async function render() {
   rootNode.render(
     <React.StrictMode>
       <Provider store={store}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <App />
       </Provider>
     </React.StrictMode>
   )

--- a/examples/query/react/kitchen-sink/src/mocks/setupTests.tsx
+++ b/examples/query/react/kitchen-sink/src/mocks/setupTests.tsx
@@ -1,15 +1,26 @@
-import React from 'react'
+import { PropsWithChildren, ReactNode } from 'react'
 import { render } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { store } from '../app/store'
 import {
-  unstable_HistoryRouter as HistoryRouter,
   Route,
-  Routes,
+  createMemoryRouter,
+  createRoutesFromElements,
+  RouterProvider,
 } from 'react-router-dom'
-import { createMemoryHistory } from 'history'
 import { mockServer } from './mockServer'
 import 'whatwg-fetch'
+
+interface DataMemoryRouterProps extends PropsWithChildren {
+  initialEntries?: string[]
+}
+
+function DataMemoryRouter({ children, initialEntries }: DataMemoryRouterProps) {
+  const router = createMemoryRouter(createRoutesFromElements(children), {
+    initialEntries,
+  })
+  return <RouterProvider router={router} />
+}
 
 export const setupTests = () => {
   const { server, state: serverState } = mockServer()
@@ -23,22 +34,18 @@ export const setupTests = () => {
     path?: string
   }
   function renderWithProvider(
-    children: React.ReactChild,
+    children: ReactNode,
     { route, path }: RenderOptions = { route: '/', path: '' }
   ) {
-    const history = createMemoryHistory()
-    history.push(route)
     return render(
       <Provider store={store}>
-        <HistoryRouter history={history}>
-          {path ? (
-            <Routes>
-              <Route path={path}>{children}</Route>
-            </Routes>
-          ) : (
-            children
-          )}
-        </HistoryRouter>
+        {path ? (
+          <DataMemoryRouter initialEntries={[route]}>
+            <Route path={path}>{children}</Route>
+          </DataMemoryRouter>
+        ) : (
+          children
+        )}
       </Provider>
     )
   }

--- a/examples/query/react/mutations/package.json
+++ b/examples/query/react/mutations/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/mutations/src/App.tsx
+++ b/examples/query/react/mutations/src/App.tsx
@@ -1,15 +1,25 @@
-import { Routes, Route } from 'react-router-dom'
+import { Outlet, createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { PostsManager } from './features/posts/PostsManager'
 import { Box } from '@chakra-ui/react'
 
-function App() {
+function AppLayout() {
   return (
     <Box>
-      <Routes>
-        <Route path="*" element={<PostsManager />} />
-      </Routes>
+      <Outlet />
     </Box>
   )
+}
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [{ path: '*', element: <PostsManager /> }],
+  },
+])
+
+function App() {
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/mutations/src/index.tsx
+++ b/examples/query/react/mutations/src/index.tsx
@@ -5,7 +5,6 @@ import { store } from './store'
 import { Provider } from 'react-redux'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 
 // Initialize the msw worker, wait for the service worker registration to resolve, then mount
@@ -14,9 +13,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <Provider store={store}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </Provider>
     </React.StrictMode>

--- a/examples/query/react/optimistic-update/package.json
+++ b/examples/query/react/optimistic-update/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1",
     "uuid": "^8.3.2"
   },

--- a/examples/query/react/optimistic-update/src/App.tsx
+++ b/examples/query/react/optimistic-update/src/App.tsx
@@ -1,12 +1,10 @@
-import { Route, Routes } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { PostsManager } from './features/posts/PostsManager'
 
+const router = createBrowserRouter([{ path: '*', element: <PostsManager /> }])
+
 function App() {
-  return (
-    <Routes>
-      <Route path="*" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/optimistic-update/src/index.tsx
+++ b/examples/query/react/optimistic-update/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/posts'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -14,9 +13,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/examples/query/react/pagination/package.json
+++ b/examples/query/react/pagination/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/pagination/src/App.tsx
+++ b/examples/query/react/pagination/src/App.tsx
@@ -1,12 +1,10 @@
-import { Route, Routes } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { PostsManager } from './features/posts/PostsManager'
 
+const router = createBrowserRouter([{ path: '*', element: <PostsManager /> }])
+
 function App() {
-  return (
-    <Routes>
-      <Route path="*" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/pagination/src/index.tsx
+++ b/examples/query/react/pagination/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/posts'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -14,9 +13,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/examples/query/react/prefetching-automatic-waterfall/package.json
+++ b/examples/query/react/prefetching-automatic-waterfall/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/prefetching-automatic-waterfall/src/App.tsx
+++ b/examples/query/react/prefetching-automatic-waterfall/src/App.tsx
@@ -1,12 +1,10 @@
-import { Route, Routes } from 'react-router-dom'
-import { PostsManager } from './features/posts/PostsManager'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import PostsManager from './features/posts/PostsManager'
+
+const router = createBrowserRouter([{ path: '*', element: <PostsManager /> }])
 
 function App() {
-  return (
-    <Routes>
-      <Route path="*" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/prefetching-automatic-waterfall/src/index.tsx
+++ b/examples/query/react/prefetching-automatic-waterfall/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/posts'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -14,9 +13,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/examples/query/react/prefetching-automatic/package.json
+++ b/examples/query/react/prefetching-automatic/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/prefetching-automatic/src/App.tsx
+++ b/examples/query/react/prefetching-automatic/src/App.tsx
@@ -1,12 +1,10 @@
-import { Route, Routes } from 'react-router-dom'
-import { PostsManager } from './features/posts/PostsManager'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import PostsManager from './features/posts/PostsManager'
+
+const router = createBrowserRouter([{ path: '*', element: <PostsManager /> }])
 
 function App() {
-  return (
-    <Routes>
-      <Route path="*" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/prefetching-automatic/src/index.tsx
+++ b/examples/query/react/prefetching-automatic/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/posts'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -14,9 +13,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/examples/query/react/prefetching/package.json
+++ b/examples/query/react/prefetching/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "3.11.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {

--- a/examples/query/react/prefetching/src/App.tsx
+++ b/examples/query/react/prefetching/src/App.tsx
@@ -1,12 +1,10 @@
-import { Route, Routes } from 'react-router-dom'
-import { PostsManager } from './features/posts/PostsManager'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import PostsManager from './features/posts/PostsManager'
+
+const router = createBrowserRouter([{ path: '*', element: <PostsManager /> }])
 
 function App() {
-  return (
-    <Routes>
-      <Route path="*" element={<PostsManager />} />
-    </Routes>
-  )
+  return <RouterProvider router={router} />
 }
 
 export default App

--- a/examples/query/react/prefetching/src/index.tsx
+++ b/examples/query/react/prefetching/src/index.tsx
@@ -4,7 +4,6 @@ import App from './App'
 import { api } from './app/services/posts'
 import { ChakraProvider } from '@chakra-ui/react'
 
-import { BrowserRouter } from 'react-router-dom'
 import { worker } from './mocks/browser'
 import { ApiProvider } from '@reduxjs/toolkit/query/react'
 
@@ -14,9 +13,7 @@ worker.start({ quiet: true }).then(() =>
     <React.StrictMode>
       <ApiProvider api={api}>
         <ChakraProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <App />
         </ChakraProvider>
       </ApiProvider>
     </React.StrictMode>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,7 +2583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.18.3
   resolution: "@babel/runtime@npm:7.18.3"
   dependencies:
@@ -4361,7 +4361,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -4471,7 +4471,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     ts-node: ^10.0.0
     typescript: 4.1.3
@@ -4500,7 +4500,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -4521,7 +4521,7 @@ __metadata:
     react: ^18.1.0
     react-dom: ^18.1.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
     whatwg-fetch: ^3.4.1
@@ -4545,7 +4545,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -4568,7 +4568,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
     uuid: ^8.3.2
@@ -4595,7 +4595,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -4635,7 +4635,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -4660,7 +4660,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -4685,7 +4685,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -15775,15 +15775,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"history@npm:^5.2.0":
-  version: 5.3.0
-  resolution: "history@npm:5.3.0"
-  dependencies:
-    "@babel/runtime": ^7.7.6
-  checksum: d73c35df49d19ac172f9547d30a21a26793e83f16a78386d99583b5bf1429cc980799fcf1827eb215d31816a6600684fba9686ce78104e23bd89ec239e7c726f
-  languageName: node
-  linkType: hard
-
 "hmac-drbg@npm:^1.0.1":
   version: 1.0.1
   resolution: "hmac-drbg@npm:1.0.1"
@@ -23149,19 +23140,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.3.0":
-  version: 6.3.0
-  resolution: "react-router-dom@npm:6.3.0"
-  dependencies:
-    history: ^5.2.0
-    react-router: 6.3.0
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 77603a654f8a8dc7f65535a2e5917a65f8d9ffcb06546d28dd297e52adcc4b8a84377e0115f48dca330b080af2da3e78f29d590c89307094d36927d2b1751ec3
-  languageName: node
-  linkType: hard
-
 "react-router-dom@npm:^5.3.3":
   version: 5.3.3
   resolution: "react-router-dom@npm:5.3.3"
@@ -23212,14 +23190,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.3.0":
-  version: 6.3.0
-  resolution: "react-router@npm:6.3.0"
+"react-router@npm:6.8.0":
+  version: 6.8.0
+  resolution: "react-router@npm:6.8.0"
   dependencies:
-    history: ^5.2.0
+    "@remix-run/router": 1.3.1
   peerDependencies:
     react: ">=16.8"
-  checksum: 7be673f5e72104be01e6ab274516bdb932efd93305243170690f6560e3bd1035dd1df3d3c9ce1e0f452638a2529f43a1e77dcf0934fc8031c4783da657be13ca
+  checksum: 6e258c47f6cbbd0b0c7c9fd7bbaf7cd5cd60472935512fbe97c91e4bbd9b1717f0dee231f5d7206bedfbccdbc21ab77eaf336ba971ea5d8c6b1277045a7b958a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4383,7 +4383,7 @@ __metadata:
     react-dom: ^18.1.0
     react-icons: 3.11.0
     react-redux: ^8.0.2
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.8.0
     react-scripts: 5.0.1
     typescript: ~4.2.4
   languageName: unknown
@@ -6412,6 +6412,13 @@ __metadata:
     react-redux:
       optional: true
   checksum: be5cdea975a8a631fe2d88cafc7077554c7bc3621a4a7031556cc17e5dec26359018f2614c325895e7ab50865f5c511025d1e589ca01de7e2bd88d95e0a1a963
+  languageName: node
+  linkType: hard
+
+"@remix-run/router@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@remix-run/router@npm:1.3.1"
+  checksum: c91cba100b13fbb83cdaf43ca66b0d9fc1ab9dfe0bc58ac80ff2a4889488bf518a111267c790350eac8c7f764cc7809402430de15bdf70282d0bd60acf06d9de
   languageName: node
   linkType: hard
 
@@ -23172,6 +23179,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-router-dom@npm:^6.8.0":
+  version: 6.8.0
+  resolution: "react-router-dom@npm:6.8.0"
+  dependencies:
+    "@remix-run/router": 1.3.1
+    react-router: 6.8.0
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: a10419023267014bdad20f50b5be04dffda49ebeb06c52ce9567795769dc0dc9b4e2fa61b52b5d70b61df4d17f85bae8f9c7e94c73d25d16974e46fd47765ced
+  languageName: node
+  linkType: hard
+
 "react-router@npm:5.3.3, react-router@npm:^5.3.3":
   version: 5.3.3
   resolution: "react-router@npm:5.3.3"
@@ -23200,6 +23220,17 @@ fsevents@^1.2.7:
   peerDependencies:
     react: ">=16.8"
   checksum: 7be673f5e72104be01e6ab274516bdb932efd93305243170690f6560e3bd1035dd1df3d3c9ce1e0f452638a2529f43a1e77dcf0934fc8031c4783da657be13ca
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.8.0":
+  version: 6.8.0
+  resolution: "react-router@npm:6.8.0"
+  dependencies:
+    "@remix-run/router": 1.3.1
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 6e258c47f6cbbd0b0c7c9fd7bbaf7cd5cd60472935512fbe97c91e4bbd9b1717f0dee231f5d7206bedfbccdbc21ab77eaf336ba971ea5d8c6b1277045a7b958a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I have updated all of the examples that use react-router-dom to use the latest current version (6.8) along with some pattern updates that reflect React Router's docs.

In the linked issue there is mention of a desire for an example that use's the new loaders pattern from react-router-dom, should I also include that example in this PR? 