### PR TITLE
Copy of "Work around known TS bug with type inference #3761"

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -28,6 +28,7 @@
   "types": "dist/index.d.ts",
   "devDependencies": {
     "@microsoft/api-extractor": "^7.13.2",
+    "@phryneas/ts-version": "^1.0.2",
     "@size-limit/preset-small-lib": "^4.11.0",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6421,6 +6421,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@phryneas/ts-version@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@phryneas/ts-version@npm:1.0.2"
+  checksum: d51914a8ea35ff8b686a9379b9e9fe6d5b5feaf2e7511b880d2835015736e33bc82952bbc369918f251d4a755f32f4a9c4a34b0ec4dfdbc3e87a41d26401105c
+  languageName: node
+  linkType: hard
+
 "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.3":
   version: 0.5.7
   resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.7"
@@ -6554,6 +6561,7 @@ __metadata:
   resolution: "@reduxjs/toolkit@workspace:packages/toolkit"
   dependencies:
     "@microsoft/api-extractor": ^7.13.2
+    "@phryneas/ts-version": ^1.0.2
     "@size-limit/preset-small-lib": ^4.11.0
     "@testing-library/react": ^13.3.0
     "@testing-library/user-event": ^13.1.5


### PR DESCRIPTION
Cherry-picked Mark's bugfix commits from the `v2.0-integration` branch. Fixes #3758.