### PR TITLE
Throw instances of Error when unwrap, instead of plain objects

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -735,7 +735,15 @@ export function unwrapResult<R extends UnwrappableAction>(
     throw action.payload
   }
   if (action.error) {
-    throw action.error
+    const errorInstance: any = new Error(action.error.message || action.error.name || 'Thunk Error')
+
+    for (const prop in action.error) {
+      if (!errorInstance[prop]) {
+        errorInstance[prop] = action.error[prop]
+      }
+    }
+
+    throw errorInstance
   }
   return action.payload
 }

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -362,7 +362,23 @@ You must add the middleware for RTK-Query to function correctly!`,
               const result = await statePromise
 
               if (result.isError) {
-                throw result.error
+                let errorMessage = '';
+                const errorMap = result.error as any;
+
+                if (errorMap && errorMap.data && errorMap.status) {
+                  errorMessage = `RTK Query responded with ${errorMap.status} when requesting ${errorMap.data.path}`
+                } else {
+                  errorMessage = errorMap.message || errorMap.name || 'RTK Query Error'
+                }
+
+                const errorToThrow: any = new Error(errorMessage)
+                for (const prop in errorMap) {
+                  if (!errorToThrow[prop]) {
+                    errorToThrow[prop] = errorMap[prop]
+                  }
+                }
+
+                throw errorToThrow
               }
 
               return result.data


### PR DESCRIPTION
Currently, when unwrap any async action, library throws plain objects. This makes such errors hard to debug, especially when using errors collectors like sentry.

I think, using `Error` objects everywhere, the code throws any exceptions, is a must-have practice. Would be even better, if library include separate types inherited from `Error` based on the internal error type we already have as a field. 