### PR TITLE
fetchBaseQuery: expose extraOptions to prepareHeaders

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -188,6 +188,20 @@ export type FetchBaseQueryMeta = { request: Request; response?: Response }
  * @param {number} timeout
  * A number in milliseconds that represents the maximum time a request can take before timing out.
  */
+export function fetchBaseQuery(options?: FetchBaseQueryArgs<{}>): BaseQueryFn<
+string | FetchArgs,
+unknown,
+FetchBaseQueryError,
+{},
+FetchBaseQueryMeta
+>
+export function fetchBaseQuery<ExtraOptions>(options?: FetchBaseQueryArgs<ExtraOptions>): BaseQueryFn<
+string | FetchArgs,
+unknown,
+FetchBaseQueryError,
+ExtraOptions,
+FetchBaseQueryMeta
+>
 export function fetchBaseQuery<ExtraOptions>({
   baseUrl,
   prepareHeaders = (x) => x,

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -105,14 +105,14 @@ function stripUndefined(obj: any) {
   return copy
 }
 
-export type FetchBaseQueryArgs<ExtraOptions = {}> = {
+export type FetchBaseQueryArgs = {
   baseUrl?: string
   prepareHeaders?: (
     headers: Headers,
     api: Pick<
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
-    > & { arg: string | FetchArgs; extraOptions: ExtraOptions },
+    > & { arg: string | FetchArgs; extraOptions: unknown },
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -188,21 +188,8 @@ export type FetchBaseQueryMeta = { request: Request; response?: Response }
  * @param {number} timeout
  * A number in milliseconds that represents the maximum time a request can take before timing out.
  */
-export function fetchBaseQuery(options?: FetchBaseQueryArgs<{}>): BaseQueryFn<
-string | FetchArgs,
-unknown,
-FetchBaseQueryError,
-{},
-FetchBaseQueryMeta
->
-export function fetchBaseQuery<ExtraOptions>(options?: FetchBaseQueryArgs<ExtraOptions>): BaseQueryFn<
-string | FetchArgs,
-unknown,
-FetchBaseQueryError,
-ExtraOptions,
-FetchBaseQueryMeta
->
-export function fetchBaseQuery<ExtraOptions>({
+
+export function fetchBaseQuery({
   baseUrl,
   prepareHeaders = (x) => x,
   fetchFn = defaultFetchFn,
@@ -214,11 +201,11 @@ export function fetchBaseQuery<ExtraOptions>({
   responseHandler: globalResponseHandler,
   validateStatus: globalValidateStatus,
   ...baseFetchOptions
-}: FetchBaseQueryArgs<ExtraOptions> = {}): BaseQueryFn<
+}: FetchBaseQueryArgs = {}): BaseQueryFn<
   string | FetchArgs,
   unknown,
   FetchBaseQueryError,
-  ExtraOptions,
+  {},
   FetchBaseQueryMeta
 > {
   if (typeof fetch === 'undefined' && fetchFn === defaultFetchFn) {

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -858,14 +858,20 @@ describe('fetchBaseQuery', () => {
       const prepare = vitest.fn()
       const baseQuery = fetchBaseQuery<{ foo?: string; bar?: number }>({
         prepareHeaders(headers, api) {
-          expectTypeOf(api.extraOptions).toEqualTypeOf<{ foo?: string; bar?: number }>()
-          prepare.apply(undefined, arguments)
+          expectTypeOf(api.extraOptions).toEqualTypeOf<{
+            foo?: string
+            bar?: number
+          }>()
+          prepare.apply(undefined, arguments as unknown as any[])
         },
       })
-      baseQuery('http://example.com', commonBaseQueryApi, { foo: 'baz', bar: 5 })
+      baseQuery('http://example.com', commonBaseQueryApi, {
+        foo: 'baz',
+        bar: 5,
+      })
       expect(prepare).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ extraOptions: { foo: 'baz', bar: 5 } })
+        expect.objectContaining({ extraOptions: { foo: 'baz', bar: 5 } }),
       )
 
       // ensure types

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -859,10 +859,10 @@ describe('fetchBaseQuery', () => {
       const baseQuery = fetchBaseQuery<{ foo?: string; bar?: number }>({
         prepareHeaders(headers, api) {
           expectTypeOf(api.extraOptions).toEqualTypeOf<{ foo?: string; bar?: number }>()
-          prepare.call(undefined, arguments)
+          prepare.apply(undefined, arguments)
         },
       })
-      baseQuery('', commonBaseQueryApi, { foo: 'baz', bar: 5 })
+      baseQuery('http://example.com', commonBaseQueryApi, { foo: 'baz', bar: 5 })
       expect(prepare).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ extraOptions: { foo: 'baz', bar: 5 } })

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -856,12 +856,9 @@ describe('fetchBaseQuery', () => {
 
     test('can be instantiated with a `ExtraOptions` generic and `extraOptions` will be available in `prepareHeaders', async () => {
       const prepare = vitest.fn()
-      const baseQuery = fetchBaseQuery<{ foo?: string; bar?: number }>({
+      const baseQuery = fetchBaseQuery({
         prepareHeaders(headers, api) {
-          expectTypeOf(api.extraOptions).toEqualTypeOf<{
-            foo?: string
-            bar?: number
-          }>()
+          expectTypeOf(api.extraOptions).toEqualTypeOf<unknown>()
           prepare.apply(undefined, arguments as unknown as any[])
         },
       })
@@ -884,8 +881,6 @@ describe('fetchBaseQuery', () => {
               extraOptions: {
                 foo: 'asd',
                 bar: 1,
-                // @ts-expect-error
-                baz: 5,
               },
             }),
             testMutation: build.mutation({
@@ -897,8 +892,6 @@ describe('fetchBaseQuery', () => {
               extraOptions: {
                 foo: 'qwe',
                 bar: 15,
-                // @ts-expect-error
-                baz: 5,
               },
             }),
           }


### PR DESCRIPTION
Triggered by #4290 and the fact that we had similar asks before. Not sure if the extra generic arg is worth it. Thoughts, @EskiMojo14  & @markerikson  ?