### PR TITLE
Codegen: better handling of duplicate param names

### DIFF
--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -17,10 +17,10 @@
     "rtk-query-codegen-openapi": "lib/bin/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x lib/bin/cli.js",
     "prepare": "npm run build && chmod +x ./lib/bin/cli.js",
     "format": "prettier --write \"src/**/*.ts\"",
-    "test:update": "lib/bin/cli.js test/fixtures/petstore.json --file test/fixtures/generated.ts -h",
+    "test:update": "jest --runInBand --updateSnapshot",
     "test:update:enum": "lib/bin/cli.js test/config.example.enum.ts",
     "test": "jest --runInBand",
     "cli": "esr src/bin/cli.ts"

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -258,29 +258,27 @@ export async function generateApi(
 
     const allNames = parameters.map((p) => p.name);
     const queryArg: QueryArgDefinitions = {};
-    for (const param of parameters) {
-      const isPureSnakeCase = /^[a-zA-Z][\\w]*$/.test(param.name);
-      const camelCaseName = camelCase(param.name);
-
-      let name = isPureSnakeCase && !allNames.includes(camelCaseName) ? camelCaseName : param.name;
-
-      if (name in queryArg) {
-        let duplicatedNewName = `${queryArg[name].param?.in}_${name}`
-        duplicatedNewName = isPureSnakeCase && !allNames.includes(duplicatedNewName) ? camelCase(duplicatedNewName) : duplicatedNewName
-        while (duplicatedNewName in queryArg) {
-          duplicatedNewName = '_' + duplicatedNewName;
-        }
-        queryArg[duplicatedNewName] = queryArg[name]
-        queryArg[duplicatedNewName].name = duplicatedNewName
-        delete queryArg[name]
-
-        name = `${param.in}_${name}`
-        name = isPureSnakeCase && !allNames.includes(name) ? camelCase(name) : name;
+    function generateName(name: string, potentialPrefix: string) {
+      const isPureSnakeCase = /^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
+      // prefix with `query`, `path` or `body` if there are multiple paramters with the same name
+      const hasNamingConflict = allNames.filter((n) => n === name).length > 1;
+      if (hasNamingConflict) {
+        name = `${potentialPrefix}_${name}`;
       }
+      // convert to camelCase if the name is pure snake_case and there are no naming conflicts
+      const camelCaseName = camelCase(name);
+      if (isPureSnakeCase && !allNames.includes(camelCaseName)) {
+        name = camelCaseName;
+      }
+      // if there are still any naming conflicts, prepend with underscore
       while (name in queryArg) {
         name = '_' + name;
       }
+      return name;
+    }
 
+    for (const param of parameters) {
+      const name = generateName(param.name, param.in);
       queryArg[name] = {
         origin: 'param',
         name,
@@ -296,11 +294,7 @@ export async function generateApi(
       const schema = apiGen.getSchemaFromContent(body.content);
       const type = apiGen.getTypeFromSchema(schema);
       const schemaName = camelCase((type as any).name || getReferenceName(schema) || 'body');
-      let name = schemaName in queryArg ? 'body' : schemaName;
-
-      while (name in queryArg) {
-        name = '_' + name;
-      }
+      const name = generateName(schemaName in queryArg ? 'body' : schemaName, 'body');
 
       queryArg[name] = {
         origin: 'body',
@@ -496,7 +490,7 @@ type QueryArgDefinition = {
   originalName: string;
   type: ts.TypeNode;
   required?: boolean;
-  param?: OpenAPIV3.ParameterObject
+  param?: OpenAPIV3.ParameterObject;
 } & (
   | {
       origin: 'param';

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -262,7 +262,24 @@ export async function generateApi(
       const isPureSnakeCase = /^[a-zA-Z][\\w]*$/.test(param.name);
       const camelCaseName = camelCase(param.name);
 
-      const name = isPureSnakeCase && !allNames.includes(camelCaseName) ? camelCaseName : param.name;
+      let name = isPureSnakeCase && !allNames.includes(camelCaseName) ? camelCaseName : param.name;
+
+      if (name in queryArg) {
+        let duplicatedNewName = `${queryArg[name].param?.in}_${name}`
+        duplicatedNewName = isPureSnakeCase && !allNames.includes(duplicatedNewName) ? camelCase(duplicatedNewName) : duplicatedNewName
+        while (duplicatedNewName in queryArg) {
+          duplicatedNewName = '_' + duplicatedNewName;
+        }
+        queryArg[duplicatedNewName] = queryArg[name]
+        queryArg[duplicatedNewName].name = duplicatedNewName
+        delete queryArg[name]
+
+        name = `${param.in}_${name}`
+        name = isPureSnakeCase && !allNames.includes(name) ? camelCase(name) : name;
+      }
+      while (name in queryArg) {
+        name = '_' + name;
+      }
 
       queryArg[name] = {
         origin: 'param',
@@ -479,6 +496,7 @@ type QueryArgDefinition = {
   originalName: string;
   type: ts.TypeNode;
   required?: boolean;
+  param?: OpenAPIV3.ParameterObject
 } & (
   | {
       origin: 'param';

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -263,6 +263,39 @@ export type User = {
 
 `;
 
+exports[`duplicate parameter names must be prefixed with a path or query prefix 1`] = `
+import { api } from './fixtures/emptyApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    patchApiV1ListByItemId: build.mutation<PatchApiV1ListByItemIdApiResponse, PatchApiV1ListByItemIdApiArg>({
+      query: (queryArg) => ({
+        url: \`/api/v1/list/\${queryArg['item.id']}\`,
+        method: 'PATCH',
+      }),
+    }),
+    patchApiV2BySomeName: build.mutation<PatchApiV2BySomeNameApiResponse, PatchApiV2BySomeNameApiArg>({
+      query: (queryArg) => ({
+        url: \`/api/v2/\${queryArg.pathSomeName}\`,
+        method: 'PATCH',
+        params: { some_name: queryArg.querySomeName },
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type PatchApiV1ListByItemIdApiResponse = /** status 200 A successful response. */ string;
+export type PatchApiV1ListByItemIdApiArg = {
+  'item.id': string;
+};
+export type PatchApiV2BySomeNameApiResponse = /** status 200 A successful response. */ string;
+export type PatchApiV2BySomeNameApiArg = {
+  pathSomeName: string;
+  querySomeName: string;
+};
+
+`;
+
 exports[`endpoint filtering: should only have endpoints loginUser, placeOrder, getOrderById, deleteOrder 1`] = `
 import { api } from './fixtures/emptyApi';
 const injectedRtkApi = api.injectEndpoints({
@@ -434,6 +467,13 @@ const injectedRtkApi = api.injectEndpoints({
         method: 'PATCH',
       }),
     }),
+    patchApiV2BySomeName: build.mutation<PatchApiV2BySomeNameApiResponse, PatchApiV2BySomeNameApiArg>({
+      query: (queryArg) => ({
+        url: \`/api/v2/\${queryArg.pathSomeName}\`,
+        method: 'PATCH',
+        params: { some_name: queryArg.querySomeName },
+      }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -441,6 +481,11 @@ export { injectedRtkApi as enhancedApi };
 export type PatchApiV1ListByItemIdApiResponse = /** status 200 A successful response. */ string;
 export type PatchApiV1ListByItemIdApiArg = {
   'item.id': string;
+};
+export type PatchApiV2BySomeNameApiResponse = /** status 200 A successful response. */ string;
+export type PatchApiV2BySomeNameApiArg = {
+  pathSomeName: string;
+  querySomeName: string;
 };
 
 `;

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -1050,7 +1050,7 @@ const injectedRtkApi = api
     overrideExisting: false,
   });
 export { injectedRtkApi as enhancedApi };
-export type GetStructureDefinitionApiResponse = unknown;
+export type GetStructureDefinitionApiResponse = /** status 200 Success */ FhirJsonResource;
 export type GetStructureDefinitionApiArg = {
   /** Some description */
   foo?: any;
@@ -1069,6 +1069,7 @@ export type GetStructureDefinitionApiArg = {
   /** Some description */
   naming_conflict?: any;
 };
+export type FhirJsonResource = object;
 export const { useGetStructureDefinitionQuery } = injectedRtkApi;
 
 `;

--- a/packages/rtk-query-codegen-openapi/test/fixtures/params.json
+++ b/packages/rtk-query-codegen-openapi/test/fixtures/params.json
@@ -27,6 +27,32 @@
           }
         ]
       }
+    },
+    "/api/v2/{some_name}": {
+      "patch": {
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "some_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "some_name",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
     }
   }
 }

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -229,6 +229,18 @@ test('should use brackets in a querystring urls arg, when the arg contains full 
   expect(api).toMatchSnapshot();
 });
 
+test('duplicate parameter names must be prefixed with a path or query prefix', async () => {
+  const api = await generateEndpoints({
+    unionUndefined: true,
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/params.json'),
+  });
+  // eslint-disable-next-line no-template-curly-in-string
+  expect(api).toContain('pathSomeName: string');
+  expect(api).toContain('querySomeName: string');
+  expect(api).toMatchSnapshot();
+});
+
 test('apiImport builds correct `import` statement', async () => {
   const api = await generateEndpoints({
     unionUndefined: true,


### PR DESCRIPTION
When we generated this swagger, the names of the path parameter and query parameter were covered and broken, so we fixed it.

```json
"/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}": {
  "get": {
    "tags": ["core_v1"],
    "description": "connect GET requests to proxy of Pod",
    "operationId": "connectCoreV1GetNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "put": {
    "tags": ["core_v1"],
    "description": "connect PUT requests to proxy of Pod",
    "operationId": "connectCoreV1PutNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "post": {
    "tags": ["core_v1"],
    "description": "connect POST requests to proxy of Pod",
    "operationId": "connectCoreV1PostNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "delete": {
    "tags": ["core_v1"],
    "description": "connect DELETE requests to proxy of Pod",
    "operationId": "connectCoreV1DeleteNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "options": {
    "tags": ["core_v1"],
    "description": "connect OPTIONS requests to proxy of Pod",
    "operationId": "connectCoreV1OptionsNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "head": {
    "tags": ["core_v1"],
    "description": "connect HEAD requests to proxy of Pod",
    "operationId": "connectCoreV1HeadNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "patch": {
    "tags": ["core_v1"],
    "description": "connect PATCH requests to proxy of Pod",
    "operationId": "connectCoreV1PatchNamespacedPodProxyWithPath",
    "responses": {
      "200": {
        "description": "OK",
        "content": { "*/*": { "schema": { "type": "string" } } }
      },
      "401": { "description": "Unauthorized" }
    },
    "x-kubernetes-action": "connect",
    "x-kubernetes-group-version-kind": {
      "group": "",
      "version": "v1",
      "kind": "PodProxyOptions"
    }
  },
  "parameters": [
    {
      "name": "name",
      "in": "path",
      "description": "name of the PodProxyOptions",
      "required": true,
      "schema": { "type": "string", "uniqueItems": true }
    },
    {
      "name": "namespace",
      "in": "path",
      "description": "object name and auth scope, such as for teams and projects",
      "required": true,
      "schema": { "type": "string", "uniqueItems": true }
    },
    {
      "name": "path",
      "in": "path",
      "description": "path to the resource",
      "required": true,
      "schema": { "type": "string", "uniqueItems": true }
    },
    {
      "name": "path",
      "in": "query",
      "description": "Path is the URL path to use for the current proxy request to pod.",
      "schema": { "type": "string", "uniqueItems": true }
    }
  ]
},
```