### PR TITLE
build: use typescript-eslint@v6 internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,26 @@
 module.exports = {
   extends: ['react-app', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'prettier',
+    'react-app',
+    'plugin:node/recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+    tsconfigRootDir: __dirname,
+  },
   rules: {
     'jsx-a11y/href-no-hash': 'off',
     'react/react-in-jsx-scope': 'off',
+
     // Taken care of by TypeScript's `noUnusedLocals` / `noUnusedParameters`
-    'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
-    // Silence some bizarre "rule not found" TSLint error
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
-    'no-redeclare': 'off',
-    // Silence some bizarre "rule not found" TSLint error
-    '@typescript-eslint/no-redeclare': 'off',
-    'no-use-before-define': 'off',
+
+    // These off/not-configured-the-way-we-want lint rules we like & opt into
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
     '@typescript-eslint/consistent-type-imports': [
       'error',
@@ -24,27 +32,35 @@ module.exports = {
         additionalHooks: '(usePossiblyImmediateEffect)',
       },
     ],
+
+    // Todo: investigate whether we'd like these on
+    '@typescript-eslint/array-type': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/consistent-indexed-object-style': 'off',
+    '@typescript-eslint/consistent-type-imports': 'off',
+    '@typescript-eslint/consistent-type-definitions': 'off',
+    '@typescript-eslint/no-confusing-void-expression': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/no-empty-interface': 'off',
+    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/no-misused-promises': 'off',
+    '@typescript-eslint/no-unsafe-argument': 'off',
+    '@typescript-eslint/no-unsafe-assignment': 'off',
+    '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/prefer-function-type': 'off',
+    '@typescript-eslint/require-await': 'off',
+    '@typescript-eslint/restrict-template-expressions': 'off',
+    '@typescript-eslint/sort-type-constituents': 'off',
+    '@typescript-eslint/unbound-method': 'off',
+    '@typescript-eslint/dot-notation': 'off',
+    'no-empty': 'off',
+    'prefer-const': 'off',
+    'prefer-rest-params': 'off',
   },
   overrides: [
-    // {
-    //   // only add after https://github.com/typescript-eslint/typescript-eslint/pull/3463 is merged
-    //   files: ['src/**/*.ts'],
-    //   excludedFiles: [
-    //     '**/tests/*.ts',
-    //     '**/tests/**/*.ts',
-    //     '**/tests/*.tsx',
-    //     '**/tests/**/*.tsx',
-    //   ],
-    //   parserOptions: {
-    //     project: './tsconfig.json',
-    //   },
-    //   rules: {
-    //     '@typescript-eslint/prefer-readonly-parameter-types': [
-    //       'warn',
-    //       { arraysAndTuplesOnly: true },
-    //     ],
-    //   },
-    // },
     {
       files: [
         'packages/toolkit/src/tests/*.ts',

--- a/examples/action-listener/counter/package.json
+++ b/examples/action-listener/counter/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.1.0",
     "react-redux": "^8.0.2",
     "react-scripts": "5.0.1",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/publish-ci/next/.eslintrc.js
+++ b/examples/publish-ci/next/.eslintrc.js
@@ -1,20 +1,30 @@
 module.exports = {
   extends: ['react-app', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'prettier',
+    'react-app',
+    'plugin:node/recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+    tsconfigRootDir: __dirname,
+  },
   rules: {
     'jsx-a11y/href-no-hash': 'off',
     'react/react-in-jsx-scope': 'off',
     // Taken care of by TypeScript's `noUnusedLocals` / `noUnusedParameters`
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
-    // Silence some bizarre "rule not found" TSLint error
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
-    'no-redeclare': 'off',
-    // Silence some bizarre "rule not found" TSLint error
-    '@typescript-eslint/no-redeclare': 'off',
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
-    '@typescript-eslint/consistent-type-imports': ['off'],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { prefer: 'type-imports', disallowTypeAnnotations: false },
+    ],
     'react-hooks/exhaustive-deps': [
       'warn',
       {

--- a/examples/query/react/advanced/package.json
+++ b/examples/query/react/advanced/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/query/react/authentication-with-extrareducers/package.json
+++ b/examples/query/react/authentication-with-extrareducers/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/authentication/package.json
+++ b/examples/query/react/authentication/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/basic/package.json
+++ b/examples/query/react/basic/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
     "msw": "^0.40.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/query/react/conditional-fetching/package.json
+++ b/examples/query/react/conditional-fetching/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/query/react/deduping-queries/package.json
+++ b/examples/query/react/deduping-queries/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/query/react/graphql-codegen/package.json
+++ b/examples/query/react/graphql-codegen/package.json
@@ -43,7 +43,7 @@
     "typescript": "4.1.3"
   },
   "resolutions": {
-    "@typescript-eslint/parser": "4.4.1"
+    "@typescript-eslint/parser": "6.0.0-alpha.158"
   },
   "scripts": {
     "develop": "cross-env CHOKIDAR_USEPOLLING=true yarn start",

--- a/examples/query/react/graphql/package.json
+++ b/examples/query/react/graphql/package.json
@@ -28,7 +28,7 @@
     "@types/faker": "^5.5.5",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/kitchen-sink/package.json
+++ b/examples/query/react/kitchen-sink/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^14.14.6",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4",
+    "typescript": "~4.3.4",
     "whatwg-fetch": "^3.4.1"
   },
   "eslintConfig": {

--- a/examples/query/react/mutations/package.json
+++ b/examples/query/react/mutations/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/optimistic-update/package.json
+++ b/examples/query/react/optimistic-update/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4",
+    "typescript": "~4.3.4",
     "whatwg-fetch": "^3.4.1"
   },
   "scripts": {

--- a/examples/query/react/pagination/package.json
+++ b/examples/query/react/pagination/package.json
@@ -25,7 +25,7 @@
     "@types/faker": "^5.5.5",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/polling/package.json
+++ b/examples/query/react/polling/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/query/react/prefetching-automatic-waterfall/package.json
+++ b/examples/query/react/prefetching-automatic-waterfall/package.json
@@ -25,7 +25,7 @@
     "@types/faker": "^5.5.5",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/prefetching-automatic/package.json
+++ b/examples/query/react/prefetching-automatic/package.json
@@ -25,7 +25,7 @@
     "@types/faker": "^5.5.5",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/prefetching/package.json
+++ b/examples/query/react/prefetching/package.json
@@ -25,7 +25,7 @@
     "@types/faker": "^5.5.5",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/query/react/with-apiprovider/package.json
+++ b/examples/query/react/with-apiprovider/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.5",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "examples/action-listener/*"
   ],
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "6.0.0-alpha.158",
+    "@typescript-eslint/parser": "6.0.0-alpha.158",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^7.0.1",
@@ -44,6 +46,8 @@
     "@babel/helper-compilation-targets": "7.19.3",
     "@babel/traverse": "7.19.3",
     "@babel/types": "7.19.3",
+    "@typescript-eslint/eslint-plugin": "6.0.0-alpha.158",
+    "@typescript-eslint/parser": "6.0.0-alpha.158",
     "console-testing-library": "patch:console-testing-library@npm:0.3.1#.yarn/patches/console-testing-library__npm_0.3.1.patch",
     "msw": "patch:msw@npm:0.40.2#.yarn/patches/msw-npm-0.40.2-2107d48752",
     "jscodeshift": "0.13.1",

--- a/packages/rtk-codemods/.eslintrc.js
+++ b/packages/rtk-codemods/.eslintrc.js
@@ -1,10 +1,18 @@
 module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
+    project: true,
+    tsconfigRootDir: __dirname,
   },
 
   plugins: ['prettier', 'node'],
-  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'plugin:node/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:prettier/recommended',
+    'plugin:node/recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
   env: {
     node: true,
   },

--- a/packages/rtk-codemods/transforms/createReducerBuilder/index.ts
+++ b/packages/rtk-codemods/transforms/createReducerBuilder/index.ts
@@ -3,12 +3,8 @@ import {
   ExpressionStatement,
   JSCodeshift,
   ObjectExpression,
-  ObjectMethod,
-  ObjectProperty,
   Transform,
 } from 'jscodeshift';
-
-type ObjectKey = ObjectMethod['key'] & ObjectProperty['key'];
 
 function wrapInAddCaseExpression(
   j: JSCodeshift,

--- a/packages/rtk-codemods/transforms/createSliceBuilder/index.ts
+++ b/packages/rtk-codemods/transforms/createSliceBuilder/index.ts
@@ -1,14 +1,5 @@
 import { ExpressionKind, SpreadElementKind } from 'ast-types/gen/kinds';
-import {
-  ExpressionStatement,
-  JSCodeshift,
-  ObjectExpression,
-  ObjectMethod,
-  ObjectProperty,
-  Transform,
-} from 'jscodeshift';
-
-type ObjectKey = ObjectMethod['key'] & ObjectProperty['key'];
+import { ExpressionStatement, JSCodeshift, ObjectExpression, Transform } from 'jscodeshift';
 
 function wrapInAddCaseExpression(
   j: JSCodeshift,
@@ -32,7 +23,7 @@ export function reducerPropsToBuilderExpression(j: JSCodeshift, defNode: ObjectE
         }
         break;
       }
-      case 'ObjectProperty': {    
+      case 'ObjectProperty': {
         const { key } = property;
 
         switch (property.value.type) {
@@ -96,10 +87,7 @@ const transform: Transform = (file, api) => {
                   p.key.name === 'extraReducers' &&
                   p.value.type === 'ObjectExpression'
                 ) {
-                  const expressionStatement = reducerPropsToBuilderExpression(
-                    j,
-                    p.value as ObjectExpression
-                  );
+                  const expressionStatement = reducerPropsToBuilderExpression(j, p.value);
                   return j.objectProperty(p.key, expressionStatement);
                 }
                 return p;

--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.2.1",
     "semver": "^7.3.5",
     "swagger2openapi": "^7.0.4",
-    "typescript": ">=4.1 <=4.5"
+    "typescript": ">=4.3 <=4.5"
   },
   "husky": {
     "hooks": {

--- a/packages/rtk-query-codegen-openapi/src/codegen.ts
+++ b/packages/rtk-query-codegen-openapi/src/codegen.ts
@@ -7,7 +7,7 @@ export type ObjectPropertyDefinitions = Record<string, ts.Expression | undefined
 export function generateObjectProperties(obj: ObjectPropertyDefinitions) {
   return Object.entries(obj)
     .filter(([_, v]) => v)
-    .map(([k, v]) => factory.createPropertyAssignment(factory.createIdentifier(k), v as ts.Expression));
+    .map(([k, v]) => factory.createPropertyAssignment(factory.createIdentifier(k), v!));
 }
 
 export function generateImportNode(pkg: string, namedImports: Record<string, string>, defaultImportName?: string) {
@@ -67,30 +67,32 @@ export function generateCreateApiCall({
     const enhanceEndpointsObjectLiteralExpression = factory.createObjectLiteralExpression(
       [factory.createShorthandPropertyAssignment(factory.createIdentifier('addTagTypes'), undefined)],
       true
-    )
+    );
     return factory.createVariableStatement(
       undefined,
       factory.createVariableDeclarationList(
-        [factory.createVariableDeclaration(
-          factory.createIdentifier("injectedRtkApi"),
-          undefined,
-          undefined,
-          factory.createCallExpression(
-            factory.createPropertyAccessExpression(
-              factory.createCallExpression(
-                factory.createPropertyAccessExpression(
-                  factory.createIdentifier("api"),
-                  factory.createIdentifier("enhanceEndpoints")
-                ),
-                undefined,
-                [enhanceEndpointsObjectLiteralExpression]
-              ),
-              factory.createIdentifier("injectEndpoints")
-            ),
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('injectedRtkApi'),
             undefined,
-            [injectEndpointsObjectLiteralExpression]
-          )
-        )],
+            undefined,
+            factory.createCallExpression(
+              factory.createPropertyAccessExpression(
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('api'),
+                    factory.createIdentifier('enhanceEndpoints')
+                  ),
+                  undefined,
+                  [enhanceEndpointsObjectLiteralExpression]
+                ),
+                factory.createIdentifier('injectEndpoints')
+              ),
+              undefined,
+              [injectEndpointsObjectLiteralExpression]
+            )
+          ),
+        ],
         ts.NodeFlags.Const
       )
     );
@@ -145,7 +147,7 @@ export function generateEndpointDefinition({
         factory.createIdentifier(type === 'query' ? 'providesTags' : 'invalidatesTags'),
         factory.createArrayLiteralExpression(tags.map((tag) => factory.createStringLiteral(tag), false))
       )
-    )
+    );
   }
   return factory.createPropertyAssignment(
     factory.createIdentifier(operationName),
@@ -153,13 +155,8 @@ export function generateEndpointDefinition({
     factory.createCallExpression(
       factory.createPropertyAccessExpression(endpointBuilder, factory.createIdentifier(type)),
       [Response, QueryArg],
-      [
-        factory.createObjectLiteralExpression(
-          objectProperties,
-          true
-        ),
-      ]
-    ),
+      [factory.createObjectLiteralExpression(objectProperties, true)]
+    )
   );
 }
 

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -34,7 +34,7 @@ function getOperationName({ verb, path, operation }: Pick<OperationDefinition, '
 }
 
 function getTags({ verb, pathItem }: Pick<OperationDefinition, 'verb' | 'pathItem'>): string[] {
-  return verb ? pathItem[verb]?.tags || [] : [];
+  return verb ? pathItem[verb]?.tags ?? [] : [];
 }
 
 function patternMatches(pattern?: TextMatcher) {

--- a/packages/rtk-query-codegen-openapi/test/cli.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/cli.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import del from 'del';
 
 function cli(args: string[], cwd: string): Promise<{ error: ExecException | null; stdout: string; stderr: string }> {
-  const pwd = (process.env && process.env.PWD) || '.';
+  const pwd = process.env?.PWD ?? '.';
   const cmd = `${require.resolve('ts-node/dist/bin')} -T -P ${path.resolve(pwd, 'tsconfig.json')} ${path.resolve(
     pwd,
     'src/bin/cli.ts'

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -40,8 +40,8 @@
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
     "@types/yargs": "^16.0.1",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "6.0.0-alpha.158",
+    "@typescript-eslint/parser": "6.0.0-alpha.158",
     "axios": "^0.19.2",
     "console-testing-library": "^0.3.1",
     "convert-source-map": "^1.7.0",
@@ -73,7 +73,7 @@
     "terser": "^5.6.1",
     "ts-jest": "^27",
     "tslib": "^1.10.0",
-    "typescript": "~4.2.4",
+    "typescript": "~4.3.4",
     "yargs": "^15.3.1"
   },
   "scripts": {

--- a/packages/toolkit/src/createAction.ts
+++ b/packages/toolkit/src/createAction.ts
@@ -179,7 +179,7 @@ export interface ActionCreatorWithNonInferrablePayload<
    * return a {@link PayloadAction} of type `T` with a payload
    * of exactly the type of the argument.
    */
-  <PT extends unknown>(payload: PT): PayloadAction<PT, T>
+  <PT>(payload: PT): PayloadAction<PT, T>
 }
 
 /**

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -534,8 +534,8 @@ export const createAsyncThunk = (() => {
           meta?: RejectedMeta
         ) => ({
           payload,
-          error: ((options && options.serializeError) || miniSerializeError)(
-            error || 'Rejected'
+          error: (options?.serializeError ?? miniSerializeError)(
+            error ?? 'Rejected'
           ) as GetSerializedErrorType<ThunkApiConfig>,
           meta: {
             ...((meta as any) || {}),
@@ -617,7 +617,7 @@ If you want to use the AbortController to react to \`abort\` events, please cons
               abortController.signal.addEventListener('abort', () =>
                 reject({
                   name: 'AbortError',
-                  message: abortReason || 'Aborted',
+                  message: abortReason ?? 'Aborted',
                 })
               )
             )
@@ -730,7 +730,7 @@ type UnwrappedActionPayload<T extends UnwrappableAction> = Exclude<
 export function unwrapResult<R extends UnwrappableAction>(
   action: R
 ): UnwrappedActionPayload<R> {
-  if (action.meta && action.meta.rejectedWithValue) {
+  if (action.meta?.rejectedWithValue) {
     throw action.payload
   }
   if (action.error) {

--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
@@ -94,12 +94,12 @@ export function expectExactType<T>(t: T) {
   return <U extends Equals<T, U>>(u: U) => {}
 }
 
-type EnsureUnknown<T extends any> = IsUnknown<T, any, never>
+type EnsureUnknown<T> = IsUnknown<T, any, never>
 export function expectUnknown<T extends EnsureUnknown<T>>(t: T) {
   return t
 }
 
-type EnsureAny<T extends any> = IsAny<T, any, never>
+type EnsureAny<T> = IsAny<T, any, never>
 export function expectExactAny<T extends EnsureAny<T>>(t: T) {
   return t
 }
@@ -184,7 +184,7 @@ describe('createListenerMiddleware', () => {
         middleware: (gDM) => gDM().prepend(listenerMiddleware.middleware),
       })
 
-      let foundExtra: number | null  = null
+      let foundExtra: number | null = null
 
       const typedAddListener =
         listenerMiddleware.startListening as TypedStartListening<
@@ -1061,12 +1061,13 @@ describe('createListenerMiddleware', () => {
         middleware: (gDM) => gDM().prepend(middleware),
       })
 
-      const typedAddListener =
-        startListening as TypedStartListening<
-          CounterState,
-          typeof store.dispatch
-        >
-      let result: [ReturnType<typeof increment>, CounterState, CounterState] | null = null
+      const typedAddListener = startListening as TypedStartListening<
+        CounterState,
+        typeof store.dispatch
+      >
+      let result:
+        | [ReturnType<typeof increment>, CounterState, CounterState]
+        | null = null
 
       typedAddListener({
         predicate: incrementByAmount.match,
@@ -1126,31 +1127,34 @@ describe('createListenerMiddleware', () => {
       expect(takeResult).toEqual([increment(), stateCurrent, stateBefore])
     })
 
-    test("take resolves to `[A, CurrentState, PreviousState] | null` if a possibly undefined timeout parameter is provided", async () => {
+    test('take resolves to `[A, CurrentState, PreviousState] | null` if a possibly undefined timeout parameter is provided', async () => {
       const store = configureStore({
         reducer: counterSlice.reducer,
         middleware: (gDM) => gDM().prepend(middleware),
       })
 
-      type ExpectedTakeResultType = readonly [ReturnType<typeof increment>, CounterState, CounterState] | null
+      type ExpectedTakeResultType =
+        | readonly [ReturnType<typeof increment>, CounterState, CounterState]
+        | null
 
       let timeout: number | undefined = undefined
       let done = false
 
-      const startAppListening = startListening as TypedStartListening<CounterState>
+      const startAppListening =
+        startListening as TypedStartListening<CounterState>
       startAppListening({
         predicate: incrementByAmount.match,
         effect: async (_, listenerApi) => {
           const stateBefore = listenerApi.getState()
-          
+
           let takeResult = await listenerApi.take(increment.match, timeout)
           const stateCurrent = listenerApi.getState()
           expect(takeResult).toEqual([increment(), stateCurrent, stateBefore])
-          
+
           timeout = 1
           takeResult = await listenerApi.take(increment.match, timeout)
           expect(takeResult).toBeNull()
-          
+
           expectType<ExpectedTakeResultType>(takeResult)
 
           done = true
@@ -1160,7 +1164,7 @@ describe('createListenerMiddleware', () => {
       store.dispatch(increment())
 
       await delay(25)
-      expect(done).toBe(true);
+      expect(done).toBe(true)
     })
 
     test('condition method resolves promise when the predicate succeeds', async () => {

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -267,12 +267,12 @@ export function expectExactType<T>(t: T) {
   return <U extends Equals<T, U>>(u: U) => {}
 }
 
-type EnsureUnknown<T extends any> = IsUnknown<T, any, never>
+type EnsureUnknown<T> = IsUnknown<T, any, never>
 export function expectUnknown<T extends EnsureUnknown<T>>(t: T) {
   return t
 }
 
-type EnsureAny<T extends any> = IsAny<T, any, never>
+type EnsureAny<T> = IsAny<T, any, never>
 export function expectExactAny<T extends EnsureAny<T>>(t: T) {
   return t
 }

--- a/packages/toolkit/src/query/tests/unionTypes.test.ts
+++ b/packages/toolkit/src/query/tests/unionTypes.test.ts
@@ -26,9 +26,9 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isLoading) {
       expectExactType('' as string | undefined)(result.data)
@@ -36,25 +36,25 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
     }
 
     // @ts-expect-error
@@ -76,10 +76,10 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isLoading) {
       expectExactType(undefined)(result.data)
@@ -87,27 +87,27 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isFetching) {
@@ -116,10 +116,10 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
+      expectExactType(false as const)(result.isUninitialized)
       expectExactType(false as boolean)(result.isLoading)
       expectExactType(false as boolean)(result.isSuccess)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isError)
     }
 
     expectExactType('' as string | undefined)(result.currentData)
@@ -155,10 +155,10 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isLoading) {
       expectExactType(undefined)(result.data)
@@ -166,27 +166,27 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isFetching) {
@@ -195,10 +195,10 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
+      expectExactType(false as const)(result.isUninitialized)
       expectExactType(false as boolean)(result.isLoading)
       expectExactType(false as boolean)(result.isSuccess)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isError)
     }
 
     // @ts-expect-error
@@ -221,10 +221,10 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isLoading) {
       expectExactType(undefined)(result.data)
@@ -232,27 +232,27 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isFetching) {
@@ -261,10 +261,10 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
+      expectExactType(false as const)(result.isUninitialized)
       expectExactType(false as boolean)(result.isLoading)
       expectExactType(false as boolean)(result.isSuccess)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isError)
     }
 
     // @ts-expect-error
@@ -287,10 +287,10 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isLoading) {
       expectExactType(undefined)(result.data)
@@ -298,27 +298,27 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
-      expectExactType(false as false)(result.isFetching)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
+      expectExactType(false as const)(result.isFetching)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
       expectExactType(false as boolean)(result.isFetching)
     }
     if (result.isFetching) {
@@ -327,10 +327,10 @@ describe.skip('TS only tests', () => {
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
+      expectExactType(false as const)(result.isUninitialized)
       expectExactType(false as boolean)(result.isLoading)
       expectExactType(false as boolean)(result.isSuccess)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isError)
     }
 
     // @ts-expect-error
@@ -438,35 +438,35 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isLoading) {
-      expectExactType(undefined as undefined)(result.data)
+      expectExactType(undefined)(result.data)
       expectExactType(
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
     }
 
     // @ts-expect-error
@@ -517,35 +517,35 @@ describe.skip('TS only tests', () => {
       expectExactType(undefined)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isLoading) {
-      expectExactType(undefined as undefined)(result.data)
+      expectExactType(undefined)(result.data)
       expectExactType(
         undefined as SerializedError | FetchBaseQueryError | undefined
       )(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isError)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isError)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isError) {
       expectExactType('' as string | undefined)(result.data)
       expectExactType({} as SerializedError | FetchBaseQueryError)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isSuccess)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isSuccess)
     }
     if (result.isSuccess) {
       expectExactType('' as string)(result.data)
       expectExactType(undefined)(result.error)
 
-      expectExactType(false as false)(result.isUninitialized)
-      expectExactType(false as false)(result.isLoading)
-      expectExactType(false as false)(result.isError)
+      expectExactType(false as const)(result.isUninitialized)
+      expectExactType(false as const)(result.isLoading)
+      expectExactType(false as const)(result.isError)
     }
 
     // @ts-expect-error

--- a/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.typetest.ts
@@ -31,14 +31,14 @@ const anyAction = { type: 'foo' } as AnyAction
   const reducer = createReducer({}, (builder) =>
     builder
       .addCase(async.pending, (_, action) => {
-        expectType<ReturnType<typeof async['pending']>>(action)
+        expectType<ReturnType<(typeof async)['pending']>>(action)
       })
       .addCase(async.fulfilled, (_, action) => {
-        expectType<ReturnType<typeof async['fulfilled']>>(action)
+        expectType<ReturnType<(typeof async)['fulfilled']>>(action)
         expectType<number>(action.payload)
       })
       .addCase(async.rejected, (_, action) => {
-        expectType<ReturnType<typeof async['rejected']>>(action)
+        expectType<ReturnType<(typeof async)['rejected']>>(action)
         expectType<Partial<Error> | undefined>(action.error)
       })
   )
@@ -52,13 +52,13 @@ const anyAction = { type: 'foo' } as AnyAction
   const result = await promise
 
   if (async.fulfilled.match(result)) {
-    expectType<ReturnType<typeof async['fulfilled']>>(result)
+    expectType<ReturnType<(typeof async)['fulfilled']>>(result)
     // @ts-expect-error
-    expectType<ReturnType<typeof async['rejected']>>(result)
+    expectType<ReturnType<(typeof async)['rejected']>>(result)
   } else {
-    expectType<ReturnType<typeof async['rejected']>>(result)
+    expectType<ReturnType<(typeof async)['rejected']>>(result)
     // @ts-expect-error
-    expectType<ReturnType<typeof async['fulfilled']>>(result)
+    expectType<ReturnType<(typeof async)['fulfilled']>>(result)
   }
 
   promise
@@ -152,6 +152,7 @@ const anyAction = { type: 'foo' } as AnyAction
  */
 ;(async () => {
   const fn = createAsyncThunk('session/isAdmin', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-inferrable-types
     const response: boolean = false
     return response
   })
@@ -216,17 +217,17 @@ const anyAction = { type: 'foo' } as AnyAction
         // let it be handled as any other unknown error
         throw err
       }
-      return rejectWithValue(error.response && error.response.data)
+      return rejectWithValue(error.response?.data)
     }
   })
 
   defaultDispatch(fetchLiveCallsError('asd')).then((result) => {
     if (fetchLiveCallsError.fulfilled.match(result)) {
       //success
-      expectType<ReturnType<typeof fetchLiveCallsError['fulfilled']>>(result)
+      expectType<ReturnType<(typeof fetchLiveCallsError)['fulfilled']>>(result)
       expectType<Item[]>(result.payload)
     } else {
-      expectType<ReturnType<typeof fetchLiveCallsError['rejected']>>(result)
+      expectType<ReturnType<(typeof fetchLiveCallsError)['rejected']>>(result)
       if (result.payload) {
         // rejected with value
         expectType<ErrorFromServer>(result.payload)
@@ -235,7 +236,7 @@ const anyAction = { type: 'foo' } as AnyAction
         expectType<undefined>(result.payload)
         expectType<SerializedError>(result.error)
         // @ts-expect-error
-        expectType<IsAny<typeof result['error'], true, false>>(true)
+        expectType<IsAny<(typeof result)['error'], true, false>>(true)
       }
     }
     defaultDispatch(fetchLiveCallsError('asd'))

--- a/packages/toolkit/src/tests/createSlice.typetest.ts
+++ b/packages/toolkit/src/tests/createSlice.typetest.ts
@@ -221,8 +221,8 @@ const value = actionCreators.anyKey
         reducer(_, action: PayloadAction<number, string>) {},
         prepare: (payload: number) => ({
           payload,
-          meta: 'meta' as 'meta',
-          error: 'error' as 'error',
+          meta: 'meta' as const,
+          error: 'error' as const,
         }),
       },
       // case: meta and error marked as "unknown" in reducer
@@ -230,8 +230,8 @@ const value = actionCreators.anyKey
         reducer(_, action: PayloadAction<number, string, unknown, unknown>) {},
         prepare: (payload: number) => ({
           payload,
-          meta: 'meta' as 'meta',
-          error: 'error' as 'error',
+          meta: 'meta' as const,
+          error: 'error' as const,
         }),
       },
       // case: meta and error are typed in the reducer as returned by prepare
@@ -239,8 +239,8 @@ const value = actionCreators.anyKey
         reducer(_, action: PayloadAction<number, string, 'meta', 'error'>) {},
         prepare: (payload: number) => ({
           payload,
-          meta: 'meta' as 'meta',
-          error: 'error' as 'error',
+          meta: 'meta' as const,
+          error: 'error' as const,
         }),
       },
       // case: meta is typed differently in the reducer than returned from prepare
@@ -250,7 +250,7 @@ const value = actionCreators.anyKey
         prepare: (payload: number) => ({
           payload,
           meta: 1,
-          error: 'error' as 'error',
+          error: 'error' as const,
         }),
       },
       // case: error is typed differently in the reducer than returned from prepare
@@ -259,7 +259,7 @@ const value = actionCreators.anyKey
         // @ts-expect-error
         prepare: (payload: number) => ({
           payload,
-          meta: 'meta' as 'meta',
+          meta: 'meta' as const,
           error: 1,
         }),
       },

--- a/packages/toolkit/src/tests/helpers.ts
+++ b/packages/toolkit/src/tests/helpers.ts
@@ -13,12 +13,12 @@ export function expectExactType<T>(t: T) {
   return <U extends Equals<T, U>>(u: U) => {}
 }
 
-type EnsureUnknown<T extends any> = IsUnknown<T, any, never>
+type EnsureUnknown<T> = IsUnknown<T, any, never>
 export function expectUnknown<T extends EnsureUnknown<T>>(t: T) {
   return t
 }
 
-type EnsureAny<T extends any> = IsAny<T, any, never>
+type EnsureAny<T> = IsAny<T, any, never>
 export function expectExactAny<T extends EnsureAny<T>>(t: T) {
   return t
 }

--- a/packages/toolkit/src/tests/immutableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/immutableStateInvariantMiddleware.test.ts
@@ -214,7 +214,7 @@ describe('trackForMutations', () => {
 
   interface TestConfig {
     getState: Store['getState']
-    fn: (s: any) => typeof s | object
+    fn: (s: any) => any
     middlewareOptions?: ImmutableStateInvariantMiddlewareOptions
     path?: string[]
   }

--- a/packages/toolkit/src/tests/injectableCombineReducers.example.ts
+++ b/packages/toolkit/src/tests/injectableCombineReducers.example.ts
@@ -8,7 +8,6 @@ import { combineSlices } from '@reduxjs/toolkit'
 import { sliceA } from 'fileA'
 import { sliceB } from 'fileB'
 import { lazySliceC } from 'fileC'
-import type { lazySliceD } from 'fileD'
 
 import { anotherReducer } from 'somewhere'
 
@@ -31,7 +30,7 @@ export const rootReducer = combineSlices(sliceA, sliceB, {
 // fileC.ts
 // "naive" approach
 
-import type { RootState } from './reducer';
+import type { RootState } from './reducer'
 import { rootReducer } from './reducer'
 import { createSlice } from '@reduxjs/toolkit'
 

--- a/packages/toolkit/src/tests/matchers.test.ts
+++ b/packages/toolkit/src/tests/matchers.test.ts
@@ -177,10 +177,7 @@ describe('isPending', () => {
     const matchAC = isPending(thunkA, thunkC)
     const matchB = isPending(thunkB)
 
-    function testPendingAction(
-      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
-      expected: boolean
-    ) {
+    function testPendingAction(thunk: typeof thunkA, expected: boolean) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(expected)
       expect(matchB(pendingAction)).toBe(!expected)
@@ -235,10 +232,7 @@ describe('isRejected', () => {
     const matchAC = isRejected(thunkA, thunkC)
     const matchB = isRejected(thunkB)
 
-    function testRejectedAction(
-      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
-      expected: boolean
-    ) {
+    function testRejectedAction(thunk: typeof thunkA, expected: boolean) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(false)
 
@@ -307,10 +301,7 @@ describe('isRejectedWithValue', () => {
     const matchAC = isRejectedWithValue(thunkA, thunkC)
     const matchB = isRejectedWithValue(thunkB)
 
-    async function testRejectedAction(
-      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
-      expected: boolean
-    ) {
+    async function testRejectedAction(thunk: typeof thunkA, expected: boolean) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(false)
 
@@ -375,10 +366,7 @@ describe('isFulfilled', () => {
     const matchAC = isFulfilled(thunkA, thunkC)
     const matchB = isFulfilled(thunkB)
 
-    function testFulfilledAction(
-      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
-      expected: boolean
-    ) {
+    function testFulfilledAction(thunk: typeof thunkA, expected: boolean) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(false)
 
@@ -433,10 +421,7 @@ describe('isAsyncThunkAction', () => {
     const matchAC = isAsyncThunkAction(thunkA, thunkC)
     const matchB = isAsyncThunkAction(thunkB)
 
-    function testAllActions(
-      thunk: typeof thunkA | typeof thunkB | typeof thunkC,
-      expected: boolean
-    ) {
+    function testAllActions(thunk: typeof thunkA, expected: boolean) {
       const pendingAction = thunk.pending('fakeRequestId')
       expect(matchAC(pendingAction)).toBe(expected)
       expect(matchB(pendingAction)).toBe(!expected)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "extends": "./packages/toolkit/tsconfig.base.json",
+  "include": ["."]
+}

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.1.0",
     "react-lite-youtube-embed": "^2.0.3",
     "remark-typescript-tools": "^1.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.4"
   },
   "browserslist": {
     "production": [

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "module": "ESNext",
+    "target": "ESNext",
+    "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,6 +4499,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.3.0":
+  version: 4.4.0
+  resolution: "@eslint-community/eslint-utils@npm:4.4.0"
+  dependencies:
+    eslint-visitor-keys: ^3.3.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: cdfe3ae42b4f572cbfb46d20edafe6f36fc5fb52bf2d90875c58aefe226892b9677fef60820e2832caf864a326fe4fc225714c46e8389ccca04d5f9288aabd22
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.5.0":
+  version: 4.5.1
+  resolution: "@eslint-community/regexpp@npm:4.5.1"
+  checksum: 6d901166d64998d591fab4db1c2f872981ccd5f6fe066a1ad0a93d4e11855ecae6bfb76660869a469563e8882d4307228cebd41142adb409d182f2966771e57e
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^0.4.2":
   version: 0.4.2
   resolution: "@eslint/eslintrc@npm:0.4.2"
@@ -4547,7 +4565,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4562,7 +4580,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4584,7 +4602,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4606,7 +4624,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4624,7 +4642,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4639,7 +4657,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4654,7 +4672,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4723,7 +4741,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4744,7 +4762,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
     whatwg-fetch: ^3.4.1
   languageName: unknown
   linkType: soft
@@ -4768,7 +4786,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4791,7 +4809,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
     uuid: ^8.3.2
     whatwg-fetch: ^3.4.1
   languageName: unknown
@@ -4818,7 +4836,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4833,7 +4851,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4858,7 +4876,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4883,7 +4901,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4908,7 +4926,7 @@ __metadata:
     react-redux: ^8.0.2
     react-router-dom: 6.3.0
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -4923,7 +4941,7 @@ __metadata:
     react-dom: ^18.1.0
     react-redux: ^8.0.2
     react-scripts: 5.0.1
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 
@@ -6566,8 +6584,8 @@ __metadata:
     "@types/react": ^18.0.12
     "@types/react-dom": ^18.0.5
     "@types/yargs": ^16.0.1
-    "@typescript-eslint/eslint-plugin": ^4.22.0
-    "@typescript-eslint/parser": ^4.22.0
+    "@typescript-eslint/eslint-plugin": 6.0.0-alpha.158
+    "@typescript-eslint/parser": 6.0.0-alpha.158
     axios: ^0.19.2
     console-testing-library: ^0.3.1
     convert-source-map: ^1.7.0
@@ -6603,7 +6621,7 @@ __metadata:
     terser: ^5.6.1
     ts-jest: ^27
     tslib: ^1.10.0
-    typescript: ~4.2.4
+    typescript: ~4.3.4
     yargs: ^15.3.1
   peerDependencies:
     react: ^16.9.0 || ^17.0.0 || ^18
@@ -6766,7 +6784,7 @@ __metadata:
     swagger2openapi: ^7.0.4
     ts-jest: ^27
     ts-node: ^10.4.0
-    typescript: ">=4.1 <=4.5"
+    typescript: ">=4.3 <=4.5"
     yalc: ^1.0.0-pre.47
   bin:
     rtk-query-codegen-openapi: lib/bin/cli.js
@@ -7757,10 +7775,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
   checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.11":
+  version: 7.0.12
+  resolution: "@types/json-schema@npm:7.0.12"
+  checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
   languageName: node
   linkType: hard
 
@@ -8076,6 +8101,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.3.12":
+  version: 7.5.0
+  resolution: "@types/semver@npm:7.5.0"
+  checksum: 0a64b9b9c7424d9a467658b18dd70d1d781c2d6f033096a6e05762d20ebbad23c1b69b0083b0484722aabf35640b78ccc3de26368bcae1129c87e9df028a22e2
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.3.9":
   version: 7.3.9
   resolution: "@types/semver@npm:7.3.9"
@@ -8253,64 +8285,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^4.22.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.26.0"
+"@typescript-eslint/eslint-plugin@npm:6.0.0-alpha.158":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.0.0-alpha.158"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.26.0
-    "@typescript-eslint/scope-manager": 4.26.0
-    debug: ^4.3.1
-    functional-red-black-tree: ^1.0.1
-    lodash: ^4.17.21
-    regexpp: ^3.1.0
-    semver: ^7.3.5
-    tsutils: ^3.21.0
-  peerDependencies:
-    "@typescript-eslint/parser": ^4.0.0
-    eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 1019fe5d0cb9d1e8683570145cc8408e3a851e6e91ec3b8557ecbf7f14edcfb9747cba09b765cb717cc0c1d335d90c7e1ce4a80865b33d87cac74b8c6e4c50c7
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/eslint-plugin@npm:^5.5.0":
-  version: 5.27.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.27.1"
-  dependencies:
-    "@typescript-eslint/scope-manager": 5.27.1
-    "@typescript-eslint/type-utils": 5.27.1
-    "@typescript-eslint/utils": 5.27.1
+    "@eslint-community/regexpp": ^4.5.0
+    "@typescript-eslint/scope-manager": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/type-utils": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/utils": 6.0.0-alpha.158+b411706a1
     debug: ^4.3.4
-    functional-red-black-tree: ^1.0.1
-    ignore: ^5.2.0
-    regexpp: ^3.2.0
-    semver: ^7.3.7
-    tsutils: ^3.21.0
+    grapheme-splitter: ^1.0.4
+    ignore: ^5.2.4
+    natural-compare: ^1.4.0
+    semver: ^7.5.0
+    ts-api-utils: ^1.0.0
   peerDependencies:
-    "@typescript-eslint/parser": ^5.0.0
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    "@typescript-eslint/parser": ^6.0.0 || ^6.0.0-alpha
+    eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ee00d8d3a7b395e346801b7bf30209e278f06b5c283ad71c03b34db9e2d68a43ca0e292e315fa7e5bf131a8839ff4a24e0ed76c37811d230f97aae7e123d73ea
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/experimental-utils@npm:4.26.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/experimental-utils@npm:4.26.0"
-  dependencies:
-    "@types/json-schema": ^7.0.7
-    "@typescript-eslint/scope-manager": 4.26.0
-    "@typescript-eslint/types": 4.26.0
-    "@typescript-eslint/typescript-estree": 4.26.0
-    eslint-scope: ^5.1.1
-    eslint-utils: ^3.0.0
-  peerDependencies:
-    eslint: "*"
-  checksum: d48fa79ae7f14cbbb7313dc9535e92133975ab5a08e6e6affe3f58c41f371f676c7470f797ab8a1b46bc78842f3293b100434fa9f3e92b6932ee07fad14297e2
+  checksum: 8d91730a682de7b22d2f45367fcb2ba5a65f05f34f32598751b7c73f8a36c11a7d60be9282018bbc8ca4db1e370066c710000ec0cd45fe7c63231f65dc473afa
   languageName: node
   linkType: hard
 
@@ -8325,47 +8320,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^4.22.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/parser@npm:4.26.0"
+"@typescript-eslint/parser@npm:6.0.0-alpha.158":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/parser@npm:6.0.0-alpha.158"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.26.0
-    "@typescript-eslint/types": 4.26.0
-    "@typescript-eslint/typescript-estree": 4.26.0
-    debug: ^4.3.1
-  peerDependencies:
-    eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: ae1655c18f7f3e806ac0f293a45945691c67eaf8bbea56fbec486aaa2f2545cd7340bbe997fe31fcb82031b94c2363a92b4c51f9607e633deb2b7eea347d7512
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:^5.5.0":
-  version: 5.27.1
-  resolution: "@typescript-eslint/parser@npm:5.27.1"
-  dependencies:
-    "@typescript-eslint/scope-manager": 5.27.1
-    "@typescript-eslint/types": 5.27.1
-    "@typescript-eslint/typescript-estree": 5.27.1
+    "@typescript-eslint/scope-manager": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/types": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/typescript-estree": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/visitor-keys": 6.0.0-alpha.158+b411706a1
     debug: ^4.3.4
   peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 0f1df76142c9d7a6c6dbfc5d19fdee02bbc0e79def6e6df4b126c7eaae1c3a46a3871ad498d4b1fc7ad5cb58d6eb70f020807f600d99c0b9add98441fc12f23b
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:4.26.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.26.0"
-  dependencies:
-    "@typescript-eslint/types": 4.26.0
-    "@typescript-eslint/visitor-keys": 4.26.0
-  checksum: 4ab0f2da294e095a9f9a7a9b1b64945c4bf0090f4aef54bddb84c39983a514b59699f66d26df10123c8b254d907cebc31a54a20b2124b34c0ce47b808fdd7065
+  checksum: 72976052e081ba3b36869065af5773c9e52a2049639a45453154c639b0ef4f87cff59d127b3e395230a226b95890c8e043a4bb39e6b1fed27799a07f5016a0de
   languageName: node
   linkType: hard
 
@@ -8379,26 +8348,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.27.1":
-  version: 5.27.1
-  resolution: "@typescript-eslint/type-utils@npm:5.27.1"
+"@typescript-eslint/scope-manager@npm:6.0.0-alpha.158+b411706a1":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/scope-manager@npm:6.0.0-alpha.158"
   dependencies:
-    "@typescript-eslint/utils": 5.27.1
-    debug: ^4.3.4
-    tsutils: ^3.21.0
-  peerDependencies:
-    eslint: "*"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 43b7da26ea1bd7d249c45d168ec88f971fb71362bbc21ec4748d73b1ecb43f4ca59f5ed338e8dbc74272ae4ebac1cab87a9b62c0fa616c6f9bd833a212dc8a40
+    "@typescript-eslint/types": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/visitor-keys": 6.0.0-alpha.158+b411706a1
+  checksum: 1ba92a6240dbbfc515a3b0895e893ecfde466b24f92de63c7d248308a7dddbecdc1a9b47c6e8cfd4f6ffb70413a183e10029542e016884c3db812413e2ccdd26
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.26.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/types@npm:4.26.0"
-  checksum: 82b92efaf6a4ff3ad3a8ecb28f948f4e377ef806cb78a9436e17429207da1f8ade99546c755739d559b9706e4f7967b29fb9049d07ddd5902d4482754b8dfd41
+"@typescript-eslint/type-utils@npm:6.0.0-alpha.158+b411706a1":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/type-utils@npm:6.0.0-alpha.158"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/utils": 6.0.0-alpha.158+b411706a1
+    debug: ^4.3.4
+    ts-api-utils: ^1.0.0
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 944df9686c012e7d69f587253cc1eb15f2cb5b55369c2b4ebf172f1e352756355aa561401abc2d99d69f27ff8fcd3bcffe06295f3146656420f6b2f1b3b24eeb
   languageName: node
   linkType: hard
 
@@ -8409,21 +8382,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.26.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.26.0"
-  dependencies:
-    "@typescript-eslint/types": 4.26.0
-    "@typescript-eslint/visitor-keys": 4.26.0
-    debug: ^4.3.1
-    globby: ^11.0.3
-    is-glob: ^4.0.1
-    semver: ^7.3.5
-    tsutils: ^3.21.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 191d7759a3e92ba7b20e496243c81c80fd9d42d303a73bb62860698ce92eb5992739090a404163154dff275b6a6f12f87d0369cf4f8b25182ae6505134f677e4
+"@typescript-eslint/types@npm:6.0.0-alpha.158+b411706a1":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/types@npm:6.0.0-alpha.158"
+  checksum: 3ad4b14505a7d5092d0ae03969b381dcad57dfbbf40b027a41a16f5fc1bff47e6449bc05d476fbb5f13aac7240f6515ef6fce35115a36fafd2bed8c09b5ccab3
   languageName: node
   linkType: hard
 
@@ -8445,6 +8407,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:6.0.0-alpha.158+b411706a1":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/typescript-estree@npm:6.0.0-alpha.158"
+  dependencies:
+    "@typescript-eslint/types": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/visitor-keys": 6.0.0-alpha.158+b411706a1
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.0
+    ts-api-utils: ^1.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: c124fe574181627f142ef41e2938d7e82a139349f91427d2efeef452b1c604e61dc61c72171fdd642b718258b25fd71b5b41abcb880637bf0f47c877ab890a44
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:5.27.1, @typescript-eslint/utils@npm:^5.13.0":
   version: 5.27.1
   resolution: "@typescript-eslint/utils@npm:5.27.1"
@@ -8461,13 +8441,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.26.0":
-  version: 4.26.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.26.0"
+"@typescript-eslint/utils@npm:6.0.0-alpha.158+b411706a1":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/utils@npm:6.0.0-alpha.158"
   dependencies:
-    "@typescript-eslint/types": 4.26.0
-    eslint-visitor-keys: ^2.0.0
-  checksum: 6e89ab718c3d5b2b3265398e2858c4470ddab8e7fe79f2bb3af3237cd0bb9593957fd4f3ecb09caaeca75387b44ed6b1e35b2a81ff676d4d7439bfb7a388b23e
+    "@eslint-community/eslint-utils": ^4.3.0
+    "@types/json-schema": ^7.0.11
+    "@types/semver": ^7.3.12
+    "@typescript-eslint/scope-manager": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/types": 6.0.0-alpha.158+b411706a1
+    "@typescript-eslint/typescript-estree": 6.0.0-alpha.158+b411706a1
+    eslint-scope: ^5.1.1
+    semver: ^7.5.0
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: a5bed5c4f40416f197bdc3e90926bce99a786b700cce15f9b6c5a55fc4cdba18bc64b52a62e4e9864b4963ef6eb3d8afa0c85b41345e376c6fc02c9361082798
   languageName: node
   linkType: hard
 
@@ -8478,6 +8466,16 @@ __metadata:
     "@typescript-eslint/types": 5.27.1
     eslint-visitor-keys: ^3.3.0
   checksum: 8f104eda321cd6c613daf284fbebbd32b149d4213d137b0ce1caec7a1334c9f46c82ed64aff1243b712ac8c13f67ac344c996cd36d21fbb15032c24d9897a64a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.0.0-alpha.158+b411706a1":
+  version: 6.0.0-alpha.158
+  resolution: "@typescript-eslint/visitor-keys@npm:6.0.0-alpha.158"
+  dependencies:
+    "@typescript-eslint/types": 6.0.0-alpha.158+b411706a1
+    eslint-visitor-keys: ^3.4.1
+  checksum: e8940eeac6740f8cd6a70130cffc0ae0b723e0a27ee342e2d860642d0ca26aa1be8738f554d83b9e100364b2a7944dee3f520511ac50868a1c54036af8233eef
   languageName: node
   linkType: hard
 
@@ -14132,6 +14130,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-visitor-keys@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "eslint-visitor-keys@npm:3.4.1"
+  checksum: f05121d868202736b97de7d750847a328fcfa8593b031c95ea89425333db59676ac087fa905eba438d0a3c5769632f828187e0c1a0d271832a2153c1d3661c2c
+  languageName: node
+  linkType: hard
+
 "eslint-webpack-plugin@npm:^3.1.1":
   version: 3.1.1
   resolution: "eslint-webpack-plugin@npm:3.1.1"
@@ -15670,6 +15675,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"grapheme-splitter@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "grapheme-splitter@npm:1.0.4"
+  checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
+  languageName: node
+  linkType: hard
+
 "graphql-config@npm:^3.3.0":
   version: 3.3.0
   resolution: "graphql-config@npm:3.3.0"
@@ -16477,6 +16489,13 @@ fsevents@^1.2.7:
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "ignore@npm:5.2.4"
+  checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
   languageName: node
   linkType: hard
 
@@ -24590,6 +24609,8 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "rtk-monorepo@workspace:."
   dependencies:
+    "@typescript-eslint/eslint-plugin": 6.0.0-alpha.158
+    "@typescript-eslint/parser": 6.0.0-alpha.158
     eslint: ^7.25.0
     eslint-config-prettier: ^8.3.0
     eslint-config-react-app: ^7.0.1
@@ -24959,6 +24980,17 @@ fsevents@^1.2.7:
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.0":
+  version: 7.5.2
+  resolution: "semver@npm:7.5.2"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 3fdf5d1e6f170fe8bcc41669e31787649af91af7f54f05c71d0865bb7aa27e8b92f68b3e6b582483e2c1c648008bc84249d2cd86301771fe5cbf7621d1fe5375
   languageName: node
   linkType: hard
 
@@ -26871,6 +26903,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "ts-api-utils@npm:1.0.1"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 78794fc7270d295b36c1ac613465b5dc7e7226907a533125b30f177efef9dd630d4e503b00be31b44335eb2ebf9e136ebe97353f8fc5d383885d5fead9d54c09
+  languageName: node
+  linkType: hard
+
 "ts-essentials@npm:^2.0.3":
   version: 2.0.12
   resolution: "ts-essentials@npm:2.0.12"
@@ -27111,7 +27152,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=4.1 <=4.5, typescript@npm:^4.1.2, typescript@npm:^4.1.3, typescript@npm:^4.3.4":
+"typescript@npm:>=4.3 <=4.5":
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.1.2, typescript@npm:^4.1.3, typescript@npm:^4.3.4":
   version: 4.5.2
   resolution: "typescript@npm:4.5.2"
   bin:
@@ -27131,16 +27182,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.2.4":
-  version: 4.2.4
-  resolution: "typescript@npm:4.2.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 89c397df192f239359ad798b96d8e8d552e12c0c189ac5676cec4c20c410d6eec636b8e59a88f2aef0a56d961a9678d99c400099be9b7cae2f7b062eb4b7b171
-  languageName: node
-  linkType: hard
-
 "typescript@npm:~4.3.2":
   version: 4.3.4
   resolution: "typescript@npm:4.3.4"
@@ -27148,6 +27189,16 @@ fsevents@^1.2.7:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 75e1f2769c7ff38c718523d05eaf1c2611dbf92c0ab0f85f603ead9bb23416af2009a5dac46e76ef6a207a8508fa53f51b43a41f2a91b1241b53cd744c16128c
+  languageName: node
+  linkType: hard
+
+"typescript@npm:~4.3.4":
+  version: 4.3.5
+  resolution: "typescript@npm:4.3.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
   languageName: node
   linkType: hard
 
@@ -27161,7 +27212,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@>=4.1 <=4.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.3.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@>=4.3 <=4.5#~builtin<compat/typescript>":
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=701156"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 858c61fa63f7274ca4aaaffeced854d550bf416cff6e558c4884041b3311fb662f476f167cf5c9f8680c607239797e26a2ee0bcc6467fbc05bfcb218e1c6c671
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.1.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.3.4#~builtin<compat/typescript>":
   version: 4.5.2
   resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=701156"
   bin:
@@ -27181,16 +27242,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.2.4#~builtin<compat/typescript>":
-  version: 4.2.4
-  resolution: "typescript@patch:typescript@npm%3A4.2.4#~builtin<compat/typescript>::version=4.2.4&hash=701156"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: eb86e0e8022e5297f7a7b871b6edfbf33b57049416ada8bf97c358760125c7c79f074fbebd1b8e8230f858ae05eb22ad0e805e8f6acd5eae1fa886681624c15e
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@~4.3.2#~builtin<compat/typescript>":
   version: 4.3.4
   resolution: "typescript@patch:typescript@npm%3A4.3.4#~builtin<compat/typescript>::version=4.3.4&hash=701156"
@@ -27198,6 +27249,16 @@ fsevents@^1.2.7:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 6ccc2e1148e172da119ea4b72c66395a0c18a53884d21fb82bb4503a948a7169e9961defe24a359040a3d77bf5ff338945804296e0e27c87b5bd22ea1d25781b
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.3.4#~builtin<compat/typescript>":
+  version: 4.3.5
+  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=701156"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 365df18cf979c971ef9543b2acaa8694377a803f98e1804c41d0ede0b09d7046cb0cd98f2eaf3884b0fe923c01a60af1f653841bd8805c9715d5479c09a4ebe4
   languageName: node
   linkType: hard
 
@@ -28330,7 +28391,7 @@ fsevents@^1.2.7:
     react-dom: ^18.1.0
     react-lite-youtube-embed: ^2.0.3
     remark-typescript-tools: ^1.1.0
-    typescript: ~4.2.4
+    typescript: ~4.3.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Upgraded typescript-eslint to v6, with reworked ESLint configurations.

You can read https://typescript-eslint.io/blog/announcing-typescript-eslint-v6-beta#user-facing-breaking-changes for the rationale behind the config changes. Essentially, the new recommended starter configs are:

* `"plugin:@typescript-eslint/recommended-type-checked"`
* `"plugin:@typescript-eslint/stylistic-type-checked"`

I've commented any changes ripe for discussion internally. This one was pretty straightforward compared to others though.

> **Note**: This is just a Draft PR to serve as a point of comparison. There are very likely build failures that would happen if the CI builds were to be approved.