### PR TITLE
proposal fix for axios base query types

### DIFF
--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -369,7 +369,7 @@ const axiosBaseQuery =
   ): BaseQueryFn<
     {
       url: string
-      method: AxiosRequestConfig['method']
+      method?: AxiosRequestConfig['method']
       data?: AxiosRequestConfig['data']
       params?: AxiosRequestConfig['params']
       headers?: AxiosRequestConfig['headers']

--- a/packages/toolkit/src/query/tests/errorHandling.test.tsx
+++ b/packages/toolkit/src/query/tests/errorHandling.test.tsx
@@ -390,7 +390,7 @@ describe('custom axios baseQuery', () => {
     ): BaseQueryFn<
       {
         url: string
-        method: AxiosRequestConfig['method']
+        method?: AxiosRequestConfig['method']
         data?: AxiosRequestConfig['data']
       },
       unknown,


### PR DESCRIPTION
To prevent this type of TS errors in file after @rtk-query/codegen-openapi: 

<img width="755" alt="Снимок экрана 2024-02-12 в 10 22 07" src="https://github.com/reduxjs/redux-toolkit/assets/3962132/53680433-5291-4e0a-9027-00ffadba3164">

This is acceptable because axios: 
<img width="490" alt="Снимок экрана 2024-02-12 в 10 22 27" src="https://github.com/reduxjs/redux-toolkit/assets/3962132/d271733d-33a3-4564-a164-7cc010acf9c7">
