### PR TITLE
Update oazapfts to 6.0.2

### DIFF
--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.2",
     "commander": "^6.2.0",
-    "oazapfts": "^4.8.0",
+    "oazapfts": "^6.0.2",
     "prettier": "^3.2.5",
     "semver": "^7.3.5",
     "swagger2openapi": "^7.0.4",

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -5,13 +5,11 @@ import ApiGenerator, {
   getReferenceName,
   isReference,
   supportDeepObjects,
-} from 'oazapfts/lib/codegen/generate';
-import {
   createPropertyAssignment,
   createQuestionToken,
   isValidIdentifier,
   keywordType,
-} from 'oazapfts/lib/codegen/tscodegen';
+} from 'oazapfts/generate';
 import type { OpenAPIV3 } from 'openapi-types';
 import ts from 'typescript';
 import type { ObjectPropertyDefinitions } from './codegen';

--- a/packages/rtk-query-codegen-openapi/src/generators/react-hooks.ts
+++ b/packages/rtk-query-codegen-openapi/src/generators/react-hooks.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { getOperationName } from 'oazapfts/lib/codegen/generate';
+import { getOperationName } from 'oazapfts/generate';
 import { capitalize, isQuery } from '../utils';
 import type { OperationDefinition, EndpointOverrides, ConfigFile } from '../types';
 import { getOverrides } from '../generate';

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
@@ -192,6 +192,7 @@ export type Pet = {
   category?: Category;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: 'available' | 'pending' | 'sold';
 };
 export type ApiResponse = {
@@ -204,6 +205,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
+  /** Order Status */
   status?: 'placed' | 'approved' | 'delivered';
   complete?: boolean;
 };
@@ -215,6 +217,7 @@ export type User = {
   email?: string;
   password?: string;
   phone?: string;
+  /** User Status */
   userStatus?: number;
 };
 "
@@ -412,6 +415,7 @@ export type Pet = {
   category?: Category;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: 'available' | 'pending' | 'sold';
 };
 export type ApiResponse = {
@@ -424,6 +428,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
+  /** Order Status */
   status?: 'placed' | 'approved' | 'delivered';
   complete?: boolean;
 };
@@ -435,6 +440,7 @@ export type User = {
   email?: string;
   password?: string;
   phone?: string;
+  /** User Status */
   userStatus?: number;
 };
 "

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -258,6 +258,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -270,6 +271,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -281,6 +283,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 "
@@ -386,6 +389,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -494,6 +498,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
@@ -680,6 +685,7 @@ export type Pet = {
   category?: Category;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold";
 };
 export const { useAddPetMutation, useGetPetByIdQuery, useLazyGetPetByIdQuery } =
@@ -729,6 +735,7 @@ export type Pet = {
   category?: Category;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold";
 };
 export const { useLazyGetPetByIdQuery } = injectedRtkApi;
@@ -777,6 +784,7 @@ export type Pet = {
   category?: Category;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold";
 };
 export const { useAddPetMutation } = injectedRtkApi;
@@ -825,6 +833,7 @@ export type Pet = {
   category?: Category;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold";
 };
 export const { useGetPetByIdQuery } = injectedRtkApi;
@@ -1153,6 +1162,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -1165,6 +1175,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -1176,6 +1187,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 export const {
@@ -1537,6 +1549,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -1549,6 +1562,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -1560,6 +1574,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 export const {

--- a/packages/rtk-query-codegen-openapi/tsconfig.json
+++ b/packages/rtk-query-codegen-openapi/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
+    "module": "ESNext",
     "declaration": true,
     "sourceMap": true,
     "outDir": "lib",
@@ -9,7 +9,7 @@
     "strict": true,
     "noUnusedLocals": false,
     "resolveJsonModule": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "types": ["vitest/globals", "vitest/importMeta"],
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7617,7 +7617,7 @@ __metadata:
     husky: "npm:^4.3.6"
     msw: "npm:^2.1.5"
     node-fetch: "npm:^3.3.2"
-    oazapfts: "npm:^4.8.0"
+    oazapfts: "npm:^6.0.2"
     openapi-types: "npm:^9.1.0"
     prettier: "npm:^3.2.5"
     pretty-quick: "npm:^3.1.0"
@@ -21400,18 +21400,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oazapfts@npm:^4.8.0":
-  version: 4.10.0
-  resolution: "oazapfts@npm:4.10.0"
+"oazapfts@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "oazapfts@npm:6.0.2"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
     lodash: "npm:^4.17.21"
     minimist: "npm:^1.2.8"
     swagger2openapi: "npm:^7.0.8"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
+  peerDependencies:
+    "@oazapfts/runtime": "*"
   bin:
-    oazapfts: lib/codegen/cli.js
-  checksum: 10/361915b5bafea470b63e54274a54ec19a1d5de09f017f11a4dc380f6e00bd7fb043ae7e0b6a166a46276c41e19a9206cc13b9213d7e7a4e0e08f783ef7b4ec07
+    oazapfts: dist/cli.js
+  checksum: 10/9132e4bbc589cefba2b93a2421309c89e7685cf75108ac8611d93f78c4e985a0d95829feb2f2b109fa22cb6feb12a6a1e03a679bba9892633c22fe9fb21bd91c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Some issues (s. #3814) have been fixed in upstream library `oazapfts` so this is an attempt to update it to the latest version.

The major updates that this update has stepped over are mainly regarding changes to exported files that have been addressed by this PR.

`oazapfts` now includes comments in the generated types, so I also needed to update the snapshot tests.

closes #3814