### PR TITLE
Preserve nullable store state type by avoiding intersection with {}

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -112,7 +112,7 @@
   ],
   "dependencies": {
     "immer": "^10.0.3",
-    "redux": "^5.0.0",
+    "redux": "https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz",
     "redux-thunk": "^3.1.0",
     "reselect": "^5.0.1"
   },

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -112,7 +112,7 @@
   ],
   "dependencies": {
     "immer": "^10.0.3",
-    "redux": "https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz",
+    "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
     "reselect": "^5.0.1"
   },

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -26,6 +26,7 @@ import type {
   ExtractDispatchExtensions,
   ExtractStoreExtensions,
   ExtractStateExtensions,
+  UnknownIfNonSpecific,
 } from './tsHelpers'
 import type { Tuple } from './utils'
 import type { GetDefaultEnhancers } from './getDefaultEnhancers'
@@ -103,7 +104,8 @@ export type EnhancedStore<
   S = any,
   A extends Action = UnknownAction,
   E extends Enhancers = Enhancers
-> = ExtractStoreExtensions<E> & Store<S & ExtractStateExtensions<E>, A>
+> = ExtractStoreExtensions<E> &
+  Store<S, A, UnknownIfNonSpecific<ExtractStateExtensions<E>>>
 
 /**
  * A friendly abstraction over the standard Redux `createStore()` function.

--- a/packages/toolkit/src/tests/configureStore.typetest.ts
+++ b/packages/toolkit/src/tests/configureStore.typetest.ts
@@ -13,7 +13,7 @@ import type { PayloadAction, ConfigureStoreOptions } from '@reduxjs/toolkit'
 import { configureStore, createSlice, Tuple } from '@reduxjs/toolkit'
 import type { ThunkMiddleware, ThunkAction, ThunkDispatch } from 'redux-thunk'
 import { thunk } from 'redux-thunk'
-import { expectNotAny, expectType } from './helpers'
+import { expectExactType, expectNotAny, expectType } from './helpers'
 
 const _anyMiddleware: any = () => () => () => {}
 
@@ -136,6 +136,17 @@ const _anyMiddleware: any = () => () => () => {}
     reducer: (_: number) => 0,
     preloadedState: 'non-matching state type',
   })
+}
+
+/**
+ * Test: nullable state is preserved
+ */
+
+{
+  const store = configureStore({
+    reducer: (): string | null => null,
+  })
+  expectExactType<string | null>(null)(store.getState())
 }
 
 /*

--- a/packages/toolkit/src/tsHelpers.ts
+++ b/packages/toolkit/src/tsHelpers.ts
@@ -205,3 +205,5 @@ export type Id<T> = { [K in keyof T]: T[K] } & {}
 export type Tail<T extends any[]> = T extends [any, ...infer Tail]
   ? Tail
   : never
+
+export type UnknownIfNonSpecific<T> = {} extends T ? unknown : T

--- a/yarn.lock
+++ b/yarn.lock
@@ -7075,7 +7075,7 @@ __metadata:
     node-fetch: ^2.6.1
     prettier: ^2.2.1
     query-string: ^7.0.1
-    redux: ^5.0.0
+    redux: "https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz"
     redux-thunk: ^3.1.0
     reselect: ^5.0.1
     rimraf: ^3.0.2
@@ -25134,6 +25134,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"redux@https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz":
+  version: 5.0.0
+  resolution: "redux@https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz"
+  checksum: 9ea2a3a8b387e6c299bd5ac4ec5b26f207ff368546c8a5c226655e57476ee5f87f52724ab2427f31e87e6cdc21566e8132f1dce1db2f5d2003b85d822c350cdc
+  languageName: node
+  linkType: hard
+
 "redux@npm:^4.1.2":
   version: 4.1.2
   resolution: "redux@npm:4.1.2"
@@ -25149,13 +25156,6 @@ fsevents@^1.2.7:
   dependencies:
     "@babel/runtime": ^7.9.2
   checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
-  languageName: node
-  linkType: hard
-
-"redux@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "redux@npm:5.0.0"
-  checksum: be49160d4bd01e10108c425ade999f1b456204895c4bdd0c7825ab09efffded51955c5c242847406a7b3f273e9011a9c102848c512a099a75617b97b13d2cca8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7075,7 +7075,7 @@ __metadata:
     node-fetch: ^2.6.1
     prettier: ^2.2.1
     query-string: ^7.0.1
-    redux: "https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz"
+    redux: ^5.0.1
     redux-thunk: ^3.1.0
     reselect: ^5.0.1
     rimraf: ^3.0.2
@@ -25134,13 +25134,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"redux@https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz":
-  version: 5.0.0
-  resolution: "redux@https://pkg.csb.dev/reduxjs/redux/commit/3e9e484f/redux/_pkg.tgz"
-  checksum: 9ea2a3a8b387e6c299bd5ac4ec5b26f207ff368546c8a5c226655e57476ee5f87f52724ab2427f31e87e6cdc21566e8132f1dce1db2f5d2003b85d822c350cdc
-  languageName: node
-  linkType: hard
-
 "redux@npm:^4.1.2":
   version: 4.1.2
   resolution: "redux@npm:4.1.2"
@@ -25156,6 +25149,13 @@ fsevents@^1.2.7:
   dependencies:
     "@babel/runtime": ^7.9.2
   checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
+  languageName: node
+  linkType: hard
+
+"redux@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "redux@npm:5.0.1"
+  checksum: e74affa9009dd5d994878b9a1ce30d6569d986117175056edb003de2651c05b10fe7819d6fa94aea1a94de9a82f252f986547f007a2fbeb35c317a2e5f5ecf2c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See https://github.com/reduxjs/redux/pull/4638 for more details - this PR depends on the changes from that one, so will need to wait for those changes to be released so we can bump the dep.