### PR TITLE
allow initialising combined slice reducer with no static slices

### DIFF
--- a/docs/api/combineSlices.mdx
+++ b/docs/api/combineSlices.mdx
@@ -86,17 +86,6 @@ However, typing will not be able to account for this. It's best to ensure that a
 
 :::
 
-:::warning
-
-Like [`combineReducers`](https://redux.js.org/api/combinereducers), `combineSlices` requires at least one reducer at initialisation.
-
-```ts no-transpile
-// will throw an error
-const rootReducer = combineSlices()
-```
-
-:::
-
 ## Return Value
 
 `combineSlices` returns a reducer function, with attached methods.

--- a/packages/toolkit/src/combineSlices.ts
+++ b/packages/toolkit/src/combineSlices.ts
@@ -359,15 +359,15 @@ const original = (state: any) => {
   return state[ORIGINAL_STATE]
 }
 
-export function combineSlices<
-  Slices extends [
-    AnySliceLike | ReducerMap,
-    ...Array<AnySliceLike | ReducerMap>,
-  ],
->(...slices: Slices): CombinedSliceReducer<Id<InitialState<Slices>>> {
+const noopReducer: Reducer<Record<string, any>> = (state = {}) => state
+
+export function combineSlices<Slices extends Array<AnySliceLike | ReducerMap>>(
+  ...slices: Slices
+): CombinedSliceReducer<Id<InitialState<Slices>>> {
   const reducerMap = Object.fromEntries<Reducer>(getReducers(slices))
 
-  const getReducer = () => combineReducers(reducerMap)
+  const getReducer = () =>
+    Object.keys(reducerMap).length ? combineReducers(reducerMap) : noopReducer
 
   let reducer = getReducer()
 

--- a/packages/toolkit/src/tests/combineSlices.test-d.ts
+++ b/packages/toolkit/src/tests/combineSlices.test-d.ts
@@ -33,7 +33,7 @@ describe('type tests', () => {
     }>()
   })
 
-  test('combineSlices allows for no initial reducers', () => {
+  test('combineSlices allows passing no initial reducers', () => {
     const rootReducer = combineSlices()
 
     expectTypeOf(rootReducer(undefined, { type: '' })).toEqualTypeOf<{}>()

--- a/packages/toolkit/src/tests/combineSlices.test-d.ts
+++ b/packages/toolkit/src/tests/combineSlices.test-d.ts
@@ -33,6 +33,12 @@ describe('type tests', () => {
     }>()
   })
 
+  test('combineSlices allows for no initial reducers', () => {
+    const rootReducer = combineSlices()
+
+    expectTypeOf(rootReducer(undefined, { type: '' })).toEqualTypeOf<{}>()
+  })
+
   test('withLazyLoadedSlices adds partial to state', () => {
     const rootReducer = combineSlices(stringSlice).withLazyLoadedSlices<
       WithSlice<typeof numberSlice> & WithSlice<typeof exampleApi>
@@ -199,8 +205,8 @@ describe('type tests', () => {
       number: number
     }>()
 
-    expectTypeOf(withNumber(undefined, { type: '' }).number).toMatchTypeOf<
-      number
-    >()
+    expectTypeOf(
+      withNumber(undefined, { type: '' }).number,
+    ).toMatchTypeOf<number>()
   })
 })

--- a/packages/toolkit/src/tests/combineSlices.test-d.ts
+++ b/packages/toolkit/src/tests/combineSlices.test-d.ts
@@ -37,6 +37,13 @@ describe('type tests', () => {
     const rootReducer = combineSlices()
 
     expectTypeOf(rootReducer(undefined, { type: '' })).toEqualTypeOf<{}>()
+
+    const declaredLazy =
+      combineSlices().withLazyLoadedSlices<WithSlice<typeof numberSlice>>()
+
+    expectTypeOf(declaredLazy(undefined, { type: '' })).toEqualTypeOf<{
+      number?: number
+    }>()
   })
 
   test('withLazyLoadedSlices adds partial to state', () => {

--- a/packages/toolkit/src/tests/combineSlices.test.ts
+++ b/packages/toolkit/src/tests/combineSlices.test.ts
@@ -64,6 +64,16 @@ describe('combineSlices', () => {
       api: api.reducer.getInitialState(),
     })
   })
+  it('allows passing no initial reducers', () => {
+    const combinedReducer = combineSlices()
+
+    const result = combinedReducer(undefined, dummyAction())
+
+    expect(result).toEqual({})
+
+    // no-op if we have no reducers yet
+    expect(combinedReducer(result, dummyAction())).toBe(result)
+  })
   describe('injects', () => {
     beforeEach(() => {
       vi.stubEnv('NODE_ENV', 'development')


### PR DESCRIPTION
```ts
const reducer = combineSlices().withLazyLoadedSlices<LazyLoadedSlices>()
``` 
currently throws an error - this makes it return a "no-op" reducer which creates an empty object and just returns it until any reducers are injected