### PR TITLE
Implement auto fork joining

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -23,6 +23,7 @@ import type {
   TaskResult,
   AbortSignalWithReason,
   UnsubscribeListenerOptions,
+  ForkOptions,
 } from './types'
 import {
   abortControllerWithReason,
@@ -78,13 +79,19 @@ const INTERNAL_NIL_TOKEN = {} as const
 
 const alm = 'listenerMiddleware' as const
 
-const createFork = (parentAbortSignal: AbortSignalWithReason<unknown>) => {
+const createFork = (
+  parentAbortSignal: AbortSignalWithReason<unknown>,
+  parentBlockingPromises: Promise<any>[]
+) => {
   const linkControllers = (controller: AbortController) =>
     addAbortSignalListener(parentAbortSignal, () =>
       abortControllerWithReason(controller, parentAbortSignal.reason)
     )
 
-  return <T>(taskExecutor: ForkedTaskExecutor<T>): ForkedTask<T> => {
+  return <T>(
+    taskExecutor: ForkedTaskExecutor<T>,
+    opts?: ForkOptions
+  ): ForkedTask<T> => {
     assertFunction(taskExecutor, 'taskExecutor')
     const childAbortController = new AbortController()
 
@@ -104,6 +111,10 @@ const createFork = (parentAbortSignal: AbortSignalWithReason<unknown>) => {
       },
       () => abortControllerWithReason(childAbortController, taskCompleted)
     )
+
+    if (opts?.autoJoin) {
+      parentBlockingPromises.push(result)
+    }
 
     return {
       result: createPause<TaskResult<T>>(parentAbortSignal)(result),
@@ -376,6 +387,7 @@ export function createListenerMiddleware<
       startListening,
       internalTaskController.signal
     )
+    const autoJoinPromises: Promise<any>[] = []
 
     try {
       entry.pending.add(internalTaskController)
@@ -394,7 +406,7 @@ export function createListenerMiddleware<
             pause: createPause<any>(internalTaskController.signal),
             extra,
             signal: internalTaskController.signal,
-            fork: createFork(internalTaskController.signal),
+            fork: createFork(internalTaskController.signal, autoJoinPromises),
             unsubscribe: entry.unsubscribe,
             subscribe: () => {
               listenerMap.set(entry.id, entry)
@@ -417,6 +429,8 @@ export function createListenerMiddleware<
         })
       }
     } finally {
+      await Promise.allSettled(autoJoinPromises)
+
       abortControllerWithReason(internalTaskController, listenerCompleted) // Notify that the task has completed
       entry.pending.delete(internalTaskController)
     }

--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -132,6 +132,15 @@ export interface ForkedTask<T> {
 }
 
 /** @public */
+export interface ForkOptions {
+  /**
+   * If true, causes the parent task to not be marked as complete until
+   * all autoJoined forks have completed or failed.
+   */
+  autoJoin: boolean;
+}
+
+/** @public */
 export interface ListenerEffectAPI<
   State,
   Dispatch extends ReduxDispatch<AnyAction>,
@@ -238,8 +247,9 @@ export interface ListenerEffectAPI<
   /**
    * Queues in the next microtask the execution of a task.
    * @param executor
+   * @param options
    */
-  fork<T>(executor: ForkedTaskExecutor<T>): ForkedTask<T>
+  fork<T>(executor: ForkedTaskExecutor<T>, options?: ForkOptions): ForkedTask<T>
   /**
    * Returns a promise that resolves when `waitFor` resolves or
    * rejects if the listener has been cancelled or is completed.


### PR DESCRIPTION
fixes #3313

Adds support for options to `api.fork` to allow for `api.fork(myForkFunc, { autoJoin: true })` to cause the current listener to wait for all `autoJoin`ed forks to complete/cancel before completing itself.

This change is backwards compatible and can be merged into 1.x.

That said, I think that anyone coming from sagas is going to assume that `fork()` behaves as `{autoJoin: true}` and this probably should just be the default in 2.x

Example:

```ts
addListener({
      actionCreator: increment,
      effect: async (_, listenerApi) => {
        const forkedTask = listenerApi.fork(async (forkApi) => {
          await forkApi.pause(delay(1_000))
        }, { autoJoin: true});
      }, // effect will not be marked as complete until the pause completes
})
```