### PR TITLE
Add missing reducer field to ConfigureStoreOptions docs

### DIFF
--- a/docs/api/configureStore.mdx
+++ b/docs/api/configureStore.mdx
@@ -46,6 +46,10 @@ interface ConfigureStoreOptions<
   P = S
 > {
   /**
+   * A single reducer function that will be used as the root reducer, or an
+   * object of slice reducers that will be passed to `combineReducers()`.
+   */
+  reducer: Reducer<S, A, P> | ReducersMapObject<S, A, P>
 
   /**
    * An array of Redux middleware to install. If not supplied, defaults to


### PR DESCRIPTION
The `reducer` field was missing from `ConfigureStoreOptions`

#4115 

I attempted to use docblock to fix these docs, but I wasn't able to have it output the information. I'm not familiar with docblock, but an error message told me the valid references were `summary,remarks,overloadSummary,overloadRemarks,examples,params,,`, and none of those worked.  A manual fix was able to add the missing option.