### PR TITLE
docs: fix inline code

### DIFF
--- a/docs/api/autoBatchEnhancer.mdx
+++ b/docs/api/autoBatchEnhancer.mdx
@@ -84,9 +84,9 @@ Any action that is tagged with `action.meta[SHOULD_AUTOBATCH] = true` will be tr
 `autoBatchEnhancer` accepts options to configure how the notification callback is queued:
 
 - `{type: 'raf'}`: queues using `requestAnimationFrame` (default)
-- `{type: 'tick'}: queues using `queueMicrotask`
+- `{type: 'tick'}`: queues using `queueMicrotask`
 - `{type: 'timer, timeout: number}`: queues using `setTimeout`
-- `{type: 'callback', queueNotification: (notify: () => void) => void}: lets you provide your own callback, such as a debounced or throttled function
+- `{type: 'callback', queueNotification: (notify: () => void) => void}`: lets you provide your own callback, such as a debounced or throttled function
 
 The default behavior is to queue the notifications using `requestAnimationFrame`.
 


### PR DESCRIPTION
This is how it looked before the change:
![before change](https://user-images.githubusercontent.com/32487868/235909176-7b2016f2-dccc-49dd-82e7-a7a3e504deed.png)
