### PR TITLE
keep subscription on data while query is running

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
@@ -1,17 +1,18 @@
-import type { InternalHandlerBuilder } from './types'
+import type { InternalHandlerBuilder, SubscriptionSelectors } from './types'
 import type { SubscriptionState } from '../apiState'
 import { produceWithPatches } from 'immer'
 import type { Action } from '@reduxjs/toolkit'
+import { countObjectKeys } from '../../utils/countObjectKeys'
 
 export const buildBatchedActionsHandler: InternalHandlerBuilder<
-  [actionShouldContinue: boolean, subscriptionExists: boolean]
+  [actionShouldContinue: boolean, returnValue: SubscriptionSelectors | boolean]
 > = ({ api, queryThunk, internalState }) => {
   const subscriptionsPrefix = `${api.reducerPath}/subscriptions`
 
   let previousSubscriptions: SubscriptionState =
     null as unknown as SubscriptionState
 
-  let dispatchQueued = false
+  let updateSyncTimer: ReturnType<typeof window.setTimeout> | null = null
 
   const { updateSubscriptionOptions, unsubscribeQueryResult } =
     api.internalActions
@@ -79,10 +80,30 @@ export const buildBatchedActionsHandler: InternalHandlerBuilder<
     return mutated
   }
 
+  const getSubscriptions = () => internalState.currentSubscriptions
+  const getSubscriptionCount = (queryCacheKey: string) => {
+    const subscriptions = getSubscriptions()
+    const subscriptionsForQueryArg = subscriptions[queryCacheKey] ?? {}
+    return countObjectKeys(subscriptionsForQueryArg)
+  }
+  const isRequestSubscribed = (queryCacheKey: string, requestId: string) => {
+    const subscriptions = getSubscriptions()
+    return !!subscriptions?.[queryCacheKey]?.[requestId]
+  }
+
+  const subscriptionSelectors: SubscriptionSelectors = {
+    getSubscriptions,
+    getSubscriptionCount,
+    isRequestSubscribed,
+  }
+
   return (
     action,
     mwApi
-  ): [actionShouldContinue: boolean, hasSubscription: boolean] => {
+  ): [
+    actionShouldContinue: boolean,
+    result: SubscriptionSelectors | boolean
+  ] => {
     if (!previousSubscriptions) {
       // Initialize it the first time this handler runs
       previousSubscriptions = JSON.parse(
@@ -92,16 +113,16 @@ export const buildBatchedActionsHandler: InternalHandlerBuilder<
 
     if (api.util.resetApiState.match(action)) {
       previousSubscriptions = internalState.currentSubscriptions = {}
+      updateSyncTimer = null
       return [true, false]
     }
 
     // Intercept requests by hooks to see if they're subscribed
-    // Necessary because we delay updating store state to the end of the tick
-    if (api.internalActions.internal_probeSubscription.match(action)) {
-      const { queryCacheKey, requestId } = action.payload
-      const hasSubscription =
-        !!internalState.currentSubscriptions[queryCacheKey]?.[requestId]
-      return [false, hasSubscription]
+    // We return the internal state reference so that hooks
+    // can do their own checks to see if they're still active.
+    // It's stupid and hacky, but it does cut down on some dispatch calls.
+    if (api.internalActions.internal_getRTKQSubscriptions.match(action)) {
+      return [false, subscriptionSelectors]
     }
 
     // Update subscription data based on this action
@@ -110,9 +131,16 @@ export const buildBatchedActionsHandler: InternalHandlerBuilder<
       action
     )
 
+    let actionShouldContinue = true
+
     if (didMutate) {
-      if (!dispatchQueued) {
-        queueMicrotask(() => {
+      if (!updateSyncTimer) {
+        // We only use the subscription state for the Redux DevTools at this point,
+        // as the real data is kept here in the middleware.
+        // Given that, we can throttle synchronizing this state significantly to
+        // save on overall perf.
+        // In 1.9, it was updated in a microtask, but now we do it at most every 500ms.
+        updateSyncTimer = setTimeout(() => {
           // Deep clone the current subscription data
           const newSubscriptions: SubscriptionState = JSON.parse(
             JSON.stringify(internalState.currentSubscriptions)
@@ -127,25 +155,23 @@ export const buildBatchedActionsHandler: InternalHandlerBuilder<
           mwApi.next(api.internalActions.subscriptionsUpdated(patches))
           // Save the cloned state for later reference
           previousSubscriptions = newSubscriptions
-          dispatchQueued = false
-        })
-        dispatchQueued = true
+          updateSyncTimer = null
+        }, 500)
       }
 
       const isSubscriptionSliceAction =
         typeof action.type == 'string' &&
         !!action.type.startsWith(subscriptionsPrefix)
+
       const isAdditionalSubscriptionAction =
         queryThunk.rejected.match(action) &&
         action.meta.condition &&
         !!action.meta.arg.subscribe
 
-      const actionShouldContinue =
+      actionShouldContinue =
         !isSubscriptionSliceAction && !isAdditionalSubscriptionAction
-
-      return [actionShouldContinue, false]
     }
 
-    return [true, false]
+    return [actionShouldContinue, false]
   }
 }

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -71,6 +71,7 @@ export function buildMiddleware<
       >),
       internalState,
       refetchQuery,
+      isThisApiSliceAction,
     }
 
     const handlers = handlerBuilders.map((build) => build(builderArgs))
@@ -93,18 +94,15 @@ export function buildMiddleware<
 
         const stateBefore = mwApi.getState()
 
-        const [actionShouldContinue, hasSubscription] = batchedActionsHandler(
-          action,
-          mwApiWithNext,
-          stateBefore
-        )
+        const [actionShouldContinue, internalProbeResult] =
+          batchedActionsHandler(action, mwApiWithNext, stateBefore)
 
         let res: any
 
         if (actionShouldContinue) {
           res = next(action)
         } else {
-          res = hasSubscription
+          res = internalProbeResult
         }
 
         if (!!mwApi.getState()[reducerPath]) {

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -9,7 +9,9 @@ import type {
   SubMiddlewareApi,
   InternalHandlerBuilder,
   ApiMiddlewareInternalHandler,
+  InternalMiddlewareState,
 } from './types'
+import { countObjectKeys } from '../../utils/countObjectKeys'
 
 export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
   reducerPath,
@@ -19,6 +21,7 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
   api,
   assertTagType,
   refetchQuery,
+  internalState,
 }) => {
   const { removeQueryResult } = api.internalActions
   const isThunkActionWithTags = isAnyOf(
@@ -35,7 +38,8 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
           endpointDefinitions,
           assertTagType
         ),
-        mwApi
+        mwApi,
+        internalState
       )
     }
 
@@ -49,16 +53,19 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
           undefined,
           assertTagType
         ),
-        mwApi
+        mwApi,
+        internalState
       )
     }
   }
 
   function invalidateTags(
     tags: readonly FullTagDescription<string>[],
-    mwApi: SubMiddlewareApi
+    mwApi: SubMiddlewareApi,
+    internalState: InternalMiddlewareState
   ) {
     const rootState = mwApi.getState()
+
     const state = rootState[reducerPath]
 
     const toInvalidate = api.util.selectInvalidatedBy(rootState, tags)
@@ -67,10 +74,11 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
       const valuesArray = Array.from(toInvalidate.values())
       for (const { queryCacheKey } of valuesArray) {
         const querySubState = state.queries[queryCacheKey]
-        const subscriptionSubState = state.subscriptions[queryCacheKey] ?? {}
+        const subscriptionSubState =
+          internalState.currentSubscriptions[queryCacheKey] ?? {}
 
         if (querySubState) {
-          if (Object.keys(subscriptionSubState).length === 0) {
+          if (countObjectKeys(subscriptionSubState) === 0) {
             mwApi.dispatch(
               removeQueryResult({
                 queryCacheKey: queryCacheKey as QueryCacheKey,

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -32,6 +32,12 @@ export interface InternalMiddlewareState {
   currentSubscriptions: SubscriptionState
 }
 
+export interface SubscriptionSelectors {
+  getSubscriptions: () => SubscriptionState
+  getSubscriptionCount: (queryCacheKey: string) => number
+  isRequestSubscribed: (queryCacheKey: string, requestId: string) => boolean
+}
+
 export interface BuildMiddlewareInput<
   Definitions extends EndpointDefinitions,
   ReducerPath extends string,
@@ -61,6 +67,7 @@ export interface BuildSubMiddlewareInput
     queryCacheKey: string,
     override?: Partial<QueryThunkArg>
   ): AsyncThunkAction<ThunkResult, QueryThunkArg, {}>
+  isThisApiSliceAction: (action: Action) => boolean
 }
 
 export type SubMiddlewareBuilder = (

--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -6,6 +6,7 @@ import type {
   InternalHandlerBuilder,
   SubMiddlewareApi,
 } from './types'
+import { countObjectKeys } from '../../utils/countObjectKeys'
 
 export const buildWindowEventHandler: InternalHandlerBuilder = ({
   reducerPath,
@@ -50,7 +51,7 @@ export const buildWindowEventHandler: InternalHandlerBuilder = ({
             state.config[type])
 
         if (shouldRefetch) {
-          if (Object.keys(subscriptionSubState).length === 0) {
+          if (countObjectKeys(subscriptionSubState) === 0) {
             api.dispatch(
               removeQueryResult({
                 queryCacheKey: queryCacheKey as QueryCacheKey,

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -147,12 +147,9 @@ export function buildSlice({
       builder
         .addCase(queryThunk.pending, (draft, { meta, meta: { arg } }) => {
           const upserting = isUpsertQuery(arg)
-          if (arg.subscribe || upserting) {
-            // only initialize substate if we want to subscribe to it
-            draft[arg.queryCacheKey] ??= {
-              status: QueryStatus.uninitialized,
-              endpointName: arg.endpointName,
-            }
+          draft[arg.queryCacheKey] ??= {
+            status: QueryStatus.uninitialized,
+            endpointName: arg.endpointName,
           }
 
           updateQuerySubstateIfExists(draft, arg.queryCacheKey, (substate) => {

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -1,4 +1,4 @@
-import type { PayloadAction, UnknownAction } from '@reduxjs/toolkit'
+import type { Action, PayloadAction, UnknownAction } from '@reduxjs/toolkit'
 import {
   combineReducers,
   createAction,
@@ -443,12 +443,7 @@ export function buildSlice({
       ) {
         // Dummy
       },
-      internal_probeSubscription(
-        d,
-        a: PayloadAction<{ queryCacheKey: string; requestId: string }>
-      ) {
-        // dummy
-      },
+      internal_getRTKQSubscriptions() {},
     },
   })
 

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -22,6 +22,7 @@ import {
 } from 'react-redux'
 import type { QueryKeys } from '../core/apiState'
 import type { PrefetchOptions } from '../core/module'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 export const reactHooksModuleName = /* @__PURE__ */ Symbol()
 export type ReactHooksModule = typeof reactHooksModuleName
@@ -147,7 +148,7 @@ export const reactHooksModule = ({
     let warned = false
     for (const hookName of hookNames) {
       // warn for old hook options
-      if (Object.keys(rest).length > 0) {
+      if (countObjectKeys(rest) > 0) {
         if ((rest as Partial<typeof hooks>)[hookName]) {
           if (!warned) {
             console.warn(

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1820,10 +1820,13 @@ describe('hooks tests', () => {
         checkSession.matchPending,
         api.internalActions.subscriptionsUpdated.match,
         checkSession.matchRejected,
+        api.internalActions.subscriptionsUpdated.match,
         login.matchPending,
         login.matchFulfilled,
         checkSession.matchPending,
-        checkSession.matchFulfilled
+        api.internalActions.subscriptionsUpdated.match,
+        checkSession.matchFulfilled,
+        api.internalActions.subscriptionsUpdated.match
       )
     })
   })

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -37,6 +37,8 @@ import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiSt
 import type { SerializedError } from '@reduxjs/toolkit'
 import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
 import { delay } from '../../utils'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 // Just setup a temporary in-memory counter for tests that `getIncrementedAmount`.
 // This can be used to test how many renders happen due to data changes or
@@ -138,6 +140,9 @@ const storeRef = setupApiStore(
   }
 )
 
+let getSubscriptions: SubscriptionSelectors['getSubscriptions']
+let getSubscriptionCount: SubscriptionSelectors['getSubscriptionCount']
+
 beforeEach(() => {
   actions = []
   listenerMiddleware.startListening({
@@ -146,6 +151,9 @@ beforeEach(() => {
       actions.push(action)
     },
   })
+  ;({ getSubscriptions, getSubscriptionCount } = storeRef.store.dispatch(
+    api.internalActions.internal_getRTKQSubscriptions()
+  ) as unknown as SubscriptionSelectors)
 })
 
 afterEach(() => {
@@ -738,14 +746,13 @@ describe('hooks tests', () => {
         withoutTestLifecycles: true,
       })
 
-      const getSubscriptions = () => storeRef.store.getState().api.subscriptions
-
       const checkNumSubscriptions = (arg: string, count: number) => {
         const subscriptions = getSubscriptions()
         const cacheKeyEntry = subscriptions[arg]
 
         if (cacheKeyEntry) {
-          expect(Object.values(cacheKeyEntry).length).toBe(count)
+          const subscriptionCount = Object.keys(cacheKeyEntry) //getSubscriptionCount(arg)
+          expect(subscriptionCount).toBe(count)
         }
       }
 
@@ -1426,25 +1433,19 @@ describe('hooks tests', () => {
 
       await screen.findByText(/isUninitialized/i)
       expect(screen.queryByText('Yay')).toBeNull()
-      expect(Object.keys(storeRef.store.getState().api.mutations).length).toBe(
-        0
-      )
+      expect(countObjectKeys(storeRef.store.getState().api.mutations)).toBe(0)
 
       userEvent.click(screen.getByRole('button', { name: 'trigger' }))
 
       await screen.findByText(/isSuccess/i)
       expect(screen.queryByText('Yay')).not.toBeNull()
-      expect(Object.keys(storeRef.store.getState().api.mutations).length).toBe(
-        1
-      )
+      expect(countObjectKeys(storeRef.store.getState().api.mutations)).toBe(1)
 
       userEvent.click(screen.getByRole('button', { name: 'reset' }))
 
       await screen.findByText(/isUninitialized/i)
       expect(screen.queryByText('Yay')).toBeNull()
-      expect(Object.keys(storeRef.store.getState().api.mutations).length).toBe(
-        0
-      )
+      expect(countObjectKeys(storeRef.store.getState().api.mutations)).toBe(0)
     })
   })
 
@@ -1747,11 +1748,7 @@ describe('hooks tests', () => {
       }),
     })
 
-    const storeRef = setupApiStore(api, {
-      actions(state: UnknownAction[] = [], action: UnknownAction) {
-        return [...state, action]
-      },
-    })
+    const storeRef = setupApiStore(api, { ...actionsReducer })
     test('initially failed useQueries that provide an tag will refetch after a mutation invalidates it', async () => {
       const checkSessionData = { name: 'matt' }
       server.use(
@@ -1818,15 +1815,11 @@ describe('hooks tests', () => {
       expect(storeRef.store.getState().actions).toMatchSequence(
         api.internalActions.middlewareRegistered.match,
         checkSession.matchPending,
-        api.internalActions.subscriptionsUpdated.match,
         checkSession.matchRejected,
-        api.internalActions.subscriptionsUpdated.match,
         login.matchPending,
         login.matchFulfilled,
         checkSession.matchPending,
-        api.internalActions.subscriptionsUpdated.match,
-        checkSession.matchFulfilled,
-        api.internalActions.subscriptionsUpdated.match
+        checkSession.matchFulfilled
       )
     })
   })
@@ -2541,11 +2534,6 @@ describe('skip behaviour', () => {
     isUninitialized: true,
   }
 
-  function subscriptionCount(key: string) {
-    return Object.keys(storeRef.store.getState().api.subscriptions[key] || {})
-      .length
-  }
-
   test('normal skip', async () => {
     const { result, rerender } = renderHook(
       ([arg, options]: Parameters<typeof api.endpoints.getUser.useQuery>) =>
@@ -2558,14 +2546,14 @@ describe('skip behaviour', () => {
 
     expect(result.current).toEqual(uninitialized)
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
 
     await act(async () => {
       rerender([1])
     })
     expect(result.current).toMatchObject({ status: QueryStatus.fulfilled })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(1)
+    expect(getSubscriptionCount('getUser(1)')).toBe(1)
 
     await act(async () => {
       rerender([1, { skip: true }])
@@ -2576,7 +2564,7 @@ describe('skip behaviour', () => {
       data: { name: 'Timmy' },
     })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
   })
 
   test('skipToken', async () => {
@@ -2592,17 +2580,17 @@ describe('skip behaviour', () => {
     expect(result.current).toEqual(uninitialized)
     await delay(1)
 
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
     // also no subscription on `getUser(skipToken)` or similar:
-    expect(storeRef.store.getState().api.subscriptions).toEqual({})
+    expect(getSubscriptions()).toEqual({})
 
     await act(async () => {
       rerender([1])
     })
     expect(result.current).toMatchObject({ status: QueryStatus.fulfilled })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(1)
-    expect(storeRef.store.getState().api.subscriptions).not.toEqual({})
+    expect(getSubscriptionCount('getUser(1)')).toBe(1)
+    expect(getSubscriptions()).not.toEqual({})
 
     await act(async () => {
       rerender([skipToken])
@@ -2613,7 +2601,7 @@ describe('skip behaviour', () => {
       data: { name: 'Timmy' },
     })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
   })
 
   test('skipping a previously fetched query retains the existing value as `data`, but clears `currentData`', async () => {

--- a/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
+++ b/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
@@ -38,7 +38,8 @@ it('invalidates the specified tags', async () => {
     api.internalActions.middlewareRegistered.match,
     getBanana.matchPending,
     api.internalActions.subscriptionsUpdated.match,
-    getBanana.matchFulfilled
+    getBanana.matchFulfilled,
+    api.internalActions.subscriptionsUpdated.match
   )
 
   await storeRef.store.dispatch(api.util.invalidateTags(['Banana', 'Bread']))
@@ -51,9 +52,12 @@ it('invalidates the specified tags', async () => {
     getBanana.matchPending,
     api.internalActions.subscriptionsUpdated.match,
     getBanana.matchFulfilled,
+    api.internalActions.subscriptionsUpdated.match,
     api.util.invalidateTags.match,
     getBanana.matchPending,
+    api.internalActions.subscriptionsUpdated.match,
     getBanana.matchFulfilled,
+    api.internalActions.subscriptionsUpdated.match,
   ]
   expect(storeRef.store.getState().actions).toMatchSequence(...firstSequence)
 
@@ -67,9 +71,12 @@ it('invalidates the specified tags', async () => {
     getBread.matchPending,
     api.internalActions.subscriptionsUpdated.match,
     getBread.matchFulfilled,
+    api.internalActions.subscriptionsUpdated.match,
     api.util.invalidateTags.match,
     getBread.matchPending,
-    getBread.matchFulfilled
+    api.internalActions.subscriptionsUpdated.match,
+    getBread.matchFulfilled,
+    api.internalActions.subscriptionsUpdated.match
   )
 })
 

--- a/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
+++ b/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
@@ -37,9 +37,7 @@ it('invalidates the specified tags', async () => {
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     getBanana.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
-    getBanana.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match
+    getBanana.matchFulfilled
   )
 
   await storeRef.store.dispatch(api.util.invalidateTags(['Banana', 'Bread']))
@@ -50,14 +48,10 @@ it('invalidates the specified tags', async () => {
   const firstSequence = [
     api.internalActions.middlewareRegistered.match,
     getBanana.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     getBanana.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
     api.util.invalidateTags.match,
     getBanana.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     getBanana.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
   ]
   expect(storeRef.store.getState().actions).toMatchSequence(...firstSequence)
 
@@ -69,14 +63,10 @@ it('invalidates the specified tags', async () => {
   expect(storeRef.store.getState().actions).toMatchSequence(
     ...firstSequence,
     getBread.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     getBread.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
     api.util.invalidateTags.match,
     getBread.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
-    getBread.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match
+    getBread.matchFulfilled
   )
 })
 

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -75,8 +75,8 @@ describe('buildSlice', () => {
             status: 'fulfilled',
           },
         },
-        // Filled in a tick later
-        subscriptions: expect.any(Object),
+        // Filled some time later
+        subscriptions: {},
       },
       auth: {
         token: '1234',
@@ -84,18 +84,6 @@ describe('buildSlice', () => {
     }
 
     expect(storeRef.store.getState()).toEqual(initialQueryState)
-
-    await delay(1)
-
-    expect(storeRef.store.getState()).toEqual({
-      ...initialQueryState,
-      api: {
-        ...initialQueryState.api,
-        subscriptions: {
-          'getUser(1)': expect.any(Object),
-        },
-      },
-    })
 
     storeRef.store.dispatch(api.util.resetApiState())
 

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -29,7 +29,9 @@ test(`query: await cleanup, defaults`, async () => {
     })
   )
 
-  store.dispatch(api.endpoints.query.initiate('arg')).unsubscribe()
+  const promise = store.dispatch(api.endpoints.query.initiate('arg'))
+  await promise
+  promise.unsubscribe()
   vi.advanceTimersByTime(59000)
   expect(onCleanup).not.toHaveBeenCalled()
   vi.advanceTimersByTime(2000)
@@ -49,7 +51,9 @@ test(`query: await cleanup, keepUnusedDataFor set`, async () => {
     })
   )
 
-  store.dispatch(api.endpoints.query.initiate('arg')).unsubscribe()
+  const promise = store.dispatch(api.endpoints.query.initiate('arg'))
+  await promise
+  promise.unsubscribe()
   vi.advanceTimersByTime(28000)
   expect(onCleanup).not.toHaveBeenCalled()
   vi.advanceTimersByTime(2000)
@@ -69,7 +73,9 @@ test(`query: handles large keepUnuseDataFor values over 32-bit ms`, async () => 
     })
   )
 
-  store.dispatch(api.endpoints.query.initiate('arg')).unsubscribe()
+  const promise = store.dispatch(api.endpoints.query.initiate('arg'))
+  await promise
+  promise.unsubscribe()
 
   // Shouldn't have been called right away
   vi.advanceTimersByTime(1000)
@@ -110,7 +116,9 @@ describe(`query: await cleanup, keepUnusedDataFor set`, () => {
   )
 
   test('global keepUnusedDataFor', async () => {
-    store.dispatch(api.endpoints.query.initiate('arg')).unsubscribe()
+    const promise = store.dispatch(api.endpoints.query.initiate('arg'))
+    await promise
+    promise.unsubscribe()
     vi.advanceTimersByTime(28000)
     expect(onCleanup).not.toHaveBeenCalled()
     vi.advanceTimersByTime(2000)
@@ -118,7 +126,10 @@ describe(`query: await cleanup, keepUnusedDataFor set`, () => {
   })
 
   test('endpoint keepUnusedDataFor', async () => {
-    store.dispatch(api.endpoints.query2.initiate('arg')).unsubscribe()
+    const promise = store.dispatch(api.endpoints.query2.initiate('arg'))
+    await promise
+    promise.unsubscribe()
+
     vi.advanceTimersByTime(34000)
     expect(onCleanup).not.toHaveBeenCalled()
     vi.advanceTimersByTime(2000)
@@ -127,7 +138,9 @@ describe(`query: await cleanup, keepUnusedDataFor set`, () => {
 
   test('endpoint keepUnusedDataFor: 0 ', async () => {
     expect(onCleanup).not.toHaveBeenCalled()
-    store.dispatch(api.endpoints.query3.initiate('arg')).unsubscribe()
+    const promise = store.dispatch(api.endpoints.query3.initiate('arg'))
+    await promise
+    promise.unsubscribe()
     expect(onCleanup).not.toHaveBeenCalled()
     vi.advanceTimersByTime(1)
     expect(onCleanup).toHaveBeenCalled()

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -6,6 +6,7 @@ import {
   THIRTY_TWO_BIT_MAX_INT,
   THIRTY_TWO_BIT_MAX_TIMER_SECONDS,
 } from '../core/buildMiddleware/cacheCollection'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 beforeAll(() => {
   vi.useFakeTimers()
@@ -177,10 +178,10 @@ function storeForApi<
   let hadQueries = false
   store.subscribe(() => {
     const queryState = store.getState().api.queries
-    if (hadQueries && Object.keys(queryState).length === 0) {
+    if (hadQueries && countObjectKeys(queryState) === 0) {
       onCleanup()
     }
-    hadQueries = hadQueries || Object.keys(queryState).length > 0
+    hadQueries = hadQueries || countObjectKeys(queryState) > 0
   })
   return { api, store }
 }

--- a/packages/toolkit/src/query/tests/cacheLifecycle.test.ts
+++ b/packages/toolkit/src/query/tests/cacheLifecycle.test.ts
@@ -76,6 +76,7 @@ describe.each([['query'], ['mutation']] as const)(
       expect(onNewCacheEntry).toHaveBeenCalledWith('arg')
       expect(onCleanup).not.toHaveBeenCalled()
 
+      await promise
       if (type === 'mutation') {
         promise.reset()
       } else {
@@ -219,6 +220,7 @@ describe.each([['query'], ['mutation']] as const)(
       )
 
       expect(onNewCacheEntry).toHaveBeenCalledWith('arg')
+      await promise
       if (type === 'mutation') {
         promise.reset()
       } else {
@@ -270,6 +272,7 @@ describe.each([['query'], ['mutation']] as const)(
       )
 
       expect(onNewCacheEntry).toHaveBeenCalledWith('arg')
+      await promise
 
       if (type === 'mutation') {
         promise.reset()
@@ -321,6 +324,7 @@ describe.each([['query'], ['mutation']] as const)(
 
       expect(onNewCacheEntry).toHaveBeenCalledWith('arg')
 
+      await promise
       if (type === 'mutation') {
         promise.reset()
       } else {
@@ -370,6 +374,7 @@ test(`query: getCacheEntry`, async () => {
   const promise = storeRef.store.dispatch(
     extended.endpoints.injected.initiate('arg')
   )
+  await promise
   promise.unsubscribe()
 
   await fakeTimerWaitFor(() => {
@@ -539,6 +544,7 @@ test('updateCachedData', async () => {
   const promise = storeRef.store.dispatch(
     extended.endpoints.injected.initiate('arg')
   )
+  await promise
   promise.unsubscribe()
 
   await fakeTimerWaitFor(() => {
@@ -576,7 +582,7 @@ test('dispatching further actions does not trigger another lifecycle', async () 
   expect(onNewCacheEntry).toHaveBeenCalledTimes(1)
 })
 
-test('dispatching a query initializer with `subscribe: false` does not start a lifecycle', async () => {
+test('dispatching a query initializer with `subscribe: false` does also start a lifecycle', async () => {
   const extended = api.injectEndpoints({
     overrideExisting: true,
     endpoints: (build) => ({
@@ -591,8 +597,9 @@ test('dispatching a query initializer with `subscribe: false` does not start a l
   await storeRef.store.dispatch(
     extended.endpoints.injected.initiate(undefined, { subscribe: false })
   )
-  expect(onNewCacheEntry).toHaveBeenCalledTimes(0)
+  expect(onNewCacheEntry).toHaveBeenCalledTimes(1)
 
+  // will not be called a second time though
   await storeRef.store.dispatch(extended.endpoints.injected.initiate(undefined))
   expect(onNewCacheEntry).toHaveBeenCalledTimes(1)
 })

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -203,5 +203,6 @@ test('Minimizes the number of subscription dispatches when multiple components a
     'api/executeQuery/pending',
     'api/internalSubscriptions/subscriptionsUpdated',
     'api/executeQuery/fulfilled',
+    'api/internalSubscriptions/subscriptionsUpdated',
   ])
 }, 25000)

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -176,7 +176,8 @@ describe('fetchBaseQuery', () => {
       expect(res.meta?.response).toBeInstanceOf(Object)
       expect(res.error).toEqual({
         status: 'PARSING_ERROR',
-        error: 'SyntaxError: Unexpected token h in JSON at position 1',
+        error:
+          'SyntaxError: Unexpected token \'h\', "this is not json!" is not valid JSON',
         originalStatus: 200,
         data: `this is not json!`,
       })
@@ -334,7 +335,8 @@ describe('fetchBaseQuery', () => {
       expect(res.meta?.response).toBeInstanceOf(Object)
       expect(res.error).toEqual({
         status: 'PARSING_ERROR',
-        error: 'SyntaxError: Unexpected token h in JSON at position 1',
+        error:
+          'SyntaxError: Unexpected token \'h\', "this is not json!" is not valid JSON',
         originalStatus: 500,
         data: `this is not json!`,
       })
@@ -435,7 +437,7 @@ describe('fetchBaseQuery', () => {
 
     it('supports a custom jsonReplacer', async () => {
       const body = {
-        items: new Set(["A", "B", "C"])
+        items: new Set(['A', 'B', 'C']),
       }
 
       let request: any
@@ -456,7 +458,8 @@ describe('fetchBaseQuery', () => {
       const baseQueryWithReplacer = fetchBaseQuery({
         baseUrl,
         fetchFn: fetchFn as any,
-        jsonReplacer: (key, value) => value instanceof Set ? [...value] : value
+        jsonReplacer: (key, value) =>
+          value instanceof Set ? [...value] : value,
       })
 
       ;({ data: request } = await baseQueryWithReplacer(
@@ -470,8 +473,7 @@ describe('fetchBaseQuery', () => {
       ))
 
       expect(request.headers['content-type']).toBe('application/json')
-      expect(request.body).toEqual({ items: ["A", "B", "C"] }) // Set is marshalled correctly by jsonReplacer
-      
+      expect(request.body).toEqual({ items: ['A', 'B', 'C'] }) // Set is marshalled correctly by jsonReplacer
     })
   })
 

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -176,8 +176,7 @@ describe('fetchBaseQuery', () => {
       expect(res.meta?.response).toBeInstanceOf(Object)
       expect(res.error).toEqual({
         status: 'PARSING_ERROR',
-        error:
-          'SyntaxError: Unexpected token \'h\', "this is not json!" is not valid JSON',
+        error: expect.stringMatching(/SyntaxError: Unexpected token/),
         originalStatus: 200,
         data: `this is not json!`,
       })
@@ -335,8 +334,7 @@ describe('fetchBaseQuery', () => {
       expect(res.meta?.response).toBeInstanceOf(Object)
       expect(res.error).toEqual({
         status: 'PARSING_ERROR',
-        error:
-          'SyntaxError: Unexpected token \'h\', "this is not json!" is not valid JSON',
+        error: expect.stringMatching(/SyntaxError: Unexpected token/),
         originalStatus: 500,
         data: `this is not json!`,
       })

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -182,6 +182,11 @@ ${expectedOutput}
 
 export const actionsReducer = {
   actions: (state: UnknownAction[] = [], action: UnknownAction) => {
+    // As of 2.0-beta.4, we are going to ignore all `subscriptionsUpdated` actions in tests
+    if (action.type.includes('subscriptionsUpdated')) {
+      return state
+    }
+
     return [...state, action]
   },
 }

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -118,7 +118,9 @@ expect.extend({
       if (!matchers[i](actions[i])) {
         return {
           message: () =>
-            `Action ${actions[i].type} does not match sequence at position ${i}.`,
+            `Action ${actions[i].type} does not match sequence at position ${i}.
+All actions:
+${actions.map((a) => a.type).join('\n')}`,
           pass: false,
         }
       }

--- a/packages/toolkit/src/query/tests/matchers.test.tsx
+++ b/packages/toolkit/src/query/tests/matchers.test.tsx
@@ -65,25 +65,22 @@ test('matches query pending & fulfilled actions for the given endpoint', async (
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchFulfilled
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     otherEndpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     otherEndpoint.matchFulfilled
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
+    api.endpoints.mutationSuccess.matchFulfilled,
     endpoint.matchRejected
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
 })
@@ -96,7 +93,6 @@ test('matches query pending & rejected actions for the given endpoint', async ()
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
@@ -122,20 +118,17 @@ test('matches lazy query pending & fulfilled actions for given endpoint', async 
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchFulfilled
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
 
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
 })
@@ -151,7 +144,6 @@ test('matches lazy query pending & rejected actions for given endpoint', async (
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -2,6 +2,7 @@ import { vi } from 'vitest'
 import { createApi } from '@reduxjs/toolkit/query'
 import { setupApiStore, waitMs } from './helpers'
 import { delay } from '../../utils'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 
 const mockBaseQuery = vi
   .fn()
@@ -23,8 +24,16 @@ const { getPosts } = api.endpoints
 
 const storeRef = setupApiStore(api)
 
+let getSubscriptions: SubscriptionSelectors['getSubscriptions']
+
+beforeEach(() => {
+  ;({ getSubscriptions } = storeRef.store.dispatch(
+    api.internalActions.internal_getRTKQSubscriptions()
+  ) as unknown as SubscriptionSelectors)
+})
+
 const getSubscribersForQueryCacheKey = (queryCacheKey: string) =>
-  storeRef.store.getState()[api.reducerPath].subscriptions[queryCacheKey] || {}
+  getSubscriptions()[queryCacheKey] || {}
 const createSubscriptionGetter = (queryCacheKey: string) => () =>
   getSubscribersForQueryCacheKey(queryCacheKey)
 

--- a/packages/toolkit/src/query/tests/refetchingBehaviors.test.tsx
+++ b/packages/toolkit/src/query/tests/refetchingBehaviors.test.tsx
@@ -432,10 +432,12 @@ describe('customListenersHandler', () => {
     })
     expect(dispatchSpy).toHaveBeenCalled()
 
-    // Ignore RTKQ middleware `internal_probeSubscription` calls
-    const mockCallsWithoutInternals = dispatchSpy.mock.calls.filter(
-      (call) => !(call[0] as any)?.type?.includes('internal')
-    )
+    // Ignore RTKQ middleware internal data calls
+    const mockCallsWithoutInternals = dispatchSpy.mock.calls.filter((call) => {
+      const type = (call[0] as any)?.type ?? ''
+      const reIsInternal = /internal/i
+      return !reIsInternal.test(type)
+    })
 
     expect(
       defaultApi.internalActions.onOnline.match(

--- a/packages/toolkit/src/query/utils/countObjectKeys.ts
+++ b/packages/toolkit/src/query/utils/countObjectKeys.ts
@@ -1,0 +1,14 @@
+// Fast method for counting an object's keys
+// without resorting to `Object.keys(obj).length
+// Will this make a big difference in perf? Probably not
+// But we can save a few allocations.
+
+export function countObjectKeys(obj: Record<any, any>) {
+  let count = 0
+
+  for (const _key in obj) {
+    count++
+  }
+
+  return count
+}


### PR DESCRIPTION
This would fix #3706 and solve a generally long-existing problem: Prior to this PR, unsubscribed `initiate` calls without an existing cache entry don't have a return value.

The downside is that now every `initiate` call creates a cache entry, even with `subscribe: false` - and trigger lifecycle actions.  
It might make sense to target 2.0 with this.