### PR TITLE
Handle bigint in useQuerySubscription

### DIFF
--- a/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
+++ b/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
@@ -18,6 +18,7 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
     serialized = cached
   } else {
     const stringified = JSON.stringify(queryArgs, (key, value) =>
+      // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
       isPlainObject(value)
         ? Object.keys(value)
             .sort()
@@ -32,7 +33,6 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
     }
     serialized = stringified
   }
-  // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
   return `${endpointName}(${serialized})`
 }
 
@@ -48,7 +48,9 @@ export const bigIntSafeSerializeQueryArgs: SerializeQueryArgs<any> = ({
     serialized = cached
   } else {
     const stringified = JSON.stringify(queryArgs, (key, value) => {
+      // Translate bigint fields to a serializable value
       value = typeof value === 'bigint' ? { $bigint: value.toString() } : value
+      // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
       value = isPlainObject(value)
         ? Object.keys(value)
             .sort()

--- a/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
+++ b/packages/toolkit/src/query/defaultSerializeQueryArgs.ts
@@ -9,7 +9,6 @@ const cache: WeakMap<any, string> | undefined = WeakMap
 export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
   endpointName,
   queryArgs,
-  replacer,
 }) => {
   let serialized = ''
 
@@ -19,8 +18,8 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({
     serialized = cached
   } else {
     const stringified = JSON.stringify(queryArgs, (key, value) => {
-      // Use custom replacer first before applying key-sorting behavior:
-      value = replacer ? replacer(key, value) : value
+      // Handle bigints
+      value = typeof value === 'bigint' ? { $bigint: value.toString() } : value
       // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
       value = isPlainObject(value)
         ? Object.keys(value)
@@ -44,14 +43,10 @@ export type SerializeQueryArgs<QueryArgs, ReturnType = string> = (_: {
   queryArgs: QueryArgs
   endpointDefinition: EndpointDefinition<any, any, any, any>
   endpointName: string
-  // Allows for a custom stringify replacer while keeping key-sorting behavior. e.g. for serializing bigint.
-  replacer?: (key: string, value: any) => {}
 }) => ReturnType
 
 export type InternalSerializeQueryArgs = (_: {
   queryArgs: any
   endpointDefinition: EndpointDefinition<any, any, any, any>
   endpointName: string
-  // Allows for a custom stringify replacer while keeping key-sorting behavior. e.g. for serializing bigint.
-  replacer?: (key: string, value: any) => {}
 }) => QueryCacheKey

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -45,7 +45,7 @@ import {
 import { shallowEqual } from 'react-redux'
 import type { BaseQueryFn } from '../baseQueryTypes'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
-import { bigIntSafeSerializeQueryArgs } from '../defaultSerializeQueryArgs'
+import { defaultSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type { UninitializedValue } from './constants'
 import { UNINITIALIZED_VALUE } from './constants'
 import type { ReactHooksModuleOptions } from './module'
@@ -761,6 +761,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         subscriptionSelectorsRef.current =
           returnedValue as unknown as SubscriptionSelectors
       }
+      const bigIntReplacer = (_: string, value: any) =>
+        typeof value === 'bigint' ? { $bigint: value.toString() } : value
       const stableArg = useStableQueryArgs(
         skip ? skipToken : arg,
         // Even if the user provided a per-endpoint `serializeQueryArgs` with
@@ -768,7 +770,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         // so we can tell if _anything_ actually changed. Otherwise, we can end up
         // with a case where the query args did change but the serialization doesn't,
         // and then we never try to initiate a refetch.
-        bigIntSafeSerializeQueryArgs,
+        (params) =>
+          defaultSerializeQueryArgs({ replacer: bigIntReplacer, ...params }),
         context.endpointDefinitions[name],
         name,
       )

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -761,8 +761,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         subscriptionSelectorsRef.current =
           returnedValue as unknown as SubscriptionSelectors
       }
-      const bigIntReplacer = (_: string, value: any) =>
-        typeof value === 'bigint' ? { $bigint: value.toString() } : value
       const stableArg = useStableQueryArgs(
         skip ? skipToken : arg,
         // Even if the user provided a per-endpoint `serializeQueryArgs` with
@@ -770,8 +768,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         // so we can tell if _anything_ actually changed. Otherwise, we can end up
         // with a case where the query args did change but the serialization doesn't,
         // and then we never try to initiate a refetch.
-        (params) =>
-          defaultSerializeQueryArgs({ replacer: bigIntReplacer, ...params }),
+        defaultSerializeQueryArgs,
         context.endpointDefinitions[name],
         name,
       )

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -45,7 +45,7 @@ import {
 import { shallowEqual } from 'react-redux'
 import type { BaseQueryFn } from '../baseQueryTypes'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/types'
-import { defaultSerializeQueryArgs } from '../defaultSerializeQueryArgs'
+import { bigIntSafeSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type { UninitializedValue } from './constants'
 import { UNINITIALIZED_VALUE } from './constants'
 import type { ReactHooksModuleOptions } from './module'
@@ -768,7 +768,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         // so we can tell if _anything_ actually changed. Otherwise, we can end up
         // with a case where the query args did change but the serialization doesn't,
         // and then we never try to initiate a refetch.
-        defaultSerializeQueryArgs,
+        bigIntSafeSerializeQueryArgs,
         context.endpointDefinitions[name],
         name,
       )

--- a/packages/toolkit/src/query/tests/defaultSerializeQueryArgs.test.ts
+++ b/packages/toolkit/src/query/tests/defaultSerializeQueryArgs.test.ts
@@ -23,6 +23,16 @@ test('number arg', () => {
   ).toMatchInlineSnapshot(`"test(5)"`)
 })
 
+test('bigint arg has non-default serialization (intead of throwing)', () => {
+  expect(
+    defaultSerializeQueryArgs({
+      endpointDefinition,
+      endpointName,
+      queryArgs: BigInt(10),
+    }),
+  ).toMatchInlineSnapshot(`"test({"$bigint":"10"})"`)
+})
+
 test('simple object arg is sorted', () => {
   expect(
     defaultSerializeQueryArgs({


### PR DESCRIPTION
fixes https://github.com/reduxjs/redux-toolkit/issues/4279

Handles query arg values that include `bigint`s while retaining behavior of always initiating refetch (even when user-supplied `serializeQueryArgs` doesn't change). This is an alternative proposed solution from https://github.com/reduxjs/redux-toolkit/pull/4297 -- which fixes `bigint` errors but diverges refetching behavior.

Note: this changes behavior for all callers of `defaultSerializeQueryArgs`; which _should_ be safe if the library doesn't try to re-serialize the args anywhere. It _may_ result in slightly surprising behavior for consumers (a potentially unexpected default serialization of bigint values) - but since it currently breaks hard with an exception for those use cases, unlikely to be a breaking change for _anybody_.