### PR TITLE
docs: use type declaration for type-safe when declare initialState

### DIFF
--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -25,7 +25,7 @@ interface CounterState {
   value: number
 }
 
-const initialState: CounterState = { value: 0 }
+const initialState = { value: 0 } satisfies CounterState as CounterState
 
 const counterSlice = createSlice({
   name: 'counter',

--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -25,7 +25,7 @@ interface CounterState {
   value: number
 }
 
-const initialState = { value: 0 } as CounterState
+const initialState: CounterState = { value: 0 }
 
 const counterSlice = createSlice({
   name: 'counter',


### PR DESCRIPTION
i think Type Declaration is type-safe than Type Assertion.

```ts
interface CounterState {
  value: number
}

// Type Declaration
const initialState: CounterState = { value: 0 }
const initialState: CounterState = { value: 0, id: 1 } // Error: ...

// Type Assertion
const initialState = { value: 0 } as CounterState
const initialState = { value: 0, id: 1 } as CounterState // Not error, but id is not type of CounterState.

```