### PR TITLE
Fix global `responseHandler` being used in `fetchBaseQuery`

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -197,6 +197,7 @@ export function fetchBaseQuery({
   jsonContentType = 'application/json',
   jsonReplacer,
   timeout: defaultTimeout,
+  responseHandler: globalResponseHandler,
   validateStatus: globalValidateStatus,
   ...baseFetchOptions
 }: FetchBaseQueryArgs = {}): BaseQueryFn<
@@ -218,7 +219,7 @@ export function fetchBaseQuery({
       url,
       headers = new Headers(baseFetchOptions.headers),
       params = undefined,
-      responseHandler = 'json' as const,
+      responseHandler = globalResponseHandler ?? ('json' as const),
       validateStatus = globalValidateStatus ?? defaultValidateStatus,
       timeout = defaultTimeout,
       ...rest

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -925,7 +925,7 @@ describe('fetchBaseQuery', () => {
       })
 
       const req = globalizedBaseQuery(
-        { url: '/success', responseHandler: 'text' },
+        { url: '/success' },
         commonBaseQueryApi,
         {}
       )
@@ -934,6 +934,7 @@ describe('fetchBaseQuery', () => {
       expect(res).toBeInstanceOf(Object)
       expect(res.meta?.request).toBeInstanceOf(Request)
       expect(res.meta?.response).toBeInstanceOf(Object)
+      expect(res.error).toBeUndefined()
       expect(res.data).toEqual(`this is not json!`)
     })
 


### PR DESCRIPTION
The changes introduced in https://github.com/reduxjs/redux-toolkit/pull/2823 missed responseHandler. responseHandler has a test that ends up using the same config for the query as the global settings, meaning it passes without the global setting being applied.

Fixes https://github.com/reduxjs/redux-toolkit/issues/3136