### PR TITLE
Bump prettier and format all files

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,5 @@
 {
   "semi": false,
   "singleQuote": true,
-  "endOfLine": "auto",
-  "overrides": [
-    {
-      "files": ["examples/**/tsconfig*.json"],
-      "options": { "parser": "json" }
-    }
-  ]
+  "endOfLine": "auto"
 }

--- a/docs/api/createSelector.mdx
+++ b/docs/api/createSelector.mdx
@@ -94,7 +94,8 @@ const draftSafeSelector = createWeakMapDraftSafeSelector(
 As of RTK 2.1, you can define a "pre-typed" version of `createDraftSafeSelector` that can have the type for `state` built in. This lets you set up those types once, so you don't have to repeat them each time you call `createDraftSafeSelector`.
 
 ```ts no-transpile
-const createTypedDraftSafeSelector = createDraftSafeSelector.withTypes<RootState>()
+const createTypedDraftSafeSelector =
+  createDraftSafeSelector.withTypes<RootState>()
 ```
 
 Import and use the pre-typed `createTypedDraftSafeSelector` function, and it will automatically know that the `state` argument is of type `RootState`.
@@ -125,13 +126,14 @@ export interface RootState {
   alerts: Alert[]
 }
 
-export const createTypedDraftSafeSelector = createDraftSafeSelector.withTypes<RootState>()
+export const createTypedDraftSafeSelector =
+  createDraftSafeSelector.withTypes<RootState>()
 
 const selectTodoIds = createTypedDraftSafeSelector(
   // Type of `state` is set to `RootState`, no need to manually set the type
-  state => state.todos,
+  (state) => state.todos,
   // ❌ Known limitation: Parameter types are not inferred in this scenario
   // so you will have to manually annotate them.
-  (todos: Todo[]) => todos.map(({ id }) => id)
+  (todos: Todo[]) => todos.map(({ id }) => id),
 )
 ```

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -23,15 +23,13 @@
       "@reduxjs/toolkit": ["packages/toolkit/src/index.ts"],
       "@reduxjs/toolkit/query": ["packages/toolkit/src/query/index.ts"],
       "@reduxjs/toolkit/query/react": [
-        "packages/toolkit/src/query/react/index.ts",
+        "packages/toolkit/src/query/react/index.ts"
       ],
       "@reduxjs/toolkit/dist/query/*": ["packages/toolkit/src/query/*"],
       "@virtual/*": ["docs/virtual/*"],
       "your-cool-library": ["docs/virtual/your-cool-library/index.ts"],
       "redux-logger": ["docs/virtual/redux-logger/index.ts"],
-      "petstore-api.generated": [
-        "docs/virtual/petstore-api.generated/index.ts",
-      ],
-    },
-  },
+      "petstore-api.generated": ["docs/virtual/petstore-api.generated/index.ts"]
+    }
+  }
 }

--- a/examples/publish-ci/cra4/package.json
+++ b/examples/publish-ci/cra4/package.json
@@ -50,7 +50,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "playwright": "^1.31.1",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^4.9.4"
   }

--- a/examples/publish-ci/cra4/yarn.lock
+++ b/examples/publish-ci/cra4/yarn.lock
@@ -12795,12 +12795,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -13960,7 +13960,7 @@ __metadata:
     "@types/react-dom": ^18.0.10
     msw: ^1.3.2
     playwright: ^1.31.1
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: ^18.2.0
     react-dom: ^18.2.0
     react-redux: ^9.0.0-rc.0

--- a/examples/publish-ci/cra5/package.json
+++ b/examples/publish-ci/cra5/package.json
@@ -50,7 +50,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "playwright": "^1.31.1",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^4.9.4"
   }

--- a/examples/publish-ci/cra5/yarn.lock
+++ b/examples/publish-ci/cra5/yarn.lock
@@ -10896,12 +10896,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -11749,7 +11749,7 @@ __metadata:
     "@types/react-dom": ^18.0.10
     msw: ^1.3.2
     playwright: ^1.31.1
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: ^18.2.0
     react-dom: ^18.2.0
     react-redux: ^9.0.0-rc.0

--- a/examples/publish-ci/expo/package.json
+++ b/examples/publish-ci/expo/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
     "jest-expo": "^49.0.0",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.3"
   },

--- a/examples/publish-ci/expo/tsconfig.json
+++ b/examples/publish-ci/expo/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true,
-  },
+    "strict": true
+  }
 }

--- a/examples/publish-ci/expo/yarn.lock
+++ b/examples/publish-ci/expo/yarn.lock
@@ -6050,7 +6050,7 @@ __metadata:
     expo-status-bar: ~1.6.0
     jest: ^29.7.0
     jest-expo: ^49.0.0
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: 18.2.0
     react-native: 0.72.6
     react-redux: ^9.0.4
@@ -10172,12 +10172,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 

--- a/examples/publish-ci/next/package.json
+++ b/examples/publish-ci/next/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "playwright": "^1.31.1",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^4.9.4"
   },

--- a/examples/publish-ci/next/yarn.lock
+++ b/examples/publish-ci/next/yarn.lock
@@ -2863,12 +2863,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -3157,7 +3157,7 @@ __metadata:
     msw: ^1.3.2
     next: ^13.2
     playwright: ^1.31.1
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: ^18.2.0
     react-dom: ^18.2.0
     react-redux: ^9.0.0-rc.0

--- a/examples/publish-ci/react-native/package.json
+++ b/examples/publish-ci/react-native/package.json
@@ -38,7 +38,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "react-test-renderer": "18.2.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"

--- a/examples/publish-ci/react-native/tsconfig.json
+++ b/examples/publish-ci/react-native/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@react-native/typescript-config/tsconfig.json",
+  "extends": "@react-native/typescript-config/tsconfig.json"
 }

--- a/examples/publish-ci/react-native/yarn.lock
+++ b/examples/publish-ci/react-native/yarn.lock
@@ -7805,12 +7805,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -7982,7 +7982,7 @@ __metadata:
     eslint-config-prettier: ^9.1.0
     eslint-plugin-prettier: ^5.1.3
     jest: ^29.7.0
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: 18.2.0
     react-native: ^0.73.2
     react-redux: ^9.1.0

--- a/examples/publish-ci/vite/package.json
+++ b/examples/publish-ci/vite/package.json
@@ -28,7 +28,7 @@
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^3.0.0",
     "playwright": "^1.31.1",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^4.9.4",
     "vite": "^4.2.1"

--- a/examples/publish-ci/vite/yarn.lock
+++ b/examples/publish-ci/vite/yarn.lock
@@ -3316,12 +3316,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -3657,7 +3657,7 @@ __metadata:
     "@vitejs/plugin-react": ^3.0.0
     msw: ^1.3.2
     playwright: ^1.31.1
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: ^18.2.0
     react-dom: ^18.2.0
     react-redux: ^9.0.0-rc.0

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
     "netlify-plugin-cache": "^1.0.3",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "release-it": "^14.12.5",
     "serve": "^14.2.0",
     "ts-node": "^10.9.2",

--- a/packages/rtk-codemods/package.json
+++ b/packages/rtk-codemods/package.json
@@ -35,7 +35,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "vitest": "^1.2.1"
   },
   "engines": {

--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -59,7 +59,7 @@
     "@apidevtools/swagger-parser": "^10.0.2",
     "commander": "^6.2.0",
     "oazapfts": "^4.8.0",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "semver": "^7.3.5",
     "swagger2openapi": "^7.0.4",
     "typescript": "^5.3.3"

--- a/packages/rtk-query-codegen-openapi/test/tsconfig.json
+++ b/packages/rtk-query-codegen-openapi/test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./test/fixtures/*"],
-      "@rtk-query/codegen-openapi": ["./src"],
+      "@rtk-query/codegen-openapi": ["./src"]
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
@@ -16,6 +16,6 @@
     "resolveJsonModule": true,
     "types": ["vitest/globals", "vitest/importMeta"],
     "allowJs": true,
-    "checkJs": true,
-  },
+    "checkJs": true
+  }
 }

--- a/packages/rtk-query-codegen-openapi/tsconfig.json
+++ b/packages/rtk-query-codegen-openapi/tsconfig.json
@@ -13,7 +13,7 @@
     "types": ["vitest/globals", "vitest/importMeta"],
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["test", "lib", "vitest.config.mts"],
+  "exclude": ["test", "lib", "vitest.config.mts"]
 }

--- a/packages/rtk-query-graphql-request-base-query/tsconfig.json
+++ b/packages/rtk-query-graphql-request-base-query/tsconfig.json
@@ -67,7 +67,7 @@
 
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts"]
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -83,7 +83,7 @@
     "json-stringify-safe": "^5.0.1",
     "msw": "^2.1.4",
     "node-fetch": "^3.3.2",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "query-string": "^7.0.1",
     "rimraf": "^3.0.2",
     "size-limit": "^11.0.1",

--- a/packages/toolkit/tsconfig.json
+++ b/packages/toolkit/tsconfig.json
@@ -5,7 +5,7 @@
   "extends": "./tsconfig.test.json",
   "compilerOptions": {
     "skipLibCheck": true,
-    "rootDir": ".",
+    "rootDir": "."
   },
-  "include": ["."],
+  "include": ["."]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,6 @@
   },
   "devDependencies": {
     "netlify-plugin-cache": "^1.0.3",
-    "prettier": "^3.2.4"
+    "prettier": "^3.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,7 +7261,7 @@ __metadata:
     execa: ^8.0.1
     globby: ^14.0.0
     jscodeshift: ^0.15.1
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     ts-node: ^10.9.2
     typescript: ^5.3.3
     vitest: ^1.2.1
@@ -7309,7 +7309,7 @@ __metadata:
     json-stringify-safe: ^5.0.1
     msw: ^2.1.4
     node-fetch: ^3.3.2
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     query-string: ^7.0.1
     redux: ^5.0.1
     redux-thunk: ^3.1.0
@@ -7586,7 +7586,7 @@ __metadata:
     node-fetch: ^3.3.2
     oazapfts: ^4.8.0
     openapi-types: ^9.1.0
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     pretty-quick: ^3.1.0
     rimraf: ^5.0.5
     semver: ^7.3.5
@@ -23612,12 +23612,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -25488,7 +25488,7 @@ __metadata:
     eslint-plugin-react: ^7.23.2
     eslint-plugin-react-hooks: ^4.2.0
     netlify-plugin-cache: ^1.0.3
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     release-it: ^14.12.5
     serve: ^14.2.0
     ts-node: ^10.9.2
@@ -29493,7 +29493,7 @@ __metadata:
     "@docusaurus/preset-classic": 2.1.0
     classnames: ^2.2.6
     netlify-plugin-cache: ^1.0.3
-    prettier: ^3.2.4
+    prettier: ^3.2.5
     react: ^18.1.0
     react-dom: ^18.1.0
     react-lite-youtube-embed: ^2.0.3


### PR DESCRIPTION
## Overview
Due to [this issue](https://github.com/reduxjs/redux-toolkit/issues/4200) which caused prettier to add trailing commas to `tsconfig.json` files which ultimately resulted in codeSandbox examples failing to compile. We had to add `overrides` field in `.prettier.json` in #4190 to resolve the issue. The newest release of Prettier fixes the problem by interpreting `tsconfig.json` files as `json` and not `jsonc`.

**This PR**:

  - [X] Bumps Prettier to 3.2.5.
  - [X] Removes the `overrides` field in `.prettier.json` file as it is no longer needed.
  - [X] Runs Prettier on all files inside the monorepo.