### PR TITLE
fix: Default export of the module has or is using private name type error when using latest alpha/beta

### DIFF
--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -233,15 +233,14 @@ createSlice({
   selectors?: Selectors
 }
 
-const reducerDefinitionType: unique symbol = Symbol.for('rtk-reducer-type')
-enum ReducerType {
+export enum ReducerType {
   reducer = 'reducer',
   reducerWithPrepare = 'reducerWithPrepare',
   asyncThunk = 'asyncThunk',
 }
 
 interface ReducerDefinition<T extends ReducerType = ReducerType> {
-  [reducerDefinitionType]: T
+  _reducerDefinitionType: T
 }
 
 export interface CaseReducerDefinition<
@@ -375,7 +374,7 @@ export interface ReducerCreators<State> {
       ReturnType<_ActionCreatorWithPreparedPayload<Prepare>>
     >
   ): {
-    [reducerDefinitionType]: ReducerType.reducerWithPrepare
+    _reducerDefinitionType: ReducerType.reducerWithPrepare
     prepare: Prepare
     reducer: CaseReducer<
       State,
@@ -748,7 +747,7 @@ function buildReducerCreators<State>(): ReducerCreators<State> {
     config: AsyncThunkSliceReducerConfig<State, any>
   ): AsyncThunkSliceReducerDefinition<State, any> {
     return {
-      [reducerDefinitionType]: ReducerType.asyncThunk,
+      _reducerDefinitionType: ReducerType.asyncThunk,
       payloadCreator,
       ...config,
     }
@@ -765,13 +764,13 @@ function buildReducerCreators<State>(): ReducerCreators<State> {
           },
         }[caseReducer.name],
         {
-          [reducerDefinitionType]: ReducerType.reducer,
+          _reducerDefinitionType: ReducerType.reducer,
         } as const
       )
     },
     preparedReducer(prepare, reducer) {
       return {
-        [reducerDefinitionType]: ReducerType.reducerWithPrepare,
+        _reducerDefinitionType: ReducerType.reducerWithPrepare,
         prepare,
         reducer,
       }
@@ -813,14 +812,14 @@ function handleNormalReducerDefinition<State>(
 function isAsyncThunkSliceReducerDefinition<State>(
   reducerDefinition: any
 ): reducerDefinition is AsyncThunkSliceReducerDefinition<State, any, any, any> {
-  return reducerDefinition[reducerDefinitionType] === ReducerType.asyncThunk
+  return reducerDefinition._reducerDefinitionType === ReducerType.asyncThunk
 }
 
 function isCaseReducerWithPrepareDefinition<State>(
   reducerDefinition: any
 ): reducerDefinition is CaseReducerWithPrepareDefinition<State, any> {
   return (
-    reducerDefinition[reducerDefinitionType] === ReducerType.reducerWithPrepare
+    reducerDefinition._reducerDefinitionType === ReducerType.reducerWithPrepare
   )
 }
 

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -67,6 +67,7 @@ export type {
 export {
   // js
   createSlice,
+  ReducerType,
 } from './createSlice'
 
 export type {
@@ -78,6 +79,7 @@ export type {
   ValidateSliceCaseReducers,
   CaseReducerWithPrepare,
   ReducerCreators,
+  SliceSelectors,
 } from './createSlice'
 export type { ActionCreatorInvariantMiddlewareOptions } from './actionCreatorInvariantMiddleware'
 export { createActionCreatorInvariantMiddleware } from './actionCreatorInvariantMiddleware'


### PR DESCRIPTION
Resolves #3455 
Version: 2.0.0-beta.0

The `reducerDefinitionType` symbol type causes TypeScript issues for consumers of `createSlice` who have the following included in their `tsconfig.json` settings:

```json
{
  "compilerOptions": {
    "moduleResolution": "Node16",
    "declaration": true,
  }
}
```

The TypeScript error appears as...
```
Exported variable 'X' has or is using name 'reducerDefinitionType' from external module "<path>/node_modules/@reduxjs/toolkit/dist/createSlice" but cannot be named.
```

Simply ensuring that `reducerDefinitionType` is exported and publicly accessible does not remove the error (could be an issue with the TypeScript compiler?). Hopefully someone knows how to correctly export this `unique symbol` or confirm that it is impossible.

Right now, the fix uses the underscore (`_`) prefix naming convention for the `reducerDefinitionType` to avoid symbols (although certainly not as unique as what I think is preferred).

Maybe having a separate object that tracks the reducer definition types on a slice can work better?

_PR additionally resolves other "not portable" TypeScript errors by exporting the needed types._

Hope this helps you guys.