### PR TITLE
Fix Immer current usage when calling addManyMutably more than once

### DIFF
--- a/packages/toolkit/src/entities/sorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/sorted_state_adapter.ts
@@ -71,7 +71,7 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     newEntities = ensureEntitiesArray(newEntities)
 
     const existingKeys = new Set<Id>(
-      existingIds ?? (current(state.ids) as Id[]),
+      existingIds ?? (getCurrent(state.ids) as Id[]),
     )
 
     const models = newEntities.filter(

--- a/packages/toolkit/src/entities/sorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/sorted_state_adapter.ts
@@ -1,4 +1,3 @@
-import { current, isDraft } from 'immer'
 import type {
   IdSelector,
   Comparer,

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -808,6 +808,31 @@ describe('Sorted State Adapter', () => {
     )
   })
 
+  it('should not throw an Immer `current` error when the adapter is called twice', () => {
+    const book1: BookModel = { id: 'a', title: 'First' }
+    const book2: BookModel = { id: 'b', title: 'Second' }
+    const initialState = adapter.getInitialState()
+    const booksSlice = createSlice({
+      name: 'books',
+      initialState,
+      reducers: {
+        testCurrentBehavior(state, action: PayloadAction<BookModel>) {
+          // Will overwrite `state.ids` with a plain array
+          adapter.removeAll(state)
+
+          // will call `splitAddedUpdatedEntities` and call `current(state.ids)`
+          adapter.addOne(state, book1)
+          adapter.addOne(state, book2)
+        },
+      },
+    })
+
+    booksSlice.reducer(
+      initialState,
+      booksSlice.actions.testCurrentBehavior(book1),
+    )
+  })
+
   describe('can be used mutably when wrapped in createNextState', () => {
     test('removeAll', () => {
       const withTwo = adapter.addMany(state, [TheGreatGatsby, AnimalFarm])


### PR DESCRIPTION
A getCurrent() util was created that checks if the value is draftable before calling current(value). Asequence of addOne() + addOne() hits the case where now state.ids is a plain array, and thus current(state.ids) will throw because it's a plain value and not a draft.

Resolves: https://github.com/reduxjs/redux-toolkit/issues/4411