### PR TITLE
Inline the deprecated `React.ReactChild` type

### DIFF
--- a/examples/query/react/kitchen-sink/src/mocks/setupTests.tsx
+++ b/examples/query/react/kitchen-sink/src/mocks/setupTests.tsx
@@ -23,7 +23,7 @@ export const setupTests = () => {
     path?: string
   }
   function renderWithProvider(
-    children: React.ReactChild,
+    children: React.ReactElement | number | string,
     { route, path }: RenderOptions = { route: '/', path: '' },
   ) {
     const history = createMemoryHistory()


### PR DESCRIPTION
## This PR:

  - [X] Runs `npx types-react-codemod deprecated-react-child .` in preparation for React 19.
  
### Relevant Links:
  
  - [`deprecated-react-child` codemod](https://github.com/eps1lon/types-react-codemod/?tab=readme-ov-file#deprecated-react-child)