### PR TITLE
Fix missed spot where use of `current` may fail if the value is not a draft

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -103,7 +103,7 @@
     "format": "prettier --write \"(src|examples)/**/*.{ts,tsx}\" \"**/*.md\"",
     "format:check": "prettier --list-different \"(src|examples)/**/*.{ts,tsx}\" \"docs/*/**.md\"",
     "lint": "eslint src examples",
-    "test": "vitest --run --typecheck",
+    "test": "vitest --typecheck --run ",
     "test:watch": "vitest --watch",
     "type-tests": "yarn tsc -p tsconfig.test.json --noEmit",
     "prepack": "yarn build",

--- a/packages/toolkit/src/entities/utils.ts
+++ b/packages/toolkit/src/entities/utils.ts
@@ -47,7 +47,7 @@ export function splitAddedUpdatedEntities<T, Id extends EntityId>(
 ): [T[], Update<T, Id>[], Id[]] {
   newEntities = ensureEntitiesArray(newEntities)
 
-  const existingIdsArray = current(state.ids) as Id[]
+  const existingIdsArray = getCurrent(state.ids) as Id[]
   const existingIds = new Set<Id>(existingIdsArray)
 
   const added: T[] = []


### PR DESCRIPTION
I had added a `getCurrent()` util that checks if the value is draftable before calling `current(value)`, but missed a spot.  Turns out that a sequence of `removeAll()` + `upsertMany()` hits the case where now `state.ids` is a plain array, and thus `current(state.ids)` will throw because it's a plain value and not a draft.