### PR TITLE
feat: filterEndpoints option for rtkq-codegen-openapi

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -7,6 +7,8 @@ export type OperationDefinition = {
   operation: OpenAPIV3.OperationObject;
 };
 
+export type ParameterDefinition = OpenAPIV3.ParameterObject;
+
 type Require<T, K extends keyof T> = { [k in K]-?: NonNullable<T[k]> } & Omit<T, K>;
 type Optional<T, K extends keyof T> = { [k in K]?: NonNullable<T[k]> } & Omit<T, K>;
 type Id<T> = { [K in keyof T]: T[K] } & {};
@@ -80,15 +82,23 @@ export type EndpointMatcherFunction = (operationName: string, operationDefinitio
 
 export type EndpointMatcher = TextMatcher | EndpointMatcherFunction;
 
+export type ParameterMatcherFunction = (argumentName: string, argumentDefinition: ParameterDefinition) => boolean;
+export type ParameterMatcher = TextMatcher | ParameterMatcherFunction;
+
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;
   filterEndpoints?: EndpointMatcher;
+  filterParameters?: ParameterMatcher;
   endpointOverrides?: EndpointOverrides[];
   /**
    * defaults to false
    * If passed as true it will generate TS enums instead of union of strings
    */
   useEnumType?: boolean;
+}
+
+export interface ArgumentFilters {
+  pattern: ParameterMatcher;
 }
 
 export interface EndpointOverrides {

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -527,6 +527,1651 @@ export const { useLoginUserMutation } = injectedRtkApi;
 "
 `;
 
+exports[`non-path parameter filtering > should filter by array of parameter strings / regex > should only have the parameters that match the regex from the endpoints 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name, status: queryArg.status },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+        headers: { api_key: queryArg.apiKey },
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+  /** Status of pet that needs to be updated */
+  status?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  apiKey?: string;
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`non-path parameter filtering > should filter by array of parameter strings / regex > should only have the parameters with an "e" or is "status" 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name, status: queryArg.status },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+        headers: { api_key: queryArg.apiKey },
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+  /** Status of pet that needs to be updated */
+  status?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  apiKey?: string;
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`non-path parameter filtering > should filter by function > should remove any parameters from the header 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByTags\`,
+        params: { tags: queryArg.tags },
+      }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name, status: queryArg.status },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username, password: queryArg.password },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = {
+  /** Tags to filter by */
+  tags?: string[];
+};
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+  /** Status of pet that needs to be updated */
+  status?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+  /** The password for login in clear text */
+  password?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`non-path parameter filtering > should filter parameters by regex > should only have the parameters that match the regex from the endpoints 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: () => ({ url: \`/pet/findByStatus\` }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+        headers: { api_key: queryArg.apiKey },
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = void;
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  apiKey?: string;
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`non-path parameter filtering > should filter parameters by regex > should only have the parameters with an "e" 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: () => ({ url: \`/pet/findByStatus\` }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+        headers: { api_key: queryArg.apiKey },
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = void;
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  apiKey?: string;
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`non-path parameter filtering > should filter parameters by string > should only have the "status" parameter from the endpoints 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { status: queryArg.status },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: () => ({ url: \`/user/login\` }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Status of pet that needs to be updated */
+  status?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = void;
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
 exports[`openapi spec > readOnly / writeOnly are merged 1`] = `
 "import { api } from "./fixtures/emptyApi";
 const injectedRtkApi = api.injectEndpoints({

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -22,6 +22,48 @@ test('calling without `outputFile` returns the generated api', async () => {
   expect(api).toMatchSnapshot();
 });
 
+describe('non-path parameter filtering', () => {
+  it('should filter parameters by string', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      filterParameters: 'status',
+    });
+    expect(api).toMatchSnapshot('should only have the "status" parameter from the endpoints');
+  });
+
+  it('should filter parameters by regex', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      filterParameters: /e/,
+    });
+    expect(api).toMatchSnapshot('should only have the parameters with an "e"');
+  });
+
+  it('should filter by array of parameter strings / regex', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      filterParameters: [/e/, 'status'],
+    });
+    expect(api).toMatchSnapshot('should only have the parameters with an "e" or is "status"');
+  });
+
+  it('should filter by function', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      filterParameters: (_, param) => !(param.in === 'header'),
+    });
+    expect(api).toMatchSnapshot('should remove any parameters from the header');
+  });
+});
+
 test('endpoint filtering', async () => {
   const api = await generateEndpoints({
     unionUndefined: true,


### PR DESCRIPTION
Add an option to filter endpoints out for RTK Query codegen for OpenApi schemas.

Both the path parameter and the body parameter aren't included in this, but could possibly be if it is thought that that would be helpful. I wasn't sure they would need to be filtered since they're less likely than other locations to be auto-added by a middleware.

This means it can filter out from the query, header, or cookie as seen in "Parameter Locations" in [the OpenAPI spec](https://swagger.io/specification/#parameter-locations)

Inspired by my issue #4285 and another relevant issue #3006