### PR TITLE
Improve sorted entity adapter sorting performance

### DIFF
--- a/packages/toolkit/src/entities/sorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/sorted_state_adapter.ts
@@ -16,6 +16,7 @@ import {
   getCurrent,
 } from './utils'
 
+// Borrowed from Replay
 export function findInsertIndex<T>(
   sortedItems: T[],
   item: T,
@@ -27,7 +28,6 @@ export function findInsertIndex<T>(
     let middleIndex = (lowIndex + highIndex) >>> 1
     const currentItem = sortedItems[middleIndex]
     const res = comparisonFunction(item, currentItem)
-    // console.log('Res: ', item, currentItem, res)
     if (res >= 0) {
       lowIndex = middleIndex + 1
     } else {
@@ -75,7 +75,6 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     )
 
     const models = newEntities.filter(
-      // (model) => !(selectId(model) in state.entities),
       (model) => !existingKeys.has(selectIdValue(model, selectId)),
     )
 
@@ -94,7 +93,6 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
   ): void {
     newEntities = ensureEntitiesArray(newEntities)
     if (newEntities.length !== 0) {
-      //const updatedIds = new Set<Id>(newEntities.map((item) => selectId(item)))
       for (const item of newEntities) {
         delete (state.entities as Record<Id, T>)[selectId(item)]
       }
@@ -123,7 +121,6 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
   ): void {
     let appliedUpdates = false
     let replacedIds = false
-    const updatedIds = new Set<Id>()
 
     for (let update of updates) {
       const entity: T | undefined = (state.entities as Record<Id, T>)[update.id]
@@ -135,11 +132,12 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
 
       Object.assign(entity, update.changes)
       const newId = selectId(entity)
-      updatedIds.add(newId)
+
       if (update.id !== newId) {
+        // We do support the case where updates can change an item's ID.
+        // This makes things trickier - go ahead and swap the IDs in state now.
         replacedIds = true
         delete (state.entities as Record<Id, T>)[update.id]
-        updatedIds.delete(update.id)
         const oldIndex = (state.ids as Id[]).indexOf(update.id)
         state.ids[oldIndex] = newId
         ;(state.entities as Record<Id, T>)[newId] = entity
@@ -147,8 +145,7 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     }
 
     if (appliedUpdates) {
-      mergeFunction(state, [], updatedIds, replacedIds)
-      // resortEntities(state, [], replacedIds)
+      mergeFunction(state, [], appliedUpdates, replacedIds)
     }
   }
 
@@ -188,168 +185,29 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     return true
   }
 
-  function merge(models: readonly T[], state: R): void {
-    // Insert/overwrite all new/updated
-    models.forEach((model) => {
-      ;(state.entities as Record<Id, T>)[selectId(model)] = model
-    })
-
-    resortEntities(state, models)
-  }
-
-  function cleanItem(item: T) {
-    return isDraft(item) ? current(item) : item
-  }
-
   type MergeFunction = (
     state: R,
     addedItems: readonly T[],
-    updatedIds?: Set<Id>,
+    appliedUpdates?: boolean,
     replacedIds?: boolean,
   ) => void
-
-  // const mergeFunction: MergeFunction = (state, addedItems) => {
-  //   const actualMergeFunction: MergeFunction = mergeOriginal
-  //   console.log('Merge function: ', actualMergeFunction.name)
-  //   actualMergeFunction(state, addedItems)
-  // }
-
-  const mergeOriginal: MergeFunction = (state, addedItems) => {
-    // Insert/overwrite all new/updated
-    addedItems.forEach((model) => {
-      ;(state.entities as Record<Id, T>)[selectId(model)] = model
-    })
-    resortEntities(state)
-
-    function resortEntities(state: R) {
-      const allEntities = Object.values(state.entities) as T[]
-      allEntities.sort(comparer)
-      const newSortedIds = allEntities.map(selectId)
-      const { ids } = state
-      if (!areArraysEqual(ids, newSortedIds)) {
-        state.ids = newSortedIds
-      }
-    }
-  }
-
-  const mergeLenz: MergeFunction = (
-    state,
-    addedItems: readonly T[],
-    updatedIds,
-    replacedIds,
-  ) => {
-    const entities = state.entities as Record<Id, T>
-    let ids = state.ids as Id[]
-    if (replacedIds) {
-      ids = Array.from(new Set(ids))
-    }
-    const oldEntities = ids // Array.from(new Set(state.ids as Id[]))
-      .map((id) => entities[id])
-      .filter(Boolean)
-
-    let newSortedIds: Id[] = []
-    const seenIds = new Set<Id>()
-
-    if (addedItems.length) {
-      const newEntities = addedItems.slice().sort(comparer)
-
-      // Insert/overwrite all new/updated
-      newEntities.forEach((model) => {
-        entities[selectId(model)] = model
-      })
-
-      let o = 0,
-        n = 0
-      while (o < oldEntities.length && n < newEntities.length) {
-        const oldEntity = oldEntities[o] as T,
-          oldId = selectId(oldEntity),
-          newEntity = newEntities[n],
-          newId = selectId(newEntity)
-
-        if (seenIds.has(newId)) {
-          n++
-          continue
-        }
-
-        const comparison = comparer(oldEntity, newEntity)
-        if (comparison < 0) {
-          // Sort the existing item first
-          newSortedIds.push(oldId)
-          seenIds.add(oldId)
-          o++
-          continue
-        }
-
-        if (comparison > 0) {
-          // Sort the new item first
-          newSortedIds.push(newId)
-          seenIds.add(newId)
-          n++
-          continue
-        }
-        // The items are equivalent. Maintain stable sorting by
-        // putting the existing  item first.
-        newSortedIds.push(oldId)
-        seenIds.add(oldId)
-        o++
-        newSortedIds.push(newId)
-        seenIds.add(newId)
-        n++
-      }
-      // Add any remaining existing items
-      while (o < oldEntities.length) {
-        newSortedIds.push(selectId(oldEntities[o]))
-        o++
-      }
-      // Add any remaining new items
-      while (n < newEntities.length) {
-        newSortedIds.push(selectId(newEntities[n]))
-        n++
-      }
-    } else if (updatedIds) {
-      oldEntities.sort(comparer)
-      newSortedIds = oldEntities.map(selectId)
-    }
-
-    if (!areArraysEqual(state.ids, newSortedIds)) {
-      state.ids = newSortedIds
-    }
-  }
 
   const mergeInsertion: MergeFunction = (
     state,
     addedItems,
-    updatedIds,
+    appliedUpdates,
     replacedIds,
   ) => {
     const currentEntities = getCurrent(state.entities) as Record<Id, T>
     const currentIds = getCurrent(state.ids) as Id[]
-    // const entities = state.entities as Record<Id, T>
+
     const stateEntities = state.entities as Record<Id, T>
-    // let ids = state.ids as Id[]
+
     let ids = currentIds
     if (replacedIds) {
       ids = Array.from(new Set(currentIds))
     }
 
-    // //let sortedEntities: T[] = []
-
-    // let sortedEntities = ids // Array.from(new Set(state.ids as Id[]))
-    //   .map((id) => entities[id])
-    //   .filter(Boolean)
-
-    // if (addedItems.length) {
-    //   if (wasPreviouslyEmpty) {
-    //     sortedEntities = addedItems.slice().sort()
-    //   }
-
-    //   for (const item of addedItems) {
-    //     entities[selectId(item)] = item
-    //     if (!wasPreviouslyEmpty) {
-    //       insert(sortedEntities, item, sort)
-    //     }
-    //   }
-    // }
     let sortedEntities: T[] = []
     for (const id of ids) {
       const entity = currentEntities[id]
@@ -357,319 +215,34 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
         sortedEntities.push(entity)
       }
     }
-    // let sortedEntities = ids // Array.from(new Set(state.ids as Id[]))
-    //   .map((id) => currentEntities[id])
-    //   .filter(Boolean)
-
     const wasPreviouslyEmpty = sortedEntities.length === 0
-
-    // let oldIds = state.ids as Id[]
-    // // if (updatedIds) {
-    // //   oldIds = oldIds.filter((id) => !updatedIds.has(id))
-    // //   const updatedItems = Array.from(updatedIds)
-    // //     .map((id) => entities[id])
-    // //     .filter(Boolean)
-    // //   models = updatedItems.concat(models)
-    // // }
-    // // console.log('Old IDs: ', oldIds)
-    // const sortedEntities = oldIds
-    //   .map((id) => (state.entities as Record<Id, T>)[id as Id])
-    //   .filter(Boolean)
 
     // Insert/overwrite all new/updated
     for (const item of addedItems) {
       stateEntities[selectId(item)] = item
-      // console.log('Inserting: ', isDraft(item) ? current(item) : item)
+
       if (!wasPreviouslyEmpty) {
+        // Binary search insertion generally requires fewer comparisons
         insert(sortedEntities, item, comparer)
       }
     }
 
     if (wasPreviouslyEmpty) {
+      // All we have is the incoming values, sort them
       sortedEntities = addedItems.slice().sort(comparer)
-    } else if (updatedIds?.size) {
-      for (const updatedId of updatedIds) {
-        const item: T = currentEntities[updatedId]
-        // const currentIndex = sortedEntities.indexOf(item)
-        // const newIndex = findInsertIndex(sortedEntities, item, comparer)
-        // console.log('Item: ', updatedId, { currentIndex, newIndex })
-      }
+    } else if (appliedUpdates) {
+      // We should have a _mostly_-sorted array already
       sortedEntities.sort(comparer)
     }
 
     const newSortedIds = sortedEntities.map(selectId)
-    // console.log('New sorted IDs: ', newSortedIds)
+
     if (!areArraysEqual(currentIds, newSortedIds)) {
       state.ids = newSortedIds
     }
   }
 
-  const mergeInitialPR: MergeFunction = (
-    state,
-    addedItems,
-    updatedIds,
-    replacedIds,
-  ) => {
-    // Insert/overwrite all new/updated
-    addedItems.forEach((model) => {
-      ;(state.entities as Record<Id, T>)[selectId(model)] = model
-    })
-
-    let allEntities: T[]
-
-    if (replacedIds) {
-      // This is a really annoying edge case. Just figure this out from scratch
-      // rather than try to be clever. This will be more expensive since it isn't sorted right.
-      allEntities = Object.values(state.entities) as T[]
-    } else {
-      // We're starting with an already-sorted list.
-      let existingIds = state.ids
-
-      if (addedItems.length) {
-        // There's a couple edge cases where we can have duplicate item IDs.
-        // Ensure we don't have duplicates.
-        const uniqueIds = new Set(existingIds as Id[])
-
-        addedItems.forEach((item) => {
-          uniqueIds.add(selectId(item))
-        })
-        existingIds = Array.from(uniqueIds)
-      }
-
-      // By this point `ids` and `entities` should be 1:1, but not necessarily sorted.
-      // Make this a sorta-mostly-sorted array.
-      allEntities = existingIds.map(
-        (id) => (state.entities as Record<Id, T>)[id as Id],
-      )
-    }
-
-    // Now when we sort, things should be _close_ already, and fewer comparisons are needed.
-    allEntities.sort(comparer)
-
-    const newSortedIds = allEntities.map(selectId)
-    const { ids } = state
-
-    if (!areArraysEqual(ids, newSortedIds)) {
-      state.ids = newSortedIds
-    }
-  }
-
-  const mergeTweakedPR: MergeFunction = (
-    state,
-    addedItems,
-    updatedIds,
-    replacedIds,
-  ) => {
-    let allEntities: T[]
-
-    let existingIds = state.ids
-    const uniqueIds = new Set(existingIds as Id[])
-    existingIds = Array.from(uniqueIds)
-
-    if (addedItems.length) {
-      // There's a couple edge cases where we can have duplicate item IDs.
-      // Ensure we don't have duplicates.
-
-      addedItems.forEach((item) => {
-        ;(state.entities as Record<Id, T>)[selectId(item)] = item
-        uniqueIds.add(selectId(item))
-      })
-      existingIds = Array.from(uniqueIds)
-    }
-
-    // By this point `ids` and `entities` should be 1:1, but not necessarily sorted.
-    // Make this a sorta-mostly-sorted array.
-    allEntities = existingIds.map(
-      (id) => (state.entities as Record<Id, T>)[id as Id],
-    )
-
-    // if (replacedIds) {
-    //     // There's a couple edge cases where we can have duplicate item IDs.
-    //     // Ensure we don't have duplicates.
-    //     const uniqueIds = new Set(existingIds as Id[])
-    //   // This is a really annoying edge case. Just figure this out from scratch
-    //   // rather than try to be clever. This will be more expensive since it isn't sorted right.
-    //   allEntities = state.ids.map(
-    //     (id) => (state.entities as Record<Id, T>)[id as Id],
-    //   )
-    // } else {
-    //   // We're starting with an already-sorted list.
-    //   let existingIds = state.ids
-
-    //   if (addedItems.length) {
-    //     // There's a couple edge cases where we can have duplicate item IDs.
-    //     // Ensure we don't have duplicates.
-    //     const uniqueIds = new Set(existingIds as Id[])
-
-    //     addedItems.forEach((item) => {
-
-    //       ;(state.entities as Record<Id, T>)[selectId(item)] = item
-    //       uniqueIds.add(selectId(item))
-    //     })
-    //     existingIds = Array.from(uniqueIds)
-    //   }
-
-    //   // By this point `ids` and `entities` should be 1:1, but not necessarily sorted.
-    //   // Make this a sorta-mostly-sorted array.
-    //   allEntities = existingIds.map(
-    //     (id) => (state.entities as Record<Id, T>)[id as Id],
-    //   )
-    // }
-
-    // Now when we sort, things should be _close_ already, and fewer comparisons are needed.
-    allEntities.sort(comparer)
-
-    const newSortedIds = allEntities.map(selectId)
-    const { ids } = state
-
-    if (!areArraysEqual(ids, newSortedIds)) {
-      state.ids = newSortedIds
-    }
-  }
-
-  const mergeJackman: MergeFunction = (
-    state,
-    addedItems,
-    updatedIds,
-    replacedIds,
-  ) => {
-    const entities = state.entities as Record<Id, T>
-    let ids = state.ids as Id[]
-    if (replacedIds) {
-      ids = Array.from(new Set(ids))
-    }
-    const existingSortedItems = ids // Array.from(new Set(state.ids as Id[]))
-      .map((id) => entities[id])
-      .filter(Boolean)
-
-    function findInsertIndex2<T>(
-      sortedItems: T[],
-      item: T,
-      comparisonFunction: Comparer<T>,
-      lowIndexOverride?: number,
-    ): number {
-      let lowIndex = lowIndexOverride ?? 0
-      let highIndex = sortedItems.length
-      while (lowIndex < highIndex) {
-        const middleIndex = (lowIndex + highIndex) >>> 1
-        const currentItem = sortedItems[middleIndex]
-        if (comparisonFunction(item, currentItem) > 0) {
-          lowIndex = middleIndex + 1
-        } else {
-          highIndex = middleIndex
-        }
-      }
-
-      return lowIndex
-    }
-
-    if (addedItems.length) {
-      const newEntities = addedItems.slice().sort(comparer)
-
-      // Insert/overwrite all new/updated
-      newEntities.forEach((model) => {
-        entities[selectId(model)] = model
-      })
-
-      const firstInstanceId = newEntities[0]
-      const lastInstanceId = newEntities[newEntities.length - 1]
-
-      const startIndex = findInsertIndex2(
-        existingSortedItems,
-        firstInstanceId,
-        comparer,
-      )
-      const endIndex = findInsertIndex2(
-        existingSortedItems,
-        lastInstanceId,
-        comparer,
-        startIndex,
-      )
-
-      const overlappingExistingIds = existingSortedItems.slice(
-        startIndex,
-        endIndex,
-      )
-      let newIdIndexOfLastInsert = 0
-      let lastRelativeInsertIndex = 0
-      for (let i = 1; i < newEntities.length; i++) {
-        const relativeInsertIndex = findInsertIndex2(
-          overlappingExistingIds,
-          newEntities[i],
-          comparer,
-          lastRelativeInsertIndex,
-        )
-        if (lastRelativeInsertIndex !== relativeInsertIndex) {
-          const insertIndex =
-            startIndex + newIdIndexOfLastInsert + lastRelativeInsertIndex
-          const arrayToInsert = newEntities.slice(newIdIndexOfLastInsert, i)
-          existingSortedItems.splice(insertIndex, 0, ...arrayToInsert)
-          newIdIndexOfLastInsert = i
-          lastRelativeInsertIndex = relativeInsertIndex
-        }
-      }
-      existingSortedItems.splice(
-        startIndex + newIdIndexOfLastInsert + lastRelativeInsertIndex,
-        0,
-        ...newEntities.slice(newIdIndexOfLastInsert),
-      )
-    } else if (updatedIds?.size) {
-      existingSortedItems.sort(comparer)
-    }
-
-    const newSortedIds = existingSortedItems.map(selectId)
-
-    if (!areArraysEqual(ids, newSortedIds)) {
-      state.ids = newSortedIds
-    }
-  }
-
   const mergeFunction: MergeFunction = mergeInsertion
-
-  function resortEntities(
-    state: R,
-    addedItems: readonly T[] = [],
-    replacedIds = false,
-  ) {
-    let allEntities: T[]
-
-    allEntities = Object.values(state.entities) as T[]
-    if (replacedIds) {
-      // This is a really annoying edge case. Just figure this out from scratch
-      // rather than try to be clever. This will be more expensive since it isn't sorted right.
-      allEntities = Object.values(state.entities) as T[]
-    } else {
-      // We're starting with an already-sorted list.
-      let existingIds = state.ids
-
-      if (addedItems.length) {
-        // There's a couple edge cases where we can have duplicate item IDs.
-        // Ensure we don't have duplicates.
-        const uniqueIds = new Set(existingIds as Id[])
-
-        addedItems.forEach((item) => {
-          uniqueIds.add(selectId(item))
-        })
-        existingIds = Array.from(uniqueIds)
-      }
-
-      // By this point `ids` and `entities` should be 1:1, but not necessarily sorted.
-      // Make this a sorta-mostly-sorted array.
-      allEntities = existingIds.map(
-        (id) => (state.entities as Record<Id, T>)[id as Id],
-      )
-    }
-
-    // Now when we sort, things should be _close_ already, and fewer comparisons are needed.
-    allEntities.sort(comparer)
-
-    const newSortedIds = allEntities.map(selectId)
-    const { ids } = state
-
-    if (!areArraysEqual(ids, newSortedIds)) {
-      state.ids = newSortedIds
-    }
-  }
 
   return {
     removeOne,

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -360,22 +360,30 @@ describe('Sorted State Adapter', () => {
     const withInitialItems = sortedItemsAdapter.setAll(
       sortedItemsAdapter.getInitialState(),
       [
-        { id: 'A', order: 1, ts: 0 },
-        { id: 'B', order: 2, ts: 0 },
         { id: 'C', order: 3, ts: 0 },
+        { id: 'A', order: 1, ts: 0 },
+        { id: 'F', order: 4, ts: 0 },
+        { id: 'B', order: 2, ts: 0 },
         { id: 'D', order: 3, ts: 0 },
         { id: 'E', order: 3, ts: 0 },
       ],
     )
 
-    expect(withInitialItems.ids).toEqual(['A', 'B', 'C', 'D', 'E'])
+    expect(withInitialItems.ids).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
 
     const updated = sortedItemsAdapter.updateOne(withInitialItems, {
       id: 'C',
       changes: { ts: 5 },
     })
 
-    expect(updated.ids).toEqual(['A', 'B', 'C', 'D', 'E'])
+    expect(updated.ids).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
+
+    const updated2 = sortedItemsAdapter.updateOne(withInitialItems, {
+      id: 'D',
+      changes: { ts: 6 },
+    })
+
+    expect(updated2.ids).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
   })
 
   it('should let you update many entities by id in the state', () => {

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -653,6 +653,8 @@ describe('Sorted State Adapter', () => {
 
     numSorts = 0
 
+    const logComparisons = false
+
     function measureComparisons(name: string, cb: () => void) {
       numSorts = 0
       const start = new Date().getTime()
@@ -660,9 +662,11 @@ describe('Sorted State Adapter', () => {
       const end = new Date().getTime()
       const duration = end - start
 
-      console.log(
-        `${name}: sortComparer called ${numSorts.toLocaleString()} times in ${duration.toLocaleString()}ms`,
-      )
+      if (logComparisons) {
+        console.log(
+          `${name}: sortComparer called ${numSorts.toLocaleString()} times in ${duration.toLocaleString()}ms`,
+        )
+      }
     }
 
     const initialItems = generateItems(INITIAL_ITEMS)
@@ -718,8 +722,8 @@ describe('Sorted State Adapter', () => {
 
     // These numbers will vary because of the randomness, but generally
     // with 10K items the old code had 200K+ sort calls, while the new code
-    // is around 130K sort calls.
-    // expect(numSorts).toBeLessThan(200_000)
+    // is around 13K sort calls.
+    expect(numSorts).toBeLessThan(20_000)
 
     const { ids } = store.getState().entity
     const middleItemId = ids[(ids.length / 2) | 0]
@@ -776,7 +780,7 @@ describe('Sorted State Adapter', () => {
     )
 
     // The old code was around 120K, the new code is around 10K.
-    // expect(numSorts).toBeLessThan(25_000)
+    //expect(numSorts).toBeLessThan(25_000)
   })
 
   describe('can be used mutably when wrapped in createNextState', () => {

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -592,8 +592,8 @@ describe('Sorted State Adapter', () => {
   })
 
   it('should minimize the amount of sorting work needed', () => {
-    const INITIAL_ITEMS = 100_000
-    const ADDED_ITEMS = 1000
+    const INITIAL_ITEMS = 10_000
+    const ADDED_ITEMS = 1_000
 
     type Entity = { id: string; name: string; position: number }
 
@@ -663,6 +663,8 @@ describe('Sorted State Adapter', () => {
       store.dispatch(entitySlice.actions.upsertMany(initialItems))
     })
 
+    expect(numSorts).toBeLessThan(INITIAL_ITEMS * 20)
+
     measureComparisons('Insert One (random)', () => {
       store.dispatch(
         entitySlice.actions.upsertOne({
@@ -672,6 +674,8 @@ describe('Sorted State Adapter', () => {
         }),
       )
     })
+
+    expect(numSorts).toBeLessThan(50)
 
     measureComparisons('Insert One (middle)', () => {
       store.dispatch(
@@ -683,6 +687,8 @@ describe('Sorted State Adapter', () => {
       )
     })
 
+    expect(numSorts).toBeLessThan(50)
+
     measureComparisons('Insert One (end)', () => {
       store.dispatch(
         entitySlice.actions.upsertOne({
@@ -693,10 +699,14 @@ describe('Sorted State Adapter', () => {
       )
     })
 
+    expect(numSorts).toBeLessThan(50)
+
     const addedItems = generateItems(ADDED_ITEMS)
     measureComparisons('Add Many', () => {
       store.dispatch(entitySlice.actions.addMany(addedItems))
     })
+
+    expect(numSorts).toBeLessThan(ADDED_ITEMS * 20)
 
     // These numbers will vary because of the randomness, but generally
     // with 10K items the old code had 200K+ sort calls, while the new code
@@ -718,6 +728,12 @@ describe('Sorted State Adapter', () => {
       )
     })
 
+    const SORTING_COUNT_BUFFER = 100
+
+    expect(numSorts).toBeLessThan(
+      INITIAL_ITEMS + ADDED_ITEMS + SORTING_COUNT_BUFFER,
+    )
+
     measureComparisons('Update One (middle)', () => {
       store.dispatch(
         // Move this middle item near the end
@@ -729,6 +745,10 @@ describe('Sorted State Adapter', () => {
         }),
       )
     })
+
+    expect(numSorts).toBeLessThan(
+      INITIAL_ITEMS + ADDED_ITEMS + SORTING_COUNT_BUFFER,
+    )
 
     measureComparisons('Update One (replace)', () => {
       store.dispatch(
@@ -742,6 +762,10 @@ describe('Sorted State Adapter', () => {
         }),
       )
     })
+
+    expect(numSorts).toBeLessThan(
+      INITIAL_ITEMS + ADDED_ITEMS + SORTING_COUNT_BUFFER,
+    )
 
     // The old code was around 120K, the new code is around 10K.
     // expect(numSorts).toBeLessThan(25_000)

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -654,8 +654,6 @@ describe('Sorted State Adapter', () => {
 
       console.log(
         `${name}: sortComparer called ${numSorts.toLocaleString()} times in ${duration.toLocaleString()}ms`,
-        numSorts.toLocaleString(),
-        'times',
       )
     }
 

--- a/packages/toolkit/src/entities/utils.ts
+++ b/packages/toolkit/src/entities/utils.ts
@@ -56,7 +56,6 @@ export function splitAddedUpdatedEntities<T, Id extends EntityId>(
   for (const entity of newEntities) {
     const id = selectIdValue(entity, selectId)
     if (existingIds.has(id)) {
-      // if (id in state.entities) {
       updated.push({ id, changes: entity })
     } else {
       added.push(entity)

--- a/packages/toolkit/src/entities/utils.ts
+++ b/packages/toolkit/src/entities/utils.ts
@@ -1,3 +1,4 @@
+import { current, isDraft } from 'immer'
 import type {
   IdSelector,
   Update,
@@ -35,23 +36,31 @@ export function ensureEntitiesArray<T, Id extends EntityId>(
   return entities
 }
 
+export function getCurrent<T>(value: T): T {
+  return isDraft(value) ? current(value) : value
+}
+
 export function splitAddedUpdatedEntities<T, Id extends EntityId>(
   newEntities: readonly T[] | Record<Id, T>,
   selectId: IdSelector<T, Id>,
   state: DraftableEntityState<T, Id>,
-): [T[], Update<T, Id>[]] {
+): [T[], Update<T, Id>[], Id[]] {
   newEntities = ensureEntitiesArray(newEntities)
+
+  const existingIdsArray = current(state.ids) as Id[]
+  const existingIds = new Set<Id>(existingIdsArray)
 
   const added: T[] = []
   const updated: Update<T, Id>[] = []
 
   for (const entity of newEntities) {
     const id = selectIdValue(entity, selectId)
-    if (id in state.entities) {
+    if (existingIds.has(id)) {
+      // if (id in state.entities) {
       updated.push({ id, changes: entity })
     } else {
       added.push(entity)
     }
   }
-  return [added, updated]
+  return [added, updated, existingIdsArray]
 }


### PR DESCRIPTION
This PR:

- Updates the sorting logic for sorted entity adapters to hopefully be more efficient most of the time

Previously we were always getting the list of items via `Object.values(state.entities)`. However, that is always going to give us an array of items in _insertion_ order, not the most recent _sorted_ order.

If we instead go `state.ids.map(id => state.entities[id])`, we at least start with a sorted array.

However, there's a couple tricky cases. If a set of updates replaced an item's ID, that throws things out of whack. It's easier to fall back to the old behavior.  There are also apparently a couple test cases where we can end up with duplicate IDs and have to watch for that.

On my own machine, the perf test case with 100K items gave me numbers like this with the existing code:

```
Upsert: sortComparer called: 3,058,124 times
Duration to upsert an item: 1,177 ms
Update: sortComparer called: 1,529,076 times
Duration to update an item: 1,139 ms
```

After this fix, it drops to:

```
Upsert: sortComparer called: 1,629,402 times
Duration to upsert an item: 533 ms
Update: sortComparer called: 100,032 times
Duration to update an item: 544 ms
```

That's still not _fast_, but it's a 50% improvement.

I _may_ have another idea or two around tracking updated items, removing those, and re-inserting them, but will need to try those later.