### PR TITLE
Website/Docs - changed styling on active Table Of Contents link to differentiate from visited

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -134,8 +134,9 @@ a.contents__link > code {
   color: inherit;
 }
 
-a.contents__link.contents__link--active {
-  font-weight: 600;
+.table-of-contents__link--active {
+  font-weight: 500;
+  text-decoration: underline;
 }
 
 .table-of-contents__link:hover > code,

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -138,6 +138,11 @@ a.contents__link.contents__link--active {
   font-weight: 600;
 }
 
+.table-of-contents__link:hover > code,
+.table-of-contents__link:hover {
+    color: var(--ifm-color-primary-lightest);
+}
+
 a:visited {
   color: var(--ifm-color-primary);
 }


### PR DESCRIPTION
This bug annoyed me while reading the docs so I decided to try fix it.

Open issue #978 - discussed and sidebar fix was implemented, so I am extending a similar implementation to TOC on each page

Not sure if there is a preferred solution to the styling here, don't mind changing it, I just picked underline and the previously existing font-weight that had incorrect css targetting.


https://github.com/reduxjs/redux-toolkit/assets/79554296/898fb1e9-94c2-40c1-be16-54ec1dd42f50

Summary:

Moved font-weight from previous unstable css targeting using infima to new working class and added an underline.
Made a copy of the Sidebar Menu's behavior that stops the flash of white when hovering over visited items (that are not active) 