### PR TITLE
Export types related to overriding the result types

### DIFF
--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -28,6 +28,9 @@ export type {
   QueryArgFrom,
   ResultTypeFrom,
   DefinitionType,
+  DefinitionsFromApi,
+  OverrideResultType,
+  TagTypesFromApi,
 } from './endpointDefinitions'
 export { fetchBaseQuery } from './fetchBaseQuery'
 export type {


### PR DESCRIPTION
This PR:

  - [X] Exports the types related to overriding the result types from the entry point in RTK Query.