### PR TITLE
feat: extend endpoint overrides for openapi codegen

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -64,7 +64,7 @@ npx @rtk-query/codegen-openapi openapi-config.ts
 
 #### Generating tags
 
-If your OpenAPI specification uses [tags](https://swagger.io/docs/specification/grouping-operations-with-tags/), you can specify the `tag` option to the codegen.  
+If your OpenAPI specification uses [tags](https://swagger.io/docs/specification/grouping-operations-with-tags/), you can specify the `tag` option to the codegen.
 That will result in all generated endpoints having `providesTags`/`invalidatesTags` declarations for the `tags` of their respective operation definition.
 
 Note that this will only result in string tags with no ids, so it might lead to scenarios where too much is invalidated and unneccessary requests are made on mutation.
@@ -143,6 +143,34 @@ const withOverride: ConfigFile = {
     {
       pattern: 'loginUser',
       type: 'mutation',
+    },
+  ],
+}
+```
+
+You can also filter the parameters that are included for an endpoint, as long as they aren't a path parameter. This filter is of type `ParameterMatcher`. For example, to only include parameters that begin with "x-" for the 'loginUser' endpoint, see the below example.
+
+```ts no-transpile title="openapi-config.ts"
+const withOverride: ConfigFile = {
+  // ...
+  endpointOverrides: [
+    {
+      pattern: 'loginUser',
+      parameterFilter: /^x-/,
+    },
+  ],
+}
+```
+
+For more complex requirements, consider the other possible matchers, such as a `ParameterMatcherFunction`. The below example filters out any parameters that are in the header of the request.
+
+```ts no-transpile title="openapi-config.ts"
+const withOverride: ConfigFile = {
+  // ...
+  endpointOverrides: [
+    {
+      pattern: /.*/,
+      parameterFilter: (_name, parameter) => parameter.in !== "header",
     },
   ],
 }

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -8,9 +8,14 @@ export type OperationDefinition = {
   operation: OpenAPIV3.OperationObject;
 };
 
+export type ParameterDefinition = OpenAPIV3.ParameterObject;
+
 type Require<T, K extends keyof T> = { [k in K]-?: NonNullable<T[k]> } & Omit<T, K>;
 type Optional<T, K extends keyof T> = { [k in K]?: NonNullable<T[k]> } & Omit<T, K>;
 type Id<T> = { [K in keyof T]: T[K] } & {};
+type AtLeastOneKey<T> = {
+  [K in keyof T]-?: Pick<T, K> & Partial<T>;
+}[keyof T];
 
 export const operationKeys = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
@@ -98,6 +103,10 @@ export type EndpointMatcherFunction = (operationName: string, operationDefinitio
 
 export type EndpointMatcher = TextMatcher | EndpointMatcherFunction;
 
+export type ParameterMatcherFunction = (parameterName: string, parameterDefinition: ParameterDefinition) => boolean;
+
+export type ParameterMatcher = TextMatcher | ParameterMatcherFunction;
+
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;
   filterEndpoints?: EndpointMatcher;
@@ -109,10 +118,12 @@ export interface OutputFileOptions extends Partial<CommonOptions> {
   useEnumType?: boolean;
 }
 
-export interface EndpointOverrides {
+export type EndpointOverrides = {
   pattern: EndpointMatcher;
+} & AtLeastOneKey<{
   type: 'mutation' | 'query';
-}
+  parameterFilter: ParameterMatcher;
+}>;
 
 export type ConfigFile =
   | Id<Require<CommonOptions & OutputFileOptions, 'outputFile'>>

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -910,7 +910,7 @@ export type Order = {
 "
 `;
 
-exports[`endpoint overrides > loginUser should be a mutation 1`] = `
+exports[`endpoint overrides > overrides endpoint type > loginUser should be a mutation 1`] = `
 "import { api } from "./fixtures/emptyApi";
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -935,6 +935,1354 @@ export type LoginUserApiArg = {
   username?: string;
   /** The password for login in clear text */
   password?: string;
+};
+"
+`;
+
+exports[`endpoint overrides > should apply first matching filter only > should remove all parameters except for findPetsByStatus 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\`, method: "POST" }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: () => ({ url: \`/user/login\` }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = void;
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`endpoint overrides > should filter by array of parameter strings / regex > should only have the parameters with an "e" or "f" 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: () => ({ url: \`/pet/findByStatus\` }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+        headers: { api_key: queryArg.apiKey },
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = void;
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  apiKey?: string;
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`endpoint overrides > should filter by function > should remove any parameters from the header 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByTags\`,
+        params: { tags: queryArg.tags },
+      }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name, status: queryArg.status },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username, password: queryArg.password },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = {
+  /** Tags to filter by */
+  tags?: string[];
+};
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+  /** Status of pet that needs to be updated */
+  status?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+  /** The password for login in clear text */
+  password?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`endpoint overrides > should override parameters by regex > should only have the parameters with an "e" 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: () => ({ url: \`/pet/findByStatus\` }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { name: queryArg.name },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+        headers: { api_key: queryArg.apiKey },
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+        params: { additionalMetadata: queryArg.additionalMetadata },
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/login\`,
+        params: { username: queryArg.username },
+      }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = void;
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Name of pet that needs to be updated */
+  name?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  apiKey?: string;
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  /** Additional Metadata */
+  additionalMetadata?: string;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = {
+  /** The user name for login */
+  username?: string;
+};
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
+};
+"
+`;
+
+exports[`endpoint overrides > should override parameters by string > should only have the "status" parameter from the endpoints 1`] = `
+"import { api } from "./fixtures/emptyApi";
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getHealthcheck: build.query<
+      GetHealthcheckApiResponse,
+      GetHealthcheckApiArg
+    >({
+      query: () => ({ url: \`/healthcheck\` }),
+    }),
+    updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
+      query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
+    }),
+    addPet: build.mutation<AddPetApiResponse, AddPetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet\`,
+        method: "POST",
+        body: queryArg.pet,
+      }),
+    }),
+    findPetsByStatus: build.query<
+      FindPetsByStatusApiResponse,
+      FindPetsByStatusApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: { status: queryArg.status },
+      }),
+    }),
+    findPetsByTags: build.query<
+      FindPetsByTagsApiResponse,
+      FindPetsByTagsApiArg
+    >({
+      query: () => ({ url: \`/pet/findByTags\` }),
+    }),
+    getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
+      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
+    }),
+    updatePetWithForm: build.mutation<
+      UpdatePetWithFormApiResponse,
+      UpdatePetWithFormApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "POST",
+        params: { status: queryArg.status },
+      }),
+    }),
+    deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: "DELETE",
+      }),
+    }),
+    uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}/uploadImage\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
+      query: () => ({ url: \`/store/inventory\` }),
+    }),
+    placeOrder: build.mutation<PlaceOrderApiResponse, PlaceOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order\`,
+        method: "POST",
+        body: queryArg.order,
+      }),
+    }),
+    getOrderById: build.query<GetOrderByIdApiResponse, GetOrderByIdApiArg>({
+      query: (queryArg) => ({ url: \`/store/order/\${queryArg.orderId}\` }),
+    }),
+    deleteOrder: build.mutation<DeleteOrderApiResponse, DeleteOrderApiArg>({
+      query: (queryArg) => ({
+        url: \`/store/order/\${queryArg.orderId}\`,
+        method: "DELETE",
+      }),
+    }),
+    createUser: build.mutation<CreateUserApiResponse, CreateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user\`,
+        method: "POST",
+        body: queryArg.user,
+      }),
+    }),
+    createUsersWithListInput: build.mutation<
+      CreateUsersWithListInputApiResponse,
+      CreateUsersWithListInputApiArg
+    >({
+      query: (queryArg) => ({
+        url: \`/user/createWithList\`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
+    loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
+      query: () => ({ url: \`/user/login\` }),
+    }),
+    logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
+      query: () => ({ url: \`/user/logout\` }),
+    }),
+    getUserByName: build.query<GetUserByNameApiResponse, GetUserByNameApiArg>({
+      query: (queryArg) => ({ url: \`/user/\${queryArg.username}\` }),
+    }),
+    updateUser: build.mutation<UpdateUserApiResponse, UpdateUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "PUT",
+        body: queryArg.user,
+      }),
+    }),
+    deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
+      query: (queryArg) => ({
+        url: \`/user/\${queryArg.username}\`,
+        method: "DELETE",
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as enhancedApi };
+export type GetHealthcheckApiResponse = /** status 200 OK */ {
+  message: string;
+};
+export type GetHealthcheckApiArg = void;
+export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
+export type UpdatePetApiArg = {
+  /** Update an existent pet in the store */
+  pet: Pet;
+};
+export type AddPetApiResponse = /** status 200 Successful operation */ Pet;
+export type AddPetApiArg = {
+  /** Create a new pet in the store */
+  pet: Pet;
+};
+export type FindPetsByStatusApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByStatusApiArg = {
+  /** Status values that need to be considered for filter */
+  status?: "available" | "pending" | "sold";
+};
+export type FindPetsByTagsApiResponse =
+  /** status 200 successful operation */ Pet[];
+export type FindPetsByTagsApiArg = void;
+export type GetPetByIdApiResponse = /** status 200 successful operation */ Pet;
+export type GetPetByIdApiArg = {
+  /** ID of pet to return */
+  petId: number;
+};
+export type UpdatePetWithFormApiResponse = unknown;
+export type UpdatePetWithFormApiArg = {
+  /** ID of pet that needs to be updated */
+  petId: number;
+  /** Status of pet that needs to be updated */
+  status?: string;
+};
+export type DeletePetApiResponse = unknown;
+export type DeletePetApiArg = {
+  /** Pet id to delete */
+  petId: number;
+};
+export type UploadFileApiResponse =
+  /** status 200 successful operation */ ApiResponse;
+export type UploadFileApiArg = {
+  /** ID of pet to update */
+  petId: number;
+  body: Blob;
+};
+export type GetInventoryApiResponse = /** status 200 successful operation */ {
+  [key: string]: number;
+};
+export type GetInventoryApiArg = void;
+export type PlaceOrderApiResponse =
+  /** status 200 successful operation */ Order;
+export type PlaceOrderApiArg = {
+  order: Order;
+};
+export type GetOrderByIdApiResponse =
+  /** status 200 successful operation */ Order;
+export type GetOrderByIdApiArg = {
+  /** ID of order that needs to be fetched */
+  orderId: number;
+};
+export type DeleteOrderApiResponse = unknown;
+export type DeleteOrderApiArg = {
+  /** ID of the order that needs to be deleted */
+  orderId: number;
+};
+export type CreateUserApiResponse = unknown;
+export type CreateUserApiArg = {
+  /** Created user object */
+  user: User;
+};
+export type CreateUsersWithListInputApiResponse =
+  /** status 200 Successful operation */ User;
+export type CreateUsersWithListInputApiArg = {
+  body: User[];
+};
+export type LoginUserApiResponse =
+  /** status 200 successful operation */ string;
+export type LoginUserApiArg = void;
+export type LogoutUserApiResponse = unknown;
+export type LogoutUserApiArg = void;
+export type GetUserByNameApiResponse =
+  /** status 200 successful operation */ User;
+export type GetUserByNameApiArg = {
+  /** The name that needs to be fetched. Use user1 for testing.  */
+  username: string;
+};
+export type UpdateUserApiResponse = unknown;
+export type UpdateUserApiArg = {
+  /** name that need to be deleted */
+  username: string;
+  /** Update an existent user in the store */
+  user: User;
+};
+export type DeleteUserApiResponse = unknown;
+export type DeleteUserApiArg = {
+  /** The name that needs to be deleted */
+  username: string;
+};
+export type Category = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Tag = {
+  id?: number | undefined;
+  name?: string | undefined;
+};
+export type Pet = {
+  id?: number | undefined;
+  name: string;
+  category?: Category | undefined;
+  photoUrls: string[];
+  tags?: Tag[] | undefined;
+  status?: ("available" | "pending" | "sold") | undefined;
+};
+export type ApiResponse = {
+  code?: number | undefined;
+  type?: string | undefined;
+  message?: string | undefined;
+};
+export type Order = {
+  id?: number | undefined;
+  petId?: number | undefined;
+  quantity?: number | undefined;
+  shipDate?: string | undefined;
+  status?: ("placed" | "approved" | "delivered") | undefined;
+  complete?: boolean | undefined;
+};
+export type User = {
+  id?: number | undefined;
+  username?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  email?: string | undefined;
+  password?: string | undefined;
+  phone?: string | undefined;
+  userStatus?: number | undefined;
 };
 "
 `;

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -965,7 +965,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/pet/findByStatus\`,
-        params: { status: queryArg.status },
+        params: {
+          status: queryArg.status,
+        },
       }),
     }),
     findPetsByTags: build.query<
@@ -1123,7 +1125,8 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = unknown;
+export type CreateUserApiResponse =
+  /** status default successful operation */ User;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1170,6 +1173,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -1182,6 +1186,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -1193,6 +1198,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 "
@@ -1240,14 +1246,18 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "POST",
-        params: { name: queryArg.name },
+        params: {
+          name: queryArg.name,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "DELETE",
-        headers: { api_key: queryArg.apiKey },
+        headers: {
+          api_key: queryArg.apiKey,
+        },
       }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
@@ -1255,7 +1265,9 @@ const injectedRtkApi = api.injectEndpoints({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: "POST",
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -1297,7 +1309,9 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username },
+        params: {
+          username: queryArg.username,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
@@ -1390,7 +1404,8 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = unknown;
+export type CreateUserApiResponse =
+  /** status default successful operation */ User;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1440,6 +1455,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -1452,6 +1468,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -1463,6 +1480,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 "
@@ -1494,7 +1512,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/pet/findByStatus\`,
-        params: { status: queryArg.status },
+        params: {
+          status: queryArg.status,
+        },
       }),
     }),
     findPetsByTags: build.query<
@@ -1503,7 +1523,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/pet/findByTags\`,
-        params: { tags: queryArg.tags },
+        params: {
+          tags: queryArg.tags,
+        },
       }),
     }),
     getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
@@ -1516,7 +1538,10 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "POST",
-        params: { name: queryArg.name, status: queryArg.status },
+        params: {
+          name: queryArg.name,
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
@@ -1530,7 +1555,9 @@ const injectedRtkApi = api.injectEndpoints({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: "POST",
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -1572,7 +1599,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
@@ -1672,7 +1702,8 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = unknown;
+export type CreateUserApiResponse =
+  /** status default successful operation */ User;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1724,6 +1755,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -1736,6 +1768,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -1747,6 +1780,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 "
@@ -1794,14 +1828,18 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "POST",
-        params: { name: queryArg.name },
+        params: {
+          name: queryArg.name,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "DELETE",
-        headers: { api_key: queryArg.apiKey },
+        headers: {
+          api_key: queryArg.apiKey,
+        },
       }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
@@ -1809,7 +1847,9 @@ const injectedRtkApi = api.injectEndpoints({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: "POST",
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -1851,7 +1891,9 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username },
+        params: {
+          username: queryArg.username,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
@@ -1944,7 +1986,8 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = unknown;
+export type CreateUserApiResponse =
+  /** status default successful operation */ User;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1994,6 +2037,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -2006,6 +2050,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -2017,6 +2062,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 "
@@ -2048,7 +2094,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/pet/findByStatus\`,
-        params: { status: queryArg.status },
+        params: {
+          status: queryArg.status,
+        },
       }),
     }),
     findPetsByTags: build.query<
@@ -2067,7 +2115,9 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "POST",
-        params: { status: queryArg.status },
+        params: {
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
@@ -2212,7 +2262,8 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = unknown;
+export type CreateUserApiResponse =
+  /** status default successful operation */ User;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -2259,6 +2310,7 @@ export type Pet = {
   category?: Category | undefined;
   photoUrls: string[];
   tags?: Tag[] | undefined;
+  /** pet status in the store */
   status?: ("available" | "pending" | "sold") | undefined;
 };
 export type ApiResponse = {
@@ -2271,6 +2323,7 @@ export type Order = {
   petId?: number | undefined;
   quantity?: number | undefined;
   shipDate?: string | undefined;
+  /** Order Status */
   status?: ("placed" | "approved" | "delivered") | undefined;
   complete?: boolean | undefined;
 };
@@ -2282,6 +2335,7 @@ export type User = {
   email?: string | undefined;
   password?: string | undefined;
   phone?: string | undefined;
+  /** User Status */
   userStatus?: number | undefined;
 };
 "

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -98,7 +98,7 @@ describe('endpoint overrides', () => {
         },
       ],
     });
-    expect(api).not.toMatch(/params: {.*queryArg\.\w+\b(?<!\bstatus)/);
+    expect(api).not.toMatch(/params: {\n.*queryArg\.\w+\b(?<!\bstatus)/);
     expect(api).toMatchSnapshot('should only have the "status" parameter from the endpoints');
   });
 
@@ -114,8 +114,8 @@ describe('endpoint overrides', () => {
         },
       ],
     });
-    expect(api).not.toMatch(/params: {.*queryArg\.[^\We]*\W/);
-    expect(api).toMatch(/params: {.*queryArg\.[\we]*\W/);
+    expect(api).not.toMatch(/params: {\n.*queryArg\.[^\We]*\W/);
+    expect(api).toMatch(/params: {\n.*queryArg\.[\we]*\W/);
     expect(api).toMatchSnapshot('should only have the parameters with an "e"');
   });
 
@@ -131,8 +131,8 @@ describe('endpoint overrides', () => {
         },
       ],
     });
-    expect(api).not.toMatch(/params: {.*queryArg\.[^\Wef]*\W/);
-    expect(api).toMatch(/params: {.*queryArg\.[\wef]*\W/);
+    expect(api).not.toMatch(/params: {\n.*queryArg\.[^\Wef]*\W/);
+    expect(api).toMatch(/params: {\n.*queryArg\.[\wef]*\W/);
     expect(api).toMatchSnapshot('should only have the parameters with an "e" or "f"');
   });
 

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -67,22 +67,110 @@ test('negated endpoint filtering', async () => {
   expect(api).not.toMatch(/loginUser:/);
 });
 
-test('endpoint overrides', async () => {
-  const api = await generateEndpoints({
-    unionUndefined: true,
-    apiFile: './fixtures/emptyApi.ts',
-    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
-    filterEndpoints: 'loginUser',
-    endpointOverrides: [
-      {
-        pattern: 'loginUser',
-        type: 'mutation',
-      },
-    ],
+describe('endpoint overrides', () => {
+  it('overrides endpoint type', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      filterEndpoints: 'loginUser',
+      endpointOverrides: [
+        {
+          pattern: 'loginUser',
+          type: 'mutation',
+        },
+      ],
+    });
+    expect(api).not.toMatch(/loginUser: build.query/);
+    expect(api).toMatch(/loginUser: build.mutation/);
+    expect(api).toMatchSnapshot('loginUser should be a mutation');
   });
-  expect(api).not.toMatch(/loginUser: build.query/);
-  expect(api).toMatch(/loginUser: build.mutation/);
-  expect(api).toMatchSnapshot('loginUser should be a mutation');
+
+  it('should override parameters by string', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      endpointOverrides: [
+        {
+          pattern: /.*/,
+          parameterFilter: 'status',
+        },
+      ],
+    });
+    expect(api).not.toMatch(/params: {.*queryArg\.\w+\b(?<!\bstatus)/);
+    expect(api).toMatchSnapshot('should only have the "status" parameter from the endpoints');
+  });
+
+  it('should override parameters by regex', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      endpointOverrides: [
+        {
+          pattern: /.*/,
+          parameterFilter: /e/,
+        },
+      ],
+    });
+    expect(api).not.toMatch(/params: {.*queryArg\.[^\We]*\W/);
+    expect(api).toMatch(/params: {.*queryArg\.[\we]*\W/);
+    expect(api).toMatchSnapshot('should only have the parameters with an "e"');
+  });
+
+  it('should filter by array of parameter strings / regex', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      endpointOverrides: [
+        {
+          pattern: /.*/,
+          parameterFilter: [/e/, /f/],
+        },
+      ],
+    });
+    expect(api).not.toMatch(/params: {.*queryArg\.[^\Wef]*\W/);
+    expect(api).toMatch(/params: {.*queryArg\.[\wef]*\W/);
+    expect(api).toMatchSnapshot('should only have the parameters with an "e" or "f"');
+  });
+
+  it('should filter by function', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      endpointOverrides: [
+        {
+          pattern: /.*/,
+          parameterFilter: (_, param) => !(param.in === 'header'),
+        },
+      ],
+    });
+    expect(api).not.toMatch(/headers: {/);
+    expect(api).toMatchSnapshot('should remove any parameters from the header');
+  });
+
+  it('should apply first matching filter only', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      endpointOverrides: [
+        { pattern: 'findPetsByStatus', parameterFilter: () => true },
+        {
+          pattern: /.*/,
+          parameterFilter: () => false,
+        },
+      ],
+    });
+
+    const paramsMatches = (api?.match(/params:/) || []).length;
+    expect(paramsMatches).toBe(1);
+    expect(api).not.toMatch(/headers: {/);
+    expect(api).toMatchSnapshot('should remove all parameters except for findPetsByStatus');
+  });
 });
 
 describe('option encodeParams', () => {


### PR DESCRIPTION
Add an option to filter parameters into endpoint overrides for RTK Query codegen for OpenApi schemas.

Both the path parameter and the body parameter aren't included in this, but could possibly be if it is thought that that would be helpful. I wasn't sure they would need to be filtered since they're less likely than other locations to be auto-added by a middleware.

This means it can filter out from the query, header, or cookie as seen in "Parameter Locations" in [the OpenAPI spec](https://swagger.io/specification/#parameter-locations)

It only runs on the first (by order of endpointOverrides array) filter. This was the existing behaviour for query type, and makes enough sense.

Inspired by my issue https://github.com/reduxjs/redux-toolkit/issues/4285 and another relevant issue https://github.com/reduxjs/redux-toolkit/issues/3006