### PR TITLE
Use original instead of immer draft for perf

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -32,7 +32,8 @@ import type {
   QueryDefinition,
 } from '../endpointDefinitions'
 import type { Patch } from 'immer'
-import { applyPatches } from 'immer'
+import { isDraft } from 'immer'
+import { applyPatches, original } from 'immer'
 import { onFocus, onFocusLost, onOffline, onOnline } from './setupListeners'
 import {
   isDocumentVisible,
@@ -208,7 +209,12 @@ export function buildSlice({
                 // Assign or safely update the cache data.
                 substate.data =
                   definitions[meta.arg.endpointName].structuralSharing ?? true
-                    ? copyWithStructuralSharing(substate.data, payload)
+                    ? copyWithStructuralSharing(
+                        isDraft(substate.data)
+                          ? original(substate.data)
+                          : substate.data,
+                        payload
+                      )
                     : payload
               }
 


### PR DESCRIPTION
Immer needs to do a lot of bookkeeping to keep track of potential changes. But `copyWithStructuralSharing` is pure, so all the work is unneeded. In my quick tests, this made a x10 performance difference. [Immer docs say](https://immerjs.github.io/immer/performance) that the difference should be more like x2-x3, so maybe the true difference is another in real applications. But I'm sure it's not just a 10% thing :-)

Here's the quick test I've run:

```js
const { produce, original } = require("immer");

const createData = () => JSON.parse(OMITTED); // 100kb of real-world data
const oldData = createData();
const newData = createData();

const v1 = () => produce(draft => copyWithStructuralSharing(draft, newData))(oldData);
const v2 = () => produce(draft => copyWithStructuralSharing(original(draft), newData))(oldData);

// warmup
for (let i = 0; i < 100; i++) {
  v1();
  v2();
}

console.time("v1");
for (let i = 0; i < 100; i++) {
  v1();
}
console.timeEnd("v1");

console.time("v2");
for (let i = 0; i < 100; i++) {
  v2();
}
console.timeEnd("v2");
```

Results:

```
v1: 992.444ms
v2: 92.098ms
```