### PR TITLE
docs(rtk-query): Add missing keys to `BaseQueryApi`

### DIFF
--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -82,11 +82,15 @@ export const { useGetPokemonByNameQuery } = pokemonApi
 #### baseQuery function arguments
 
 - `args` - The return value of the `query` function for a given endpoint
-- `api` - The `BaseQueryApi` object, containing `signal`, `dispatch`, `getState` and `extra` properties
+- `api` - The `BaseQueryApi` object contains:
   - `signal` - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object that may be used to abort DOM requests and/or read whether the request is aborted.
+  - `abort` - The [`abort()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort) method of the AbortController attached to `signal`.
   - `dispatch` - The `store.dispatch` method for the corresponding Redux store
   - `getState` - A function that may be called to access the current store state
   - `extra` - Provided as thunk.extraArgument to the configureStore getDefaultMiddleware option.
+  - `endpoint` - The name of the endpoint. 
+  - `type` - Type of request (`query` or `mutation`).
+  - `forced` - Indicates if a query has been forced.
 - `extraOptions` - The value of the optional `extraOptions` property provided for a given endpoint
 
 #### baseQuery function signature
@@ -106,8 +110,13 @@ export type BaseQueryFn<
 
 export interface BaseQueryApi {
   signal: AbortSignal
+  abort: (reason?: string) => void
   dispatch: ThunkDispatch<any, any, any>
   getState: () => unknown
+  extra: unknown
+  endpoint: string
+  type: 'query' | 'mutation'
+  forced?: boolean
 }
 
 export type QueryReturnValue<T = unknown, E = unknown, M = unknown> =


### PR DESCRIPTION
The `BaseQueryApi` type is missing keys in the [documentation](https://redux-toolkit.js.org/rtk-query/api/createApi#basequery). I've added a short description and I am happy to reword it if anyone has better suggestions.

Thank you for all the hard work you've done on redux-toolkit!