### PR TITLE
Add second parameter to getInitialState to prefill entities

### DIFF
--- a/packages/toolkit/src/entities/create_adapter.ts
+++ b/packages/toolkit/src/entities/create_adapter.ts
@@ -1,28 +1,17 @@
-import type {
-  EntityDefinition,
-  Comparer,
-  IdSelector,
-  EntityAdapter,
-  EntityId,
-} from './models'
+import type { EntityAdapter, EntityId, EntityAdapterOptions } from './models'
 import { createInitialStateFactory } from './entity_state'
 import { createSelectorsFactory } from './state_selectors'
 import { createSortedStateAdapter } from './sorted_state_adapter'
 import { createUnsortedStateAdapter } from './unsorted_state_adapter'
+import type { WithRequiredProp } from '../tsHelpers'
 
-export interface EntityAdapterOptions<T, Id extends EntityId> {
-  selectId?: IdSelector<T, Id>
-  sortComparer?: false | Comparer<T>
-}
+export function createEntityAdapter<T, Id extends EntityId>(
+  options: WithRequiredProp<EntityAdapterOptions<T, Id>, 'selectId'>,
+): EntityAdapter<T, Id>
 
-export function createEntityAdapter<T, Id extends EntityId>(options: {
-  selectId: IdSelector<T, Id>
-  sortComparer?: false | Comparer<T>
-}): EntityAdapter<T, Id>
-
-export function createEntityAdapter<T extends { id: EntityId }>(options?: {
-  sortComparer?: false | Comparer<T>
-}): EntityAdapter<T, T['id']>
+export function createEntityAdapter<T extends { id: EntityId }>(
+  options?: Omit<EntityAdapterOptions<T, T['id']>, 'selectId'>,
+): EntityAdapter<T, T['id']>
 
 /**
  *
@@ -31,12 +20,12 @@ export function createEntityAdapter<T extends { id: EntityId }>(options?: {
  * @public
  */
 export function createEntityAdapter<T>(
-  options: {
-    selectId?: IdSelector<T, EntityId>
-    sortComparer?: false | Comparer<T>
-  } = {},
+  options: EntityAdapterOptions<T, EntityId> = {},
 ): EntityAdapter<T, EntityId> {
-  const { selectId, sortComparer }: EntityDefinition<T, EntityId> = {
+  const {
+    selectId,
+    sortComparer,
+  }: Required<EntityAdapterOptions<T, EntityId>> = {
     sortComparer: false,
     selectId: (instance: any) => instance.id,
     ...options,

--- a/packages/toolkit/src/entities/create_adapter.ts
+++ b/packages/toolkit/src/entities/create_adapter.ts
@@ -34,7 +34,7 @@ export function createEntityAdapter<T>(
   const stateAdapter = sortComparer
     ? createSortedStateAdapter(selectId, sortComparer)
     : createUnsortedStateAdapter(selectId)
-  const stateFactory = createInitialStateFactory({ stateAdapter })
+  const stateFactory = createInitialStateFactory(stateAdapter)
   const selectorsFactory = createSelectorsFactory<T, EntityId>()
 
   return {

--- a/packages/toolkit/src/entities/create_adapter.ts
+++ b/packages/toolkit/src/entities/create_adapter.ts
@@ -42,11 +42,11 @@ export function createEntityAdapter<T>(
     ...options,
   }
 
-  const stateFactory = createInitialStateFactory<T, EntityId>()
-  const selectorsFactory = createSelectorsFactory<T, EntityId>()
   const stateAdapter = sortComparer
     ? createSortedStateAdapter(selectId, sortComparer)
     : createUnsortedStateAdapter(selectId)
+  const stateFactory = createInitialStateFactory({ stateAdapter })
+  const selectorsFactory = createSelectorsFactory<T, EntityId>()
 
   return {
     selectId,

--- a/packages/toolkit/src/entities/entity_state.ts
+++ b/packages/toolkit/src/entities/entity_state.ts
@@ -1,4 +1,9 @@
-import type { EntityId, EntityState } from './models'
+import type {
+  EntityId,
+  EntityState,
+  EntityStateAdapter,
+  EntityStateFactory,
+} from './models'
 
 export function getInitialEntityState<T, Id extends EntityId>(): EntityState<
   T,
@@ -10,13 +15,25 @@ export function getInitialEntityState<T, Id extends EntityId>(): EntityState<
   }
 }
 
-export function createInitialStateFactory<T, Id extends EntityId>() {
-  function getInitialState(): EntityState<T, Id>
+export function createInitialStateFactory<T, Id extends EntityId>({
+  stateAdapter,
+}: {
+  stateAdapter: EntityStateAdapter<T, Id>
+}): EntityStateFactory<T, Id> {
+  function getInitialState(
+    state?: undefined,
+    entities?: readonly T[] | Record<Id, T>,
+  ): EntityState<T, Id>
   function getInitialState<S extends object>(
     additionalState: S,
+    entities?: readonly T[] | Record<Id, T>,
   ): EntityState<T, Id> & S
-  function getInitialState(additionalState: any = {}): any {
-    return Object.assign(getInitialEntityState(), additionalState)
+  function getInitialState(
+    additionalState: any = {},
+    entities?: readonly T[] | Record<Id, T>,
+  ): any {
+    const state = Object.assign(getInitialEntityState(), additionalState)
+    return entities ? stateAdapter.setAll(state, entities) : state
   }
 
   return { getInitialState }

--- a/packages/toolkit/src/entities/entity_state.ts
+++ b/packages/toolkit/src/entities/entity_state.ts
@@ -15,11 +15,9 @@ export function getInitialEntityState<T, Id extends EntityId>(): EntityState<
   }
 }
 
-export function createInitialStateFactory<T, Id extends EntityId>({
-  stateAdapter,
-}: {
-  stateAdapter: EntityStateAdapter<T, Id>
-}): EntityStateFactory<T, Id> {
+export function createInitialStateFactory<T, Id extends EntityId>(
+  stateAdapter: EntityStateAdapter<T, Id>,
+): EntityStateFactory<T, Id> {
   function getInitialState(
     state?: undefined,
     entities?: readonly T[] | Record<Id, T>,

--- a/packages/toolkit/src/entities/models.ts
+++ b/packages/toolkit/src/entities/models.ts
@@ -35,9 +35,9 @@ export interface EntityState<T, Id extends EntityId> {
 /**
  * @public
  */
-export interface EntityDefinition<T, Id extends EntityId> {
-  selectId: IdSelector<T, Id>
-  sortComparer: false | Comparer<T>
+export interface EntityAdapterOptions<T, Id extends EntityId> {
+  selectId?: IdSelector<T, Id>
+  sortComparer?: false | Comparer<T>
 }
 
 export type PreventAny<S, T, Id extends EntityId> = CastAny<
@@ -166,6 +166,9 @@ export interface EntitySelectors<T, V, Id extends EntityId> {
   selectById: (state: V, id: Id) => Compute<UncheckedIndexedAccess<T>>
 }
 
+/**
+ * @public
+ */
 export interface EntityStateFactory<T, Id extends EntityId> {
   getInitialState(
     state?: undefined,
@@ -182,9 +185,8 @@ export interface EntityStateFactory<T, Id extends EntityId> {
  */
 export interface EntityAdapter<T, Id extends EntityId>
   extends EntityStateAdapter<T, Id>,
-    EntityStateFactory<T, Id> {
-  selectId: IdSelector<T, Id>
-  sortComparer: false | Comparer<T>
+    EntityStateFactory<T, Id>,
+    Required<EntityAdapterOptions<T, Id>> {
   getSelectors(
     selectState?: undefined,
     options?: GetSelectorsOptions,

--- a/packages/toolkit/src/entities/models.ts
+++ b/packages/toolkit/src/entities/models.ts
@@ -166,15 +166,25 @@ export interface EntitySelectors<T, V, Id extends EntityId> {
   selectById: (state: V, id: Id) => Compute<UncheckedIndexedAccess<T>>
 }
 
+export interface EntityStateFactory<T, Id extends EntityId> {
+  getInitialState(
+    state?: undefined,
+    entities?: Record<Id, T> | readonly T[],
+  ): EntityState<T, Id>
+  getInitialState<S extends object>(
+    state: S,
+    entities?: Record<Id, T> | readonly T[],
+  ): EntityState<T, Id> & S
+}
+
 /**
  * @public
  */
 export interface EntityAdapter<T, Id extends EntityId>
-  extends EntityStateAdapter<T, Id> {
+  extends EntityStateAdapter<T, Id>,
+    EntityStateFactory<T, Id> {
   selectId: IdSelector<T, Id>
   sortComparer: false | Comparer<T>
-  getInitialState(): EntityState<T, Id>
-  getInitialState<S extends object>(state: S): EntityState<T, Id> & S
   getSelectors(
     selectState?: undefined,
     options?: GetSelectorsOptions,

--- a/packages/toolkit/src/entities/tests/entity_state.test.ts
+++ b/packages/toolkit/src/entities/tests/entity_state.test.ts
@@ -35,6 +35,27 @@ describe('Entity State', () => {
     })
   })
 
+  it('should let you provide initial entities', () => {
+    const book1: BookModel = { id: 'a', title: 'First' }
+
+    const initialState = adapter.getInitialState(undefined, [book1])
+
+    expect(initialState).toEqual({
+      ids: [book1.id],
+      entities: { [book1.id]: book1 },
+    })
+
+    const additionalProperties = { isHydrated: true }
+
+    const initialState2 = adapter.getInitialState(additionalProperties, [book1])
+
+    expect(initialState2).toEqual({
+      ...additionalProperties,
+      ids: [book1.id],
+      entities: { [book1.id]: book1 },
+    })
+  })
+
   it('should allow methods to be passed as reducers', () => {
     const upsertBook = createAction<BookModel>('otherBooks/upsert')
 


### PR DESCRIPTION
instead of having to call `adapter.setAll(adapter.getInitialState(), entities)`, this enables calling `adapter.getInitialState(undefined, entities)`