### PR TITLE
[RED-26] Remove Request.clone() usage in fetchBaseQuery

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -266,7 +266,7 @@ export function fetchBaseQuery({
     url = joinUrls(baseUrl, url)
 
     const request = new Request(url, config)
-    const requestClone = request.clone()
+    const requestClone = new Request(url, config)
     meta = { request: requestClone }
 
     let response,


### PR DESCRIPTION
This is a proposed fix for #3716. It is a workaround for a bug in Chromium which has not been fixed for 3 years. For more information check the issue.

<sub>[RED-26](https://linear.app/redux/issue/RED-26/remove-requestclone-usage-in-fetchbasequery)</sub>