### PR TITLE
Fix docs build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,6 @@
     "@manaflair/redux-batch": "^1.0.0",
     "@types/nanoid": "^2.1.0",
     "@types/react": "^18.0",
-    "@types/redux-logger": "^3.0.8",
     "async-mutex": "^0.3.2",
     "axios": "^0.20.0",
     "formik": "^2.1.5",

--- a/docs/rtk-query/usage/customizing-create-api.mdx
+++ b/docs/rtk-query/usage/customizing-create-api.mdx
@@ -23,7 +23,12 @@ If you want the hooks to use different versions of `useSelector`, `useDispatch` 
 
 ```ts
 import * as React from 'react'
-import { createDispatchHook, ReactReduxContextValue } from 'react-redux'
+import {
+  createDispatchHook,
+  createSelectorHook,
+  createStoreHook,
+  ReactReduxContextValue,
+} from 'react-redux'
 import {
   buildCreateApi,
   coreModule,

--- a/docs/rtk-query/usage/error-handling.mdx
+++ b/docs/rtk-query/usage/error-handling.mdx
@@ -93,7 +93,13 @@ export const rtkQueryErrorLogger: Middleware =
     // RTK Query uses `createAsyncThunk` from redux-toolkit under the hood, so we're able to utilize these matchers!
     if (isRejectedWithValue(action)) {
       console.warn('We got a rejected action!')
-      toast.warn({ title: 'Async error!', message: action.error.data.message })
+      toast.warn({
+        title: 'Async error!',
+        message:
+          'data' in action.error
+            ? (action.error.data as { message: string }).message
+            : action.error.message,
+      })
     }
 
     return next(action)

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -18,17 +18,36 @@
     "baseUrl": "..",
     "jsx": "preserve",
     "paths": {
-      "react": [ "../node_modules/@types/react" ],
-      "react-dom": [ "../node_modules/@types/react-dom" ],
-      "@reduxjs/toolkit": ["packages/toolkit/src/index.ts"],
-      "@reduxjs/toolkit/query": ["packages/toolkit/src/query/index.ts"],
+      "react": [
+        "../node_modules/@types/react"
+      ],
+      "react-dom": [
+        "../node_modules/@types/react-dom"
+      ],
+      "@reduxjs/toolkit": [
+        "packages/toolkit/src/index.ts"
+      ],
+      "@reduxjs/toolkit/query": [
+        "packages/toolkit/src/query/index.ts"
+      ],
       "@reduxjs/toolkit/query/react": [
         "packages/toolkit/src/query/react/index.ts"
       ],
-      "@reduxjs/toolkit/dist/query/*": ["packages/toolkit/src/query/*"],
-      "@virtual/*": ["docs/virtual/*"],
-      "your-cool-library": ["docs/virtual/your-cool-library/index.ts"],
-      "petstore-api.generated": ["docs/virtual/petstore-api.generated/index.ts"]
+      "@reduxjs/toolkit/dist/query/*": [
+        "packages/toolkit/src/query/*"
+      ],
+      "@virtual/*": [
+        "docs/virtual/*"
+      ],
+      "your-cool-library": [
+        "docs/virtual/your-cool-library/index.ts"
+      ],
+      "redux-logger": [
+        "docs/virtual/redux-logger/index.ts"
+      ],
+      "petstore-api.generated": [
+        "docs/virtual/petstore-api.generated/index.ts"
+      ]
     }
   }
 }

--- a/docs/virtual/redux-logger/index.ts
+++ b/docs/virtual/redux-logger/index.ts
@@ -1,0 +1,7 @@
+import type { Middleware } from 'redux'
+
+declare const logger: Middleware
+
+export { logger }
+
+export default logger

--- a/yarn.lock
+++ b/yarn.lock
@@ -8234,15 +8234,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/redux-logger@npm:^3.0.8":
-  version: 3.0.8
-  resolution: "@types/redux-logger@npm:3.0.8"
-  dependencies:
-    redux: ^4.0.0
-  checksum: 68dee8799db09aab2625435008230543f23a6dcf4f29cb8f74d2ec3c723c98765d6ed8fbf1edf2deb440f4a1969082b7d35d9548ab810e9054aa381bc925874c
-  languageName: node
-  linkType: hard
-
 "@types/resolve@npm:1.17.1":
   version: 1.17.1
   resolution: "@types/resolve@npm:1.17.1"
@@ -13456,7 +13447,6 @@ __metadata:
     "@manaflair/redux-batch": ^1.0.0
     "@types/nanoid": ^2.1.0
     "@types/react": ^18.0
-    "@types/redux-logger": ^3.0.8
     async-mutex: ^0.3.2
     axios: ^0.20.0
     formik: ^2.1.5
@@ -24686,7 +24676,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.0, redux@npm:^4.1.2":
+"redux@npm:^4.1.2":
   version: 4.1.2
   resolution: "redux@npm:4.1.2"
   dependencies:


### PR DESCRIPTION
- replaces redux-logger with our own stub (to use latest Middleware type)
- add missing imports
- make example error handling middleware work