### PR TITLE
Improve usability of the `initiate()` action for mutations.

### DIFF
--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -93,8 +93,12 @@ type StartMutationActionCreator<
 export type MutationActionCreatorResult<
   D extends MutationDefinition<any, any, any, any>,
 > = SafePromise<
-  | { data: ResultTypeFrom<D> }
   | {
+      data: ResultTypeFrom<D>
+      error?: undefined
+    }
+  | {
+      data?: undefined
       error:
         | Exclude<
             BaseQueryError<


### PR DESCRIPTION
When running requests by manually dispatching the `initiate()` action the usability of mutation endpoints is worse than queries.

When using a query you can easily check for the presence of a `data` or `error` prop in the union returned to make decisions. For example:
```
const { data, error } = dispatch(api.endpoints.getPosts.initiate());
if (error) {
  // Handle error case
}
```

In the case of mutation that code will have a type error:
```
const { data, error } = dispatch(api.endpoints.setPost.initiate());
Property 'data' does not exist on type '{ ... } | { error: FetchBaseQueryError | SerializedError; }'.ts
```

Infact the only typesafe way to read the data or error property is to do something like this:
```
const response = dispatch(api.endpoints.setPost.initiate());
if("error" in response) {
  // Handle error
}
```

The reason it works for queries is because each entry in the discriminated union always includes an explicit `error` and `data` property, set to undefined if it's not included in that case.

This PR makes the same change to the return type for mutations.
