### PR TITLE
Add example for persisting api reducer

### DIFF
--- a/docs/rtk-query/usage/persistence-and-rehydration.mdx
+++ b/docs/rtk-query/usage/persistence-and-rehydration.mdx
@@ -44,8 +44,14 @@ export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
   // highlight-start
   extractRehydrationInfo(action, { reducerPath }) {
+    // when persisting the root reducer
     if (action.type === REHYDRATE) {
       return action.payload[reducerPath]
+    }
+
+    // when persisting the api reducer
+    if (action.type === REHYDRATE && action.key === 'key used with redux-persist') {
+      return action.payload
     }
   },
   // highlight-end


### PR DESCRIPTION
if you're using redux-persist by persisting individual reducers, you'll have multiple `REHYDRATE` actions and will need to respond to the correct one. Added a code example