### PR TITLE
Allow customising createSelector instance used by RTKQ

### DIFF
--- a/docs/rtk-query/usage/customizing-create-api.mdx
+++ b/docs/rtk-query/usage/customizing-create-api.mdx
@@ -35,7 +35,7 @@ import {
   reactHooksModule,
 } from '@reduxjs/toolkit/query/react'
 
-const MyContext = React.createContext<ReactReduxContextValue | null>(null)
+const MyContext = React.createContext<ReactReduxContextValue>(null as any)
 const customCreateApi = buildCreateApi(
   coreModule(),
   reactHooksModule({

--- a/docs/rtk-query/usage/customizing-create-api.mdx
+++ b/docs/rtk-query/usage/customizing-create-api.mdx
@@ -35,7 +35,7 @@ import {
   reactHooksModule,
 } from '@reduxjs/toolkit/query/react'
 
-const MyContext = React.createContext<ReactReduxContextValue>(null as any)
+const MyContext = React.createContext<ReactReduxContextValue | null>(null)
 const customCreateApi = buildCreateApi(
   coreModule(),
   reactHooksModule({
@@ -45,6 +45,27 @@ const customCreateApi = buildCreateApi(
       useStore: createStoreHook(MyContext),
     },
   })
+)
+```
+
+## Customizing `createSelector` for RTKQ
+
+Both `coreModule` and `reactHooksModule` accept a `createSelector` option which should be a selector creator instance from Reselect or with an equivalent signature.
+
+```ts
+import * as React from 'react'
+import { createSelectorCreator, lruMemoize } from '@reduxjs/toolkit'
+import {
+  buildCreateApi,
+  coreModule,
+  reactHooksModule,
+} from '@reduxjs/toolkit/query/react'
+
+const createLruSelector = createSelectorCreator(lruMemoize)
+
+const customCreateApi = buildCreateApi(
+  coreModule({ createSelector: createLruSelector }),
+  reactHooksModule({ createSelector: createLruSelector })
 )
 ```
 

--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -1,4 +1,5 @@
-import { createNextState, createSelector } from './rtkImports'
+import type { createSelector as _createSelector } from './rtkImports'
+import { createNextState } from './rtkImports'
 import type {
   MutationSubState,
   QuerySubState,
@@ -123,9 +124,11 @@ export function buildSelectors<
 >({
   serializeQueryArgs,
   reducerPath,
+  createSelector,
 }: {
   serializeQueryArgs: InternalSerializeQueryArgs
   reducerPath: ReducerPath
+  createSelector: typeof _createSelector
 }) {
   type RootState = _RootState<Definitions, string, string>
 

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -49,6 +49,7 @@ import type { ReferenceCacheLifecycle } from './buildMiddleware/cacheLifecycle'
 import type { ReferenceQueryLifecycle } from './buildMiddleware/queryLifecycle'
 import type { ReferenceCacheCollection } from './buildMiddleware/cacheCollection'
 import { enablePatches } from 'immer'
+import { createSelector as _createSelector } from './rtkImports'
 
 /**
  * `ifOlderThan` - (default: `false` | `number`) - _number is value in seconds_
@@ -431,6 +432,13 @@ export type ListenerActions = {
 
 export type InternalActions = SliceActions & ListenerActions
 
+export interface CoreModuleOptions {
+  /**
+   * A selector creator (usually from `reselect`, or matching the same signature)
+   */
+  createSelector?: typeof _createSelector
+}
+
 /**
  * Creates a module containing the basic redux logic for use with `buildCreateApi`.
  *
@@ -439,7 +447,9 @@ export type InternalActions = SliceActions & ListenerActions
  * const createBaseApi = buildCreateApi(coreModule());
  * ```
  */
-export const coreModule = (): Module<CoreModule> => ({
+export const coreModule = ({
+  createSelector = _createSelector,
+}: CoreModuleOptions = {}): Module<CoreModule> => ({
   name: coreModuleName,
   init(
     api,
@@ -548,6 +558,7 @@ export const coreModule = (): Module<CoreModule> => ({
     } = buildSelectors({
       serializeQueryArgs: serializeQueryArgs as any,
       reducerPath,
+      createSelector,
     })
 
     safeAssign(api.util, { selectInvalidatedBy, selectCachedArgsForQuery })

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -53,10 +53,7 @@ import { UNINITIALIZED_VALUE } from './constants'
 import { useShallowStableValue } from './useShallowStableValue'
 import type { BaseQueryFn } from '../baseQueryTypes'
 import { defaultSerializeQueryArgs } from '../defaultSerializeQueryArgs'
-import {
-  InternalMiddlewareState,
-  SubscriptionSelectors,
-} from '../core/buildMiddleware/types'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 
 // Copy-pasted from React-Redux
 export const useIsomorphicLayoutEffect =
@@ -582,6 +579,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     batch,
     hooks: { useDispatch, useSelector, useStore },
     unstable__sideEffectsInRender,
+    createSelector,
   },
   serializeQueryArgs,
   context,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -4,7 +4,6 @@ import type {
   ThunkAction,
   ThunkDispatch,
 } from '@reduxjs/toolkit'
-import { createSelector } from '@reduxjs/toolkit'
 import type { DependencyList } from 'react'
 import {
   useCallback,

--- a/packages/toolkit/src/query/react/module.ts
+++ b/packages/toolkit/src/query/react/module.ts
@@ -23,6 +23,7 @@ import {
 import type { QueryKeys } from '../core/apiState'
 import type { PrefetchOptions } from '../core/module'
 import { countObjectKeys } from '../utils/countObjectKeys'
+import { createSelector as _createSelector } from 'reselect'
 
 export const reactHooksModuleName = /* @__PURE__ */ Symbol()
 export type ReactHooksModule = typeof reactHooksModuleName
@@ -111,6 +112,10 @@ export interface ReactHooksModuleOptions {
    * ```
    */
   unstable__sideEffectsInRender?: boolean
+  /**
+   * A selector creator (usually from `reselect`, or matching the same signature)
+   */
+  createSelector?: typeof _createSelector
 }
 
 /**
@@ -140,6 +145,7 @@ export const reactHooksModule = ({
     useSelector: rrUseSelector,
     useStore: rrUseStore,
   },
+  createSelector = _createSelector,
   unstable__sideEffectsInRender = false,
   ...rest
 }: ReactHooksModuleOptions = {}): Module<ReactHooksModule> => {
@@ -191,6 +197,7 @@ export const reactHooksModule = ({
           batch,
           hooks,
           unstable__sideEffectsInRender,
+          createSelector,
         },
         serializeQueryArgs,
         context,

--- a/packages/toolkit/src/query/tests/buildCreateApi.test.tsx
+++ b/packages/toolkit/src/query/tests/buildCreateApi.test.tsx
@@ -35,7 +35,12 @@ import { server } from './mocks/server'
 import type { UnknownAction } from 'redux'
 import type { SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiState'
 import type { SerializedError } from '@reduxjs/toolkit'
-import { createListenerMiddleware, configureStore } from '@reduxjs/toolkit'
+import {
+  createListenerMiddleware,
+  configureStore,
+  lruMemoize,
+  createSelectorCreator,
+} from '@reduxjs/toolkit'
 import { delay } from '../../utils'
 
 const MyContext = React.createContext<ReactReduxContextValue>(null as any)
@@ -122,5 +127,66 @@ describe('buildCreateApi', () => {
     expect(callBuildCreateApi).toThrowErrorMatchingInlineSnapshot(
       `"When using custom hooks for context, all 3 hooks need to be provided: useDispatch, useSelector, useStore.\nHook useStore was either not provided or not a function."`
     )
+  })
+  test('allows passing createSelector instance', async () => {
+    const memoize = vi.fn(lruMemoize)
+    const createSelector = createSelectorCreator(memoize)
+    const createApi = buildCreateApi(
+      coreModule({ createSelector }),
+      reactHooksModule({ createSelector })
+    )
+    const api = createApi({
+      baseQuery: async (arg: any) => {
+        await waitMs()
+
+        return {
+          data: arg?.body ? { ...arg.body } : {},
+        }
+      },
+      endpoints: (build) => ({
+        getUser: build.query<{ name: string }, number>({
+          query: () => ({
+            body: { name: 'Timmy' },
+          }),
+        }),
+      }),
+    })
+
+    const storeRef = setupApiStore(api, {}, { withoutTestLifecycles: true })
+
+    await storeRef.store.dispatch(api.endpoints.getUser.initiate(1))
+
+    const selectUser = api.endpoints.getUser.select(1)
+
+    expect(selectUser(storeRef.store.getState()).data).toEqual({
+      name: 'Timmy',
+    })
+
+    expect(memoize).toHaveBeenCalledTimes(4)
+
+    memoize.mockClear()
+
+    function User() {
+      const { isFetching } = api.endpoints.getUser.useQuery(1)
+
+      return (
+        <div>
+          <div data-testid="isFetching">{String(isFetching)}</div>
+        </div>
+      )
+    }
+
+    function Wrapper({ children }: any) {
+      return <Provider store={storeRef.store}>{children}</Provider>
+    }
+
+    render(<User />, { wrapper: Wrapper })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('isFetching').textContent).toBe('false')
+    )
+
+    // select() + selectFromResult
+    expect(memoize).toHaveBeenCalledTimes(8)
   })
 })


### PR DESCRIPTION
Can now create modules using different memoiser:
```ts
const createApi = buildCreateApi(coreModule({ createSelector }), reactHooksModule({ createSelector }))
```