### PR TITLE
Docs: unused value 'isRejected' in code snippet

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -521,7 +521,7 @@ If a thunk was cancelled, the result of the promise will be a `rejected` action 
 So if you wanted to test that a thunk was cancelled before executing, you can do the following:
 
 ```ts no-transpile
-import { createAsyncThunk, isRejected } from '@reduxjs/toolkit'
+import { createAsyncThunk } from '@reduxjs/toolkit'
 
 test('this thunk should always be skipped', async () => {
   const thunk = createAsyncThunk(


### PR DESCRIPTION
While going through the documentation, I found an unused import value `isRejected` from one of the sample code snippets. Feel free to merge or reject. 👍🏼 