### PR TITLE
Add settled matcher for createAsyncThunk

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -5,8 +5,16 @@ import type {
 } from './createAction'
 import { createAction } from './createAction'
 import type { ThunkDispatch } from 'redux-thunk'
-import type { FallbackIfUnknown, Id, IsAny, IsUnknown } from './tsHelpers'
+import type {
+  ActionFromMatcher,
+  FallbackIfUnknown,
+  Id,
+  IsAny,
+  IsUnknown,
+  TypeGuard,
+} from './tsHelpers'
 import { nanoid } from './nanoid'
+import { isAnyOf } from './matchers'
 
 // @ts-ignore we need the import of these types due to a bundling issue.
 type _Keep = PayloadAction | ActionCreatorWithPreparedPayload<any, unknown>
@@ -415,6 +423,13 @@ export type AsyncThunk<
     ThunkArg,
     ThunkApiConfig
   >
+  // matchSettled?
+  settled: (
+    action: any
+  ) => action is ReturnType<
+    | AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig>
+    | AsyncThunkFulfilledActionCreator<Returned, ThunkArg, ThunkApiConfig>
+  >
   typePrefix: string
 }
 
@@ -676,6 +691,7 @@ export const createAsyncThunk = (() => {
         pending,
         rejected,
         fulfilled,
+        settled: isAnyOf(rejected, fulfilled),
         typePrefix,
       }
     )

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -37,6 +37,20 @@ describe('createAsyncThunk', () => {
     expect(thunkActionCreator.typePrefix).toBe('testType')
   })
 
+  it('includes a settled matcher', () => {
+    const thunkActionCreator = createAsyncThunk('testType', async () => 42)
+    expect(thunkActionCreator.settled).toEqual(expect.any(Function))
+    expect(thunkActionCreator.settled(thunkActionCreator.pending(''))).toBe(
+      false
+    )
+    expect(
+      thunkActionCreator.settled(thunkActionCreator.rejected(null, ''))
+    ).toBe(true)
+    expect(
+      thunkActionCreator.settled(thunkActionCreator.fulfilled(42, ''))
+    ).toBe(true)
+  })
+
   it('works without passing arguments to the payload creator', async () => {
     const thunkActionCreator = createAsyncThunk('testType', async () => 42)
 
@@ -513,7 +527,7 @@ describe('createAsyncThunk with abortController', () => {
         }
       )
 
-      expect(longRunningAsyncThunk()).toThrow("AbortController is not defined")
+      expect(longRunningAsyncThunk()).toThrow('AbortController is not defined')
     })
   })
 })
@@ -975,6 +989,7 @@ describe('meta', () => {
     expect(thunk.fulfilled).toEqual(expectFunction)
     expect(thunk.pending).toEqual(expectFunction)
     expect(thunk.rejected).toEqual(expectFunction)
+    expect(thunk.settled).toEqual(expectFunction)
     expect(thunk.fulfilled.type).toBe('a/fulfilled')
   })
 })

--- a/packages/toolkit/src/tests/createSlice.test.ts
+++ b/packages/toolkit/src/tests/createSlice.test.ts
@@ -576,6 +576,9 @@ describe('createSlice', () => {
     function rejected(state: any[], action: any) {
       state.push(['rejectedReducer', action])
     }
+    function settled(state: any[], action: any) {
+      state.push(['settledReducer', action])
+    }
 
     test('successful thunk', async () => {
       const slice = createSlice({
@@ -586,7 +589,7 @@ describe('createSlice', () => {
             function payloadCreator(arg, api) {
               return Promise.resolve('resolved payload')
             },
-            { pending, fulfilled, rejected }
+            { pending, fulfilled, rejected, settled }
           ),
         }),
       })
@@ -610,6 +613,13 @@ describe('createSlice', () => {
             payload: 'resolved payload',
           },
         ],
+        [
+          'settledReducer',
+          {
+            type: 'test/thunkReducers/fulfilled',
+            payload: 'resolved payload',
+          },
+        ],
       ])
     })
 
@@ -623,7 +633,7 @@ describe('createSlice', () => {
             function payloadCreator(arg, api): any {
               throw new Error('')
             },
-            { pending, fulfilled, rejected }
+            { pending, fulfilled, rejected, settled }
           ),
         }),
       })
@@ -642,6 +652,13 @@ describe('createSlice', () => {
         ],
         [
           'rejectedReducer',
+          {
+            type: 'test/thunkReducers/rejected',
+            payload: undefined,
+          },
+        ],
+        [
+          'settledReducer',
           {
             type: 'test/thunkReducers/rejected',
             payload: undefined,
@@ -669,6 +686,7 @@ describe('createSlice', () => {
               pending,
               fulfilled,
               rejected,
+              settled,
             }
           ),
         }),
@@ -687,6 +705,14 @@ describe('createSlice', () => {
             meta: { condition: true },
           },
         ],
+        [
+          'settledReducer',
+          {
+            type: 'test/thunkReducers/rejected',
+            payload: undefined,
+            meta: { condition: true },
+          },
+        ],
       ])
     })
 
@@ -699,13 +725,14 @@ describe('createSlice', () => {
             function payloadCreator(arg, api) {
               return Promise.resolve('resolved payload')
             },
-            { pending, fulfilled }
+            { pending, fulfilled, settled }
           ),
         }),
       })
 
       expect(slice.caseReducers.thunkReducers.pending).toBe(pending)
       expect(slice.caseReducers.thunkReducers.fulfilled).toBe(fulfilled)
+      expect(slice.caseReducers.thunkReducers.settled).toBe(settled)
       // even though it is not defined above, this should at least be a no-op function to match the TypeScript typings
       // and should be callable as a reducer even if it does nothing
       expect(() =>

--- a/packages/toolkit/src/tests/createSlice.typetest.ts
+++ b/packages/toolkit/src/tests/createSlice.typetest.ts
@@ -16,7 +16,7 @@ import type {
   ThunkDispatch,
   ValidateSliceCaseReducers,
 } from '@reduxjs/toolkit'
-import { configureStore } from '@reduxjs/toolkit'
+import { configureStore, isRejected } from '@reduxjs/toolkit'
 import { createAction, createSlice } from '@reduxjs/toolkit'
 import { expectExactType, expectType, expectUnknown } from './helpers'
 import { castDraft } from 'immer'
@@ -642,6 +642,18 @@ const value = actionCreators.anyKey
               expectType<TestArg>(action.meta.arg)
               expectType<SerializedError>(action.error)
             },
+            settled(state, action) {
+              expectType<TestState>(state)
+              if (isRejected(action)) {
+                expectType<TestState>(state)
+                expectType<TestArg>(action.meta.arg)
+                expectType<SerializedError>(action.error)
+              } else {
+                expectType<TestState>(state)
+                expectType<TestArg>(action.meta.arg)
+                expectType<TestReturned>(action.payload)
+              }
+            },
           }
         ),
         testExplicitType: create.asyncThunk<
@@ -679,6 +691,19 @@ const value = actionCreators.anyKey
               expectType<SerializedError>(action.error)
               expectType<TestReject | undefined>(action.payload)
             },
+            settled(state, action) {
+              expectType<TestState>(state)
+              if (isRejected(action)) {
+                expectType<TestState>(state)
+                expectType<TestArg>(action.meta.arg)
+                expectType<SerializedError>(action.error)
+                expectType<TestReject | undefined>(action.payload)
+              } else {
+                expectType<TestState>(state)
+                expectType<TestArg>(action.meta.arg)
+                expectType<TestReturned>(action.payload)
+              }
+            },
           }
         ),
         testPretyped: pretypedAsyncThunk(
@@ -701,6 +726,19 @@ const value = actionCreators.anyKey
               expectType<TestArg>(action.meta.arg)
               expectType<SerializedError>(action.error)
               expectType<TestReject | undefined>(action.payload)
+            },
+            settled(state, action) {
+              expectType<TestState>(state)
+              if (isRejected(action)) {
+                expectType<TestState>(state)
+                expectType<TestArg>(action.meta.arg)
+                expectType<SerializedError>(action.error)
+                expectType<TestReject | undefined>(action.payload)
+              } else {
+                expectType<TestState>(state)
+                expectType<TestArg>(action.meta.arg)
+                expectType<TestReturned>(action.payload)
+              }
             },
           }
         ),

--- a/packages/toolkit/src/tests/createSlice.typetest.ts
+++ b/packages/toolkit/src/tests/createSlice.typetest.ts
@@ -644,13 +644,10 @@ const value = actionCreators.anyKey
             },
             settled(state, action) {
               expectType<TestState>(state)
+              expectType<TestArg>(action.meta.arg)
               if (isRejected(action)) {
-                expectType<TestState>(state)
-                expectType<TestArg>(action.meta.arg)
                 expectType<SerializedError>(action.error)
               } else {
-                expectType<TestState>(state)
-                expectType<TestArg>(action.meta.arg)
                 expectType<TestReturned>(action.payload)
               }
             },
@@ -693,14 +690,11 @@ const value = actionCreators.anyKey
             },
             settled(state, action) {
               expectType<TestState>(state)
+              expectType<TestArg>(action.meta.arg)
               if (isRejected(action)) {
-                expectType<TestState>(state)
-                expectType<TestArg>(action.meta.arg)
                 expectType<SerializedError>(action.error)
                 expectType<TestReject | undefined>(action.payload)
               } else {
-                expectType<TestState>(state)
-                expectType<TestArg>(action.meta.arg)
                 expectType<TestReturned>(action.payload)
               }
             },
@@ -729,14 +723,11 @@ const value = actionCreators.anyKey
             },
             settled(state, action) {
               expectType<TestState>(state)
+              expectType<TestArg>(action.meta.arg)
               if (isRejected(action)) {
-                expectType<TestState>(state)
-                expectType<TestArg>(action.meta.arg)
                 expectType<SerializedError>(action.error)
                 expectType<TestReject | undefined>(action.payload)
               } else {
-                expectType<TestState>(state)
-                expectType<TestArg>(action.meta.arg)
                 expectType<TestReturned>(action.payload)
               }
             },


### PR DESCRIPTION
Adds a `settled` matcher (matches against both fulfilled and rejected actions) to an async thunk instance, and adds the ability to supply a reducer for it with the create callback syntax
```ts
builder.addMatcher(asyncThunk.settled, reducer);
// or
create.asyncThunk(payloadCreator, { settled })
```