### PR TITLE
Allow passing selector creators with different memoize options to getSelectors

### DIFF
--- a/packages/toolkit/src/entities/state_selectors.ts
+++ b/packages/toolkit/src/entities/state_selectors.ts
@@ -2,9 +2,15 @@ import type { CreateSelectorFunction, Selector, createSelector } from 'reselect'
 import { createDraftSafeSelector } from '../createDraftSafeSelector'
 import type { EntityState, EntitySelectors, EntityId } from './models'
 
+type AnyFunction = (...args: any) => any
+type AnyCreateSelectorFunction = CreateSelectorFunction<
+  <F extends AnyFunction>(f: F) => F,
+  <F extends AnyFunction>(f: F) => F
+>
+
 export interface GetSelectorsOptions {
   // TODO Review if this causes issues or if we can go back to using `CreateSelectorFunction`
-  createSelector?: typeof createSelector
+  createSelector?: AnyCreateSelectorFunction
 }
 
 export function createSelectorsFactory<T, Id extends EntityId>() {
@@ -20,7 +26,9 @@ export function createSelectorsFactory<T, Id extends EntityId>() {
     selectState?: (state: V) => EntityState<T, Id>,
     options: GetSelectorsOptions = {}
   ): EntitySelectors<T, any, Id> {
-    const { createSelector = createDraftSafeSelector } = options
+    let { createSelector } = options
+    createSelector ??= createDraftSafeSelector
+
     const selectIds = (state: EntityState<T, Id>) => state.ids
 
     const selectEntities = (state: EntityState<T, Id>) => state.entities

--- a/packages/toolkit/src/entities/state_selectors.ts
+++ b/packages/toolkit/src/entities/state_selectors.ts
@@ -9,7 +9,6 @@ type AnyCreateSelectorFunction = CreateSelectorFunction<
 >
 
 export interface GetSelectorsOptions {
-  // TODO Review if this causes issues or if we can go back to using `CreateSelectorFunction`
   createSelector?: AnyCreateSelectorFunction
 }
 

--- a/packages/toolkit/src/entities/state_selectors.ts
+++ b/packages/toolkit/src/entities/state_selectors.ts
@@ -25,8 +25,7 @@ export function createSelectorsFactory<T, Id extends EntityId>() {
     selectState?: (state: V) => EntityState<T, Id>,
     options: GetSelectorsOptions = {}
   ): EntitySelectors<T, any, Id> {
-    let { createSelector } = options
-    createSelector ??= createDraftSafeSelector
+    const { createSelector = createDraftSafeSelector as AnyCreateSelectorFunction } = options
 
     const selectIds = (state: EntityState<T, Id>) => state.ids
 

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -11,8 +11,8 @@ import {
 import { createNextState } from '../..'
 
 describe('Sorted State Adapter', () => {
-  let adapter: EntityAdapter<string, BookModel>
-  let state: EntityState<string, BookModel>
+  let adapter: EntityAdapter<BookModel, string>
+  let state: EntityState<BookModel, string>
 
   beforeAll(() => {
     //eslint-disable-next-line
@@ -349,7 +349,7 @@ describe('Sorted State Adapter', () => {
       order: number
       ts: number
     }
-    const sortedItemsAdapter = createEntityAdapter<string, OrderedEntity>({
+    const sortedItemsAdapter = createEntityAdapter<OrderedEntity>({
       sortComparer: (a, b) => a.order - b.order,
     })
     const withInitialItems = sortedItemsAdapter.setAll(

--- a/packages/toolkit/src/entities/tests/state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/state_adapter.test.ts
@@ -6,7 +6,7 @@ import { createSlice } from '../../createSlice'
 import type { BookModel } from './fixtures/book'
 
 describe('createStateOperator', () => {
-  let adapter: EntityAdapter<string, BookModel>
+  let adapter: EntityAdapter<BookModel, string>
 
   beforeEach(() => {
     adapter = createEntityAdapter({

--- a/packages/toolkit/src/entities/tests/state_selectors.test.ts
+++ b/packages/toolkit/src/entities/tests/state_selectors.test.ts
@@ -130,7 +130,10 @@ describe('Entity State Selectors', () => {
   })
   describe('custom createSelector instance', () => {
     it('should use the custom createSelector function if provided', () => {
-      const memoizeSpy = vi.fn(weakMapMemoize)
+      const memoizeSpy = vi.fn(
+        // test that we're allowed to pass memoizers with different options, as long as they're optional
+        <F extends (...args: any[]) => any>(fn: F, param?: boolean) => fn
+      )
       const createCustomSelector = createDraftSafeSelectorCreator(memoizeSpy)
 
       const adapter = createEntityAdapter({


### PR DESCRIPTION
also fixes a few misplaced generics in tests