### PR TITLE
Restore query status types

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -452,7 +452,14 @@ type UseQueryStateDefaultResult<D extends QueryDefinition<any, any, any, any>> =
             Pick<UseQueryStateBaseResult<D>, 'error'>
           >)
       >
-  >
+  > & {
+    /**
+     * @deprecated Included for completeness, but discouraged.
+     * Please use the `isLoading`, `isFetching`, `isSuccess`, `isError`
+     * and `isUninitialized` flags instead
+     */
+    status: QueryStatus
+  }
 
 export type MutationStateSelector<
   R extends Record<string, any>,


### PR DESCRIPTION
Per https://github.com/reduxjs/redux-toolkit/pull/3398/files#r1186497607 it's apparently worth keeping this around.