### PR TITLE
Create code gen module imports absolute paths

### DIFF
--- a/docs/rtk-query/usage/customizing-create-api.mdx
+++ b/docs/rtk-query/usage/customizing-create-api.mdx
@@ -44,9 +44,9 @@ If you want to create your own module, you should review [the react-hooks module
 Here is a very stripped down version:
 
 ```ts no-transpile
-import { CoreModule } from '@internal/core/module'
 import {
   BaseQueryFn,
+  CoreModule,
   EndpointDefinitions,
   Api,
   Module,
@@ -57,7 +57,7 @@ import {
 export const customModuleName = Symbol()
 export type CustomModule = typeof customModuleName
 
-declare module '../apiTypes' {
+declare module '@reduxjs/toolkit/query' {
   export interface ApiModules<
     BaseQuery extends BaseQueryFn,
     Definitions extends EndpointDefinitions,


### PR DESCRIPTION
Use absolute paths for imports and module declarations to reflect how this would be used in an actual project that depends on redux toolkit, as opposed to how it is used inside the rtk monorepo.