### PR TITLE
Fix #3970 - Expose types allowing library consumers to build generic utils on top of @reduxjs/toolkit.

### DIFF
--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -14,9 +14,14 @@ const createApi = /* @__PURE__ */ buildCreateApi(
 )
 
 export type {
+  LazyQueryTrigger,
+  MutationTrigger,
   TypedUseMutationResult,
   TypedUseQueryHookResult,
   TypedUseQueryStateResult,
   TypedUseQuerySubscriptionResult,
+  UseMutation,
+  UseQuery,
+  UseQueryHookResult,
 } from './buildHooks'
 export { createApi, reactHooksModule, reactHooksModuleName }


### PR DESCRIPTION
As discussed on th issue, exposing more types is a good thing as it allows library consumers to build generic piece of code on top of the library.

As I was not sure about which strategy you want to adopt, I choose to expose only the types discussed on the issue.