### PR TITLE
[RED-23] fix: Updated type references to resolve portable types issue

### DIFF
--- a/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
+++ b/packages/rtk-query-graphql-request-base-query/src/GraphqlBaseQueryTypes.ts
@@ -1,4 +1,4 @@
-import type { BaseQueryApi } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import type { BaseQueryApi } from '@reduxjs/toolkit/query'
 import type {
   GraphQLClient,
   RequestOptions,

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -196,3 +196,5 @@ export {
   autoBatchEnhancer,
 } from './autoBatchEnhancer'
 export type { AutoBatchOptions } from './autoBatchEnhancer'
+
+export type { ExtractDispatchExtensions as TSHelpersExtractDispatchExtensions } from './tsHelpers'

--- a/packages/toolkit/src/query/core/index.ts
+++ b/packages/toolkit/src/query/core/index.ts
@@ -3,4 +3,4 @@ import { coreModule, coreModuleName } from './module'
 
 const createApi = /* @__PURE__ */ buildCreateApi(coreModule())
 
-export { createApi, coreModule }
+export { createApi, coreModule, coreModuleName }

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -1,5 +1,13 @@
+export type {
+  CombinedState,
+  QueryCacheKey,
+  QueryKeys,
+  QuerySubState,
+  RootState,
+  SubscriptionOptions,
+} from './core/apiState'
 export { QueryStatus } from './core/apiState'
-export type { Api, Module, ApiModules } from './apiTypes'
+export type { Api, ApiContext, ApiModules, Module } from './apiTypes'
 export type {
   BaseQueryApi,
   BaseQueryEnhancer,
@@ -11,6 +19,9 @@ export type {
   QueryDefinition,
   MutationDefinition,
   TagDescription,
+  QueryArgFrom,
+  ResultTypeFrom,
+  DefinitionType,
 } from './endpointDefinitions'
 export { fetchBaseQuery } from './fetchBaseQuery'
 export type {
@@ -21,10 +32,31 @@ export type {
 export { retry } from './retry'
 export { setupListeners } from './core/setupListeners'
 export { skipSelector, skipToken } from './core/buildSelectors'
-export type { SkipToken } from './core/buildSelectors'
+export type {
+  QueryResultSelectorResult,
+  MutationResultSelectorResult,
+  SkipToken,
+} from './core/buildSelectors'
+export type {
+  QueryActionCreatorResult,
+  MutationActionCreatorResult,
+} from './core/buildInitiate'
 export type { CreateApi, CreateApiOptions } from './createApi'
 export { buildCreateApi } from './createApi'
 export { fakeBaseQuery } from './fakeBaseQuery'
 export { copyWithStructuralSharing } from './utils/copyWithStructuralSharing'
-export { createApi, coreModule } from './core'
+export { createApi, coreModule, coreModuleName } from './core'
+export type {
+  ApiEndpointMutation,
+  ApiEndpointQuery,
+  CoreModule,
+  PrefetchOptions,
+} from './core/module'
 export { defaultSerializeQueryArgs } from './defaultSerializeQueryArgs'
+export type { SerializeQueryArgs } from './defaultSerializeQueryArgs'
+
+export type {
+  Id as TSHelpersId,
+  NoInfer as TSHelpersNoInfer,
+  Override as TSHelpersOverride,
+} from './tsHelpers'

--- a/packages/toolkit/src/query/react/ApiProvider.tsx
+++ b/packages/toolkit/src/query/react/ApiProvider.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import { Provider } from 'react-redux'
 import { setupListeners } from '@reduxjs/toolkit/query'
-import type { Api } from '@reduxjs/toolkit/dist/query/apiTypes'
+import type { Api } from '@reduxjs/toolkit/query'
 
 /**
  * Can be used as a `Provider` if you **do not already have a Redux store**.

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -17,37 +17,37 @@ import type {
   SubscriptionOptions,
   QueryKeys,
   RootState,
-} from '@reduxjs/toolkit/dist/query/core/apiState'
+} from '@reduxjs/toolkit/query'
 import type {
   EndpointDefinitions,
   MutationDefinition,
   QueryDefinition,
   QueryArgFrom,
   ResultTypeFrom,
-} from '@reduxjs/toolkit/dist/query/endpointDefinitions'
+} from '@reduxjs/toolkit/query'
 import type {
   QueryResultSelectorResult,
   MutationResultSelectorResult,
   SkipToken,
-} from '@reduxjs/toolkit/dist/query/core/buildSelectors'
+} from '@reduxjs/toolkit/query'
 import type {
   QueryActionCreatorResult,
   MutationActionCreatorResult,
-} from '@reduxjs/toolkit/dist/query/core/buildInitiate'
-import type { SerializeQueryArgs } from '@reduxjs/toolkit/dist/query/defaultSerializeQueryArgs'
+} from '@reduxjs/toolkit/query'
+import type { SerializeQueryArgs } from '@reduxjs/toolkit/query'
 import { shallowEqual } from 'react-redux'
-import type { Api, ApiContext } from '@reduxjs/toolkit/dist/query/apiTypes'
+import type { Api, ApiContext } from '@reduxjs/toolkit/query'
 import type {
-  Id,
-  NoInfer,
-  Override,
-} from '@reduxjs/toolkit/dist/query/tsHelpers'
+  TSHelpersId,
+  TSHelpersNoInfer,
+  TSHelpersOverride,
+} from '@reduxjs/toolkit/query'
 import type {
   ApiEndpointMutation,
   ApiEndpointQuery,
   CoreModule,
   PrefetchOptions,
-} from '@reduxjs/toolkit/dist/query/core/module'
+} from '@reduxjs/toolkit/query'
 import type { ReactHooksModuleOptions } from './module'
 import { useStableQueryArgs } from './useSerializedStableValue'
 import type { UninitializedValue } from './constants'
@@ -374,7 +374,7 @@ export type UseQueryStateOptions<
 export type UseQueryStateResult<
   _ extends QueryDefinition<any, any, any, any>,
   R
-> = NoInfer<R>
+> = TSHelpersNoInfer<R>
 
 /**
  * Helper type to manually type the result
@@ -387,7 +387,7 @@ export type TypedUseQueryStateResult<
   R = UseQueryStateDefaultResult<
     QueryDefinition<QueryArg, BaseQuery, string, ResultType, string>
   >
-> = NoInfer<R>
+> = TSHelpersNoInfer<R>
 
 type UseQueryStateBaseResult<D extends QueryDefinition<any, any, any, any>> =
   QuerySubState<D> & {
@@ -420,15 +420,15 @@ type UseQueryStateBaseResult<D extends QueryDefinition<any, any, any, any>> =
   }
 
 type UseQueryStateDefaultResult<D extends QueryDefinition<any, any, any, any>> =
-  Id<
-    | Override<
+  TSHelpersId<
+    | TSHelpersOverride<
         Extract<
           UseQueryStateBaseResult<D>,
           { status: QueryStatus.uninitialized }
         >,
         { isUninitialized: true }
       >
-    | Override<
+    | TSHelpersOverride<
         UseQueryStateBaseResult<D>,
         | { isLoading: true; isFetching: boolean; data: undefined }
         | ({
@@ -477,7 +477,7 @@ export type UseMutationStateOptions<
 export type UseMutationStateResult<
   D extends MutationDefinition<any, any, any, any>,
   R
-> = NoInfer<R> & {
+> = TSHelpersNoInfer<R> & {
   originalArgs?: QueryArgFrom<D>
   /**
    * Resets the hook state to it's initial `uninitialized` state.

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -1,17 +1,5 @@
-import { coreModule, buildCreateApi, CreateApi } from '@reduxjs/toolkit/query'
+import { coreModule, buildCreateApi } from '@reduxjs/toolkit/query'
 import { reactHooksModule, reactHooksModuleName } from './module'
-
-import type { MutationHooks, QueryHooks } from './buildHooks'
-import type {
-  EndpointDefinitions,
-  QueryDefinition,
-  MutationDefinition,
-  QueryArgFrom,
-} from '@reduxjs/toolkit/dist/query/endpointDefinitions'
-import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
-
-import type { QueryKeys } from '@reduxjs/toolkit/dist/query/core/apiState'
-import type { PrefetchOptions } from '@reduxjs/toolkit/dist/query/core/module'
 
 export * from '@reduxjs/toolkit/query'
 export { ApiProvider } from './ApiProvider'
@@ -27,4 +15,4 @@ export type {
   TypedUseQuerySubscriptionResult,
   TypedUseMutationResult,
 } from './buildHooks'
-export { createApi, reactHooksModule }
+export { createApi, reactHooksModule, reactHooksModuleName }

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -6,11 +6,11 @@ import type {
   QueryDefinition,
   MutationDefinition,
   QueryArgFrom,
-} from '@reduxjs/toolkit/dist/query/endpointDefinitions'
+} from '@reduxjs/toolkit/query'
 import type { Api, Module } from '../apiTypes'
 import { capitalize } from '../utils'
 import { safeAssign } from '../tsHelpers'
-import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import type { BaseQueryFn } from '@reduxjs/toolkit/query'
 
 import type { HooksWithUniqueNames } from './namedHooks'
 
@@ -26,7 +26,7 @@ import type { PrefetchOptions } from '../core/module'
 export const reactHooksModuleName = /* @__PURE__ */ Symbol()
 export type ReactHooksModule = typeof reactHooksModuleName
 
-declare module '@reduxjs/toolkit/dist/query/apiTypes' {
+declare module '@reduxjs/toolkit/query' {
   export interface ApiModules<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     BaseQuery extends BaseQueryFn,

--- a/packages/toolkit/src/query/react/namedHooks.ts
+++ b/packages/toolkit/src/query/react/namedHooks.ts
@@ -4,7 +4,7 @@ import type {
   EndpointDefinitions,
   MutationDefinition,
   QueryDefinition,
-} from '@reduxjs/toolkit/dist/query/endpointDefinitions'
+} from '@reduxjs/toolkit/query'
 
 export type HooksWithUniqueNames<Definitions extends EndpointDefinitions> =
   keyof Definitions extends infer Keys

--- a/packages/toolkit/src/query/react/useSerializedStableValue.ts
+++ b/packages/toolkit/src/query/react/useSerializedStableValue.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useMemo } from 'react'
-import type { SerializeQueryArgs } from '@reduxjs/toolkit/dist/query/defaultSerializeQueryArgs'
-import type { EndpointDefinition } from '@reduxjs/toolkit/dist/query/endpointDefinitions'
+import type { SerializeQueryArgs } from '@reduxjs/toolkit/query'
+import type { EndpointDefinition } from '@reduxjs/toolkit/query'
 
 export function useStableQueryArgs<T>(
   queryArgs: T,


### PR DESCRIPTION
- Tries to fix all of our uses of `/dist/` in type imports, by re-exporting needed types

<sub>[RED-23](https://linear.app/redux/issue/RED-23/fix-updated-type-references-to-resolve-portable-types-issue)</sub>