### PR TITLE
fix: flattened optional type not optional

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -324,7 +324,6 @@ export async function generateApi(
     const queryArgValues = Object.values(queryArg);
 
     const isFlatArg = flattenArg && queryArgValues.length === 1;
-
     const QueryArg = factory.createTypeReferenceNode(
       registerInterface(
         factory.createTypeAliasDeclaration(
@@ -333,7 +332,16 @@ export async function generateApi(
           undefined,
           queryArgValues.length > 0
             ? isFlatArg
-              ? withQueryComment({ ...queryArgValues[0].type }, queryArgValues[0], false)
+              ? withQueryComment(
+                  factory.createUnionTypeNode([
+                    queryArgValues[0].type,
+                    ...(!queryArgValues[0].required
+                      ? [factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword)]
+                      : []),
+                  ]),
+                  queryArgValues[0],
+                  false
+                )
               : factory.createTypeLiteralNode(
                   queryArgValues.map((def) =>
                     withQueryComment(

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -113,6 +113,22 @@ describe('option flattenArg', () => {
     });
     expect(api).toContain('queryArg.body');
   });
+
+  it('should flatten an optional arg as an optional type', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: 'findPetsByTags',
+    });
+    expect(api).toMatch(/\| undefined/);
+  });
+
+  it('should not flatten a non-optional arg with a superfluous union', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: 'getPetById',
+    });
+    expect(api).not.toMatch(/^\s*\|/);
+  });
 });
 
 test('hooks generation', async () => {


### PR DESCRIPTION
when flattening an argument, if the type is optional, it should be a union with undefined.

the PR implements this by adding a union node for the type of the arg. if the type is required, then the union node function is given just the original type and returns it. if the type is not required, then the union node function is given the original type and the undefined keyword, creating an optional type.

see issue #4304 for inspiration

