### PR TITLE
Fix wrong state for injected slices when not declared via `withLazyLoadedSlices`

### DIFF
--- a/packages/toolkit/src/combineSlices.ts
+++ b/packages/toolkit/src/combineSlices.ts
@@ -121,7 +121,7 @@ export interface CombinedSliceReducer<
     config?: InjectConfig,
   ): CombinedSliceReducer<
     InitialState,
-    Id<DeclaredState & WithSlice<SliceLike<ReducerPath, String>>>
+    Id<DeclaredState & WithSlice<SliceLike<ReducerPath, State>>>
   >
 
   /**

--- a/packages/toolkit/src/tests/combineSlices.test-d.ts
+++ b/packages/toolkit/src/tests/combineSlices.test-d.ts
@@ -186,4 +186,21 @@ describe('type tests', () => {
       (rootState: RootState, num: number) => rootState.inner,
     )
   })
+
+  test('correct type of state is inferred when not declared via `withLazyLoadedSlices`', () => {
+    // Related to https://github.com/reduxjs/redux-toolkit/issues/4171
+
+    const combinedReducer = combineSlices(stringSlice)
+
+    const withNumber = combinedReducer.inject(numberSlice)
+
+    expectTypeOf(withNumber).returns.toEqualTypeOf<{
+      string: string
+      number: number
+    }>()
+
+    expectTypeOf(withNumber(undefined, { type: '' }).number).toMatchTypeOf<
+      number | undefined
+    >()
+  })
 })

--- a/packages/toolkit/src/tests/combineSlices.test-d.ts
+++ b/packages/toolkit/src/tests/combineSlices.test-d.ts
@@ -200,7 +200,7 @@ describe('type tests', () => {
     }>()
 
     expectTypeOf(withNumber(undefined, { type: '' }).number).toMatchTypeOf<
-      number | undefined
+      number
     >()
   })
 })


### PR DESCRIPTION
This PR:

  - [X] Fixes #4171