### PR TITLE
Just build a RN bundle, not the whole app

### DIFF
--- a/examples/publish-ci/expo/metro.config.js
+++ b/examples/publish-ci/expo/metro.config.js
@@ -1,0 +1,7 @@
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+module.exports = config;

--- a/examples/publish-ci/expo/package.json
+++ b/examples/publish-ci/expo/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "build": "expo prebuild --clean -p android && cd android && chmod +x ./gradlew && ./gradlew bundleRelease --no-daemon && cd .. && react-native build-android",
+    "build": "react-native bundle --entry-file App.tsx --bundle-output app.bundle",
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",

--- a/examples/publish-ci/react-native/package.json
+++ b/examples/publish-ci/react-native/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "cd android && chmod +x ./gradlew && ./gradlew bundleRelease --no-daemon && cd .. && react-native build-android",
+    "build": "react-native bundle --entry-file index.js --bundle-output app.bundle",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",


### PR DESCRIPTION
This will drastically cut down on test run times, as we're building an entire app binary each time. That's total overkill when we're really interested in if Metro will bundle our package or not.

Follow up to #3984 and #3985