### PR TITLE
Replace usage of deprecated `JSX` global namespace with `React.JSX`

### DIFF
--- a/examples/query/react/basic/src/test/test-utils.tsx
+++ b/examples/query/react/basic/src/test/test-utils.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import type { RenderOptions } from '@testing-library/react'
-import React, { PropsWithChildren } from 'react'
+import type React from 'react'
+import type { PropsWithChildren, JSX } from 'react'
 import { Provider } from 'react-redux'
 import { setupStore } from '../store'
 import type { AppStore, RootState } from '../store'

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react": "npm:^18.2.0",
     "react-dom": "npm:18.2.0",
     "resolve": "1.22.1",
-    "@types/react": "npm:18.0.12",
+    "@types/react": "npm:^18.0.12",
     "@types/react-dom": "npm:18.0.5",
     "@types/inquirer": "npm:8.2.1",
     "website/react": "npm:17.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "esbuild": "0.19.7",
     "jest-snapshot": "29.3.1",
     "react-redux": "npm:9.1.0",
-    "react": "npm:18.2.0",
+    "react": "npm:^18.2.0",
     "react-dom": "npm:18.2.0",
     "resolve": "1.22.1",
     "@types/react": "npm:18.0.12",

--- a/website/src/theme/DocPage/Layout/Main/index.tsx
+++ b/website/src/theme/DocPage/Layout/Main/index.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from 'react'
+import type { ComponentProps, JSX } from 'react'
 import React from 'react'
 import Main from '@theme-original/DocPage/Layout/Main'
 import type MainType from '@theme-original/DocPage/Layout/Main'

--- a/yarn.lock
+++ b/yarn.lock
@@ -24490,12 +24490,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:^18.2.0":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/b9214a9bd79e99d08de55f8bef2b7fc8c39630be97c4e29d7be173d14a9a10670b5325e94485f74cd8bff4966ef3c78ee53c79a7b0b9b70cba20aa8973acc694
+  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8889,14 +8889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:18.0.12":
-  version: 18.0.12
-  resolution: "@types/react@npm:18.0.12"
+"@types/react@npm:^18.0.12":
+  version: 18.3.1
+  resolution: "@types/react@npm:18.3.1"
   dependencies:
     "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/b010b0d300555a8f70f0513b79d5c35400500cbada71303bbeb72167ddf6154803f92a2edab923c7460a2f1eaa430658b88953ca4a5fe08b276c3587ec91f4f7
+  checksum: 10/baa6b8a75c471c89ebf3477b4feab57102ced25f0c1e553dd04ef6a1f0def28d5e0172fa626a631f22e223f840b5aaa2403b2d4bb671c83c5a9d6c7ae39c7a05
   languageName: node
   linkType: hard
 
@@ -8931,13 +8930,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/f4b5451fc15a7151fc626ba16a91cea7ec1ce8ae3357f4737523b1d336a004b242ce9508c061f012d8e4ef25345ca9e9e3ea459f51b97263b299d6f848787182
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.16.1
-  resolution: "@types/scheduler@npm:0.16.1"
-  checksum: 10/709f02113c64289a03b15b7ecd541b1846caa224dacaf506f93b6931ec88b8c33e435122303e54e4501eecc9671817e133c3e98377c3751d8e0eb5019bd2bd35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## This PR:

  - [X] Runs `npx types-react-codemod scoped-jsx .` to replace usage of the deprecated `JSX` global namespace with `React.JSX` in preparation for React 19.
  
### Relevant Links:
  
  - [The `JSX` namespace in TypeScript](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript)
  - [`scoped-jsx` codemod](https://github.com/eps1lon/types-react-codemod/?tab=readme-ov-file#scoped-jsx)