### PR TITLE
Docs: Add a note that .take and .condition resolve only after an action is dispatched

### DIFF
--- a/docs/api/createListenerMiddleware.mdx
+++ b/docs/api/createListenerMiddleware.mdx
@@ -422,6 +422,8 @@ These methods provide the ability to write conditional logic based on future dis
 
 Both these methods are cancellation-aware, and will throw a `TaskAbortError` if the listener instance is cancelled while paused.
 
+Note that both `take` and `condition` will only resolve **after the next action** has been dispatched. They do not resolve immediately even if their predicate would return true for the current state.
+
 ### Child Tasks
 
 - `fork: (executor: (forkApi: ForkApi) => T | Promise<T>) => ForkedTask<T>`: Launches a "child task" that may be used to accomplish additional work. Accepts any sync or async function as its argument, and returns a `{result, cancel}` object that can be used to check the final status and return value of the child task, or cancel it while in-progress.


### PR DESCRIPTION
This was just a quick and dirty attempt to get the message across. Maybe it doesn't warrant so many words? Feel free to edit to your heart's content. :-)

Thanks for redux toolkit btw, it saves us a ton of boilerplate writing redux code. 🧡 🧡 🧡 