### PR TITLE
Update oazapfts to latest version

### DIFF
--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.2",
     "commander": "^6.2.0",
-    "oazapfts": "^6.0.2",
+    "oazapfts": "^6.1.0",
     "prettier": "^3.2.5",
     "semver": "^7.3.5",
     "swagger2openapi": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7733,7 +7733,7 @@ __metadata:
     husky: "npm:^4.3.6"
     msw: "npm:^2.1.5"
     node-fetch: "npm:^3.3.2"
-    oazapfts: "npm:^6.0.2"
+    oazapfts: "npm:^6.1.0"
     openapi-types: "npm:^9.1.0"
     prettier: "npm:^3.2.5"
     pretty-quick: "npm:^4.0.0"
@@ -21526,20 +21526,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oazapfts@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "oazapfts@npm:6.0.2"
+"oazapfts@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "oazapfts@npm:6.1.0"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
     lodash: "npm:^4.17.21"
     minimist: "npm:^1.2.8"
     swagger2openapi: "npm:^7.0.8"
-    typescript: "npm:^5.3.3"
+    tapable: "npm:^2.2.1"
+    typescript: "npm:^5.4.5"
   peerDependencies:
     "@oazapfts/runtime": "*"
   bin:
-    oazapfts: dist/cli.js
-  checksum: 10/9132e4bbc589cefba2b93a2421309c89e7685cf75108ac8611d93f78c4e985a0d95829feb2f2b109fa22cb6feb12a6a1e03a679bba9892633c22fe9fb21bd91c
+    oazapfts: cli.js
+  checksum: 10/804c3936702acf66bb9bcff6bdcdce2708783b31c83262d7097fb04a53d3720d96114cec345408cbf3f933f9c5d198815457853a07362796c6a6d5db7a31d150
   languageName: node
   linkType: hard
 
@@ -27487,6 +27488,13 @@ __metadata:
   version: 2.2.0
   resolution: "tapable@npm:2.2.0"
   checksum: 10/c3f3a0d941503454ab288dc73e6419e4e3ace42b69b91c1b8ba5bbcb73cccc736ad4db1f4e7aade72967fdb13c3dc2bdf2a798b21cf5f0bf14455a2df4e2e18a
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "tapable@npm:2.2.1"
+  checksum: 10/1769336dd21481ae6347611ca5fca47add0962fd8e80466515032125eca0084a4f0ede11e65341b9c0018ef4e1cf1ad820adbb0fba7cc99865c6005734000b0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Context
This is a follow-up of this PR: https://github.com/reduxjs/redux-toolkit/pull/4198

I've found some issues on the `@rtk-query/codegen-openapi` that point to dependency issues. Here are some of them:
- https://github.com/reduxjs/redux-toolkit/issues/3918
- https://github.com/reduxjs/redux-toolkit/issues/4455
- https://github.com/reduxjs/redux-toolkit/issues/1788

From version 6.0.2, which was merged yesterday to version 6.1.0, there are several more fixes added to `oazapfts`. These are a few:
- https://github.com/oazapfts/oazapfts/issues/626
- https://github.com/oazapfts/oazapfts/issues/578

List of [releases](https://github.com/oazapfts/oazapfts/releases) changelog:
- support moduleResolution: node
- codegen: upgrade dependencies
- do not treat numeric values in multipart as blob
- codegen: handle negative numbers correctly
- support boolean schemas

I was looking at the [issue on the pipeline](https://github.com/reduxjs/redux-toolkit/actions/runs/9507010843/job/26205509725#step:4:73) when you tried to publish the package. There are issues with the cache. Rerunning the pipeline could help. Here is a reference on this issue: https://github.com/yarnpkg/berry/issues/2948

# What is done in this PR?
- Updating `oazapfts` package to the latest version to fix issues
- Rollback [SimonEggert](https://github.com/SimonEggert) update to the [package module](https://github.com/reduxjs/redux-toolkit/pull/4198/files#r1489566002) to test everything is working based on the package update