### PR TITLE
Add `createApiProvider` function to allow for `configureStore` options to be set for `ApiProvider`

### DIFF
--- a/packages/toolkit/src/query/react/ApiProvider.tsx
+++ b/packages/toolkit/src/query/react/ApiProvider.tsx
@@ -8,19 +8,27 @@ import { setupListeners } from '@reduxjs/toolkit/query'
 import type { Api } from '@reduxjs/toolkit/dist/query/apiTypes'
 import type { ConfigureStoreOptions } from '../../configureStore';
 import { configureStore } from '../../configureStore'
-import type { ThunkMiddlewareFor } from '../../getDefaultMiddleware'
+import type { CurriedGetDefaultMiddleware, ThunkMiddlewareFor } from '../../getDefaultMiddleware'
 
 // copied from configureStore
 type Middlewares<S> = ReadonlyArray<Middleware<{}, S>>
 
 type Enhancers = ReadonlyArray<StoreEnhancer>
 
+/**
+ * Low-level way to create a custom ApiProvider with configureStore options
+ * `options` is the same as for `configureStore` minus the `reducer` property
+ * Useful for if you need to set devtool or additional middlewares to the store
+ */
 export function createApiProvider<
   A extends Action = AnyAction,
   M extends Middlewares<any> = [ThunkMiddlewareFor<any>],
   E extends Enhancers = [StoreEnhancer]
 >(options: Omit<ConfigureStoreOptions<any, A, M, E>, 'reducer'>) {
   const { middleware, ...remaining } = options;
+
+  const processMiddleware = (apiMiddleware: Middleware) => (gDM: CurriedGetDefaultMiddleware<any>) =>
+    Array.isArray(middleware) ? middleware.concat([apiMiddleware]) : gDM().concat(apiMiddleware);
 
   return function <A extends Api<any, {}, any, any>>(props: {
     children: any
@@ -33,7 +41,7 @@ export function createApiProvider<
         reducer: {
           [props.api.reducerPath]: props.api.reducer,
         },
-        middleware: (gDM) => gDM().concat(props.api.middleware),
+        middleware: processMiddleware(props.api.middleware),
         ...remaining
       })
     )
@@ -55,28 +63,28 @@ export function createApiProvider<
 }
 
 /**
-   * Can be used as a `Provider` if you **do not already have a Redux store**.
-   *
-   * @example
-   * ```tsx
-   * // codeblock-meta title="Basic usage - wrap your App with ApiProvider"
-   * import * as React from 'react';
-   * import { ApiProvider } from '@reduxjs/toolkit/query/react';
-   * import { Pokemon } from './features/Pokemon';
-   *
-   * function App() {
-   *   return (
-   *     <ApiProvider api={api}>
-   *       <Pokemon />
-   *     </ApiProvider>
-   *   );
-   * }
-   * ```
-   *
-   * @remarks
-   * Using this together with an existing redux store, both will
-   * conflict with each other - please use the traditional redux setup
-   * in that case.
-   */
+ * Can be used as a `Provider` if you **do not already have a Redux store**.
+ *
+ * @example
+ * ```tsx
+ * // codeblock-meta title="Basic usage - wrap your App with ApiProvider"
+ * import * as React from 'react';
+ * import { ApiProvider } from '@reduxjs/toolkit/query/react';
+ * import { Pokemon } from './features/Pokemon';
+ *
+ * function App() {
+ *   return (
+ *     <ApiProvider api={api}>
+ *       <Pokemon />
+ *     </ApiProvider>
+ *   );
+ * }
+ * ```
+ *
+ * @remarks
+ * Using this together with an existing redux store, both will
+ * conflict with each other - please use the traditional redux setup
+ * in that case.
+ */
 export const ApiProvider = createApiProvider({});
 

--- a/packages/toolkit/src/query/react/ApiProvider.tsx
+++ b/packages/toolkit/src/query/react/ApiProvider.tsx
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit'
+import type { Action, AnyAction, Middleware, StoreEnhancer } from 'redux'
 import type { Context } from 'react'
 import { useEffect } from 'react'
 import React from 'react'
@@ -6,57 +6,77 @@ import type { ReactReduxContextValue } from 'react-redux'
 import { Provider } from 'react-redux'
 import { setupListeners } from '@reduxjs/toolkit/query'
 import type { Api } from '@reduxjs/toolkit/dist/query/apiTypes'
+import type { ConfigureStoreOptions } from '../../configureStore';
+import { configureStore } from '../../configureStore'
+import type { ThunkMiddlewareFor } from '../../getDefaultMiddleware'
+
+// copied from configureStore
+type Middlewares<S> = ReadonlyArray<Middleware<{}, S>>
+
+type Enhancers = ReadonlyArray<StoreEnhancer>
+
+export function createApiProvider<
+  A extends Action = AnyAction,
+  M extends Middlewares<any> = [ThunkMiddlewareFor<any>],
+  E extends Enhancers = [StoreEnhancer]
+>(options: Omit<ConfigureStoreOptions<any, A, M, E>, 'reducer'>) {
+  const { middleware, ...remaining } = options;
+
+  return function <A extends Api<any, {}, any, any>>(props: {
+    children: any
+    api: A
+    setupListeners?: Parameters<typeof setupListeners>[1] | false
+    context?: Context<ReactReduxContextValue>
+  }) {
+    const [store] = React.useState(() =>
+      configureStore({
+        reducer: {
+          [props.api.reducerPath]: props.api.reducer,
+        },
+        middleware: (gDM) => gDM().concat(props.api.middleware),
+        ...remaining
+      })
+    )
+    // Adds the event listeners for online/offline/focus/etc
+    useEffect(
+      (): undefined | (() => void) =>
+        props.setupListeners === false
+          ? undefined
+          : setupListeners(store.dispatch, props.setupListeners),
+      [props.setupListeners, store.dispatch]
+    )
+
+    return (
+      <Provider store={store} context={props.context}>
+        {props.children}
+      </Provider>
+    )
+  }
+}
 
 /**
- * Can be used as a `Provider` if you **do not already have a Redux store**.
- *
- * @example
- * ```tsx
- * // codeblock-meta title="Basic usage - wrap your App with ApiProvider"
- * import * as React from 'react';
- * import { ApiProvider } from '@reduxjs/toolkit/query/react';
- * import { Pokemon } from './features/Pokemon';
- *
- * function App() {
- *   return (
- *     <ApiProvider api={api}>
- *       <Pokemon />
- *     </ApiProvider>
- *   );
- * }
- * ```
- *
- * @remarks
- * Using this together with an existing redux store, both will
- * conflict with each other - please use the traditional redux setup
- * in that case.
- */
-export function ApiProvider<A extends Api<any, {}, any, any>>(props: {
-  children: any
-  api: A
-  setupListeners?: Parameters<typeof setupListeners>[1] | false
-  context?: Context<ReactReduxContextValue>
-}) {
-  const [store] = React.useState(() =>
-    configureStore({
-      reducer: {
-        [props.api.reducerPath]: props.api.reducer,
-      },
-      middleware: (gDM) => gDM().concat(props.api.middleware),
-    })
-  )
-  // Adds the event listeners for online/offline/focus/etc
-  useEffect(
-    (): undefined | (() => void) =>
-      props.setupListeners === false
-        ? undefined
-        : setupListeners(store.dispatch, props.setupListeners),
-    [props.setupListeners, store.dispatch]
-  )
+   * Can be used as a `Provider` if you **do not already have a Redux store**.
+   *
+   * @example
+   * ```tsx
+   * // codeblock-meta title="Basic usage - wrap your App with ApiProvider"
+   * import * as React from 'react';
+   * import { ApiProvider } from '@reduxjs/toolkit/query/react';
+   * import { Pokemon } from './features/Pokemon';
+   *
+   * function App() {
+   *   return (
+   *     <ApiProvider api={api}>
+   *       <Pokemon />
+   *     </ApiProvider>
+   *   );
+   * }
+   * ```
+   *
+   * @remarks
+   * Using this together with an existing redux store, both will
+   * conflict with each other - please use the traditional redux setup
+   * in that case.
+   */
+export const ApiProvider = createApiProvider({});
 
-  return (
-    <Provider store={store} context={props.context}>
-      {props.children}
-    </Provider>
-  )
-}

--- a/packages/toolkit/src/query/react/ApiProvider.tsx
+++ b/packages/toolkit/src/query/react/ApiProvider.tsx
@@ -12,7 +12,6 @@ import type { CurriedGetDefaultMiddleware, ThunkMiddlewareFor } from '../../getD
 
 // copied from configureStore
 type Middlewares<S> = ReadonlyArray<Middleware<{}, S>>
-
 type Enhancers = ReadonlyArray<StoreEnhancer>
 
 /**


### PR DESCRIPTION
In RTK-query, the included `<ApiProvider>` does not allow for any customization of the `configureStore()` that is created in a `useState()`

This MR wraps the `ApiProvider` in a factory function that accepts `Omit<ConfigureStoreOptions, 'reducer'>` to allow for that customization.

I'm particularly interested in allowing for `devTools` to be set to `process.env.NODE_ENV === 'production'`, a general use-case, but I figured that I would allow for all `ConfigureStoreOptions` (except `reducer` of course)

I choose to do this as a factory function since the `ConfigureStoreOptions` I don't see as something that should be mutable via react-props. It's something you set up in advance to be shared across usages of the resultant `<ApiProvider>`

the previous `ApiProvider` is now simply `export const ApiProvider = createApiProvider({});`