### PR TITLE
cacheLifecycle fix for fixedCacheKey in mutationThunk

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -251,9 +251,11 @@ export const buildCacheLifecycleHandler: InternalHandlerBuilder = ({
     }
   }
 
-  function getCacheKey(action: any) {
+    function getCacheKey(action: any) {
     if (isQueryThunk(action)) return action.meta.arg.queryCacheKey
-    if (isMutationThunk(action)) return action.meta.requestId
+    if (isMutationThunk(action)) {
+      return action.meta.arg.fixedCacheKey ?? action.meta.requestId;
+    }
     if (api.internalActions.removeQueryResult.match(action))
       return action.payload.queryCacheKey
     if (api.internalActions.removeMutationResult.match(action))

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -251,10 +251,10 @@ export const buildCacheLifecycleHandler: InternalHandlerBuilder = ({
     }
   }
 
-    function getCacheKey(action: any) {
+  function getCacheKey(action: any) {
     if (isQueryThunk(action)) return action.meta.arg.queryCacheKey
     if (isMutationThunk(action)) {
-      return action.meta.arg.fixedCacheKey ?? action.meta.requestId;
+      return action.meta.arg.fixedCacheKey ?? action.meta.requestId
     }
     if (api.internalActions.removeQueryResult.match(action))
       return action.payload.queryCacheKey

--- a/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
+++ b/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
@@ -20,6 +20,9 @@ describe('fixedCacheKey', () => {
     endpoints: (build) => ({
       send: build.mutation<string, string | Promise<string>>({
         query: (arg) => arg,
+        onCacheEntryAdded: (arg) => {
+          onNewCacheEntry(arg)
+        },
       }),
     }),
   })
@@ -359,18 +362,6 @@ describe('fixedCacheKey', () => {
   })
 
   test('using fixedCacheKey should create a new cache entry', async () => {
-    api.injectEndpoints({
-      overrideExisting: true,
-      endpoints: (build) => ({
-        send: build.mutation<string, string | Promise<string>>({
-          query: (arg) => arg,
-          onCacheEntryAdded(arg, {}) {
-            onNewCacheEntry(arg)
-          },
-        }),
-      }),
-    })
-
     render(<Component name="C1" fixedCacheKey={'testKey'} />, {
       wrapper: storeRef.wrapper,
     })

--- a/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
+++ b/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
@@ -364,14 +364,14 @@ describe('fixedCacheKey', () => {
       endpoints: (build) => ({
         send: build.mutation<string, string | Promise<string>>({
           query: (arg) => arg,
-          onCacheEntryAdded(arg, { }) {
+          onCacheEntryAdded(arg, {}) {
             onNewCacheEntry(arg)
           },
         }),
       }),
     })
 
-    render(<Component name="C1" fixedCacheKey={"testKey"} />, {
+    render(<Component name="C1" fixedCacheKey={'testKey'} />, {
       wrapper: storeRef.wrapper,
     })
 

--- a/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
+++ b/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
@@ -20,9 +20,6 @@ describe('fixedCacheKey', () => {
     endpoints: (build) => ({
       send: build.mutation<string, string | Promise<string>>({
         query: (arg) => arg,
-        onCacheEntryAdded: (arg) => {
-          onNewCacheEntry(arg)
-        },
       }),
     }),
   })
@@ -362,6 +359,14 @@ describe('fixedCacheKey', () => {
   })
 
   test('using fixedCacheKey should create a new cache entry', async () => {
+    api.enhanceEndpoints({
+      endpoints: {
+        send: {
+          onCacheEntryAdded: (arg) => onNewCacheEntry(arg),
+        },
+      },
+    })
+
     render(<Component name="C1" fixedCacheKey={'testKey'} />, {
       wrapper: storeRef.wrapper,
     })
@@ -377,5 +382,13 @@ describe('fixedCacheKey', () => {
     })
 
     expect(onNewCacheEntry).toHaveBeenCalledWith('C1')
+
+    api.enhanceEndpoints({
+      endpoints: {
+        send: {
+          onCacheEntryAdded: undefined,
+        },
+      },
+    })
   })
 })

--- a/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
+++ b/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
@@ -8,8 +8,11 @@ import {
   waitFor,
   act,
 } from '@testing-library/react'
+import { vi } from 'vitest'
 
 describe('fixedCacheKey', () => {
+  const onNewCacheEntry = vi.fn()
+
   const api = createApi({
     async baseQuery(arg: string | Promise<string>) {
       return { data: await arg }
@@ -353,5 +356,35 @@ describe('fixedCacheKey', () => {
 
     expect(getByTestId(c1, 'status').textContent).toBe('fulfilled')
     expect(getByTestId(c1, 'data').textContent).toBe('this should be visible')
+  })
+
+  test('using fixedCacheKey should create a new cache entry', async () => {
+    api.injectEndpoints({
+      overrideExisting: true,
+      endpoints: (build) => ({
+        send: build.mutation<string, string | Promise<string>>({
+          query: (arg) => arg,
+          onCacheEntryAdded(arg, { }) {
+            onNewCacheEntry(arg)
+          },
+        }),
+      }),
+    })
+
+    render(<Component name="C1" fixedCacheKey={"testKey"} />, {
+      wrapper: storeRef.wrapper,
+    })
+
+    let c1 = screen.getByTestId('C1')
+
+    expect(getByTestId(c1, 'status').textContent).toBe('uninitialized')
+    expect(getByTestId(c1, 'originalArgs').textContent).toBe('undefined')
+
+    await act(async () => {
+      getByTestId(c1, 'trigger').click()
+      await Promise.resolve()
+    })
+
+    expect(onNewCacheEntry).toHaveBeenCalledWith('C1')
   })
 })


### PR DESCRIPTION
fixes #2943 

This PR fixes the initiation of the cacheLifecycle when using fixedCacheKey in mutationThunk and adds a test to verify the creation of a new cache entry when using fixedCacheKey. The getCacheKey function has been refactored to return the fixedCache Key if it exists, otherwise it returns the requestId. A new test has been added to ensure that a new cache entry is created when using fixedCache Key.