### PR TITLE
Use default Node version in CI

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -29,16 +29,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: ['16.x']
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - run: yarn install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,21 +25,17 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.toolkit == 'true' }}
 
-    name: Lint, Test, Build & Pack on Node ${{ matrix.node }}
+    name: Lint, Test, Build & Pack on Node
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['16.x']
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -64,18 +60,13 @@ jobs:
     name: Test against dist
     needs: [build]
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['16.x']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -104,16 +95,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16.x']
         ts: ['4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9.2-rc']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -148,7 +137,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16.x']
         example:
           [
             'cra4',
@@ -166,10 +154,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps

--- a/packages/rtk-codemods/.github/workflows/ci.yml
+++ b/packages/rtk-codemods/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '*'
   pull_request: {}
   schedule:
-  - cron:  '0 6 * * 0' # weekly, on sundays
+    - cron: '0 6 * * 0' # weekly, on sundays
 
 jobs:
   lint:
@@ -18,43 +18,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: install dependencies
-      run: yarn install --frozen-lockfile
-    - name: linting
-      run: yarn lint
+      - uses: actions/checkout@v1
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      - name: linting
+        run: yarn lint
 
   test:
     name: Tests
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node: ['10', '12', '14']
-
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node }}
-    - name: install dependencies
-      run: yarn install --frozen-lockfile
-    - name: test
-      run: yarn test
+      - uses: actions/checkout@v1
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      - name: test
+        run: yarn test
 
   floating-test:
     name: Floating dependencies
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - name: install dependencies
-      run: yarn install --no-lockfile
-    - name: test
-      run: yarn test
+      - uses: actions/checkout@v1
+      - name: install dependencies
+        run: yarn install --no-lockfile
+      - name: test
+        run: yarn test


### PR DESCRIPTION
Deprecated Node versions are used in CI, potentially causing security and reliability issues. Instead, it's better to use GitHub's default Node version, which also doesn't require additional downloads or installations.