### PR TITLE
types: export `GetThunkAPI` type

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -130,6 +130,7 @@ export type {
   AsyncThunkAction,
   AsyncThunkPayloadCreatorReturnValue,
   AsyncThunkPayloadCreator,
+  GetThunkAPI,
   SerializedError,
 } from './createAsyncThunk'
 


### PR DESCRIPTION
This utility type is useful for creating custom wrappers around `createAsyncThunk`. 