### PR TITLE
[RTK v2.0] output selector fields are currently missing in selector functions created using `createDraftSafeSelector`.

### DIFF
--- a/packages/toolkit/src/createDraftSafeSelector.ts
+++ b/packages/toolkit/src/createDraftSafeSelector.ts
@@ -9,6 +9,7 @@ export const createDraftSafeSelectorCreator: typeof createSelectorCreator = (
     const selector = createSelector(...args)
     const wrappedSelector = (value: unknown, ...rest: unknown[]) =>
       selector(isDraft(value) ? current(value) : value, ...rest)
+    Object.assign(wrappedSelector, selector)
     return wrappedSelector as any
   }
 }

--- a/packages/toolkit/src/tests/createDraftSafeSelector.test.ts
+++ b/packages/toolkit/src/tests/createDraftSafeSelector.test.ts
@@ -11,6 +11,13 @@ test('handles normal values correctly', () => {
   let state = { value: 1 }
   expect(unsafeSelector(state)).toBe(1)
   expect(draftSafeSelector(state)).toBe(1)
+  expect(draftSafeSelector).toHaveProperty('resultFunc')
+  expect(draftSafeSelector).toHaveProperty('memoizedResultFunc')
+  expect(draftSafeSelector).toHaveProperty('lastResult')
+  expect(draftSafeSelector).toHaveProperty('dependencies')
+  expect(draftSafeSelector).toHaveProperty('recomputations')
+  expect(draftSafeSelector).toHaveProperty('resetRecomputations')
+  expect(draftSafeSelector).toHaveProperty('clearCache')
 
   state = { value: 2 }
   expect(unsafeSelector(state)).toBe(2)


### PR DESCRIPTION
In v2.0.0-beta.1 selectors that are created with `createDraftSafeSelector`, are missing the output selector fields like: `resultFunc`, `memoizedResultFunc`, `lastResult`, `dependencies`, `recomputations`, `resetRecomputations` and `clearCache`. I wasn't sure if this was by design or not, since the ts type for `createDraftSafeSelectorCreator` is the same as `createSelectorCreator`. Therefore in TypeScript the generated draft safe selectors seem to have all the output selector fields, but will result in an error being thrown during runtime.

Anyway I have a simple fix that should take care of the problem during runtime, however if you do not want the output selector fields to be attached to draft safe selectors I can also fix the ts type.