### PR TITLE
chore: Fixed oazapfts typescript version in rtk-query-codegen-openapi

### DIFF
--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -63,6 +63,9 @@
     "swagger2openapi": "^7.0.4",
     "typescript": ">=4.1 <=4.5"
   },
+  "resolutions": {
+    "typescript": ">=4.1 <=4.5"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"

--- a/packages/rtk-query-codegen-openapi/test/cli.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/cli.test.ts
@@ -70,7 +70,7 @@ Done
 
     expect(fromTs).toEqual(fromJs);
     expect(fromJson).toEqual(fromJs);
-  }, 25000);
+  }, 45000);
 
   test('missing parameters doesnt fail', async () => {
     const out = await cli([`./config.invalid-example.json`], __dirname);

--- a/yarn.lock
+++ b/yarn.lock
@@ -27111,7 +27111,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=4.1 <=4.5, typescript@npm:^4.1.2, typescript@npm:^4.1.3, typescript@npm:^4.3.4":
+"typescript@npm:>=4.1 <=4.5":
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.1.2, typescript@npm:^4.1.3, typescript@npm:^4.3.4":
   version: 4.5.2
   resolution: "typescript@npm:4.5.2"
   bin:
@@ -27161,7 +27171,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@>=4.1 <=4.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.3.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@>=4.1 <=4.5#~builtin<compat/typescript>":
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=701156"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 858c61fa63f7274ca4aaaffeced854d550bf416cff6e558c4884041b3311fb662f476f167cf5c9f8680c607239797e26a2ee0bcc6467fbc05bfcb218e1c6c671
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.1.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.3.4#~builtin<compat/typescript>":
   version: 4.5.2
   resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=701156"
   bin:


### PR DESCRIPTION
https://github.com/reduxjs/redux-toolkit/issues/3765

The reason for this is that codegen's TypeScript version was 4.5, but oazapfts' TypeScript version was 4.9.2, which broke compatibility.

To fix this problem, it would be best to use the resolution field and fix the oazapfts TypeScript version to the user's TypeScript version.

The test timed out, so the test time was extended.
https://github.com/reduxjs/redux-toolkit/actions/runs/6388673287/job/17338896802