### PR TITLE
Use vite-tsconfig-paths to make path aliasing easier

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -91,6 +91,7 @@
     "tsup": "^7.2.0",
     "tsx": "^3.12.2",
     "typescript": "^5.3.3",
+    "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.1.3",
     "yargs": "^15.3.1"
   },

--- a/packages/toolkit/tsconfig.base.json
+++ b/packages/toolkit/tsconfig.base.json
@@ -31,20 +31,14 @@
     "downlevelIteration": false,
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true,
-    "baseUrl": ".",
     "types": ["vitest/globals", "vitest/importMeta"],
     "paths": {
-      "@reduxjs/toolkit": ["src/index.ts"], // @remap-prod-remove-line
-      "@reduxjs/toolkit/react": ["src/react/index.ts"], // @remap-prod-remove-line
-      "@reduxjs/toolkit/query": ["src/query/index.ts"], // @remap-prod-remove-line
-      "@reduxjs/toolkit/query/react": ["src/query/react/index.ts"], // @remap-prod-remove-line
-      // for type imports in tests only
-      "@reduxjs/toolkit/dist/*": ["src/*"], // @remap-prod-remove-line
-      // for type imports in tests only
-      "@reduxjs/toolkit/dist/query/*": ["src/query/*"], // @remap-prod-remove-line
+      "@reduxjs/toolkit": ["./src/index.ts"], // @remap-prod-remove-line
+      "@reduxjs/toolkit/react": ["./src/react/index.ts"], // @remap-prod-remove-line
+      "@reduxjs/toolkit/query": ["./src/query/index.ts"], // @remap-prod-remove-line
+      "@reduxjs/toolkit/query/react": ["./src/query/react/index.ts"], // @remap-prod-remove-line
       // internal imports in tests only
-      "@internal/*": ["src/*"],
-      "react": ["node_modules/react"]
+      "@internal/*": ["./src/*"]
     }
   }
 }

--- a/packages/toolkit/vitest.config.mts
+++ b/packages/toolkit/vitest.config.mts
@@ -1,29 +1,19 @@
-import { defineConfig } from 'vitest/config'
-
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
 
 // No __dirname under Node ESM
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default defineConfig({
+  plugins: [tsconfigPaths({ root: import.meta.dirname })],
   test: {
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['./src/**/*.(spec|test).[jt]s?(x)'],
-    alias: {
-      // prettier-ignore
-      '@reduxjs/toolkit/query/react': path.join(__dirname,'./src/query/react/index.ts'), // @remap-prod-remove-line
-      '@reduxjs/toolkit/query': path.join(__dirname, './src/query/index.ts'), // @remap-prod-remove-line
-      '@reduxjs/toolkit/react': path.join(__dirname, './src/index.ts'), // @remap-prod-remove-line
-      '@reduxjs/toolkit': path.join(__dirname, './src/index.ts'), // @remap-prod-remove-line
-
-      // this mapping is disabled as we want `dist` imports in the tests only to be used for "type-only" imports which don't play a role for jest
-      //'^@reduxjs/toolkit/dist/(.*)$': '<rootDir>/src/*',
-      '@internal': path.join(__dirname, './src'),
-    },
     server: { deps: { inline: ['redux', '@reduxjs/toolkit'] } },
   },
 })

--- a/packages/toolkit/vitest.config.mts
+++ b/packages/toolkit/vitest.config.mts
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default defineConfig({
-  plugins: [tsconfigPaths({ root: import.meta.dirname })],
+  plugins: [tsconfigPaths({ root: __dirname })],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7320,6 +7320,7 @@ __metadata:
     tsup: ^7.2.0
     tsx: ^3.12.2
     typescript: ^5.3.3
+    vite-tsconfig-paths: ^4.3.1
     vitest: ^1.1.3
     yargs: ^15.3.1
   peerDependencies:
@@ -27800,6 +27801,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "tsconfck@npm:3.0.2"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: bf40e547a01610571a55ff33beb74751942561963f9c5f1152ad415ad4bd27eb90d65e9fb2edbb60ecb9407b115d1d52a633fc1f83cf4ea0424041a10e7eeea3
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.1":
   version: 3.14.1
   resolution: "tsconfig-paths@npm:3.14.1"
@@ -28815,6 +28830,22 @@ __metadata:
   bin:
     vite-node: vite-node.mjs
   checksum: 559740675bfbba36e1a1c6a52805fca12bfc3e955cc13b5984c7de4cd452276497fd3873ed45e786d4ece4e2a186b0757b9ebb0f58f14ef1acdafacc2cccfbd5
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "vite-tsconfig-paths@npm:4.3.1"
+  dependencies:
+    debug: ^4.1.1
+    globrex: ^0.1.2
+    tsconfck: ^3.0.1
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 2934d5d674e0b6ab8d435d4262ff30143c30512072d71ece5a3859a70a188cbdbcc2b0370277049ab551f7bbb6ffb2be94a0bf30154e5c58d38b32adce9740bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

  - [X] Adds [vite-tsconfig-paths](https://github.com/aleclarson/vite-tsconfig-paths) as a dev dependency.
  - [X] Removes `baseUrl` from `tsconfig.base.json`.
  - [X] Removes `dist` paths aliases.
  - [X] Removes `react` path alias.