### PR TITLE
require queryFn meta to match base query

### DIFF
--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -148,7 +148,13 @@ interface EndpointDefinitionWithQueryFn<
     api: BaseQueryApi,
     extraOptions: BaseQueryExtraOptions<BaseQuery>,
     baseQuery: (arg: Parameters<BaseQuery>[0]) => ReturnType<BaseQuery>
-  ): MaybePromise<QueryReturnValue<ResultType, BaseQueryError<BaseQuery>>>
+  ): MaybePromise<
+    QueryReturnValue<
+      ResultType,
+      BaseQueryError<BaseQuery>,
+      BaseQueryMeta<BaseQuery>
+    >
+  >
   query?: never
   transformResponse?: never
   transformErrorResponse?: never


### PR DESCRIPTION
we already do this for errors, and the types for providesTags/invalidatesTags assumes we do this already

i would count this as a bug fix even if it's breaking, but happy to be overruled if we want to push this over to 3.0

![image](https://github.com/reduxjs/redux-toolkit/assets/18308300/2325c5a3-77e2-4e02-abe3-8ce8dfa5aa7e)
