### PR TITLE
Support for explicit resource management "using statements" on RTK Query subscriptions

### DIFF
--- a/packages/toolkit/src/query/tests/buildInitiate.test.tsx
+++ b/packages/toolkit/src/query/tests/buildInitiate.test.tsx
@@ -52,3 +52,30 @@ test('multiple synchonrous initiate calls with pre-existing cache entry', async 
     requestId: thirdValue.requestId,
   })
 })
+
+test('subscriptions can be unsubscribed with the using keyword', async () => {
+  const { store, api } = storeRef
+
+  // Polyfill Symbol.dispose for this test
+  // Explicit any can be removed once this library is upgraded to TypeScript 5.2
+  const anySymbol = Symbol as any;
+  anySymbol.dispose = anySymbol.dispose ?? Symbol.for('Symbol.dispose');
+  
+  // Helper to count the number of subscriptions for the increment endpoint
+  const getSubscriptionCount = () =>
+    Object.keys(
+      store.getState().api.subscriptions['increment(undefined)'] ?? {}
+    ).length
+
+  const initialSubscriptionCount = getSubscriptionCount()
+  const subscription = store.dispatch(api.endpoints.increment.initiate())
+  await subscription;
+
+  // Simulate the dispose call made by the using keyword
+  (subscription as any)[anySymbol.dispose]();
+
+  // Wait for the unsubscribe to be processed as it's done asynchronously
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  expect(getSubscriptionCount()).toBe(initialSubscriptionCount)
+})

--- a/packages/toolkit/src/query/utils/disposableIfAvailable.ts
+++ b/packages/toolkit/src/query/utils/disposableIfAvailable.ts
@@ -1,0 +1,46 @@
+/**
+ * DisposableIfAvailable
+ * 
+ * The explicit resource management TC39 proposal introduces a new symbol
+ * `symbol.dispose` that can be used to mark objects as disposable.
+ * 
+ * It's important that this type can be compiled in older TypeScript versions
+ * that don't include the symbol so consumers of the library don't face type
+ * errors.
+ * 
+ * At compile time DisposableIfAvailable will be either:
+ * 
+ * - `{ [Symbol.dispose]: () => void }` if the symbol is defined
+ * - `{}` if the symbol is not defined
+ */
+type DisposeSymbolType = SymbolConstructor extends { dispose: symbol }
+  ? typeof Symbol['dispose']
+  : 'unused-literal'
+
+// Explicit any can be removed once this library is upgraded to TypeScript 5.2
+const disposeSymbol: DisposeSymbolType = (Symbol as any)['dispose']
+export type DisposableIfAvailable = SymbolConstructor extends {
+  dispose: symbol
+}
+  ? { [disposeSymbol]: () => void }
+  : {}
+
+/**
+ * At runtime check for the existence of Symbol.dispose and if available return
+ * an object with a dispose method.
+ * 
+ * This needs to be a runtime check as the symbol is not available in every environment.
+ */
+export const disposableIfAvailable = (
+  disposeFn: () => void
+): DisposableIfAvailable => {
+  
+  // Explicit any can be removed once we upgrade to TypeScript 5.2
+  const dispose: DisposeSymbolType = (Symbol as any)['dispose']
+  if (dispose) {
+    return {
+      [dispose]: () => disposeFn(),
+    }
+  }
+  return {} as DisposableIfAvailable
+}


### PR DESCRIPTION
Issue: #3707

This PR proposes the addition of a `[Symbol.dispose]: () => void` to be added to the object returned from `dispatch(endpoint.initiate())` to enable explicit resource management with using statements.

I've put effort into ensuring that none of the exported types reference `Symbol.dispose` when it's not available so consumers with older versions of Typescript won't have any type errors.

There are some explicit any casts within `disposableIfAvailable.ts` that allows this change to be compiled without needing to update the whole library to use Typescritp 5.2+ We're currently on 4.2.4. These any types are only internal to the module.

## Testing
I've manually tested this change using the example code snippet in #3707