### PR TITLE
Bump Reselect to 5.0.0-rc.0 to pick up `weakMapMemoize` change

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -114,7 +114,7 @@
     "immer": "^10.0.3",
     "redux": "^5.0.0-rc.1",
     "redux-thunk": "^3.0.0-rc.0",
-    "reselect": "^5.0.0-beta.1"
+    "reselect": "^5.0.0-rc.0"
   },
   "peerDependencies": {
     "react": "^16.9.0 || ^17.0.0 || ^18",

--- a/packages/toolkit/src/createDraftSafeSelector.ts
+++ b/packages/toolkit/src/createDraftSafeSelector.ts
@@ -1,5 +1,5 @@
 import { current, isDraft } from 'immer'
-import { createSelectorCreator, defaultMemoize } from 'reselect'
+import { createSelectorCreator, weakMapMemoize } from 'reselect'
 
 export const createDraftSafeSelectorCreator: typeof createSelectorCreator = (
   ...args: unknown[]
@@ -22,4 +22,4 @@ export const createDraftSafeSelectorCreator: typeof createSelectorCreator = (
  * @public
  */
 export const createDraftSafeSelector =
-  createDraftSafeSelectorCreator(defaultMemoize)
+  createDraftSafeSelectorCreator(weakMapMemoize)

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -17,12 +17,7 @@ export {
   defaultMemoize,
   weakMapMemoize,
 } from 'reselect'
-export type {
-  Selector,
-  OutputParametricSelector,
-  OutputSelector,
-  ParametricSelector,
-} from 'reselect'
+export type { Selector, OutputSelector } from 'reselect'
 export {
   createDraftSafeSelector,
   createDraftSafeSelectorCreator,

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -11,7 +11,7 @@ import { DefinitionType, isQueryDefinition } from './endpointDefinitions'
 import { nanoid } from './core/rtkImports'
 import type { UnknownAction } from '@reduxjs/toolkit'
 import type { NoInfer } from './tsHelpers'
-import { defaultMemoize } from 'reselect'
+import { weakMapMemoize } from 'reselect'
 
 export interface CreateApiOptions<
   BaseQuery extends BaseQueryFn,
@@ -253,7 +253,7 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
   ...modules: Modules
 ): CreateApi<Modules[number]['name']> {
   return function baseCreateApi(options) {
-    const extractRehydrationInfo = defaultMemoize((action: UnknownAction) =>
+    const extractRehydrationInfo = weakMapMemoize((action: UnknownAction) =>
       options.extractRehydrationInfo?.(action, {
         reducerPath: (options.reducerPath ?? 'api') as any,
       })
@@ -304,7 +304,7 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
       },
       apiUid: nanoid(),
       extractRehydrationInfo,
-      hasRehydrationInfo: defaultMemoize(
+      hasRehydrationInfo: weakMapMemoize(
         (action) => extractRehydrationInfo(action) != null
       ),
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7077,7 +7077,7 @@ __metadata:
     query-string: ^7.0.1
     redux: ^5.0.0-rc.1
     redux-thunk: ^3.0.0-rc.0
-    reselect: ^5.0.0-beta.1
+    reselect: ^5.0.0-rc.0
     rimraf: ^3.0.2
     size-limit: ^4.11.0
     tslib: ^1.10.0
@@ -25611,10 +25611,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"reselect@npm:^5.0.0-beta.1":
-  version: 5.0.0-beta.1
-  resolution: "reselect@npm:5.0.0-beta.1"
-  checksum: dd707e2285c6c4d27c245634e87cf12ef5043cf01c48478f80b3e178efa8f4cd8576d56ac2691180a63704532fb3f12861df81b66ddd7819decbf64d6908779e
+"reselect@npm:^5.0.0-rc.0":
+  version: 5.0.0-rc.0
+  resolution: "reselect@npm:5.0.0-rc.0"
+  checksum: 3de8f67e543da56261e97a4db9a677544637ec59f037b651a617cf91fb9cb32d540dc8a9aa8a36f7dbcc9997bd4c4391c53e5ac9298b983a0da9bf576688e5db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

- Bumps Reselect to 5.0.0-rc.0 to pick up `weakMapMemoize` change
- Updates RTK's usages of `createSelector` to use `weakMapMemoize` where needed