### PR TITLE
Update queries.mdx, added apostrophe - "posts" to "post's"

### DIFF
--- a/docs/rtk-query/usage/queries.mdx
+++ b/docs/rtk-query/usage/queries.mdx
@@ -292,7 +292,7 @@ function PostsList() {
 }
 
 function PostById({ id }: { id: number }) {
-  // Will select the post with the given id, and will only rerender if the given posts data changes
+  // Will select the post with the given id, and will only rerender if the given post's data changes
   const { post } = api.useGetPostsQuery(undefined, {
     selectFromResult: ({ data }) => ({
       post: data?.find((post) => post.id === id),


### PR DESCRIPTION
Added an apostrophe, changing `...the given posts data...` to `...the given post's data...`. An extremely minor change to be sure, but when writing about a post in a group of posts being able to easily distinguish between the two is important.