### PR TITLE
Remove abort event listner for AbortController

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -608,6 +608,7 @@ export const createAsyncThunk = /* @__PURE__ */ (() => {
                   message: abortReason || 'Aborted',
                 })
               }
+              abortController.signal.addEventListener('abort', abortHandler)
             })
             dispatch(
               pending(


### PR DESCRIPTION
Call removeEventListener() to prevent potential memory leak.

In theory, new AbortController() should be removed by GC per action.
However it's always safe to remove the event listener explicitly when we no longer need it.


If we somehow