### PR TITLE
Update rtk-query redux-persist Example

### DIFF
--- a/docs/rtk-query/usage/persistence-and-rehydration.mdx
+++ b/docs/rtk-query/usage/persistence-and-rehydration.mdx
@@ -45,7 +45,7 @@ export const api = createApi({
   // highlight-start
   extractRehydrationInfo(action, { reducerPath }) {
     if (action.type === REHYDRATE) {
-      return action.payload[reducerPath]
+      return action.payload?.[reducerPath]
     }
   },
   // highlight-end


### PR DESCRIPTION
Found that when rehydration is set up per the existing docs there is a runtime error when trying to load first time, or after clearing storage. Optionally accessing reducer path seems to work well, and was published on stack overflow https://stackoverflow.com/a/72959139. Updating these docs should save others the trouble I had. 