### PR TITLE
types: make it easier to wrap createAsyncThunk

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -15,7 +15,7 @@ export type BaseThunkAPI<
   S,
   E,
   D extends Dispatch = Dispatch,
-  RejectedValue = undefined,
+  RejectedValue = unknown,
   RejectedMeta = unknown,
   FulfilledMeta = unknown
 > = {
@@ -137,7 +137,7 @@ type GetDispatch<ThunkApiConfig> = ThunkApiConfig extends {
     >
   : ThunkDispatch<GetState<ThunkApiConfig>, GetExtra<ThunkApiConfig>, AnyAction>
 
-type GetThunkAPI<ThunkApiConfig> = BaseThunkAPI<
+export type GetThunkAPI<ThunkApiConfig> = BaseThunkAPI<
   GetState<ThunkApiConfig>,
   GetExtra<ThunkApiConfig>,
   GetDispatch<ThunkApiConfig>,


### PR DESCRIPTION
Not exporting `GetThunkAPI` requires code dup when wrapping `createAsyncThunk` (in order to get top level access to the `ThunkAPI`'s type). There also was a minor typo making the default value of the `RejectedValue` type parameter `undefined` instead of `unknown`.