### PR TITLE
Add export for FetchBaseQueryArgs

### DIFF
--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -34,6 +34,7 @@ export type {
 } from './endpointDefinitions'
 export { fetchBaseQuery } from './fetchBaseQuery'
 export type {
+  FetchBaseQueryArgs,
   FetchBaseQueryError,
   FetchBaseQueryMeta,
   FetchArgs,


### PR DESCRIPTION
This PR adds an exports for the `FetchBaseQueryArgs` type that was only available internally.

Related issue: https://github.com/reduxjs/redux-toolkit/issues/4464