### PR TITLE
Add example to refetch request in `usage without react hooks` documentation page

### DIFF
--- a/docs/rtk-query/usage/usage-without-react-hooks.mdx
+++ b/docs/rtk-query/usage/usage-without-react-hooks.mdx
@@ -23,10 +23,8 @@ Cache subscriptions are used to tell RTK Query that it needs to fetch data for a
 With React hooks, this behavior is instead handled within [`useQuery`](../api/created-api/hooks.mdx#usequery), [`useQuerySubscription`](../api/created-api/hooks.mdx#usequerysubscription), [`useLazyQuery`](../api/created-api/hooks.mdx#uselazyquery), and [`useLazyQuerySubscription`](../api/created-api/hooks.mdx#uselazyquerysubscription).
 
 ```ts title="Subscribing to cached data" no-transpile
-const subscription = dispatch(api.endpoints.getPosts.initiate())
-// The subscription contains the same methods as you would find in the hook
-// ...subscription.refetch();
-// ...subscription.isLoading;
+// interact with the cache in the same way as you would with a useFetch...() hook
+const {data, refetch, isLoading, isSuccess, /*...*/} = dispatch(api.endpoints.getPosts.initiate())
 ```
 
 ## Removing a subscription

--- a/docs/rtk-query/usage/usage-without-react-hooks.mdx
+++ b/docs/rtk-query/usage/usage-without-react-hooks.mdx
@@ -23,7 +23,10 @@ Cache subscriptions are used to tell RTK Query that it needs to fetch data for a
 With React hooks, this behavior is instead handled within [`useQuery`](../api/created-api/hooks.mdx#usequery), [`useQuerySubscription`](../api/created-api/hooks.mdx#usequerysubscription), [`useLazyQuery`](../api/created-api/hooks.mdx#uselazyquery), and [`useLazyQuerySubscription`](../api/created-api/hooks.mdx#uselazyquerysubscription).
 
 ```ts title="Subscribing to cached data" no-transpile
-dispatch(api.endpoints.getPosts.initiate())
+const subscription = dispatch(api.endpoints.getPosts.initiate())
+// The subscription contains the same methods as you would find in the hook
+// ...subscription.refetch();
+// ...subscription.isLoading;
 ```
 
 ## Removing a subscription


### PR DESCRIPTION
I experienced the issue that my endpoint wouldn't get refetched when I subscribed to the cache using the code example on the `usage without react hooks` page. The problem was that subscribing isn't enough, you need to call `refetch()` on the subscription.

This PR adds a short comment to make clear that the subscription is the object you can _use_ to interact with the cache, not sending the request itself.

I believe that wanting to re-send the request is a common enough use-case to be mentioned directly in the first example.

The wording can of course be changed if preferred.