### PR TITLE
Escape hatch added to defaultSerializeQueryArgs for unserializable data

### DIFF
--- a/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
+++ b/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
@@ -10,7 +10,7 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
   endpointName,
   queryArgs,
 }) => {
-  let serialized = ''
+  let serialized
 
   const cached = cache?.get(queryArgs)
 

--- a/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
+++ b/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
@@ -17,7 +17,9 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
   if (typeof cached === 'string') {
     serialized = cached
   } else {
-    const stringified = JSON.stringify(queryArgs, (key, value) =>
+    let stringified = ''
+    try {
+    stringified = JSON.stringify(queryArgs, (key, value) =>
       isPlainObject(value)
         ? Object.keys(value)
             .sort()
@@ -27,6 +29,13 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
             }, {})
         : value,
     )
+      // Non-serializable values will trigger the catch and the users
+    } catch (e) {
+      if (
+        typeof process !== 'undefined' &&
+        process.env.NODE_ENV === 'development'
+      ) console.warn("Failed to serialize query args for hook", endpointName, e)
+    }
     if (isPlainObject(queryArgs)) {
       cache?.set(queryArgs, stringified)
     }

--- a/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
+++ b/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
@@ -29,7 +29,6 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
             }, {})
         : value,
     )
-      // Non-serializable values will trigger the catch and the users
     } catch (e) {
       if (
         typeof process !== 'undefined' &&

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -100,7 +100,7 @@ const api = createApi({
     getError: build.query({
       query: () => '/error',
     }),
-    listItems: build.query<Item[], { pageNumber: bigint | number }>({
+    listItems: build.query<Item[], { pageNumber: number | bigint }>({
       serializeQueryArgs: ({ endpointName }) => {
         return endpointName
       },


### PR DESCRIPTION
fixes #4279

There's some discussion there about the expected behaviour and potential other fixes involving additional options or control for a user to override the defaultSerializeQueryArgs implementation.

I figured this is the best initial starting point because if `defaultQueryArgs` does throw an error due to say BigInt being passed, it will just continue the process that involves running the user defined `serializeQueryArgs` anyway.

I am not sure what the handling for the error should be. I presume a warning being sent every single time this happens especially if a user is aware it will happen isn't what we want? But I wanted to put something there for clarity.