### PR TITLE
fix: improve selectFromResult memoization

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -915,7 +915,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
               (_: ApiRootState, lastResult: any) => lastResult,
               (_: ApiRootState) => stableArg,
             ],
-            queryStatePreSelector
+            queryStatePreSelector,
+            {
+              memoizeOptions: {
+                resultEqualityCheck: shallowEqual,
+              },
+            }
           ),
         [select, stableArg]
       )

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -35,7 +35,7 @@ import { server } from './mocks/server'
 import type { UnknownAction } from 'redux'
 import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiState'
 import type { SerializedError } from '@reduxjs/toolkit'
-import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
+import { createListenerMiddleware, configureStore, createSlice } from '@reduxjs/toolkit'
 import { delay } from '../../utils'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 import { countObjectKeys } from '../utils/countObjectKeys'
@@ -2052,22 +2052,18 @@ describe('hooks with createApi defaults set', () => {
       }),
     })
 
-    const counterReducer = {
-      counter: (
-        state: { count: number } = { count: 0 },
-        action: UnknownAction
-      ) => {
-        if (action.type === 'INCREMENT_COUNT') {
-          return {
-            count: state.count + 1,
-          }
+    const counterSlice = createSlice({
+      name: "counter",
+      initialState: { count: 0 },
+      reducers: {
+        increment(state) {
+          state.count++
         }
-        return state
-      },
-    }
+      }
+    })
 
     const storeRef = setupApiStore(api, {
-      ...counterReducer,
+      counter: counterSlice.reducer,
     })
 
     expectExactType(api.useGetPostsQuery)(api.endpoints.getPosts.useQuery)
@@ -2357,7 +2353,7 @@ describe('hooks with createApi defaults set', () => {
         return (
           <div
             data-testid="incrementButton"
-            onClick={() => storeRef.store.dispatch({ type: 'INCREMENT_COUNT' })}
+            onClick={() => storeRef.store.dispatch(counterSlice.actions.increment())}
           >
             Increment Count
           </div>

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -2372,14 +2372,10 @@ describe('hooks with createApi defaults set', () => {
         { wrapper: storeRef.wrapper }
       )
 
-      await delay(1)
+      await waitFor(() => expect(getRenderCount()).toBe(2))
+
       const incrementBtn = screen.getByTestId('incrementButton')
       fireEvent.click(incrementBtn)
-      await delay(1)
-      fireEvent.click(incrementBtn)
-      await delay(1)
-      fireEvent.click(incrementBtn)
-      await delay(1)
       expect(getRenderCount()).toBe(2)
     })
 

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -2052,7 +2052,23 @@ describe('hooks with createApi defaults set', () => {
       }),
     })
 
-    const storeRef = setupApiStore(api)
+    const counterReducer = {
+      counter: (
+        state: { count: number } = { count: 0 },
+        action: UnknownAction
+      ) => {
+        if (action.type === 'INCREMENT_COUNT') {
+          return {
+            count: state.count + 1,
+          }
+        }
+        return state
+      },
+    }
+
+    const storeRef = setupApiStore(api, {
+      ...counterReducer,
+    })
 
     expectExactType(api.useGetPostsQuery)(api.endpoints.getPosts.useQuery)
     expectExactType(api.useUpdatePostMutation)(
@@ -2315,6 +2331,56 @@ describe('hooks with createApi defaults set', () => {
 
       fireEvent.click(addBtn)
       await waitFor(() => expect(getRenderCount()).toBe(3))
+    })
+
+    test('useQuery with selectFromResult option does not update when unrelated data in the store changes', async () => {
+      function Posts() {
+        const { posts } = api.endpoints.getPosts.useQuery(undefined, {
+          selectFromResult: ({ data }) => ({
+            // Intentionally use an unstable reference to force a rerender
+            posts: data?.filter((post) => post.name.includes('post')),
+          }),
+        })
+
+        getRenderCount = useRenderCounter()
+
+        return (
+          <div>
+            {posts?.map((post) => (
+              <div key={post.id}>{post.name}</div>
+            ))}
+          </div>
+        )
+      }
+
+      function CounterButton() {
+        return (
+          <div
+            data-testid="incrementButton"
+            onClick={() => storeRef.store.dispatch({ type: 'INCREMENT_COUNT' })}
+          >
+            Increment Count
+          </div>
+        )
+      }
+
+      render(
+        <div>
+          <Posts />
+          <CounterButton />
+        </div>,
+        { wrapper: storeRef.wrapper }
+      )
+
+      await delay(1)
+      const incrementBtn = screen.getByTestId('incrementButton')
+      fireEvent.click(incrementBtn)
+      await delay(1)
+      fireEvent.click(incrementBtn)
+      await delay(1)
+      fireEvent.click(incrementBtn)
+      await delay(1)
+      expect(getRenderCount()).toBe(2)
     })
 
     test('useQuery with selectFromResult option has a type error if the result is not an object', async () => {


### PR DESCRIPTION
Improve `selectFromResult` memoization to only run the callback when relevant data is changed.

Fixes this issue: https://github.com/reduxjs/redux-toolkit/issues/4028.