### PR TITLE
Revert "clear data on skip" back to its original behavior

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -740,7 +740,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       })
 
       usePossiblyImmediateEffect((): void | undefined => {
-        promiseRef.current = undefined
+        if (subscriptionRemoved) {
+          promiseRef.current = undefined
+        }
       }, [subscriptionRemoved])
 
       usePossiblyImmediateEffect((): void | undefined => {

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -626,9 +626,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       )
         lastResult = undefined
     }
-    if (queryArgs === skipToken) {
-      lastResult = undefined
-    }
+
     // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
     let data = currentState.isSuccess ? currentState.data : lastResult?.data
     if (data === undefined) data = currentState.data


### PR DESCRIPTION
This PR:

- Reverts the "clear data on `skip`" logic that was added in #2779 back to its original implementation, where `data` is kept on skip but `currentData` is cleared
- Fixes a related issue with the `useQuery` hook internal promise ref being cleared out when the `subscriptionRemoved` check is actually false, causing an extra thunk dispatch and subscription to be created.

Fixes #2871 .
Fixes #3182 .