### PR TITLE
Fix `expectExactType` to be compatible with TypeScript 5.4

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
@@ -96,7 +96,7 @@ type Equals<T, U> = IsAny<
   IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? any : never) : never>
 >
 export function expectExactType<T>(t: T) {
-  return <U extends Equals<T, U>>(u: U) => {}
+  return <U extends T>(u: U & Equals<T, U>) => {}
 }
 
 type EnsureUnknown<T extends any> = IsUnknown<T, any, never>

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -296,7 +296,7 @@ export function expectType<T>(t: T): T {
 type Equals<T, U> = IsAny<
   T,
   never,
-  IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? any : never) : never>
+  IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? unknown : never) : never>
 >
 export function expectExactType<T>(t: T) {
   return <U extends T>(u: U & Equals<T, U>) => {}

--- a/packages/toolkit/src/query/tests/helpers.tsx
+++ b/packages/toolkit/src/query/tests/helpers.tsx
@@ -299,7 +299,7 @@ type Equals<T, U> = IsAny<
   IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? any : never) : never>
 >
 export function expectExactType<T>(t: T) {
-  return <U extends Equals<T, U>>(u: U) => {}
+  return <U extends T>(u: U & Equals<T, U>) => {}
 }
 
 type EnsureUnknown<T extends any> = IsUnknown<T, any, never>

--- a/packages/toolkit/src/query/tests/unionTypes.test.ts
+++ b/packages/toolkit/src/query/tests/unionTypes.test.ts
@@ -123,7 +123,6 @@ describe.skip('TS only tests', () => {
     }
 
     expectExactType('' as string | undefined)(result.currentData)
-    // @ts-expect-error
     expectExactType('' as string)(result.currentData)
 
     if (result.isSuccess) {
@@ -131,7 +130,6 @@ describe.skip('TS only tests', () => {
         expectExactType('' as string)(result.currentData)
       } else {
         expectExactType('' as string | undefined)(result.currentData)
-        // @ts-expect-error
         expectExactType('' as string)(result.currentData)
       }
     }
@@ -359,7 +357,6 @@ describe.skip('TS only tests', () => {
     const { refetch, ...useQueryResultWithoutMethods } = useQueryResult
     expectExactType(useQueryStateResult)(useQueryResultWithoutMethods)
     expectExactType(useQueryStateWithSelectFromResult)(
-      // @ts-expect-error
       useQueryResultWithoutMethods
     )
     expectType<ReturnType<ReturnType<typeof api.endpoints.test.select>>>(

--- a/packages/toolkit/src/query/tests/unionTypes.test.ts
+++ b/packages/toolkit/src/query/tests/unionTypes.test.ts
@@ -1,10 +1,10 @@
 import type { SerializedError } from '@reduxjs/toolkit'
 import type {
   FetchBaseQueryError,
+  TypedUseMutationResult,
   TypedUseQueryHookResult,
   TypedUseQueryStateResult,
   TypedUseQuerySubscriptionResult,
-  TypedUseMutationResult,
 } from '@reduxjs/toolkit/query/react'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { expectExactType, expectType } from './helpers'
@@ -123,6 +123,7 @@ describe.skip('TS only tests', () => {
     }
 
     expectExactType('' as string | undefined)(result.currentData)
+    // @ts-expect-error
     expectExactType('' as string)(result.currentData)
 
     if (result.isSuccess) {
@@ -130,6 +131,7 @@ describe.skip('TS only tests', () => {
         expectExactType('' as string)(result.currentData)
       } else {
         expectExactType('' as string | undefined)(result.currentData)
+        // @ts-expect-error
         expectExactType('' as string)(result.currentData)
       }
     }
@@ -357,6 +359,7 @@ describe.skip('TS only tests', () => {
     const { refetch, ...useQueryResultWithoutMethods } = useQueryResult
     expectExactType(useQueryStateResult)(useQueryResultWithoutMethods)
     expectExactType(useQueryStateWithSelectFromResult)(
+      // @ts-expect-error
       useQueryResultWithoutMethods
     )
     expectType<ReturnType<ReturnType<typeof api.endpoints.test.select>>>(

--- a/packages/toolkit/src/tests/helpers.ts
+++ b/packages/toolkit/src/tests/helpers.ts
@@ -10,7 +10,7 @@ type Equals<T, U> = IsAny<
   IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? any : never) : never>
 >
 export function expectExactType<T>(t: T) {
-  return <U extends Equals<T, U>>(u: U) => {}
+  return <U extends T>(u: U & Equals<T, U>) => {}
 }
 
 type EnsureUnknown<T extends any> = IsUnknown<T, any, never>

--- a/packages/toolkit/src/tests/helpers.ts
+++ b/packages/toolkit/src/tests/helpers.ts
@@ -7,7 +7,7 @@ export function expectType<T>(t: T): T {
 type Equals<T, U> = IsAny<
   T,
   never,
-  IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? any : never) : never>
+  IsAny<U, never, [T] extends [U] ? ([U] extends [T] ? unknown : never) : never>
 >
 export function expectExactType<T>(t: T) {
   return <U extends T>(u: U & Equals<T, U>) => {}


### PR DESCRIPTION
This PR:

  - [X] Fixes `expectExactType` to be compatible with TypeScript 5.4 per reduxjs/react-redux#2123