### PR TITLE
Rewrite RTKQ internal subscription lookups and subscription syncing

### DIFF
--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -266,7 +266,9 @@ export function buildInitiate({
   function middlewareWarning(dispatch: Dispatch) {
     if (process.env.NODE_ENV !== 'production') {
       if ((middlewareWarning as any).triggered) return
-      const returnedValue = dispatch(api.internalActions.getRTKQInternalState())
+      const returnedValue = dispatch(
+        api.internalActions.internal_getRTKQSubscriptions()
+      )
 
       ;(middlewareWarning as any).triggered = true
 

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -265,19 +265,16 @@ export function buildInitiate({
   function middlewareWarning(dispatch: Dispatch) {
     if (process.env.NODE_ENV !== 'production') {
       if ((middlewareWarning as any).triggered) return
-      const registered:
-        | ReturnType<typeof api.internalActions.internal_probeSubscription>
-        | boolean = dispatch(
-        api.internalActions.internal_probeSubscription({
-          queryCacheKey: 'DOES_NOT_EXIST',
-          requestId: 'DUMMY_REQUEST_ID',
-        })
-      )
+      const returnedValue = dispatch(api.internalActions.getRTKQInternalState())
 
       ;(middlewareWarning as any).triggered = true
 
-      // The RTKQ middleware _should_ always return a boolean for `probeSubscription`
-      if (typeof registered !== 'boolean') {
+      // The RTKQ middleware should return the internal state object,
+      // but it should _not_ be the action object.
+      if (
+        typeof returnedValue !== 'object' ||
+        typeof returnedValue?.type === 'string'
+      ) {
         // Otherwise, must not have been added
         throw new Error(
           `Warning: Middleware for RTK-Query API at reducerPath "${api.reducerPath}" has not been added to the store.

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -20,6 +20,7 @@ import type { BaseQueryError, QueryReturnValue } from '../baseQueryTypes'
 import type { QueryResultSelectorResult } from './buildSelectors'
 import type { Dispatch } from 'redux'
 import { isNotNullish } from '../utils/isNotNullish'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 declare module './module' {
   export interface ApiEndpointQuery<
@@ -392,7 +393,7 @@ You must add the middleware for RTK-Query to function correctly!`
 
           statePromise.then(() => {
             delete running[queryCacheKey]
-            if (!Object.keys(running).length) {
+            if (!countObjectKeys(running)) {
               runningQueries.delete(dispatch)
             }
           })
@@ -440,7 +441,7 @@ You must add the middleware for RTK-Query to function correctly!`
         running[requestId] = ret
         ret.then(() => {
           delete running[requestId]
-          if (!Object.keys(running).length) {
+          if (!countObjectKeys(running)) {
             runningMutations.delete(dispatch)
           }
         })
@@ -449,7 +450,7 @@ You must add the middleware for RTK-Query to function correctly!`
           ret.then(() => {
             if (running[fixedCacheKey] === ret) {
               delete running[fixedCacheKey]
-              if (!Object.keys(running).length) {
+              if (!countObjectKeys(running)) {
                 runningMutations.delete(dispatch)
               }
             }

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -71,6 +71,7 @@ export function buildMiddleware<
       >),
       internalState,
       refetchQuery,
+      isThisApiSliceAction,
     }
 
     const handlers = handlerBuilders.map((build) => build(builderArgs))
@@ -93,18 +94,15 @@ export function buildMiddleware<
 
         const stateBefore = mwApi.getState()
 
-        const [actionShouldContinue, hasSubscription] = batchedActionsHandler(
-          action,
-          mwApiWithNext,
-          stateBefore
-        )
+        const [actionShouldContinue, internalProbeResult] =
+          batchedActionsHandler(action, mwApiWithNext, stateBefore)
 
         let res: any
 
         if (actionShouldContinue) {
           res = next(action)
         } else {
-          res = hasSubscription
+          res = internalProbeResult
         }
 
         if (!!mwApi.getState()[reducerPath]) {

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -11,6 +11,7 @@ import type {
   ApiMiddlewareInternalHandler,
   InternalMiddlewareState,
 } from './types'
+import { countObjectKeys } from '../../utils/countObjectKeys'
 
 export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
   reducerPath,
@@ -77,7 +78,7 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
           internalState.currentSubscriptions[queryCacheKey] ?? {}
 
         if (querySubState) {
-          if (Object.keys(subscriptionSubState).length === 0) {
+          if (countObjectKeys(subscriptionSubState) === 0) {
             mwApi.dispatch(
               removeQueryResult({
                 queryCacheKey: queryCacheKey as QueryCacheKey,

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -61,6 +61,7 @@ export interface BuildSubMiddlewareInput
     queryCacheKey: string,
     override?: Partial<QueryThunkArg>
   ): AsyncThunkAction<ThunkResult, QueryThunkArg, {}>
+  isThisApiSliceAction: (action: Action) => boolean
 }
 
 export type SubMiddlewareBuilder = (

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -32,6 +32,12 @@ export interface InternalMiddlewareState {
   currentSubscriptions: SubscriptionState
 }
 
+export interface SubscriptionSelectors {
+  getSubscriptions: () => SubscriptionState
+  getSubscriptionCount: (queryCacheKey: string) => number
+  isRequestSubscribed: (queryCacheKey: string, requestId: string) => boolean
+}
+
 export interface BuildMiddlewareInput<
   Definitions extends EndpointDefinitions,
   ReducerPath extends string,

--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -6,6 +6,7 @@ import type {
   InternalHandlerBuilder,
   SubMiddlewareApi,
 } from './types'
+import { countObjectKeys } from '../../utils/countObjectKeys'
 
 export const buildWindowEventHandler: InternalHandlerBuilder = ({
   reducerPath,
@@ -50,7 +51,7 @@ export const buildWindowEventHandler: InternalHandlerBuilder = ({
             state.config[type])
 
         if (shouldRefetch) {
-          if (Object.keys(subscriptionSubState).length === 0) {
+          if (countObjectKeys(subscriptionSubState) === 0) {
             api.dispatch(
               removeQueryResult({
                 queryCacheKey: queryCacheKey as QueryCacheKey,

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -443,7 +443,7 @@ export function buildSlice({
       ) {
         // Dummy
       },
-      getRTKQInternalState() {},
+      internal_getRTKQSubscriptions() {},
     },
   })
 

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -1,4 +1,4 @@
-import type { PayloadAction, UnknownAction } from '@reduxjs/toolkit'
+import type { Action, PayloadAction, UnknownAction } from '@reduxjs/toolkit'
 import {
   combineReducers,
   createAction,
@@ -443,12 +443,7 @@ export function buildSlice({
       ) {
         // Dummy
       },
-      internal_probeSubscription(
-        d,
-        a: PayloadAction<{ queryCacheKey: string; requestId: string }>
-      ) {
-        // dummy
-      },
+      getRTKQInternalState() {},
     },
   })
 

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -22,6 +22,7 @@ import {
 } from 'react-redux'
 import type { QueryKeys } from '../core/apiState'
 import type { PrefetchOptions } from '../core/module'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 export const reactHooksModuleName = /* @__PURE__ */ Symbol()
 export type ReactHooksModule = typeof reactHooksModuleName
@@ -147,7 +148,7 @@ export const reactHooksModule = ({
     let warned = false
     for (const hookName of hookNames) {
       // warn for old hook options
-      if (Object.keys(rest).length > 0) {
+      if (countObjectKeys(rest) > 0) {
         if ((rest as Partial<typeof hooks>)[hookName]) {
           if (!warned) {
             console.warn(

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -37,7 +37,7 @@ import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiSt
 import type { SerializedError } from '@reduxjs/toolkit'
 import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
 import { delay } from '../../utils'
-import type { InternalMiddlewareState } from '../core/buildMiddleware/types'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 import { countObjectKeys } from '../utils/countObjectKeys'
 
 // Just setup a temporary in-memory counter for tests that `getIncrementedAmount`.
@@ -140,18 +140,8 @@ const storeRef = setupApiStore(
   }
 )
 
-function getSubscriptions() {
-  const internalState = storeRef.store.dispatch(
-    api.internalActions.getRTKQInternalState()
-  ) as unknown as InternalMiddlewareState
-  return internalState?.currentSubscriptions ?? {}
-}
-
-function getSubscriptionCount(key: string) {
-  const subscriptions = getSubscriptions()
-  const subscriptionsForQueryArg = subscriptions[key] ?? {}
-  return countObjectKeys(subscriptionsForQueryArg)
-}
+let getSubscriptions: SubscriptionSelectors['getSubscriptions']
+let getSubscriptionCount: SubscriptionSelectors['getSubscriptionCount']
 
 beforeEach(() => {
   actions = []
@@ -161,6 +151,9 @@ beforeEach(() => {
       actions.push(action)
     },
   })
+  ;({ getSubscriptions, getSubscriptionCount } = storeRef.store.dispatch(
+    api.internalActions.internal_getRTKQSubscriptions()
+  ) as unknown as SubscriptionSelectors)
 })
 
 afterEach(() => {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -37,6 +37,7 @@ import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiSt
 import type { SerializedError } from '@reduxjs/toolkit'
 import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
 import { delay } from '../../utils'
+import type { InternalMiddlewareState } from '../core/buildMiddleware/types'
 
 // Just setup a temporary in-memory counter for tests that `getIncrementedAmount`.
 // This can be used to test how many renders happen due to data changes or
@@ -137,6 +138,19 @@ const storeRef = setupApiStore(
     },
   }
 )
+
+function getSubscriptions() {
+  const internalState = storeRef.store.dispatch(
+    api.internalActions.getRTKQInternalState()
+  ) as unknown as InternalMiddlewareState
+  return internalState?.currentSubscriptions ?? {}
+}
+
+function getSubscriptionCount(key: string) {
+  const subscriptions = getSubscriptions()
+  const subscriptionsForQueryArg = subscriptions[key] ?? {}
+  return Object.keys(subscriptionsForQueryArg).length
+}
 
 beforeEach(() => {
   actions = []
@@ -738,14 +752,13 @@ describe('hooks tests', () => {
         withoutTestLifecycles: true,
       })
 
-      const getSubscriptions = () => storeRef.store.getState().api.subscriptions
-
       const checkNumSubscriptions = (arg: string, count: number) => {
         const subscriptions = getSubscriptions()
         const cacheKeyEntry = subscriptions[arg]
 
         if (cacheKeyEntry) {
-          expect(Object.values(cacheKeyEntry).length).toBe(count)
+          const subscriptionCount = Object.keys(cacheKeyEntry) //getSubscriptionCount(arg)
+          expect(subscriptionCount).toBe(count)
         }
       }
 
@@ -1747,11 +1760,7 @@ describe('hooks tests', () => {
       }),
     })
 
-    const storeRef = setupApiStore(api, {
-      actions(state: UnknownAction[] = [], action: UnknownAction) {
-        return [...state, action]
-      },
-    })
+    const storeRef = setupApiStore(api, { ...actionsReducer })
     test('initially failed useQueries that provide an tag will refetch after a mutation invalidates it', async () => {
       const checkSessionData = { name: 'matt' }
       server.use(
@@ -1818,15 +1827,11 @@ describe('hooks tests', () => {
       expect(storeRef.store.getState().actions).toMatchSequence(
         api.internalActions.middlewareRegistered.match,
         checkSession.matchPending,
-        api.internalActions.subscriptionsUpdated.match,
         checkSession.matchRejected,
-        api.internalActions.subscriptionsUpdated.match,
         login.matchPending,
         login.matchFulfilled,
         checkSession.matchPending,
-        api.internalActions.subscriptionsUpdated.match,
-        checkSession.matchFulfilled,
-        api.internalActions.subscriptionsUpdated.match
+        checkSession.matchFulfilled
       )
     })
   })
@@ -2541,11 +2546,6 @@ describe('skip behaviour', () => {
     isUninitialized: true,
   }
 
-  function subscriptionCount(key: string) {
-    return Object.keys(storeRef.store.getState().api.subscriptions[key] || {})
-      .length
-  }
-
   test('normal skip', async () => {
     const { result, rerender } = renderHook(
       ([arg, options]: Parameters<typeof api.endpoints.getUser.useQuery>) =>
@@ -2558,14 +2558,14 @@ describe('skip behaviour', () => {
 
     expect(result.current).toEqual(uninitialized)
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
 
     await act(async () => {
       rerender([1])
     })
     expect(result.current).toMatchObject({ status: QueryStatus.fulfilled })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(1)
+    expect(getSubscriptionCount('getUser(1)')).toBe(1)
 
     await act(async () => {
       rerender([1, { skip: true }])
@@ -2576,7 +2576,7 @@ describe('skip behaviour', () => {
       data: { name: 'Timmy' },
     })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
   })
 
   test('skipToken', async () => {
@@ -2592,17 +2592,17 @@ describe('skip behaviour', () => {
     expect(result.current).toEqual(uninitialized)
     await delay(1)
 
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
     // also no subscription on `getUser(skipToken)` or similar:
-    expect(storeRef.store.getState().api.subscriptions).toEqual({})
+    expect(getSubscriptions()).toEqual({})
 
     await act(async () => {
       rerender([1])
     })
     expect(result.current).toMatchObject({ status: QueryStatus.fulfilled })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(1)
-    expect(storeRef.store.getState().api.subscriptions).not.toEqual({})
+    expect(getSubscriptionCount('getUser(1)')).toBe(1)
+    expect(getSubscriptions()).not.toEqual({})
 
     await act(async () => {
       rerender([skipToken])
@@ -2613,7 +2613,7 @@ describe('skip behaviour', () => {
       data: { name: 'Timmy' },
     })
     await delay(1)
-    expect(subscriptionCount('getUser(1)')).toBe(0)
+    expect(getSubscriptionCount('getUser(1)')).toBe(0)
   })
 
   test('skipping a previously fetched query retains the existing value as `data`, but clears `currentData`', async () => {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -38,6 +38,7 @@ import type { SerializedError } from '@reduxjs/toolkit'
 import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
 import { delay } from '../../utils'
 import type { InternalMiddlewareState } from '../core/buildMiddleware/types'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 // Just setup a temporary in-memory counter for tests that `getIncrementedAmount`.
 // This can be used to test how many renders happen due to data changes or
@@ -149,7 +150,7 @@ function getSubscriptions() {
 function getSubscriptionCount(key: string) {
   const subscriptions = getSubscriptions()
   const subscriptionsForQueryArg = subscriptions[key] ?? {}
-  return Object.keys(subscriptionsForQueryArg).length
+  return countObjectKeys(subscriptionsForQueryArg)
 }
 
 beforeEach(() => {
@@ -1439,25 +1440,19 @@ describe('hooks tests', () => {
 
       await screen.findByText(/isUninitialized/i)
       expect(screen.queryByText('Yay')).toBeNull()
-      expect(Object.keys(storeRef.store.getState().api.mutations).length).toBe(
-        0
-      )
+      expect(countObjectKeys(storeRef.store.getState().api.mutations)).toBe(0)
 
       userEvent.click(screen.getByRole('button', { name: 'trigger' }))
 
       await screen.findByText(/isSuccess/i)
       expect(screen.queryByText('Yay')).not.toBeNull()
-      expect(Object.keys(storeRef.store.getState().api.mutations).length).toBe(
-        1
-      )
+      expect(countObjectKeys(storeRef.store.getState().api.mutations)).toBe(1)
 
       userEvent.click(screen.getByRole('button', { name: 'reset' }))
 
       await screen.findByText(/isUninitialized/i)
       expect(screen.queryByText('Yay')).toBeNull()
-      expect(Object.keys(storeRef.store.getState().api.mutations).length).toBe(
-        0
-      )
+      expect(countObjectKeys(storeRef.store.getState().api.mutations)).toBe(0)
     })
   })
 

--- a/packages/toolkit/src/query/tests/buildInitiate.test.tsx
+++ b/packages/toolkit/src/query/tests/buildInitiate.test.tsx
@@ -31,15 +31,6 @@ function getSubscriptions() {
   ) as unknown as InternalMiddlewareState
   return internalState?.currentSubscriptions ?? {}
 }
-
-function getSubscriptionCount(key: string) {
-  const subscriptions = getSubscriptions()
-  const subscriptionsForQueryArg = subscriptions[key] ?? {}
-  return Object.keys(subscriptionsForQueryArg).length
-  //return Object.keys(storeRef.store.getState().api.subscriptions[key] || {})
-  //.length
-}
-
 function isRequestSubscribed(key: string, requestId: string) {
   const subscriptions = getSubscriptions()
   return !!subscriptions?.[key]?.[requestId]

--- a/packages/toolkit/src/query/tests/buildInitiate.test.tsx
+++ b/packages/toolkit/src/query/tests/buildInitiate.test.tsx
@@ -1,5 +1,5 @@
 import { createApi } from '../core'
-import { InternalMiddlewareState } from '../core/buildMiddleware/types'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 import { fakeBaseQuery } from '../fakeBaseQuery'
 import { setupApiStore } from './helpers'
 
@@ -25,16 +25,14 @@ const api = createApi({
 
 const storeRef = setupApiStore(api)
 
-function getSubscriptions() {
-  const internalState = storeRef.store.dispatch(
-    api.internalActions.getRTKQInternalState()
-  ) as unknown as InternalMiddlewareState
-  return internalState?.currentSubscriptions ?? {}
-}
-function isRequestSubscribed(key: string, requestId: string) {
-  const subscriptions = getSubscriptions()
-  return !!subscriptions?.[key]?.[requestId]
-}
+let getSubscriptions: SubscriptionSelectors['getSubscriptions']
+let isRequestSubscribed: SubscriptionSelectors['isRequestSubscribed']
+
+beforeEach(() => {
+  ;({ getSubscriptions, isRequestSubscribed } = storeRef.store.dispatch(
+    api.internalActions.internal_getRTKQSubscriptions()
+  ) as unknown as SubscriptionSelectors)
+})
 
 test('multiple synchonrous initiate calls with pre-existing cache entry', async () => {
   const { store, api } = storeRef

--- a/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
+++ b/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
@@ -37,9 +37,7 @@ it('invalidates the specified tags', async () => {
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     getBanana.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
-    getBanana.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match
+    getBanana.matchFulfilled
   )
 
   await storeRef.store.dispatch(api.util.invalidateTags(['Banana', 'Bread']))
@@ -50,14 +48,10 @@ it('invalidates the specified tags', async () => {
   const firstSequence = [
     api.internalActions.middlewareRegistered.match,
     getBanana.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     getBanana.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
     api.util.invalidateTags.match,
     getBanana.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     getBanana.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
   ]
   expect(storeRef.store.getState().actions).toMatchSequence(...firstSequence)
 
@@ -69,14 +63,10 @@ it('invalidates the specified tags', async () => {
   expect(storeRef.store.getState().actions).toMatchSequence(
     ...firstSequence,
     getBread.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     getBread.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
     api.util.invalidateTags.match,
     getBread.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
-    getBread.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match
+    getBread.matchFulfilled
   )
 })
 

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -75,8 +75,8 @@ describe('buildSlice', () => {
             status: 'fulfilled',
           },
         },
-        // Filled in a tick later
-        subscriptions: expect.any(Object),
+        // Filled some time later
+        subscriptions: {},
       },
       auth: {
         token: '1234',
@@ -84,18 +84,6 @@ describe('buildSlice', () => {
     }
 
     expect(storeRef.store.getState()).toEqual(initialQueryState)
-
-    await delay(1)
-
-    expect(storeRef.store.getState()).toEqual({
-      ...initialQueryState,
-      api: {
-        ...initialQueryState.api,
-        subscriptions: {
-          'getUser(1)': expect.any(Object),
-        },
-      },
-    })
 
     storeRef.store.dispatch(api.util.resetApiState())
 

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -6,6 +6,7 @@ import {
   THIRTY_TWO_BIT_MAX_INT,
   THIRTY_TWO_BIT_MAX_TIMER_SECONDS,
 } from '../core/buildMiddleware/cacheCollection'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 beforeAll(() => {
   vi.useFakeTimers()
@@ -177,10 +178,10 @@ function storeForApi<
   let hadQueries = false
   store.subscribe(() => {
     const queryState = store.getState().api.queries
-    if (hadQueries && Object.keys(queryState).length === 0) {
+    if (hadQueries && countObjectKeys(queryState) === 0) {
       onCleanup()
     }
-    hadQueries = hadQueries || Object.keys(queryState).length > 0
+    hadQueries = hadQueries || countObjectKeys(queryState) > 0
   })
   return { api, store }
 }

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -7,6 +7,7 @@ import { createApi, QueryStatus } from '@reduxjs/toolkit/query/react'
 import { render, waitFor, act, screen } from '@testing-library/react'
 import { setupApiStore } from './helpers'
 import { InternalMiddlewareState } from '../core/buildMiddleware/types'
+import { countObjectKeys } from '../utils/countObjectKeys'
 
 const tick = () => new Promise((res) => setImmediate(res))
 
@@ -207,7 +208,7 @@ test('Minimizes the number of subscription dispatches when multiple components a
 
   const subscriptions = getSubscriptionsA()
 
-  expect(Object.keys(subscriptions!).length).toBe(NUM_LIST_ITEMS)
+  expect(countObjectKeys(subscriptions!)).toBe(NUM_LIST_ITEMS)
 
   expect(actionTypes).toEqual([
     'api/config/middlewareRegistered',

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -182,6 +182,11 @@ ${expectedOutput}
 
 export const actionsReducer = {
   actions: (state: UnknownAction[] = [], action: UnknownAction) => {
+    // As of 2.0-beta.4, we are going to ignore all `subscriptionsUpdated` actions in tests
+    if (action.type.includes('subscriptionsUpdated')) {
+      return state
+    }
+
     return [...state, action]
   },
 }

--- a/packages/toolkit/src/query/tests/matchers.test.tsx
+++ b/packages/toolkit/src/query/tests/matchers.test.tsx
@@ -65,25 +65,22 @@ test('matches query pending & fulfilled actions for the given endpoint', async (
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchFulfilled
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     otherEndpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     otherEndpoint.matchFulfilled
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
+    api.endpoints.mutationSuccess.matchFulfilled,
     endpoint.matchRejected
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
 })
@@ -96,7 +93,6 @@ test('matches query pending & rejected actions for the given endpoint', async ()
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
@@ -122,20 +118,17 @@ test('matches lazy query pending & fulfilled actions for given endpoint', async 
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchFulfilled
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchFulfilled,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
 
   expect(storeRef.store.getState().actions).not.toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
 })
@@ -151,7 +144,6 @@ test('matches lazy query pending & rejected actions for given endpoint', async (
   expect(storeRef.store.getState().actions).toMatchSequence(
     api.internalActions.middlewareRegistered.match,
     endpoint.matchPending,
-    api.internalActions.subscriptionsUpdated.match,
     endpoint.matchRejected
   )
   expect(storeRef.store.getState().actions).not.toMatchSequence(

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -2,7 +2,7 @@ import { vi } from 'vitest'
 import { createApi } from '@reduxjs/toolkit/query'
 import { setupApiStore, waitMs } from './helpers'
 import { delay } from '../../utils'
-import type { InternalMiddlewareState } from '../core/buildMiddleware/types'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 
 const mockBaseQuery = vi
   .fn()
@@ -24,12 +24,13 @@ const { getPosts } = api.endpoints
 
 const storeRef = setupApiStore(api)
 
-function getSubscriptions() {
-  const internalState = storeRef.store.dispatch(
-    api.internalActions.getRTKQInternalState()
-  ) as unknown as InternalMiddlewareState
-  return internalState?.currentSubscriptions ?? {}
-}
+let getSubscriptions: SubscriptionSelectors['getSubscriptions']
+
+beforeEach(() => {
+  ;({ getSubscriptions } = storeRef.store.dispatch(
+    api.internalActions.internal_getRTKQSubscriptions()
+  ) as unknown as SubscriptionSelectors)
+})
 
 const getSubscribersForQueryCacheKey = (queryCacheKey: string) =>
   getSubscriptions()[queryCacheKey] || {}

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -2,6 +2,7 @@ import { vi } from 'vitest'
 import { createApi } from '@reduxjs/toolkit/query'
 import { setupApiStore, waitMs } from './helpers'
 import { delay } from '../../utils'
+import type { InternalMiddlewareState } from '../core/buildMiddleware/types'
 
 const mockBaseQuery = vi
   .fn()
@@ -23,8 +24,15 @@ const { getPosts } = api.endpoints
 
 const storeRef = setupApiStore(api)
 
+function getSubscriptions() {
+  const internalState = storeRef.store.dispatch(
+    api.internalActions.getRTKQInternalState()
+  ) as unknown as InternalMiddlewareState
+  return internalState?.currentSubscriptions ?? {}
+}
+
 const getSubscribersForQueryCacheKey = (queryCacheKey: string) =>
-  storeRef.store.getState()[api.reducerPath].subscriptions[queryCacheKey] || {}
+  getSubscriptions()[queryCacheKey] || {}
 const createSubscriptionGetter = (queryCacheKey: string) => () =>
   getSubscribersForQueryCacheKey(queryCacheKey)
 

--- a/packages/toolkit/src/query/tests/refetchingBehaviors.test.tsx
+++ b/packages/toolkit/src/query/tests/refetchingBehaviors.test.tsx
@@ -432,10 +432,12 @@ describe('customListenersHandler', () => {
     })
     expect(dispatchSpy).toHaveBeenCalled()
 
-    // Ignore RTKQ middleware `internal_probeSubscription` calls
-    const mockCallsWithoutInternals = dispatchSpy.mock.calls.filter(
-      (call) => !(call[0] as any)?.type?.includes('internal')
-    )
+    // Ignore RTKQ middleware internal data calls
+    const mockCallsWithoutInternals = dispatchSpy.mock.calls.filter((call) => {
+      const type = (call[0] as any)?.type ?? ''
+      const reIsInternal = /internal/i
+      return !reIsInternal.test(type)
+    })
 
     expect(
       defaultApi.internalActions.onOnline.match(

--- a/packages/toolkit/src/query/utils/countObjectKeys.ts
+++ b/packages/toolkit/src/query/utils/countObjectKeys.ts
@@ -1,0 +1,14 @@
+// Fast method for counting an object's keys
+// without resorting to `Object.keys(obj).length
+// Will this make a big difference in perf? Probably not
+// But we can save a few allocations.
+
+export function countObjectKeys(obj: Record<any, any>) {
+  let count = 0
+
+  for (const _key in obj) {
+    count++
+  }
+
+  return count
+}


### PR DESCRIPTION
- Changed `subscriptionUpdated` from a microtask to a 500ms throttle
- ~~Exposed the RTKQ internal middleware state to be returned via an
  internal action, so that hooks can read that state directly without
  needing to call `dispatch()` on every render.~~
  Updated the `batchActions` middleware to return a `SubscriptionSelectors` object with `{getSubscriptions, getSubscriptionCount, isRequestSubscribed}`, and used that in the hook (and tests)
- Reworked tests to completely ignore `subscriptionsUpdated` in any
  action sequence checks due to timing changes and irrelevance
- Fixed case where `invalidateTags` was still reading from store state