### PR TITLE
Fixed Stackoverflow bug if children prop is a ref to root/parent object

### DIFF
--- a/packages/toolkit/src/immutableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/immutableStateInvariantMiddleware.ts
@@ -92,11 +92,13 @@ function trackProperties(
   isImmutable: IsImmutableFunc,
   ignorePaths: IgnorePaths = [],
   obj: Record<string, any>,
-  path: string = ''
+  path: string = '',
+  checkedObjects: Set<Record<string, any>> = new Set()
 ) {
   const tracked: Partial<TrackedProperty> = { value: obj }
 
-  if (!isImmutable(obj)) {
+  if (!isImmutable(obj) && !checkedObjects.has(obj)) {
+    checkedObjects.add(obj);
     tracked.children = {}
 
     for (const key in obj) {


### PR DESCRIPTION
Fixed Stackoverflow bug if children prop is a ref to root/parent object

Fixed Bug:
RangeError: Maximum call stack size exceeded at trackProperties (.../node_modules/@reduxjs/toolkit/dist/redux-toolkit.cjs.development.js:322:25)