### PR TITLE
Throw error when type is empty in builder.addCase

### DIFF
--- a/packages/toolkit/src/mapBuilders.ts
+++ b/packages/toolkit/src/mapBuilders.ts
@@ -140,7 +140,7 @@ export function executeReducerBuilderCallback<S>(
     ) {
       if (process.env.NODE_ENV !== 'production') {
         /*
-         to keep the definition by the user in line with actual behavior, 
+         to keep the definition by the user in line with actual behavior,
          we enforce `addCase` to always be called before calling `addMatcher`
          as matching cases take precedence over matchers
          */
@@ -159,6 +159,11 @@ export function executeReducerBuilderCallback<S>(
         typeof typeOrActionCreator === 'string'
           ? typeOrActionCreator
           : typeOrActionCreator.type
+      if (!type) {
+        throw new Error(
+          '`builder.addCase` cannot be called with an empty action type'
+        )
+      }
       if (type in actionsMap) {
         throw new Error(
           'addCase cannot be called with two reducers for the same action type'

--- a/packages/toolkit/src/mapBuilders.ts
+++ b/packages/toolkit/src/mapBuilders.ts
@@ -166,7 +166,7 @@ export function executeReducerBuilderCallback<S>(
       }
       if (type in actionsMap) {
         throw new Error(
-          'addCase cannot be called with two reducers for the same action type'
+          '`builder.addCase` cannot be called with two reducers for the same action type'
         )
       }
       actionsMap[type] = reducer

--- a/packages/toolkit/src/tests/createReducer.test.ts
+++ b/packages/toolkit/src/tests/createReducer.test.ts
@@ -473,6 +473,24 @@ describe('createReducer', () => {
         `"addCase cannot be called with two reducers for the same action type"`
       )
     })
+
+    test('will throw if an empty type is used', () => {
+      const customActionCreator = (payload: number) => ({
+        type: 'custom_action',
+        payload,
+      })
+      customActionCreator.type = ""
+      expect(() =>
+        createReducer(0, (builder) =>
+          builder.addCase(
+            customActionCreator,
+            (state, action) => state + action.payload
+          )
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        '"`builder.addCase` cannot be called with an empty action type"'
+      )
+    })
   })
 
   describe('builder "addMatcher" method', () => {

--- a/packages/toolkit/src/tests/createReducer.test.ts
+++ b/packages/toolkit/src/tests/createReducer.test.ts
@@ -460,7 +460,7 @@ describe('createReducer', () => {
             .addCase(decrement, (state, action) => state - action.payload)
         )
       ).toThrowErrorMatchingInlineSnapshot(
-        `"addCase cannot be called with two reducers for the same action type"`
+        '"`builder.addCase` cannot be called with two reducers for the same action type"'
       )
       expect(() =>
         createReducer(0, (builder) =>
@@ -470,7 +470,7 @@ describe('createReducer', () => {
             .addCase(decrement, (state, action) => state - action.payload)
         )
       ).toThrowErrorMatchingInlineSnapshot(
-        `"addCase cannot be called with two reducers for the same action type"`
+        '"`builder.addCase` cannot be called with two reducers for the same action type"'
       )
     })
 


### PR DESCRIPTION
Resolves #3570 

Some of the thrown errors in `mapBuilders` are only executed when `NODE_ENV !== 'production'`. I decided to not use this guard because this functionality seemed to closely match the intent of the `type in actionsMap` check, which also does not have the aforementioned guard applied. I don't have strong opinions on it though!