### PR TITLE
added bailout to updateQueryData if patches is empty

### DIFF
--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -321,6 +321,10 @@ export function buildThunks<
         }
       }
 
+      if (ret.patches.length === 0) {
+        return ret
+      }
+
       dispatch(
         api.util.patchQueryData(
           endpointName,


### PR DESCRIPTION
fixes #3090 