### PR TITLE
[Docs, createEntityAdapter API]: add missing setOne and setMany signature

### DIFF
--- a/docs/api/createEntityAdapter.mdx
+++ b/docs/api/createEntityAdapter.mdx
@@ -139,6 +139,12 @@ export interface EntityStateAdapter<T> {
   addMany<S extends EntityState<T>>(state: S, entities: T[]): S
   addMany<S extends EntityState<T>>(state: S, entities: PayloadAction<T[]>): S
 
+  setOne<S extends EntityState<T>>(state: S, entity: T): S
+  setOne<S extends EntityState<T>>(state: S, action: PayloadAction<T>): S
+
+  setMany<S extends EntityState<T>>(state: S, entities: T[]): S
+  setMany<S extends EntityState<T>>(state: S, entities: PayloadAction<T[]>): S
+
   setAll<S extends EntityState<T>>(state: S, entities: T[]): S
   setAll<S extends EntityState<T>>(state: S, entities: PayloadAction<T[]>): S
 


### PR DESCRIPTION
RTK createEntityAdapter API documentation has minor mistake - it skips `setOne` and `setMany` signatures where other returned CRUD functions are described.
https://redux-toolkit.js.org/api/createEntityAdapter#return-value