### PR TITLE
ensure it's only possible to pass all or none of the hooks to reactHooksModule

### DIFF
--- a/docs/rtk-query/usage/customizing-create-api.mdx
+++ b/docs/rtk-query/usage/customizing-create-api.mdx
@@ -19,7 +19,7 @@ You can create your own versions of `createApi` by either specifying non-default
 
 ## Customizing the React-Redux Hooks
 
-If you want the hooks to use different versions of `useSelector` or `useDispatch`, such as if you are using a custom context, you can pass these in at module creation:
+If you want the hooks to use different versions of `useSelector`, `useDispatch` and `useStore`, such as if you are using a custom context, you can pass these in at module creation:
 
 ```ts
 import * as React from 'react'
@@ -33,7 +33,13 @@ import {
 const MyContext = React.createContext<ReactReduxContextValue>(null as any)
 const customCreateApi = buildCreateApi(
   coreModule(),
-  reactHooksModule({ useDispatch: createDispatchHook(MyContext) })
+  reactHooksModule({
+    hooks: {
+      useDispatch: createDispatchHook(MyContext),
+      useSelector: createSelectorHook(MyContext),
+      useStore: createStoreHook(MyContext),
+    },
+  })
 )
 ```
 
@@ -81,7 +87,7 @@ export const myModule = (): Module<CustomModule> => ({
 
     return {
       injectEndpoint(endpoint, definition) {
-        const anyApi = (api as any) as Api<
+        const anyApi = api as any as Api<
           any,
           Record<string, any>,
           string,

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -219,7 +219,11 @@ export type CreateApi<Modules extends ModuleName> = {
  * const MyContext = React.createContext<ReactReduxContextValue>(null as any);
  * const customCreateApi = buildCreateApi(
  *   coreModule(),
- *   reactHooksModule({ useDispatch: createDispatchHook(MyContext) })
+ *   reactHooksModule({
+ *     useDispatch: createDispatchHook(MyContext),
+ *     useSelector: createSelectorHook(MyContext),
+ *     useStore: createStoreHook(MyContext)
+ *   })
  * );
  * ```
  *

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -220,9 +220,11 @@ export type CreateApi<Modules extends ModuleName> = {
  * const customCreateApi = buildCreateApi(
  *   coreModule(),
  *   reactHooksModule({
- *     useDispatch: createDispatchHook(MyContext),
- *     useSelector: createSelectorHook(MyContext),
- *     useStore: createStoreHook(MyContext)
+ *     hooks: {
+ *       useDispatch: createDispatchHook(MyContext),
+ *       useSelector: createSelectorHook(MyContext),
+ *       useStore: createStoreHook(MyContext)
+ *     }
  *   })
  * );
  * ```

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -581,9 +581,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   api,
   moduleOptions: {
     batch,
-    useDispatch,
-    useSelector,
-    useStore,
+    hooks: { useDispatch, useSelector, useStore },
     unstable__sideEffectsInRender,
   },
   serializeQueryArgs,

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -9,7 +9,6 @@ import type {
 } from '@reduxjs/toolkit/dist/query/endpointDefinitions'
 import type { Api, Module } from '../apiTypes'
 import { capitalize } from '../utils'
-import type { AllOrNone } from '../tsHelpers'
 import { safeAssign } from '../tsHelpers'
 import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
 
@@ -70,22 +69,24 @@ declare module '@reduxjs/toolkit/dist/query/apiTypes' {
 
 type RR = typeof import('react-redux')
 
-type ReactHooks = {
+export interface ReactHooksModuleOptions {
   /**
-   * The version of the `useDispatch` hook to be used
+   * The hooks from React Redux to be used
    */
-  useDispatch: RR['useDispatch']
-  /**
-   * The version of the `useSelector` hook to be used
-   */
-  useSelector: RR['useSelector']
-  /**
-   * The version of the `useStore` hook to be used
-   */
-  useStore: RR['useStore']
-}
-
-export type ReactHooksModuleOptions = AllOrNone<ReactHooks> & {
+  hooks?: {
+    /**
+     * The version of the `useDispatch` hook to be used
+     */
+    useDispatch: RR['useDispatch']
+    /**
+     * The version of the `useSelector` hook to be used
+     */
+    useSelector: RR['useSelector']
+    /**
+     * The version of the `useStore` hook to be used
+     */
+    useStore: RR['useStore']
+  }
   /**
    * The version of the `batchedUpdates` function to be used
    */
@@ -120,9 +121,11 @@ export type ReactHooksModuleOptions = AllOrNone<ReactHooks> & {
  * const customCreateApi = buildCreateApi(
  *   coreModule(),
  *   reactHooksModule({
- *     useDispatch: createDispatchHook(MyContext),
- *     useSelector: createSelectorHook(MyContext),
- *     useStore: createStoreHook(MyContext)
+ *     hooks: {
+ *       useDispatch: createDispatchHook(MyContext),
+ *       useSelector: createSelectorHook(MyContext),
+ *       useStore: createStoreHook(MyContext)
+ *     }
  *   })
  * );
  * ```
@@ -131,9 +134,11 @@ export type ReactHooksModuleOptions = AllOrNone<ReactHooks> & {
  */
 export const reactHooksModule = ({
   batch = rrBatch,
-  useDispatch = rrUseDispatch,
-  useSelector = rrUseSelector,
-  useStore = rrUseStore,
+  hooks = {
+    useDispatch: rrUseDispatch,
+    useSelector: rrUseSelector,
+    useStore: rrUseStore,
+  },
   unstable__sideEffectsInRender = false,
 }: ReactHooksModuleOptions = {}): Module<ReactHooksModule> => ({
   name: reactHooksModuleName,
@@ -149,9 +154,7 @@ export const reactHooksModule = ({
       api,
       moduleOptions: {
         batch,
-        useDispatch,
-        useSelector,
-        useStore,
+        hooks,
         unstable__sideEffectsInRender,
       },
       serializeQueryArgs,

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -9,6 +9,7 @@ import type {
 } from '@reduxjs/toolkit/dist/query/endpointDefinitions'
 import type { Api, Module } from '../apiTypes'
 import { capitalize } from '../utils'
+import type { AllOrNone } from '../tsHelpers'
 import { safeAssign } from '../tsHelpers'
 import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
 
@@ -69,23 +70,26 @@ declare module '@reduxjs/toolkit/dist/query/apiTypes' {
 
 type RR = typeof import('react-redux')
 
-export interface ReactHooksModuleOptions {
+type ReactHooks = {
+  /**
+   * The version of the `useDispatch` hook to be used
+   */
+  useDispatch: RR['useDispatch']
+  /**
+   * The version of the `useSelector` hook to be used
+   */
+  useSelector: RR['useSelector']
+  /**
+   * The version of the `useStore` hook to be used
+   */
+  useStore: RR['useStore']
+}
+
+export type ReactHooksModuleOptions = AllOrNone<ReactHooks> & {
   /**
    * The version of the `batchedUpdates` function to be used
    */
   batch?: RR['batch']
-  /**
-   * The version of the `useDispatch` hook to be used
-   */
-  useDispatch?: RR['useDispatch']
-  /**
-   * The version of the `useSelector` hook to be used
-   */
-  useSelector?: RR['useSelector']
-  /**
-   * The version of the `useStore` hook to be used
-   */
-  useStore?: RR['useStore']
   /**
    * Enables performing asynchronous tasks immediately within a render.
    *
@@ -115,7 +119,11 @@ export interface ReactHooksModuleOptions {
  * const MyContext = React.createContext<ReactReduxContextValue>(null as any);
  * const customCreateApi = buildCreateApi(
  *   coreModule(),
- *   reactHooksModule({ useDispatch: createDispatchHook(MyContext) })
+ *   reactHooksModule({
+ *     useDispatch: createDispatchHook(MyContext),
+ *     useSelector: createSelectorHook(MyContext),
+ *     useStore: createStoreHook(MyContext)
+ *   })
  * );
  * ```
  *

--- a/packages/toolkit/src/query/tsHelpers.ts
+++ b/packages/toolkit/src/query/tsHelpers.ts
@@ -2,13 +2,14 @@ export type Id<T> = { [K in keyof T]: T[K] } & {}
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>
 export type Override<T1, T2> = T2 extends any ? Omit<T1, keyof T2> & T2 : never
+export type AllOrNone<T> = T | { [K in keyof T]?: never }
 export function assertCast<T>(v: any): asserts v is T {}
 
 export function safeAssign<T extends object>(
   target: T,
   ...args: Array<Partial<NoInfer<T>>>
-) {
-  Object.assign(target, ...args)
+): T {
+  return Object.assign(target, ...args)
 }
 
 /**

--- a/packages/toolkit/src/query/tsHelpers.ts
+++ b/packages/toolkit/src/query/tsHelpers.ts
@@ -2,7 +2,6 @@ export type Id<T> = { [K in keyof T]: T[K] } & {}
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>
 export type Override<T1, T2> = T2 extends any ? Omit<T1, keyof T2> & T2 : never
-export type AllOrNone<T> = T | { [K in keyof T]?: never }
 export function assertCast<T>(v: any): asserts v is T {}
 
 export function safeAssign<T extends object>(


### PR DESCRIPTION
as per #3399, it's not actually clear that in most cases (i.e. custom contexts) you need to pass all three hooks, (useDispatch, useSelector, *and* useStore) when you create the module.

This MR moves those three hooks under a single key, and changes types to hopefully make it more clear that in most cases you'd want to provide all three. (which is a breaking change, hence the 2.0 target)

In the rare case where only one is wanted to be overwritten, the user would have to pass in the React Redux defaults themselves.