### PR TITLE
Bump deps for 2.0-alpha.6

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -110,10 +110,10 @@
     "react"
   ],
   "dependencies": {
-    "immer": "^10.0.1",
+    "immer": "^10.0.2",
     "redux": "5.0.0-alpha.6",
     "redux-thunk": "3.0.0-alpha.3",
-    "reselect": "^4.1.8"
+    "reselect": "^5.0.0-alpha.2"
   },
   "peerDependencies": {
     "react": "^16.9.0 || ^17.0.0 || ^18",

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -7,7 +7,13 @@ export {
   isDraft,
 } from 'immer'
 export type { Draft } from 'immer'
-export { createSelector } from 'reselect'
+export {
+  createSelector,
+  createSelectorCreator,
+  defaultMemoize,
+  autotrackMemoize,
+  weakMapMemoize,
+} from 'reselect'
 export type {
   Selector,
   OutputParametricSelector,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6776,7 +6776,7 @@ __metadata:
     eslint-plugin-react: ^7.23.2
     eslint-plugin-react-hooks: ^4.2.0
     fs-extra: ^9.1.0
-    immer: ^10.0.1
+    immer: ^10.0.2
     invariant: ^2.2.4
     jsdom: ^21.0.0
     json-stringify-safe: ^5.0.1
@@ -6786,7 +6786,7 @@ __metadata:
     query-string: ^7.0.1
     redux: 5.0.0-alpha.6
     redux-thunk: 3.0.0-alpha.3
-    reselect: ^4.1.8
+    reselect: ^5.0.0-alpha.2
     rimraf: ^3.0.2
     size-limit: ^4.11.0
     tslib: ^1.10.0
@@ -16874,10 +16874,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"immer@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "immer@npm:10.0.1"
-  checksum: 24ab640e9d928385047f6f31bc77966117087236faf1a1f52b6b9a0159f78d543f648fecbf04d5e8c782a6f6cddd6eeb9e09c3b616a104632e701c7a22735654
+"immer@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "immer@npm:10.0.2"
+  checksum: 525a3b14210d02ae420c3b9f6ca14f7e9bcf625611d1356e773e7739f14c7c8de50dac442e6c7de3a6e24a782f7b792b6b8666bc0b3f00269d21a95f8f68ca84
   languageName: node
   linkType: hard
 
@@ -25139,10 +25139,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"reselect@npm:^4.1.7, reselect@npm:^4.1.8":
+"reselect@npm:^4.1.7":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.0.0-alpha.2":
+  version: 5.0.0-alpha.2
+  resolution: "reselect@npm:5.0.0-alpha.2"
+  checksum: c47b66999800e1297721cbc4b2464b520fade9823c598d578759c9fba3eb6be03b184e13c20f30820cc18fe2688fc9fb4475f83e59d8f2347aa0d591e465637d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Bumped Reselect to v5.0-alpha.2
- Re-exported Reselect's memoizers (and `createSelectorCreator`, which is the only way to use them atm)