### PR TITLE
Prevent inference of any in create.asyncThunk

### DIFF
--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -427,15 +427,7 @@ export interface ReducerCreators<State> {
  * @public
  */
 export type SliceCaseReducers<State> =
-  | Record<
-      string,
-      | CaseReducerDefinition<State, PayloadAction<any>>
-      | CaseReducerWithPrepareDefinition<
-          State,
-          PayloadAction<any, string, any, any>
-        >
-      | AsyncThunkSliceReducerDefinition<State, any, any, any>
-    >
+  | Record<string, ReducerDefinition>
   | Record<
       string,
       | CaseReducer<State, PayloadAction<any>>
@@ -692,7 +684,7 @@ export function buildCreateSlice({ creators }: BuildCreateSliceConfig = {}) {
       } else {
         handleNormalReducerDefinition<State>(
           reducerDetails,
-          reducerDefinition,
+          reducerDefinition as any,
           contextMethods,
         )
       }

--- a/packages/toolkit/src/tests/createSlice.test-d.ts
+++ b/packages/toolkit/src/tests/createSlice.test-d.ts
@@ -652,6 +652,38 @@ describe('type tests', () => {
               expectTypeOf(action.error).toEqualTypeOf<'error'>()
             },
           ),
+          testInferVoid: create.asyncThunk(() => {}, {
+            pending(state, action) {
+              expectTypeOf(state).toEqualTypeOf<TestState>()
+
+              expectTypeOf(action.meta.arg).toBeVoid()
+            },
+            fulfilled(state, action) {
+              expectTypeOf(state).toEqualTypeOf<TestState>()
+
+              expectTypeOf(action.meta.arg).toBeVoid()
+
+              expectTypeOf(action.payload).toBeVoid()
+            },
+            rejected(state, action) {
+              expectTypeOf(state).toEqualTypeOf<TestState>()
+
+              expectTypeOf(action.meta.arg).toBeVoid()
+
+              expectTypeOf(action.error).toEqualTypeOf<SerializedError>()
+            },
+            settled(state, action) {
+              expectTypeOf(state).toEqualTypeOf<TestState>()
+
+              expectTypeOf(action.meta.arg).toBeVoid()
+
+              if (isRejected(action)) {
+                expectTypeOf(action.error).toEqualTypeOf<SerializedError>()
+              } else {
+                expectTypeOf(action.payload).toBeVoid()
+              }
+            },
+          }),
           testInfer: create.asyncThunk(
             function payloadCreator(arg: TestArg, api) {
               return Promise.resolve<TestReturned>({ payload: 'foo' })
@@ -855,6 +887,12 @@ describe('type tests', () => {
         'meta'
       >
     >()
+
+    expectTypeOf(slice.actions.testInferVoid).toEqualTypeOf<
+      AsyncThunk<void, void, {}>
+    >()
+
+    expectTypeOf(slice.actions.testInferVoid).toBeCallableWith()
 
     expectTypeOf(slice.actions.testInfer).toEqualTypeOf<
       AsyncThunk<TestReturned, TestArg, {}>

--- a/packages/toolkit/src/tests/createSlice.test.ts
+++ b/packages/toolkit/src/tests/createSlice.test.ts
@@ -678,7 +678,7 @@ describe('createSlice', () => {
         initialState: [] as any[],
         reducers: (create) => ({
           thunkReducers: create.asyncThunk(
-            function payloadCreator(arg, api) {
+            function payloadCreator(arg: string, api) {
               return Promise.resolve('resolved payload')
             },
             { pending, fulfilled, rejected, settled },
@@ -722,7 +722,7 @@ describe('createSlice', () => {
         reducers: (create) => ({
           thunkReducers: create.asyncThunk(
             // payloadCreator isn't allowed to return never
-            function payloadCreator(arg, api): any {
+            function payloadCreator(arg: string, api): any {
               throw new Error('')
             },
             { pending, fulfilled, rejected, settled },
@@ -765,7 +765,7 @@ describe('createSlice', () => {
         initialState: [] as any[],
         reducers: (create) => ({
           thunkReducers: create.asyncThunk(
-            function payloadCreator(arg, api) {
+            function payloadCreator(arg: string, api) {
               return 'should not call this'
             },
             {
@@ -833,7 +833,6 @@ describe('createSlice', () => {
           slice.actions.thunkReducers.rejected(
             new Error('test'),
             'fakeRequestId',
-            {},
           ),
         ),
       ).not.toThrow()


### PR DESCRIPTION
fixes https://github.com/reduxjs/redux-toolkit/issues/4060#issuecomment-2091201562

we're also making this change over in #3894 (https://github.com/reduxjs/redux-toolkit/pull/3894/files#diff-ee57feab8b392faa360ea66691a847a2dbed2f82486f5726c3723d6a194f22f0R507) so it's mostly unavoidable once we have creators
