### PR TITLE
rtk query code gen: add optional prettierrc override

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/index.ts
+++ b/packages/rtk-query-codegen-openapi/src/index.ts
@@ -15,11 +15,14 @@ export async function generateEndpoints(options: GenerationOptions): Promise<str
     const { generateApi } = await import('./generate');
     return generateApi(schemaAbsPath, options);
   });
-  const { outputFile } = options;
+  const { outputFile, prettierConfigFile } = options;
   if (outputFile) {
-    fs.writeFileSync(path.resolve(process.cwd(), outputFile), await prettify(outputFile, sourceCode));
+    fs.writeFileSync(
+      path.resolve(process.cwd(), outputFile),
+      await prettify(outputFile, sourceCode, prettierConfigFile)
+    );
   } else {
-    return await prettify(null, sourceCode);
+    return await prettify(null, sourceCode, prettierConfigFile);
   }
 }
 

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -79,9 +79,17 @@ export interface CommonOptions {
    */
   mergeReadWriteOnly?: boolean;
   /**
+   *
    * HTTPResolverOptions object that is passed to the SwaggerParser bundle function.
    */
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions;
+
+  /**
+   * defaults to undefined
+   * If present the given file will be used as prettier config when formatting the generated code. If undefined the default prettier config
+   * resolution mechanism will be used.
+   */
+  prettierConfigFile?: string;
 }
 
 export type TextMatcher = string | RegExp | (string | RegExp)[];

--- a/packages/rtk-query-codegen-openapi/src/utils/prettier.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/prettier.ts
@@ -19,7 +19,7 @@ const EXTENSION_TO_PARSER: Record<string, string> = {
   json: 'json',
 };
 
-export async function prettify(filePath: string | null, content: string): Promise<string> {
+export async function prettify(filePath: string | null, content: string, prettierConfigFile?: string): Promise<string> {
   let config = null;
   let parser = 'typescript';
 
@@ -28,7 +28,13 @@ export async function prettify(filePath: string | null, content: string): Promis
     parser = EXTENSION_TO_PARSER[fileExtension];
     config = await prettier.resolveConfig(process.cwd(), {
       useCache: true,
-      editorconfig: true,
+      editorconfig: !prettierConfigFile,
+      config: prettierConfigFile,
+    });
+  } else if (prettierConfigFile) {
+    config = await prettier.resolveConfig(process.cwd(), {
+      useCache: true,
+      config: prettierConfigFile,
     });
   }
 


### PR DESCRIPTION
Allow users to optionally provide the explicit location of the prettier config to use. For example unblocks users that are using an incompatible/different major version of prettier as part of their project that breaks the prettier version rtk query code gen depends on.

Example:
```typescript
import type { ConfigFile } from "@rtk-query/codegen-openapi"

const config: ConfigFile = {
  schemaFile: "http://localhost:8080/openapi",
  ...,
  prettierConfigFile: "./rtk-codegen.prettierrc.json",
}

export default config
```

see #4038