### PR TITLE
rename TypedUseMutationTrigger to TypedMutationTrigger, and add deprecated alias

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -589,13 +589,22 @@ export type MutationTrigger<D extends MutationDefinition<any, any, any, any>> =
     (arg: QueryArgFrom<D>): MutationActionCreatorResult<D>
   }
 
-export type TypedUseMutationTrigger<
+export type TypedMutationTrigger<
   ResultType,
   QueryArg,
   BaseQuery extends BaseQueryFn,
 > = MutationTrigger<
   MutationDefinition<QueryArg, BaseQuery, string, ResultType, string>
 >
+
+/**
+ * @deprecated Prefer `TypedMutationTrigger`, this will be removed in the next major version.
+ */
+export type TypedUseMutationTrigger<
+  ResultType,
+  QueryArg,
+  BaseQuery extends BaseQueryFn,
+> = TypedMutationTrigger<ResultType, QueryArg, BaseQuery>
 
 /**
  * Wrapper around `defaultQueryStateSelector` to be used in `useQuery`.

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -598,15 +598,6 @@ export type TypedMutationTrigger<
 >
 
 /**
- * @deprecated Prefer `TypedMutationTrigger`, this will be removed in the next major version.
- */
-export type TypedUseMutationTrigger<
-  ResultType,
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-> = TypedMutationTrigger<ResultType, QueryArg, BaseQuery>
-
-/**
  * Wrapper around `defaultQueryStateSelector` to be used in `useQuery`.
  * We want the initial render to already come back with
  * `{ isUninitialized: false, isFetching: true, isLoading: true }`

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -21,7 +21,7 @@ export type {
   TypedLazyQueryTrigger,
   TypedUseLazyQuery,
   TypedUseMutation,
-  TypedUseMutationTrigger,
+  TypedMutationTrigger,
   TypedUseQueryState,
   TypedUseQuery,
   TypedUseQuerySubscription,

--- a/packages/toolkit/src/query/tests/unionTypes.test-d.ts
+++ b/packages/toolkit/src/query/tests/unionTypes.test-d.ts
@@ -10,7 +10,7 @@ import type {
   TypedUseLazyQuery,
   TypedUseLazyQuerySubscription,
   TypedUseMutation,
-  TypedUseMutationTrigger,
+  TypedMutationTrigger,
   TypedUseQuerySubscription,
   TypedUseQuery,
 } from '@reduxjs/toolkit/query/react'
@@ -838,7 +838,7 @@ describe('"Typed" helper types', () => {
     const [trigger, result] = api.endpoints.mutation.useMutation()
 
     expectTypeOf<
-      TypedUseMutationTrigger<string, void, typeof baseQuery>
+      TypedMutationTrigger<string, void, typeof baseQuery>
     >().toMatchTypeOf(trigger)
 
     expectTypeOf<


### PR DESCRIPTION
fixes #4203