### PR TITLE
fix: fix typo

### DIFF
--- a/docs/tutorials/quick-start.mdx
+++ b/docs/tutorials/quick-start.mdx
@@ -49,7 +49,7 @@ npm install @reduxjs/toolkit react-redux
 
 Create a file named `src/app/store.js`. Import the `configureStore` API from Redux Toolkit. We'll start by creating an empty Redux store, and exporting it:
 
-```ts title="app/store.js"
+```ts title="app/store.ts"
 import { configureStore } from '@reduxjs/toolkit'
 
 export const store = configureStore({


### PR DESCRIPTION
Fix a small typo changing from file extension .js to .ts for a typescript file. 