### PR TITLE
Fix example not using correct accessor

### DIFF
--- a/docs/tutorials/rtk-query.mdx
+++ b/docs/tutorials/rtk-query.mdx
@@ -72,7 +72,7 @@ export const pokemonApi = createApi({
 // highlight-start
 // Export hooks for usage in functional components, which are
 // auto-generated based on the defined endpoints
-export const { useGetPokemonByNameQuery } = pokemonApi
+export const { useGetPokemonByNameQuery } = pokemonApi.endpoints
 // highlight-end
 ```
 
@@ -183,7 +183,7 @@ export const pokemonApi = createApi({
   }),
 })
 
-export const { useGetPokemonByNameQuery } = pokemonApi
+export const { useGetPokemonByNameQuery } = pokemonApi.endpoints
 
 // file: App.tsx
 import * as React from 'react'


### PR DESCRIPTION
Hey while following the docs I found that the RTK-Query example was using the wrong accessor. 

Desctructuring just`pokemonApi` did not allow me access the endpoints. I had to append `.endpoints` to be able to get them. Could be an error on my end though, sorry if that's the case. 


Here some examples from my editor showing TypeScript complaining: 


<img src="https://github.com/reduxjs/redux-toolkit/assets/24259317/1ae6087f-ac91-46d1-b07f-e5c78cd1bafc" width="600px" />


<img src="https://github.com/reduxjs/redux-toolkit/assets/24259317/f23cf4eb-9e73-48d2-85dd-8e335d6ee4df" width="600px" />
