### PR TITLE
Remove Unused Imports

### DIFF
--- a/packages/toolkit/scripts/build.ts
+++ b/packages/toolkit/scripts/build.ts
@@ -14,7 +14,7 @@ import yargs from 'yargs/yargs'
 
 import { extractInlineSourcemap, removeInlineSourceMap } from './sourcemap'
 import type { BuildOptions, EntryPointOptions } from './types'
-import { appendInlineSourceMap, getLocation } from './sourcemap'
+import { appendInlineSourceMap } from './sourcemap'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 

--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -1,5 +1,4 @@
-import type { AnyAction, Reducer } from 'redux'
-import { createNextState } from '.'
+import type { Reducer } from 'redux'
 import type {
   ActionCreatorWithoutPayload,
   PayloadAction,
@@ -13,7 +12,7 @@ import type {
   CaseReducers,
   ReducerWithInitialState,
 } from './createReducer'
-import { createReducer, NotFunction } from './createReducer'
+import { createReducer } from './createReducer'
 import type { ActionReducerMapBuilder } from './mapBuilders'
 import { executeReducerBuilderCallback } from './mapBuilders'
 import type { NoInfer } from './tsHelpers'

--- a/packages/toolkit/src/entities/state_adapter.ts
+++ b/packages/toolkit/src/entities/state_adapter.ts
@@ -2,7 +2,6 @@ import createNextState, { isDraft } from 'immer'
 import type { EntityState, PreventAny } from './models'
 import type { PayloadAction } from '../createAction'
 import { isFSA } from '../createAction'
-import { IsAny } from '../tsHelpers'
 
 export function createSingleArgumentStateOperator<V>(
   mutator: (state: EntityState<V>) => void

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -1,6 +1,6 @@
 import type { EntityAdapter, EntityState } from '../models'
 import { createEntityAdapter } from '../create_adapter'
-import { createAction, createSlice, configureStore } from '@reduxjs/toolkit'
+import { createAction } from '@reduxjs/toolkit'
 import type { BookModel } from './fixtures/book'
 import {
   TheGreatGatsby,

--- a/packages/toolkit/src/listenerMiddleware/tests/effectScenarios.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/effectScenarios.test.ts
@@ -5,11 +5,9 @@ import {
   isAnyOf,
 } from '@reduxjs/toolkit'
 
-import type { AnyAction, PayloadAction, Action } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
 
 import { createListenerMiddleware, TaskAbortError } from '../index'
-
-import type { TypedAddListener } from '../index'
 
 describe('Saga-style Effects Scenarios', () => {
   interface CounterState {

--- a/packages/toolkit/src/listenerMiddleware/tests/fork.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/fork.test.ts
@@ -1,4 +1,3 @@
-import type { EnhancedStore } from '@reduxjs/toolkit'
 import { configureStore, createSlice, createAction } from '@reduxjs/toolkit'
 
 import type { PayloadAction } from '@reduxjs/toolkit'

--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
@@ -5,7 +5,7 @@ import {
   isAnyOf,
 } from '@reduxjs/toolkit'
 
-import type { AnyAction, PayloadAction, Action } from '@reduxjs/toolkit'
+import type { AnyAction, PayloadAction } from '@reduxjs/toolkit'
 
 import {
   createListenerMiddleware,
@@ -22,7 +22,6 @@ import type {
   TypedAddListener,
   TypedStartListening,
   UnsubscribeListener,
-  ListenerMiddleware,
 } from '../index'
 import type {
   AbortSignalWithReason,

--- a/packages/toolkit/src/listenerMiddleware/tests/useCases.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/useCases.test.ts
@@ -2,14 +2,12 @@ import {
   configureStore,
   createAction,
   createSlice,
-  isAnyOf,
 } from '@reduxjs/toolkit'
 
 import type { PayloadAction } from '@reduxjs/toolkit'
 
 import { createListenerMiddleware } from '../index'
 
-import type { TypedAddListener } from '../index'
 import { TaskAbortError } from '../exceptions'
 
 interface CounterState {

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -5,10 +5,9 @@ import type {
   QueryArgFrom,
   ResultTypeFrom,
 } from '../endpointDefinitions'
-import { DefinitionType, isQueryDefinition } from '../endpointDefinitions'
 import type { QueryThunk, MutationThunk, QueryThunkArg } from './buildThunks'
 import type { AnyAction, ThunkAction, SerializedError } from '@reduxjs/toolkit'
-import type { SubscriptionOptions, RootState } from './apiState'
+import type { SubscriptionOptions } from './apiState'
 import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type { Api, ApiContext } from '../apiTypes'
 import type { ApiEndpointQuery } from './module'

--- a/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
@@ -1,13 +1,7 @@
-import type { QueryThunk, RejectedAction } from '../buildThunks'
 import type { InternalHandlerBuilder } from './types'
-import type {
-  SubscriptionState,
-  QuerySubstateIdentifier,
-  Subscribers,
-} from '../apiState'
+import type { SubscriptionState } from '../apiState'
 import { produceWithPatches } from 'immer'
 import type { AnyAction } from '@reduxjs/toolkit';
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 // Copied from https://github.com/feross/queue-microtask
 let promise: Promise<any>

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -7,7 +7,6 @@ import type {
   TimeoutId,
   InternalHandlerBuilder,
   ApiMiddlewareInternalHandler,
-  InternalMiddlewareState,
 } from './types'
 
 export type ReferenceCacheCollection = never

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -6,7 +6,6 @@ import type {
   TimeoutId,
   InternalHandlerBuilder,
   ApiMiddlewareInternalHandler,
-  InternalMiddlewareState,
 } from './types'
 
 export const buildPollingHandler: InternalHandlerBuilder = ({

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -1,4 +1,4 @@
-import type { AnyAction, PayloadAction } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
 import {
   combineReducers,
   createAction,
@@ -24,7 +24,7 @@ import type {
   ConfigState,
 } from './apiState'
 import { QueryStatus } from './apiState'
-import type { MutationThunk, QueryThunk, RejectedAction } from './buildThunks'
+import type { MutationThunk, QueryThunk } from './buildThunks'
 import { calculateProvidedByThunk } from './buildThunks'
 import type {
   AssertTagTypes,

--- a/packages/toolkit/src/query/core/index.ts
+++ b/packages/toolkit/src/query/core/index.ts
@@ -1,5 +1,5 @@
-import { buildCreateApi, CreateApi } from '../createApi'
-import { coreModule, coreModuleName } from './module'
+import { buildCreateApi } from '../createApi'
+import { coreModule } from './module'
 
 const createApi = /* @__PURE__ */ buildCreateApi(coreModule())
 

--- a/packages/toolkit/src/query/core/setupListeners.ts
+++ b/packages/toolkit/src/query/core/setupListeners.ts
@@ -1,6 +1,7 @@
 import type {
   ThunkDispatch,
-  ActionCreatorWithoutPayload, // Workaround for API-Extractor
+  // @ts-ignore Workaround for API-Extractor
+  ActionCreatorWithoutPayload
 } from '@reduxjs/toolkit'
 import { createAction } from '@reduxjs/toolkit'
 

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -7,7 +7,7 @@ import type {
   EndpointBuilder,
   EndpointDefinitions,
 } from './endpointDefinitions'
-import { DefinitionType, isQueryDefinition } from './endpointDefinitions'
+import { DefinitionType } from './endpointDefinitions'
 import { nanoid } from '@reduxjs/toolkit'
 import type { AnyAction } from '@reduxjs/toolkit'
 import type { NoInfer } from './tsHelpers'

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -1,17 +1,5 @@
-import { coreModule, buildCreateApi, CreateApi } from '@reduxjs/toolkit/query'
-import { reactHooksModule, reactHooksModuleName } from './module'
-
-import type { MutationHooks, QueryHooks } from './buildHooks'
-import type {
-  EndpointDefinitions,
-  QueryDefinition,
-  MutationDefinition,
-  QueryArgFrom,
-} from '@reduxjs/toolkit/dist/query/endpointDefinitions'
-import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
-
-import type { QueryKeys } from '@reduxjs/toolkit/dist/query/core/apiState'
-import type { PrefetchOptions } from '@reduxjs/toolkit/dist/query/core/module'
+import { coreModule, buildCreateApi } from '@reduxjs/toolkit/query'
+import { reactHooksModule } from './module'
 
 export * from '@reduxjs/toolkit/query'
 export { ApiProvider } from './ApiProvider'

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -21,7 +21,6 @@ import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
 import {
   actionsReducer,
-  ANY,
   expectExactType,
   expectType,
   setupApiStore,

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -1,12 +1,11 @@
 // tests for "cleanup-after-unsubscribe" behaviour
 
-import React, { Profiler, ProfilerOnRenderCallback } from 'react'
+import React from 'react'
 
 import { createListenerMiddleware } from '@reduxjs/toolkit'
 import { createApi, QueryStatus } from '@reduxjs/toolkit/query/react'
 import { render, waitFor, act, screen } from '@testing-library/react'
 import { setupApiStore } from './helpers'
-import { delay } from '../../utils'
 
 const tick = () => new Promise((res) => setImmediate(res))
 

--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -22,7 +22,6 @@ import {
 import { server } from './mocks/server'
 import { rest } from 'msw'
 import type { SerializeQueryArgs } from '../defaultSerializeQueryArgs'
-import { string } from 'yargs'
 import type {
   DefinitionsFromApi,
   OverrideResultType,

--- a/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
@@ -1,6 +1,5 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { actionsReducer, hookWaitFor, setupApiStore, waitMs } from './helpers'
-import { skipToken } from '../core/buildSelectors'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { delay } from '../../utils'
 

--- a/packages/toolkit/src/tests/MiddlewareArray.typetest.ts
+++ b/packages/toolkit/src/tests/MiddlewareArray.typetest.ts
@@ -1,4 +1,4 @@
-import { getDefaultMiddleware, configureStore } from '@reduxjs/toolkit'
+import { configureStore } from '@reduxjs/toolkit'
 import type { Middleware } from 'redux'
 
 declare const expectType: <T>(t: T) => T

--- a/packages/toolkit/src/tests/configureStore.test.ts
+++ b/packages/toolkit/src/tests/configureStore.test.ts
@@ -1,6 +1,5 @@
 import type { StoreEnhancer, StoreEnhancerStoreCreator } from '@reduxjs/toolkit'
 import { configureStore } from '@reduxjs/toolkit'
-import * as RTK from '@reduxjs/toolkit'
 import * as redux from 'redux'
 import * as devtools from '@internal/devtoolsExtension'
 

--- a/packages/toolkit/src/tests/getDefaultMiddleware.test.ts
+++ b/packages/toolkit/src/tests/getDefaultMiddleware.test.ts
@@ -15,7 +15,6 @@ import thunk from 'redux-thunk'
 import type { ThunkMiddleware } from 'redux-thunk'
 
 import { expectType } from './helpers'
-import { BaseActionCreator } from '@internal/createAction'
 
 describe('getDefaultMiddleware', () => {
   const ORIGINAL_NODE_ENV = process.env.NODE_ENV

--- a/packages/toolkit/src/tests/injectableCombineReducers.example.ts
+++ b/packages/toolkit/src/tests/injectableCombineReducers.example.ts
@@ -8,7 +8,6 @@ import { combineSlices } from '@reduxjs/toolkit'
 import { sliceA } from 'fileA'
 import { sliceB } from 'fileB'
 import { lazySliceC } from 'fileC'
-import type { lazySliceD } from 'fileD'
 
 import { anotherReducer } from 'somewhere'
 

--- a/packages/toolkit/src/tests/matchers.typetest.ts
+++ b/packages/toolkit/src/tests/matchers.typetest.ts
@@ -1,5 +1,4 @@
 import { expectExactType, expectUnknown } from './helpers'
-import { IsUnknown } from '@internal/tsHelpers'
 import type { AnyAction } from 'redux'
 import type { SerializedError } from '../../src'
 import {

--- a/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
@@ -3,7 +3,7 @@ import {
   createConsole,
   getLog,
 } from 'console-testing-library/pure'
-import type { AnyAction, Reducer } from '@reduxjs/toolkit'
+import type { Reducer } from '@reduxjs/toolkit'
 import {
   createNextState,
   configureStore,


### PR DESCRIPTION
A follow-up to #2246, removing some new imports that are causing `tsc` errors when the library is used in a project with `--noUnusedLocals` enabled.

<details>
<summary>Some example error output from `tsc`</summary>

```
node_modules/@reduxjs/toolkit/src/query/core/buildInitiate.ts:8:1 - error TS6192: All imports in import declaration are unused.

8 import { DefinitionType, isQueryDefinition } from '../endpointDefinitions'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@reduxjs/toolkit/src/query/core/buildInitiate.ts:11:36 - error TS6196: 'RootState' is declared but never used.

11 import type { SubscriptionOptions, RootState } from './apiState'

[...]
```
</details>