### PR TITLE
Option for queries to pause polling when unfocused

### DIFF
--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -87,6 +87,8 @@ export type SubscriptionOptions = {
    *  Defaults to 'false'. This setting allows you to control whether RTK Query will continue polling if the window is not focused.
    *
    *  If pollingInterval is not set or set to 0, this **will not be evaluated** until pollingInterval is greater than 0.
+   *
+   *  Note: requires [`setupListeners`](./setupListeners) to have been called.
    */
   skipPollOnFocusLost?: boolean
   /**

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -84,6 +84,12 @@ export type SubscriptionOptions = {
    */
   pollingInterval?: number
   /**
+   *  Defaults to 'false'. This setting allows you to control whether RTK Query will continue polling if the window is not focused.
+   *
+   *  If pollingInterval is not set or set to 0, this **will not be evaluated** until pollingInterval is greater than 0.
+   */
+  skipPollOnFocusLost?: boolean
+  /**
    * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
    *
    * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -90,7 +90,7 @@ export type SubscriptionOptions = {
    *
    *  Note: requires [`setupListeners`](./setupListeners) to have been called.
    */
-  skipPollOnFocusLost?: boolean
+  skipPollingIfUnfocused?: boolean
   /**
    * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
    *

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -53,38 +53,36 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
     { queryCacheKey }: QuerySubstateIdentifier,
     api: SubMiddlewareApi
   ) {
-    const state = api.getState()[reducerPath];
-    const querySubState = state.queries[queryCacheKey];
-    const subscriptions = internalState.currentSubscriptions[queryCacheKey];
+    const state = api.getState()[reducerPath]
+    const querySubState = state.queries[queryCacheKey]
+    const subscriptions = internalState.currentSubscriptions[queryCacheKey]
 
     if (!querySubState || querySubState.status === QueryStatus.uninitialized)
-      return;
+      return
 
-    const { lowestPollingInterval, skipPollOnFocusLost } = findLowestPollingInterval(subscriptions);
-    if (!Number.isFinite(lowestPollingInterval)) return;
+    const { lowestPollingInterval, skipPollOnFocusLost } =
+      findLowestPollingInterval(subscriptions)
+    if (!Number.isFinite(lowestPollingInterval)) return
 
-    const currentPoll = currentPolls[queryCacheKey];
+    const currentPoll = currentPolls[queryCacheKey]
 
     if (currentPoll?.timeout) {
-      clearTimeout(currentPoll.timeout);
-      currentPoll.timeout = undefined;
+      clearTimeout(currentPoll.timeout)
+      currentPoll.timeout = undefined
     }
 
-    const nextPollTimestamp = Date.now() + lowestPollingInterval;
+    const nextPollTimestamp = Date.now() + lowestPollingInterval
 
-    // Always update the polling interval
     currentPolls[queryCacheKey] = {
       nextPollTimestamp,
       pollingInterval: lowestPollingInterval,
       timeout: setTimeout(() => {
-        // Conditionally dispatch the query
         if (document.hasFocus() || !skipPollOnFocusLost) {
-          api.dispatch(refetchQuery(querySubState, queryCacheKey));
+          api.dispatch(refetchQuery(querySubState, queryCacheKey))
         }
-        // Regardless of dispatch, set up the next poll
-        startNextPoll({ queryCacheKey }, api);
+        startNextPoll({ queryCacheKey }, api)
       }, lowestPollingInterval),
-    };
+    }
   }
 
   function updatePollingInterval(

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -60,7 +60,7 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
     if (!querySubState || querySubState.status === QueryStatus.uninitialized)
       return
 
-    const { lowestPollingInterval, skipPollOnFocusLost } =
+    const { lowestPollingInterval, skipPollingIfUnfocused } =
       findLowestPollingInterval(subscriptions)
     if (!Number.isFinite(lowestPollingInterval)) return
 
@@ -77,7 +77,7 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
       nextPollTimestamp,
       pollingInterval: lowestPollingInterval,
       timeout: setTimeout(() => {
-        if (state.config.focused || !skipPollOnFocusLost) {
+        if (state.config.focused || !skipPollingIfUnfocused) {
           api.dispatch(refetchQuery(querySubState, queryCacheKey))
         }
         startNextPoll({ queryCacheKey }, api)
@@ -127,7 +127,7 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
   }
 
   function findLowestPollingInterval(subscribers: Subscribers = {}) {
-    let skipPollOnFocusLost: boolean | undefined = false
+    let skipPollingIfUnfocused: boolean | undefined = false
     let lowestPollingInterval = Number.POSITIVE_INFINITY
     for (let key in subscribers) {
       if (!!subscribers[key].pollingInterval) {
@@ -135,14 +135,14 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
           subscribers[key].pollingInterval!,
           lowestPollingInterval
         )
-        skipPollOnFocusLost =
-          subscribers[key].skipPollOnFocusLost || skipPollOnFocusLost
+        skipPollingIfUnfocused =
+          subscribers[key].skipPollingIfUnfocused || skipPollingIfUnfocused
       }
     }
 
     return {
       lowestPollingInterval,
-      skipPollOnFocusLost,
+      skipPollingIfUnfocused,
     }
   }
 

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -135,9 +135,7 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
           subscribers[key].pollingInterval!,
           lowestPollingInterval
         )
-        // if (!skipPollOnFocusLost) {
-          skipPollOnFocusLost = subscribers[key].skipPollOnFocusLost
-        // }
+        skipPollOnFocusLost = subscribers[key].skipPollOnFocusLost
       }
     }
 

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -135,7 +135,8 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
           subscribers[key].pollingInterval!,
           lowestPollingInterval
         )
-        skipPollOnFocusLost = subscribers[key].skipPollOnFocusLost
+        skipPollOnFocusLost =
+          subscribers[key].skipPollOnFocusLost || skipPollOnFocusLost
       }
     }
 

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -77,7 +77,7 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
       nextPollTimestamp,
       pollingInterval: lowestPollingInterval,
       timeout: setTimeout(() => {
-        if (document.hasFocus() || !skipPollOnFocusLost) {
+        if (state.config.focused || !skipPollOnFocusLost) {
           api.dispatch(refetchQuery(querySubState, queryCacheKey))
         }
         startNextPoll({ queryCacheKey }, api)
@@ -135,7 +135,9 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
           subscribers[key].pollingInterval!,
           lowestPollingInterval
         )
-        skipPollOnFocusLost = subscribers[key].skipPollOnFocusLost
+        // if (!skipPollOnFocusLost) {
+          skipPollOnFocusLost = subscribers[key].skipPollOnFocusLost
+        // }
       }
     }
 

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -672,7 +672,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         refetchOnMountOrArgChange,
         skip = false,
         pollingInterval = 0,
-        skipPollOnFocusLost = false,
+        skipPollingIfUnfocused = false,
       } = {}
     ) => {
       const { initiate } = api.endpoints[name] as ApiEndpointQuery<
@@ -716,7 +716,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         refetchOnReconnect,
         refetchOnFocus,
         pollingInterval,
-        skipPollOnFocusLost,
+        skipPollingIfUnfocused,
       })
 
       const lastRenderHadSubscription = useRef(false)
@@ -817,7 +817,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       refetchOnReconnect,
       refetchOnFocus,
       pollingInterval = 0,
-      skipPollOnFocusLost = false,
+      skipPollingIfUnfocused = false,
     } = {}) => {
       const { initiate } = api.endpoints[name] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
@@ -832,7 +832,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         refetchOnReconnect,
         refetchOnFocus,
         pollingInterval,
-        skipPollOnFocusLost,
+        skipPollingIfUnfocused,
       })
 
       usePossiblyImmediateEffect(() => {

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -672,6 +672,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         refetchOnMountOrArgChange,
         skip = false,
         pollingInterval = 0,
+        skipPollOnFocusLost = false,
       } = {}
     ) => {
       const { initiate } = api.endpoints[name] as ApiEndpointQuery<
@@ -715,6 +716,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         refetchOnReconnect,
         refetchOnFocus,
         pollingInterval,
+        skipPollOnFocusLost,
       })
 
       const lastRenderHadSubscription = useRef(false)
@@ -815,6 +817,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       refetchOnReconnect,
       refetchOnFocus,
       pollingInterval = 0,
+      skipPollOnFocusLost = false,
     } = {}) => {
       const { initiate } = api.endpoints[name] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
@@ -829,6 +832,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         refetchOnReconnect,
         refetchOnFocus,
         pollingInterval,
+        skipPollOnFocusLost,
       })
 
       usePossiblyImmediateEffect(() => {

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -123,11 +123,14 @@ describe('polling tests', () => {
     expect(mockBaseQuery.mock.calls.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('respects skipPollOnFocusLost', async () => {
+  it('respects skipPollingIfUnfocused', async () => {
     mockBaseQuery.mockClear()
     storeRef.store.dispatch(
       getPosts.initiate(2, {
-        subscriptionOptions: { pollingInterval: 10, skipPollOnFocusLost: true },
+        subscriptionOptions: {
+          pollingInterval: 10,
+          skipPollingIfUnfocused: true,
+        },
         subscribe: true,
       })
     )
@@ -140,7 +143,7 @@ describe('polling tests', () => {
       getPosts.initiate(2, {
         subscriptionOptions: {
           pollingInterval: 10,
-          skipPollOnFocusLost: false,
+          skipPollingIfUnfocused: false,
         },
         subscribe: true,
       })
@@ -157,12 +160,12 @@ describe('polling tests', () => {
     storeRef.store.dispatch(api.util.resetApiState())
   })
 
-  it('respects skipPollOnFocusLost if at least one subscription has it', async () => {
+  it('respects skipPollingIfUnfocused if at least one subscription has it', async () => {
     storeRef.store.dispatch(
       getPosts.initiate(3, {
         subscriptionOptions: {
           pollingInterval: 10,
-          skipPollOnFocusLost: false,
+          skipPollingIfUnfocused: false,
         },
         subscribe: true,
       })
@@ -173,7 +176,10 @@ describe('polling tests', () => {
 
     storeRef.store.dispatch(
       getPosts.initiate(3, {
-        subscriptionOptions: { pollingInterval: 15, skipPollOnFocusLost: true },
+        subscriptionOptions: {
+          pollingInterval: 15,
+          skipPollingIfUnfocused: true,
+        },
         subscribe: true,
       })
     )
@@ -182,7 +188,7 @@ describe('polling tests', () => {
       getPosts.initiate(3, {
         subscriptionOptions: {
           pollingInterval: 20,
-          skipPollOnFocusLost: false,
+          skipPollingIfUnfocused: false,
         },
         subscribe: true,
       })
@@ -197,13 +203,13 @@ describe('polling tests', () => {
     expect(callsWithSkip).toBe(callsWithoutSkip + 1)
   })
 
-  it('replaces skipPollOnFocusLost when the subscription options are updated', async () => {
+  it('replaces skipPollingIfUnfocused when the subscription options are updated', async () => {
     const { requestId, queryCacheKey, ...subscription } =
       storeRef.store.dispatch(
         getPosts.initiate(1, {
           subscriptionOptions: {
             pollingInterval: 10,
-            skipPollOnFocusLost: false,
+            skipPollingIfUnfocused: false,
           },
           subscribe: true,
         })
@@ -213,15 +219,15 @@ describe('polling tests', () => {
 
     await delay(1)
     expect(Object.keys(getSubs())).toHaveLength(1)
-    expect(getSubs()[requestId].skipPollOnFocusLost).toBe(false)
+    expect(getSubs()[requestId].skipPollingIfUnfocused).toBe(false)
 
     subscription.updateSubscriptionOptions({
       pollingInterval: 20,
-      skipPollOnFocusLost: true,
+      skipPollingIfUnfocused: true,
     })
 
     await delay(1)
     expect(Object.keys(getSubs())).toHaveLength(1)
-    expect(getSubs()[requestId].skipPollOnFocusLost).toBe(true)
+    expect(getSubs()[requestId].skipPollingIfUnfocused).toBe(true)
   })
 })

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -2,7 +2,6 @@ import { createApi } from '@reduxjs/toolkit/query'
 import { delay } from 'msw'
 import { setupApiStore } from './helpers'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
-import { createListenerMiddleware } from '@reduxjs/toolkit'
 
 const mockBaseQuery = vi
   .fn()
@@ -126,26 +125,18 @@ describe('polling tests', () => {
 
   it('respects skipPollOnFocusLost', async () => {
     mockBaseQuery.mockClear()
-    const listenerMiddleware = createListenerMiddleware()
-    const storeListenerRef = setupApiStore(api, undefined, {
-      middleware: {
-        concat: [listenerMiddleware.middleware],
-      },
-      withoutTestLifecycles: true,
-    })
-
-    storeListenerRef.store.dispatch(
+    storeRef.store.dispatch(
       getPosts.initiate(2, {
         subscriptionOptions: { pollingInterval: 10, skipPollOnFocusLost: true },
         subscribe: true,
       })
     )
-    storeListenerRef.store.dispatch(api.internalActions?.onFocusLost())
+    storeRef.store.dispatch(api.internalActions?.onFocusLost())
 
     await delay(50)
     const callsWithSkip = mockBaseQuery.mock.calls.length
 
-    storeListenerRef.store.dispatch(
+    storeRef.store.dispatch(
       getPosts.initiate(2, {
         subscriptionOptions: {
           pollingInterval: 10,
@@ -155,7 +146,7 @@ describe('polling tests', () => {
       })
     )
 
-    storeListenerRef.store.dispatch(api.internalActions?.onFocus())
+    storeRef.store.dispatch(api.internalActions?.onFocus())
 
     await delay(50)
     const callsWithoutSkip = mockBaseQuery.mock.calls.length
@@ -163,19 +154,11 @@ describe('polling tests', () => {
     expect(callsWithSkip).toBe(1)
     expect(callsWithoutSkip).toBeGreaterThan(2)
 
-    storeListenerRef.store.dispatch(api.util.resetApiState())
+    storeRef.store.dispatch(api.util.resetApiState())
   })
 
   it('respects skipPollOnFocusLost of the most recent mounted subscription', async () => {
-    const listenerMiddleware = createListenerMiddleware()
-    const storeListenerRef = setupApiStore(api, undefined, {
-      middleware: {
-        concat: [listenerMiddleware.middleware],
-      },
-      withoutTestLifecycles: true,
-    })
-
-    storeListenerRef.store.dispatch(
+    storeRef.store.dispatch(
       getPosts.initiate(3, {
         subscriptionOptions: {
           pollingInterval: 10,
@@ -188,14 +171,14 @@ describe('polling tests', () => {
     await delay(50)
     const callsWithSkip = mockBaseQuery.mock.calls.length
 
-    storeListenerRef.store.dispatch(
+    storeRef.store.dispatch(
       getPosts.initiate(3, {
         subscriptionOptions: { pollingInterval: 15, skipPollOnFocusLost: true },
         subscribe: true,
       })
     )
 
-    storeListenerRef.store.dispatch(api.internalActions?.onFocusLost())
+    storeRef.store.dispatch(api.internalActions?.onFocusLost())
 
     await delay(50)
     const callsWithoutSkip = mockBaseQuery.mock.calls.length

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -4,7 +4,6 @@ import { setupApiStore } from './helpers'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
 import { createListenerMiddleware } from '@reduxjs/toolkit'
 
-
 const mockBaseQuery = vi
   .fn()
   .mockImplementation((args: any) => ({ data: args }))
@@ -167,7 +166,7 @@ describe('polling tests', () => {
     storeListenerRef.store.dispatch(api.util.resetApiState())
   })
 
-  it('respects skipPollOnFocusLost if any subscription is true', async () => {
+  it('respects skipPollOnFocusLost of the most recent mounted subscription', async () => {
     const listenerMiddleware = createListenerMiddleware()
     const storeListenerRef = setupApiStore(api, undefined, {
       middleware: {

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -185,7 +185,10 @@ describe('polling tests', () => {
     const { requestId, queryCacheKey, ...subscription } =
       storeRef.store.dispatch(
         getPosts.initiate(1, {
-          subscriptionOptions: { pollingInterval: 10, skipPollOnFocusLost: false },
+          subscriptionOptions: {
+            pollingInterval: 10,
+            skipPollOnFocusLost: false,
+          },
           subscribe: true,
         })
       )

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -124,6 +124,7 @@ describe('polling tests', () => {
   })
 
   it('respects skipPollOnFocusLost', async () => {
+    mockBaseQuery.mockClear()
     storeRef.store.dispatch(
       getPosts.initiate(1, {
         subscriptionOptions: { pollingInterval: 10, skipPollOnFocusLost: true },
@@ -146,6 +147,7 @@ describe('polling tests', () => {
 
     await delay(30)
     const callsWithoutSkip = mockBaseQuery.mock.calls.length
+    console.log(callsWithSkip, callsWithoutSkip)
 
     expect(callsWithSkip).toBe(1)
     expect(callsWithoutSkip).toBeGreaterThan(2)
@@ -183,7 +185,7 @@ describe('polling tests', () => {
     const { requestId, queryCacheKey, ...subscription } =
       storeRef.store.dispatch(
         getPosts.initiate(1, {
-          subscriptionOptions: { pollingInterval: 10 },
+          subscriptionOptions: { pollingInterval: 10, skipPollOnFocusLost: false },
           subscribe: true,
         })
       )

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -157,7 +157,7 @@ describe('polling tests', () => {
     storeRef.store.dispatch(api.util.resetApiState())
   })
 
-  it('respects skipPollOnFocusLost of the most recent mounted subscription', async () => {
+  it('respects skipPollOnFocusLost if at least one subscription has it', async () => {
     storeRef.store.dispatch(
       getPosts.initiate(3, {
         subscriptionOptions: {
@@ -169,7 +169,7 @@ describe('polling tests', () => {
     )
 
     await delay(50)
-    const callsWithSkip = mockBaseQuery.mock.calls.length
+    const callsWithoutSkip = mockBaseQuery.mock.calls.length
 
     storeRef.store.dispatch(
       getPosts.initiate(3, {
@@ -178,13 +178,23 @@ describe('polling tests', () => {
       })
     )
 
+    storeRef.store.dispatch(
+      getPosts.initiate(3, {
+        subscriptionOptions: {
+          pollingInterval: 20,
+          skipPollOnFocusLost: false,
+        },
+        subscribe: true,
+      })
+    )
+
     storeRef.store.dispatch(api.internalActions?.onFocusLost())
 
     await delay(50)
-    const callsWithoutSkip = mockBaseQuery.mock.calls.length
+    const callsWithSkip = mockBaseQuery.mock.calls.length
 
-    expect(callsWithSkip).toBeGreaterThan(2)
-    expect(callsWithoutSkip).toBe(callsWithSkip + 1)
+    expect(callsWithoutSkip).toBeGreaterThan(2)
+    expect(callsWithSkip).toBe(callsWithoutSkip + 1)
   })
 
   it('replaces skipPollOnFocusLost when the subscription options are updated', async () => {


### PR DESCRIPTION
fixes #2516 

~PR will be in a draft state as I plan on finishing tests around it but wanted to get the PR up with the initial implementation in case there is some input~

- `skipPollOnFocusLost` option added to SubscriptionOptions
- Extended `findLowestPollingInterval` function in pollingHandler to also return the skipPollOnFocusLost flag that is stored in each subscriptions data alongside pollingInterval. Figured a per subscription setting gave the most granular control if I was going to pick one place for the first setting.

```ts
function findLowestPollingInterval(subscribers: Subscribers = {}) {
    let skipPollOnFocusLost: boolean | undefined = false
    let lowestPollingInterval = Number.POSITIVE_INFINITY
    for (let key in subscribers) {
      if (!!subscribers[key].pollingInterval) {
        lowestPollingInterval = Math.min(
          subscribers[key].pollingInterval!,
          lowestPollingInterval
        )
        skipPollOnFocusLost = subscribers[key].skipPollOnFocusLost
      }
    }

    return {
      lowestPollingInterval,
      skipPollOnFocusLost,
    }
  }
  ```
  
  - Added tests to cover base functionality
  
Notes for review:

- I used document.hasFocus() in the focus check rather than using the focus state that requires the listenerMiddleware, but I can change that if it aligns better with the vision of RTKQ.

- Existing functionality in polling is that it takes the lowest interval of all subscriptions set for the queryCacheKey, where as I have the current functionality set as taking the most recently mounted skipPollOnFocusLost flag, but it still takes the lowest poll interval

- Also review the name it probably sucks and let me know what docs I need to change