### PR TITLE
Add "creator callback" syntax to slice reducer field, to allow for async thunk creation

### DIFF
--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -301,15 +301,11 @@ reducers: (create) => {
 
   return {
     fetchTodo: createAThunk<Todo, string>(async (id, thunkApi) => {
-      const state = thunkApi.getState() as RootState
-      const dispatch = thunkApi.dispatch as AppDispatch
       throw thunkApi.rejectWithValue({
         error: 'Oh no!',
       })
     }),
     fetchTodos: createAThunk<Todo[], string>(async (id, thunkApi) => {
-      const state = thunkApi.getState() as RootState
-      const dispatch = thunkApi.dispatch as AppDispatch
       throw thunkApi.rejectWithValue({
         error: 'Oh no, not again!',
       })

--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -130,6 +130,196 @@ const todosSlice = createSlice({
 })
 ```
 
+### The `reducers` "creator callback" notation
+
+Alternatively, the `reducers` field can be a callback which receives a "create" object.
+
+The main benefit of this is that you can create [async thunks](./createAsyncThunk) as part of your slice. Types are also slightly simplified for prepared reducers.
+
+```ts title="Creator callback for reducers"
+import { createSlice, nanoid } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+interface Item {
+  id: string
+  text: string
+}
+
+interface TodoState {
+  loading: boolean
+  todos: Item[]
+}
+
+const todosSlice = createSlice({
+  name: 'todos',
+  initialState: {
+    loading: false,
+    todos: [],
+  } as TodoState,
+  reducers: (create) => ({
+    deleteTodo: create.reducer((state, action: PayloadAction<number>) => {
+      state.todos.splice(action.payload, 1)
+    }),
+    addTodo: create.preparedReducer(
+      (text: string) => {
+        const id = nanoid()
+        return { payload: { id, text } }
+      },
+      // action type is inferred from prepare callback
+      (state, action) => {
+        state.todos.push(action.payload)
+      }
+    ),
+    fetchTodo: create.asyncThunk(
+      async (id: string, thunkApi) => {
+        const res = await fetch(`myApi/todos?id=${id}`)
+        return (await res.json()) as Item
+      },
+      {
+        pending: (state) => {
+          state.loading = true
+        },
+        rejected: (state, action) => {
+          state.loading = false
+        },
+        fulfilled: (state, action) => {
+          state.loading = false
+          state.todos.push(action.payload)
+        },
+      }
+    ),
+  }),
+})
+
+export const { addTodo, deleteTodo, fetchTodo } = todosSlice.actions
+```
+
+#### Create Methods
+
+#### `create.reducer`
+
+A standard slice case reducer.
+
+**Parameters**
+
+- **reducer** The slice case reducer to use.
+
+```ts no-transpile
+create.reducer((state, action: PayloadAction<Todo>) => {
+  state.todos.push(action.payload)
+})
+```
+
+#### `create.preparedReducer`
+
+A [prepared](#customizing-generated-action-creators) reducer, to customize the action creator.
+
+**Parameters**
+
+- **prepareAction** The [`prepare callback`](./createAction#using-prepare-callbacks-to-customize-action-contents).
+- **reducer** The slice case reducer to use.
+
+The action passed to the case reducer will be inferred from the prepare callback's return.
+
+```ts no-transpile
+create.preparedReducer(
+  (text: string) => {
+    const id = nanoid()
+    return { payload: { id, text } }
+  },
+  (state, action) => {
+    state.todos.push(action.payload)
+  }
+)
+```
+
+#### `create.asyncThunk`
+
+Creates an async thunk instead of an action creator.
+
+**Parameters**
+
+- **payloadCreator** The thunk [payload creator](./createAsyncThunk#payloadcreator).
+- **config** The configuration object. (optional)
+
+The configuration object can contain case reducers for each of the [lifecycle actions](./createAsyncThunk#promise-lifecycle-actions) (`pending`, `fulfilled`, and `rejected`).
+
+Each case reducer will be attached to the slice's `caseReducers` object, e.g. `slice.caseReducers.fetchTodo.fulfilled`.
+
+The configuration object can also contain [`options`](./createAsyncThunk#options).
+
+```ts no-transpile
+create.asyncThunk(
+  async (id: string, thunkApi) => {
+    const res = await fetch(`myApi/todos?id=${id}`)
+    return (await res.json()) as Item
+  },
+  {
+    pending: (state) => {
+      state.loading = true
+    },
+    rejected: (state, action) => {
+      state.loading = false
+    },
+    fulfilled: (state, action) => {
+      state.loading = false
+      state.todos.push(action.payload)
+    },
+    options: {
+      idGenerator: uuid,
+    },
+  }
+)
+```
+
+:::note
+
+Typing for the `create.asyncThunk` works in the same way as [`createAsyncThunk`](usage/usage-with-typescript#createasyncthunk), with one key difference.
+
+A type for `state` and/or `dispatch` _cannot_ be provided as part of the `ThunkApiConfig`, as this would cause circular types.
+
+Instead, it is necessary to assert the type when needed.
+
+```ts no-transpile
+create.asyncThunk<Todo, string, { rejectValue: { error: string } }>(
+  async (id, thunkApi) => {
+    const state = thunkApi.getState() as RootState
+    const dispatch = thunkApi.dispatch as AppDispatch
+    throw thunkApi.rejectWithValue({
+      error: 'Oh no!',
+    })
+  }
+)
+```
+
+For common thunk API configuration options, a [`withTypes` helper](usage/usage-with-typescript#defining-a-pre-typed-createasyncthunk) is provided:
+
+```ts no-transpile
+reducers: (create) => {
+  const createAThunk =
+    create.asyncThunk.withTypes<{ rejectValue: { error: string } }>()
+
+  return {
+    fetchTodo: createAThunk<Todo, string>(async (id, thunkApi) => {
+      const state = thunkApi.getState() as RootState
+      const dispatch = thunkApi.dispatch as AppDispatch
+      throw thunkApi.rejectWithValue({
+        error: 'Oh no!',
+      })
+    }),
+    fetchTodos: createAThunk<Todo[], string>(async (id, thunkApi) => {
+      const state = thunkApi.getState() as RootState
+      const dispatch = thunkApi.dispatch as AppDispatch
+      throw thunkApi.rejectWithValue({
+        error: 'Oh no, not again!',
+      })
+    }),
+  }
+}
+```
+
+:::
+
 ### `extraReducers`
 
 One of the key concepts of Redux is that each slice reducer "owns" its slice of state, and that many slice reducers

--- a/docs/api/getDefaultMiddleware.mdx
+++ b/docs/api/getDefaultMiddleware.mdx
@@ -40,14 +40,7 @@ to the store. `configureStore` will not add any extra middleware beyond what you
 `getDefaultMiddleware` is useful if you want to add some custom middleware, but also still want to have the default
 middleware added as well:
 
-```ts
-// file: reducer.ts noEmit
-
-export default function rootReducer(state = {}, action: any) {
-  return state
-}
-
-// file: store.ts
+```ts no-transpile
 import { configureStore } from '@reduxjs/toolkit'
 
 import logger from 'redux-logger'

--- a/docs/rtk-query/usage/error-handling.mdx
+++ b/docs/rtk-query/usage/error-handling.mdx
@@ -80,7 +80,7 @@ Redux Toolkit has [action matching utilities](../../api/matching-utilities.mdx#m
 
 :::
 
-```ts title="Error catching middleware example"
+```ts no-transpile title="Error catching middleware example"
 import { isRejectedWithValue } from '@reduxjs/toolkit'
 import type { MiddlewareAPI, Middleware } from '@reduxjs/toolkit'
 import { toast } from 'your-cool-library'

--- a/packages/toolkit/src/createAction.ts
+++ b/packages/toolkit/src/createAction.ts
@@ -50,26 +50,6 @@ export type PrepareAction<P> =
   | ((...args: any[]) => { payload: P; error: any })
   | ((...args: any[]) => { payload: P; meta: any; error: any })
 
-export type _PayloadActionForPrepare<
-  PA extends PrepareAction<any>,
-  T extends string = string
-> = PA extends PrepareAction<infer P>
-  ? PayloadAction<
-      P,
-      T,
-      ReturnType<PA> extends {
-        meta: infer M
-      }
-        ? M
-        : never,
-      ReturnType<PA> extends {
-        error: infer E
-      }
-        ? E
-        : never
-    >
-  : never
-
 /**
  * Internal version of `ActionCreatorWithPreparedPayload`. Not to be used externally.
  *

--- a/packages/toolkit/src/createAction.ts
+++ b/packages/toolkit/src/createAction.ts
@@ -50,6 +50,26 @@ export type PrepareAction<P> =
   | ((...args: any[]) => { payload: P; error: any })
   | ((...args: any[]) => { payload: P; meta: any; error: any })
 
+export type _PayloadActionForPrepare<
+  PA extends PrepareAction<any>,
+  T extends string = string
+> = PA extends PrepareAction<infer P>
+  ? PayloadAction<
+      P,
+      T,
+      ReturnType<PA> extends {
+        meta: infer M
+      }
+        ? M
+        : never,
+      ReturnType<PA> extends {
+        error: infer E
+      }
+        ? E
+        : never
+    >
+  : never
+
 /**
  * Internal version of `ActionCreatorWithPreparedPayload`. Not to be used externally.
  *

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -105,7 +105,7 @@ export const miniSerializeError = (value: any): SerializedError => {
   return { message: String(value) }
 }
 
-type AsyncThunkConfig = {
+export type AsyncThunkConfig = {
   state?: unknown
   dispatch?: Dispatch
   extra?: unknown
@@ -414,7 +414,7 @@ export type AsyncThunk<
   typePrefix: string
 }
 
-type OverrideThunkApiConfigs<OldConfig, NewConfig> = Id<
+export type OverrideThunkApiConfigs<OldConfig, NewConfig> = Id<
   NewConfig & Omit<OldConfig, keyof NewConfig>
 >
 

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -1,10 +1,11 @@
-import type { AnyAction, Reducer } from 'redux'
+import type { Action, AnyAction, Reducer } from 'redux'
 import type {
   ActionCreatorWithoutPayload,
   PayloadAction,
   PayloadActionCreator,
   PrepareAction,
   _ActionCreatorWithPreparedPayload,
+  _PayloadActionForPrepare,
 } from './createAction'
 import { createAction } from './createAction'
 import type {
@@ -18,6 +19,14 @@ import { executeReducerBuilderCallback } from './mapBuilders'
 import type { Id, NoInfer, Tail } from './tsHelpers'
 import { freezeDraftable } from './utils'
 import type { CombinedSliceReducer, InjectConfig } from './combineSlices'
+import type {
+  AsyncThunk,
+  AsyncThunkConfig,
+  AsyncThunkOptions,
+  AsyncThunkPayloadCreator,
+  OverrideThunkApiConfigs,
+} from './createAsyncThunk'
+import { createAsyncThunk } from './createAsyncThunk'
 
 let hasWarnedAboutObjectNotation = false
 
@@ -178,7 +187,9 @@ export interface CreateSliceOptions<
    * functions. For every action type, a matching action creator will be
    * generated using `createAction()`.
    */
-  reducers: ValidateSliceCaseReducers<State, CR>
+  reducers:
+    | ValidateSliceCaseReducers<State, CR>
+    | ((creators: ReducerCreators<State>) => CR)
 
   /**
    * A callback that receives a *builder* object to define
@@ -222,13 +233,28 @@ createSlice({
 })
 ```
    */
-  extraReducers?: (builder: ActionReducerMapBuilder<NoInfer<State>>) => void
+  extraReducers?: (builder: ActionReducerMapBuilder<State>) => void
 
   /**
    * A map of selectors that receive the slice's state and any additional arguments, and return a result.
    */
   selectors?: Selectors
 }
+
+const reducerDefinitionType: unique symbol = Symbol.for('rtk-reducer-type')
+enum ReducerType {
+  reducer = 'reducer',
+  reducerWithPrepare = 'reducerWithPrepare',
+  asyncThunk = 'asyncThunk',
+}
+
+interface ReducerDefinition<T extends ReducerType = ReducerType> {
+  [reducerDefinitionType]: T
+}
+
+export interface CaseReducerDefinition<S = any, A extends Action = AnyAction>
+  extends CaseReducer<S, A>,
+    ReducerDefinition<ReducerType.reducer> {}
 
 /**
  * A CaseReducer with a `prepare` method.
@@ -240,16 +266,141 @@ export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
   prepare: PrepareAction<Action['payload']>
 }
 
+export interface CaseReducerWithPrepareDefinition<
+  State,
+  Action extends PayloadAction
+> extends CaseReducerWithPrepare<State, Action>,
+    ReducerDefinition<ReducerType.reducerWithPrepare> {}
+
+export interface AsyncThunkSliceReducerConfig<
+  State,
+  ThunkArg extends any,
+  Returned = unknown,
+  ThunkApiConfig extends AsyncThunkConfig = {}
+> {
+  pending?: CaseReducer<
+    State,
+    ReturnType<AsyncThunk<Returned, ThunkArg, ThunkApiConfig>['pending']>
+  >
+  rejected?: CaseReducer<
+    State,
+    ReturnType<AsyncThunk<Returned, ThunkArg, ThunkApiConfig>['rejected']>
+  >
+  fulfilled?: CaseReducer<
+    State,
+    ReturnType<AsyncThunk<Returned, ThunkArg, ThunkApiConfig>['fulfilled']>
+  >
+  options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>
+}
+
+export interface AsyncThunkSliceReducerDefinition<
+  State,
+  ThunkArg extends any,
+  Returned = unknown,
+  ThunkApiConfig extends AsyncThunkConfig = {}
+> extends AsyncThunkSliceReducerConfig<
+      State,
+      ThunkArg,
+      Returned,
+      ThunkApiConfig
+    >,
+    ReducerDefinition<ReducerType.asyncThunk> {
+  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, ThunkApiConfig>
+}
+
+/**
+ * Providing these as part of the config would cause circular types, so we disallow passing them
+ */
+type PreventCircular<ThunkApiConfig> = {
+  [K in keyof ThunkApiConfig]: K extends 'state' | 'dispatch'
+    ? never
+    : ThunkApiConfig[K]
+}
+
+interface AsyncThunkCreator<
+  State,
+  CurriedThunkApiConfig extends PreventCircular<AsyncThunkConfig> = PreventCircular<AsyncThunkConfig>
+> {
+  <ThunkArg extends any, Returned = unknown>(
+    payloadCreator: AsyncThunkPayloadCreator<
+      Returned,
+      ThunkArg,
+      CurriedThunkApiConfig
+    >,
+    config?: AsyncThunkSliceReducerConfig<
+      State,
+      ThunkArg,
+      Returned,
+      CurriedThunkApiConfig
+    >
+  ): AsyncThunkSliceReducerDefinition<
+    State,
+    ThunkArg,
+    Returned,
+    CurriedThunkApiConfig
+  >
+  <
+    ThunkArg extends any,
+    Returned = unknown,
+    ThunkApiConfig extends PreventCircular<AsyncThunkConfig> = {}
+  >(
+    payloadCreator: AsyncThunkPayloadCreator<
+      Returned,
+      ThunkArg,
+      ThunkApiConfig
+    >,
+    config?: AsyncThunkSliceReducerConfig<
+      State,
+      ThunkArg,
+      Returned,
+      ThunkApiConfig
+    >
+  ): AsyncThunkSliceReducerDefinition<State, ThunkArg, Returned, ThunkApiConfig>
+  withTypes<
+    ThunkApiConfig extends PreventCircular<AsyncThunkConfig>
+  >(): AsyncThunkCreator<
+    State,
+    OverrideThunkApiConfigs<CurriedThunkApiConfig, ThunkApiConfig>
+  >
+}
+
+interface ReducerCreators<State> {
+  reducer<Payload>(
+    caseReducer: CaseReducer<State, PayloadAction<Payload>>
+  ): CaseReducerDefinition<State, PayloadAction<Payload>>
+
+  asyncThunk: AsyncThunkCreator<State>
+
+  preparedReducer<Prepare extends PrepareAction<any>>(
+    prepare: Prepare,
+    reducer: CaseReducer<State, _PayloadActionForPrepare<Prepare>>
+  ): {
+    [reducerDefinitionType]: ReducerType.reducerWithPrepare
+    prepare: Prepare
+    reducer: CaseReducer<State, _PayloadActionForPrepare<Prepare>>
+  }
+}
+
 /**
  * The type describing a slice's `reducers` option.
  *
  * @public
  */
-export type SliceCaseReducers<State> = {
-  [K: string]:
-    | CaseReducer<State, PayloadAction<any>>
-    | CaseReducerWithPrepare<State, PayloadAction<any, string, any, any>>
-}
+export type SliceCaseReducers<State> =
+  | Record<
+      string,
+      | CaseReducerDefinition<State, PayloadAction<any>>
+      | CaseReducerWithPrepareDefinition<
+          State,
+          PayloadAction<any, string, any, any>
+        >
+      | AsyncThunkSliceReducerDefinition<State, any, any, any>
+    >
+  | Record<
+      string,
+      | CaseReducer<State, PayloadAction<any>>
+      | CaseReducerWithPrepare<State, PayloadAction<any, string, any, any>>
+    >
 
 /**
  * The type describing a slice's `selectors` option.
@@ -272,15 +423,29 @@ export type CaseReducerActions<
   CaseReducers extends SliceCaseReducers<any>,
   SliceName extends string
 > = {
-  [Type in keyof CaseReducers]: CaseReducers[Type] extends { prepare: any }
-    ? ActionCreatorForCaseReducerWithPrepare<
-        CaseReducers[Type],
-        SliceActionType<SliceName, Type>
-      >
-    : ActionCreatorForCaseReducer<
-        CaseReducers[Type],
-        SliceActionType<SliceName, Type>
-      >
+  [Type in keyof CaseReducers]: CaseReducers[Type] extends infer Definition
+    ? Definition extends { prepare: any }
+      ? ActionCreatorForCaseReducerWithPrepare<
+          Definition,
+          SliceActionType<SliceName, Type>
+        >
+      : Definition extends AsyncThunkSliceReducerDefinition<
+          any,
+          infer ThunkArg,
+          infer Returned,
+          infer ThunkApiConfig
+        >
+      ? AsyncThunk<Returned, ThunkArg, ThunkApiConfig>
+      : Definition extends { reducer: any }
+      ? ActionCreatorForCaseReducer<
+          Definition['reducer'],
+          SliceActionType<SliceName, Type>
+        >
+      : ActionCreatorForCaseReducer<
+          Definition,
+          SliceActionType<SliceName, Type>
+        >
+    : never
 }
 
 /**
@@ -314,11 +479,15 @@ type ActionCreatorForCaseReducer<CR, Type extends string> = CR extends (
  * @internal
  */
 type SliceDefinedCaseReducers<CaseReducers extends SliceCaseReducers<any>> = {
-  [Type in keyof CaseReducers]: CaseReducers[Type] extends {
-    reducer: infer Reducer
-  }
-    ? Reducer
-    : CaseReducers[Type]
+  [Type in keyof CaseReducers]: CaseReducers[Type] extends infer Definition
+    ? Definition extends AsyncThunkSliceReducerDefinition<any, any, any, any>
+      ? Id<Pick<Required<Definition>, 'fulfilled' | 'rejected' | 'pending'>>
+      : Definition extends {
+          reducer: infer Reducer
+        }
+      ? Reducer
+      : Definition
+    : never
 }
 
 /**
@@ -373,8 +542,6 @@ function getType(slice: string, actionKey: string): string {
  * action creators and action types that correspond to the
  * reducers and state.
  *
- * The `reducer` argument is passed to `createReducer()`.
- *
  * @public
  */
 export function createSlice<
@@ -407,33 +574,39 @@ export function createSlice<
       ? options.initialState
       : freezeDraftable(options.initialState)
 
-  const reducers = options.reducers || {}
+  const reducers =
+    typeof options.reducers === 'function'
+      ? options.reducers(buildReducerCreators<State>())
+      : options.reducers || {}
 
   const reducerNames = Object.keys(reducers)
 
-  const sliceCaseReducersByName: Record<string, CaseReducer> = {}
-  const sliceCaseReducersByType: Record<string, CaseReducer> = {}
-  const actionCreators: Record<string, Function> = {}
+  const context: ReducerHandlingContext<State> = {
+    sliceCaseReducersByName: {},
+    sliceCaseReducersByType: {},
+    actionCreators: {},
+  }
 
   reducerNames.forEach((reducerName) => {
-    const maybeReducerWithPrepare = reducers[reducerName]
-    const type = getType(name, reducerName)
-
-    let caseReducer: CaseReducer<State, any>
-    let prepareCallback: PrepareAction<any> | undefined
-
-    if ('reducer' in maybeReducerWithPrepare) {
-      caseReducer = maybeReducerWithPrepare.reducer
-      prepareCallback = maybeReducerWithPrepare.prepare
-    } else {
-      caseReducer = maybeReducerWithPrepare
+    const reducerDefinition = reducers[reducerName]
+    const reducerDetails: ReducerDetails = {
+      reducerName,
+      type: getType(name, reducerName),
+      createNotation: typeof options.reducers === 'function',
     }
-
-    sliceCaseReducersByName[reducerName] = caseReducer
-    sliceCaseReducersByType[type] = caseReducer
-    actionCreators[reducerName] = prepareCallback
-      ? createAction(type, prepareCallback)
-      : createAction(type)
+    if (isAsyncThunkSliceReducerDefinition<State>(reducerDefinition)) {
+      handleThunkCaseReducerDefinition(
+        reducerDetails,
+        reducerDefinition,
+        context
+      )
+    } else {
+      handleNormalReducerDefinition<State>(
+        reducerDetails,
+        reducerDefinition,
+        context
+      )
+    }
   })
 
   function buildReducer() {
@@ -453,7 +626,10 @@ export function createSlice<
         ? executeReducerBuilderCallback(options.extraReducers)
         : [options.extraReducers]
 
-    const finalCaseReducers = { ...extraReducers, ...sliceCaseReducersByType }
+    const finalCaseReducers = {
+      ...extraReducers,
+      ...context.sliceCaseReducersByType,
+    }
 
     return createReducer(initialState, (builder) => {
       for (let key in finalCaseReducers) {
@@ -492,8 +668,8 @@ export function createSlice<
 
       return _reducer(state, action)
     },
-    actions: actionCreators as any,
-    caseReducers: sliceCaseReducersByName as any,
+    actions: context.actionCreators as any,
+    caseReducers: context.sliceCaseReducersByName as any,
     getInitialState() {
       if (!_reducer) _reducer = buildReducer()
 
@@ -548,3 +724,133 @@ export function createSlice<
   }
   return slice
 }
+
+interface ReducerHandlingContext<State> {
+  sliceCaseReducersByName: Record<
+    string,
+    | CaseReducer<State, any>
+    | Pick<
+        AsyncThunkSliceReducerDefinition<State, any, any, any>,
+        'fulfilled' | 'rejected' | 'pending'
+      >
+  >
+  sliceCaseReducersByType: Record<string, CaseReducer<State, any>>
+  actionCreators: Record<string, Function>
+}
+
+interface ReducerDetails {
+  reducerName: string
+  type: string
+  createNotation: boolean
+}
+
+function buildReducerCreators<State>(): ReducerCreators<State> {
+  function asyncThunk(
+    payloadCreator: AsyncThunkPayloadCreator<any, any>,
+    config: AsyncThunkSliceReducerConfig<State, any>
+  ): AsyncThunkSliceReducerDefinition<State, any> {
+    return {
+      [reducerDefinitionType]: ReducerType.asyncThunk,
+      payloadCreator,
+      ...config,
+    }
+  }
+  asyncThunk.withTypes = () => asyncThunk
+  return {
+    reducer(caseReducer) {
+      return Object.assign(
+        {
+          // hack so the wrapping function has the same name as the original
+          // we need to create a wrapper so the `reducerDefinitionType` is not assigned to the original
+          [caseReducer.name](...args: Parameters<typeof caseReducer>) {
+            return caseReducer(...args)
+          },
+        }[caseReducer.name],
+        {
+          [reducerDefinitionType]: ReducerType.reducer,
+        } as const
+      )
+    },
+    preparedReducer(prepare, reducer) {
+      return {
+        [reducerDefinitionType]: ReducerType.reducerWithPrepare,
+        prepare,
+        reducer,
+      }
+    },
+    asyncThunk: asyncThunk as any,
+  }
+}
+
+function handleNormalReducerDefinition<State>(
+  { type, reducerName, createNotation }: ReducerDetails,
+  maybeReducerWithPrepare:
+    | CaseReducer<State, { payload: any; type: string }>
+    | CaseReducerWithPrepare<State, PayloadAction<any, string, any, any>>,
+  context: ReducerHandlingContext<State>
+) {
+  let caseReducer: CaseReducer<State, any>
+  let prepareCallback: PrepareAction<any> | undefined
+  if ('reducer' in maybeReducerWithPrepare) {
+    if (
+      createNotation &&
+      !isCaseReducerWithPrepareDefinition(maybeReducerWithPrepare)
+    ) {
+      throw new Error(
+        'Please use the `create.preparedReducer` notation for prepared action creators with the `create` notation.'
+      )
+    }
+    caseReducer = maybeReducerWithPrepare.reducer
+    prepareCallback = maybeReducerWithPrepare.prepare
+  } else {
+    caseReducer = maybeReducerWithPrepare
+  }
+  context.sliceCaseReducersByName[reducerName] = caseReducer
+  context.sliceCaseReducersByType[type] = caseReducer
+  context.actionCreators[reducerName] = prepareCallback
+    ? createAction(type, prepareCallback)
+    : createAction(type)
+}
+
+function isAsyncThunkSliceReducerDefinition<State>(
+  reducerDefinition: any
+): reducerDefinition is AsyncThunkSliceReducerDefinition<State, any, any, any> {
+  return reducerDefinition[reducerDefinitionType] === ReducerType.asyncThunk
+}
+
+function isCaseReducerWithPrepareDefinition<State>(
+  reducerDefinition: any
+): reducerDefinition is CaseReducerWithPrepareDefinition<State, any> {
+  return (
+    reducerDefinition[reducerDefinitionType] === ReducerType.reducerWithPrepare
+  )
+}
+
+function handleThunkCaseReducerDefinition<State>(
+  { type, reducerName }: ReducerDetails,
+  reducerDefinition: AsyncThunkSliceReducerDefinition<State, any, any, any>,
+  context: ReducerHandlingContext<State>
+) {
+  const { payloadCreator, fulfilled, pending, rejected, options } =
+    reducerDefinition
+  const thunk = createAsyncThunk(type, payloadCreator, options as any)
+  context.actionCreators[reducerName] = thunk
+
+  if (fulfilled) {
+    context.sliceCaseReducersByType[thunk.fulfilled.type] = fulfilled
+  }
+  if (pending) {
+    context.sliceCaseReducersByType[thunk.pending.type] = pending
+  }
+  if (rejected) {
+    context.sliceCaseReducersByType[thunk.rejected.type] = rejected
+  }
+
+  context.sliceCaseReducersByName[reducerName] = {
+    fulfilled: fulfilled || noop,
+    pending: pending || noop,
+    rejected: rejected || noop,
+  }
+}
+
+function noop() {}

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -574,15 +574,10 @@ export function createSlice<
     }
   }
 
-  const initialState =
-    typeof options.initialState == 'function'
-      ? options.initialState
-      : freezeDraftable(options.initialState)
-
   const reducers =
-    typeof options.reducers === 'function'
+    (typeof options.reducers === 'function'
       ? options.reducers(buildReducerCreators<State>())
-      : options.reducers || {}
+      : options.reducers) || {}
 
   const reducerNames = Object.keys(reducers)
 
@@ -636,7 +631,7 @@ export function createSlice<
       ...context.sliceCaseReducersByType,
     }
 
-    return createReducer(initialState, (builder) => {
+    return createReducer(options.initialState, (builder) => {
       for (let key in finalCaseReducers) {
         builder.addCase(key, finalCaseReducers[key] as CaseReducer<any>)
       }

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -363,7 +363,7 @@ interface AsyncThunkCreator<
   >
 }
 
-interface ReducerCreators<State> {
+export interface ReducerCreators<State> {
   reducer<Payload>(
     caseReducer: CaseReducer<State, PayloadAction<Payload>>
   ): CaseReducerDefinition<State, PayloadAction<Payload>>

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -5,7 +5,6 @@ import type {
   PayloadActionCreator,
   PrepareAction,
   _ActionCreatorWithPreparedPayload,
-  _PayloadActionForPrepare,
 } from './createAction'
 import { createAction } from './createAction'
 import type {
@@ -373,11 +372,17 @@ interface ReducerCreators<State> {
 
   preparedReducer<Prepare extends PrepareAction<any>>(
     prepare: Prepare,
-    reducer: CaseReducer<State, _PayloadActionForPrepare<Prepare>>
+    reducer: CaseReducer<
+      State,
+      ReturnType<_ActionCreatorWithPreparedPayload<Prepare>>
+    >
   ): {
     [reducerDefinitionType]: ReducerType.reducerWithPrepare
     prepare: Prepare
-    reducer: CaseReducer<State, _PayloadActionForPrepare<Prepare>>
+    reducer: CaseReducer<
+      State,
+      ReturnType<_ActionCreatorWithPreparedPayload<Prepare>>
+    >
   }
 }
 

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -70,6 +70,7 @@ export type {
   ValidateSliceCaseReducers,
   CaseReducerWithPrepare,
   SliceActionCreator,
+  ReducerCreators,
 } from './createSlice'
 export {
   // js

--- a/packages/toolkit/src/tests/createSlice.test.ts
+++ b/packages/toolkit/src/tests/createSlice.test.ts
@@ -1,7 +1,11 @@
 import { vi } from 'vitest'
 import type { PayloadAction, WithSlice } from '@reduxjs/toolkit'
-import { combineSlices } from '@reduxjs/toolkit'
-import { createSlice, createAction } from '@reduxjs/toolkit'
+import {
+  configureStore,
+  combineSlices,
+  createSlice,
+  createAction,
+} from '@reduxjs/toolkit'
 import {
   mockConsole,
   createConsole,
@@ -551,6 +555,217 @@ describe('createSlice', () => {
       const injected2State = combinedReducer(undefined, increment())
 
       expect(injected2State.injected2).toBe(slice.getInitialState() + 1)
+    })
+  })
+  describe('reducers definition with asyncThunks', () => {
+    function pending(state: any[], action: any) {
+      state.push(['pendingReducer', action])
+    }
+    function fulfilled(state: any[], action: any) {
+      state.push(['fulfilledReducer', action])
+    }
+    function rejected(state: any[], action: any) {
+      state.push(['rejectedReducer', action])
+    }
+
+    test('successful thunk', async () => {
+      const slice = createSlice({
+        name: 'test',
+        initialState: [] as any[],
+        reducers: (create) => ({
+          thunkReducers: create.asyncThunk(
+            function payloadCreator(arg, api) {
+              return Promise.resolve('resolved payload')
+            },
+            { pending, fulfilled, rejected }
+          ),
+        }),
+      })
+
+      const store = configureStore({
+        reducer: slice.reducer,
+      })
+      await store.dispatch(slice.actions.thunkReducers('test'))
+      expect(store.getState()).toMatchObject([
+        [
+          'pendingReducer',
+          {
+            type: 'test/thunkReducers/pending',
+            payload: undefined,
+          },
+        ],
+        [
+          'fulfilledReducer',
+          {
+            type: 'test/thunkReducers/fulfilled',
+            payload: 'resolved payload',
+          },
+        ],
+      ])
+    })
+
+    test('rejected thunk', async () => {
+      const slice = createSlice({
+        name: 'test',
+        initialState: [] as any[],
+        reducers: (create) => ({
+          thunkReducers: create.asyncThunk(
+            // payloadCreator isn't allowed to return never
+            function payloadCreator(arg, api): any {
+              throw new Error('')
+            },
+            { pending, fulfilled, rejected }
+          ),
+        }),
+      })
+
+      const store = configureStore({
+        reducer: slice.reducer,
+      })
+      await store.dispatch(slice.actions.thunkReducers('test'))
+      expect(store.getState()).toMatchObject([
+        [
+          'pendingReducer',
+          {
+            type: 'test/thunkReducers/pending',
+            payload: undefined,
+          },
+        ],
+        [
+          'rejectedReducer',
+          {
+            type: 'test/thunkReducers/rejected',
+            payload: undefined,
+          },
+        ],
+      ])
+    })
+
+    test('with options', async () => {
+      const slice = createSlice({
+        name: 'test',
+        initialState: [] as any[],
+        reducers: (create) => ({
+          thunkReducers: create.asyncThunk(
+            function payloadCreator(arg, api) {
+              return 'should not call this'
+            },
+            {
+              options: {
+                condition() {
+                  return false
+                },
+                dispatchConditionRejection: true,
+              },
+              pending,
+              fulfilled,
+              rejected,
+            }
+          ),
+        }),
+      })
+
+      const store = configureStore({
+        reducer: slice.reducer,
+      })
+      await store.dispatch(slice.actions.thunkReducers('test'))
+      expect(store.getState()).toMatchObject([
+        [
+          'rejectedReducer',
+          {
+            type: 'test/thunkReducers/rejected',
+            payload: undefined,
+            meta: { condition: true },
+          },
+        ],
+      ])
+    })
+
+    test('has caseReducers for the asyncThunk', async () => {
+      const slice = createSlice({
+        name: 'test',
+        initialState: [],
+        reducers: (create) => ({
+          thunkReducers: create.asyncThunk(
+            function payloadCreator(arg, api) {
+              return Promise.resolve('resolved payload')
+            },
+            { pending, fulfilled }
+          ),
+        }),
+      })
+
+      expect(slice.caseReducers.thunkReducers.pending).toBe(pending)
+      expect(slice.caseReducers.thunkReducers.fulfilled).toBe(fulfilled)
+      // even though it is not defined above, this should at least be a no-op function to match the TypeScript typings
+      // and should be callable as a reducer even if it does nothing
+      expect(() =>
+        slice.caseReducers.thunkReducers.rejected(
+          [],
+          slice.actions.thunkReducers.rejected(
+            new Error('test'),
+            'fakeRequestId',
+            {}
+          )
+        )
+      ).not.toThrow()
+    })
+
+    test('can define reducer with prepare statement using create.preparedReducer', async () => {
+      const slice = createSlice({
+        name: 'test',
+        initialState: [] as any[],
+        reducers: (create) => ({
+          prepared: create.preparedReducer(
+            (p: string, m: number, e: { message: string }) => ({
+              payload: p,
+              meta: m,
+              error: e,
+            }),
+            (state, action) => {
+              state.push(action)
+            }
+          ),
+        }),
+      })
+
+      expect(
+        slice.reducer([], slice.actions.prepared('test', 1, { message: 'err' }))
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "error": {
+              "message": "err",
+            },
+            "meta": 1,
+            "payload": "test",
+            "type": "test/prepared",
+          },
+        ]
+      `)
+    })
+
+    test('throws an error when invoked with a normal `prepare` object that has not gone through a `create.preparedReducer` call', async () => {
+      expect(() =>
+        createSlice({
+          name: 'test',
+          initialState: [] as any[],
+          reducers: (create) => ({
+            prepared: {
+              prepare: (p: string, m: number, e: { message: string }) => ({
+                payload: p,
+                meta: m,
+                error: e,
+              }),
+              reducer: (state, action) => {
+                state.push(action)
+              },
+            },
+          }),
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Please use the \`create.preparedReducer\` notation for prepared action creators with the \`create\` notation."`
+      )
     })
   })
 })

--- a/packages/toolkit/src/tests/createSlice.typetest.ts
+++ b/packages/toolkit/src/tests/createSlice.typetest.ts
@@ -17,7 +17,7 @@ import type {
 } from '@reduxjs/toolkit'
 import { configureStore } from '@reduxjs/toolkit'
 import { createAction, createSlice } from '@reduxjs/toolkit'
-import { expectType, expectUnknown } from './helpers'
+import { expectExactType, expectType, expectUnknown } from './helpers'
 
 /*
  * Test: Slice name is strongly typed.
@@ -597,6 +597,19 @@ const value = actionCreators.anyKey
           expectType<TestState>(state)
           expectType<string>(action.payload)
         }),
+        preparedReducer: create.preparedReducer(
+          (payload: string) => ({
+            payload,
+            meta: 'meta' as const,
+            error: 'error' as const,
+          }),
+          (state, action) => {
+            expectType<TestState>(state)
+            expectType<string>(action.payload)
+            expectExactType('meta' as const)(action.meta)
+            expectExactType('error' as const)(action.error)
+          }
+        ),
         testInfer: create.asyncThunk(
           function payloadCreator(arg: TestArg, api) {
             return Promise.resolve<TestReturned>({ payload: 'foo' })
@@ -688,6 +701,15 @@ const value = actionCreators.anyKey
   type StoreDispatch = typeof store.dispatch
 
   expectType<PayloadActionCreator<string>>(slice.actions.normalReducer)
+  expectType<
+    ActionCreatorWithPreparedPayload<
+      [string],
+      string,
+      'test/preparedReducer',
+      'error',
+      'meta'
+    >
+  >(slice.actions.preparedReducer)
   expectType<AsyncThunk<TestReturned, TestArg, {}>>(slice.actions.testInfer)
   expectType<AsyncThunk<TestReturned, TestArg, { rejectValue: TestReject }>>(
     slice.actions.testExplicitType


### PR DESCRIPTION
reuses code from #637, with some changes to alleviate previous concerns:

- create.asyncThunk now has .withTypes, to allow for defining common config within a slice
- config passed must **not** include state or dispatch, as those will cause circular type issues
  - instead, they should be cast **inside** the payload creator, in the same way that RTKQ requires.

remaining concerns:
- no way to only import cAT *if* we need it
- because we can't use the state and dispatch type, the created async thunk will not have knowledge of what state/dispatch type it expects
  - this means it would technically be possible to dispatch the thunk into a dispatch that would not give it the state/dispatch signatures it expects
  - as a counterpoint, it seems like a rare case where an app would have more than one rootstate/appdispatch type

fixes #1045 and #629