### PR TITLE
Incorrect builder method referenced

### DIFF
--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -371,7 +371,7 @@ Similar to `createReducer`, the `extraReducers` field uses a "builder callback" 
 
 [examples](docblock://createSlice.ts?token=CreateSliceOptions.extraReducers)
 
-See [the "Builder Callback Notation" section of the `createReducer` reference](./createReducer.mdx#usage-with-the-builder-callback-notation) for details on how to use `builder.addCase`, `builder.addMatcher`, and `builder.addDefault`
+See [the "Builder Callback Notation" section of the `createReducer` reference](./createReducer.mdx#usage-with-the-builder-callback-notation) for details on how to use `builder.addCase`, `builder.addMatcher`, and `builder.addDefaultCase`
 
 ### `reducerPath`
 


### PR DESCRIPTION
The builder method referred to as `builder.addDefault` is incorrect. Changed to `builder.addDefaultCase`