### PR TITLE
fix: unclear error when run cts config without ts-node in rtk-query-codegen-openapi

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/bin/cli.ts
+++ b/packages/rtk-query-codegen-openapi/src/bin/cli.ts
@@ -38,7 +38,7 @@ const configFile = program.args[0];
 if (program.args.length === 0 || !/\.(c?(jsx?|tsx?)|jsonc?)?$/.test(configFile)) {
   program.help();
 } else {
-  if (/\.tsx?$/.test(configFile) && !ts) {
+  if (/\.[mc]?tsx?$/.test(configFile) && !ts) {
     console.error('Encountered a TypeScript configfile, but neither esbuild-runner nor ts-node are installed.');
     process.exit(1);
   }

--- a/packages/rtk-query-codegen-openapi/src/bin/cli.ts
+++ b/packages/rtk-query-codegen-openapi/src/bin/cli.ts
@@ -38,7 +38,7 @@ const configFile = program.args[0];
 if (program.args.length === 0 || !/\.(c?(jsx?|tsx?)|jsonc?)?$/.test(configFile)) {
   program.help();
 } else {
-  if (/\.[mc]?tsx?$/.test(configFile) && !ts) {
+  if (/\.c?tsx?$/.test(configFile) && !ts) {
     console.error('Encountered a TypeScript configfile, but neither esbuild-runner nor ts-node are installed.');
     process.exit(1);
   }

--- a/packages/rtk-query-codegen-openapi/src/bin/cli.ts
+++ b/packages/rtk-query-codegen-openapi/src/bin/cli.ts
@@ -35,10 +35,10 @@ program.version(meta.version).usage('</path/to/config.js>').parse(process.argv);
 
 const configFile = program.args[0];
 
-if (program.args.length === 0 || !/\.(c?(jsx?|tsx?)|jsonc?)?$/.test(configFile)) {
+if (program.args.length === 0 || !/\.([mc]?(jsx?|tsx?)|jsonc?)?$/.test(configFile)) {
   program.help();
 } else {
-  if (/\.c?tsx?$/.test(configFile) && !ts) {
+  if (/\.[mc]?tsx?$/.test(configFile) && !ts) {
     console.error('Encountered a TypeScript configfile, but neither esbuild-runner nor ts-node are installed.');
     process.exit(1);
   }


### PR DESCRIPTION
Related to https://github.com/reduxjs/redux-toolkit/issues/2437 https://github.com/reduxjs/redux-toolkit/pull/2438

When you use cts without ts-node in `rtk-query-codegen-openapi`, the error message is unclear and difficult to troubleshoot.

Before
```
(node:56745) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)

/Users/user/project/openapi-config.cts:1
import type { ConfigFile } from '@rtk-query/codegen-openapi'
^^^^^^

SyntaxError: Cannot use import statement outside a module
```

After

```
Encountered a TypeScript configfile, but neither esbuild-runner nor ts-node are installed.
```