### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,9 +92,11 @@ jobs:
       - name: Install build artifact
         run: yarn workspace @reduxjs/toolkit add $(pwd)/package.tgz
 
-      - run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json ./vitest.config.mts ./src/tests/*.* ./src/query/tests/*.*
+      - run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json
 
       - name: Run tests, against dist
+        env:
+          TEST_DIST: true
         run: yarn test
 
   test-types:
@@ -134,9 +136,11 @@ jobs:
       - name: Show installed RTK versions
         run: yarn info @reduxjs/toolkit
 
-      - run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json ./vitest.config.mts ./src/tests/*.* ./src/query/tests/*.*
+      - run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json
 
       - name: Test types
+        env:
+          TEST_DIST: true
         run: |
           yarn tsc --version
           yarn type-tests

--- a/packages/toolkit/src/tests/configureStore.test.ts
+++ b/packages/toolkit/src/tests/configureStore.test.ts
@@ -39,7 +39,11 @@ describe('configureStore', async () => {
         expect.any(Function),
       )
       expect(redux.applyMiddleware).toHaveBeenCalled()
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledTimes(2)
+      }
     })
   })
 
@@ -53,7 +57,11 @@ describe('configureStore', async () => {
       expect(configureStore({ reducer })).toBeInstanceOf(Object)
       expect(redux.combineReducers).toHaveBeenCalledWith(reducer)
       expect(redux.applyMiddleware).toHaveBeenCalled()
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         expect.any(Function),
         undefined,
@@ -76,7 +84,11 @@ describe('configureStore', async () => {
         configureStore({ middleware: () => new Tuple(), reducer }),
       ).toBeInstanceOf(Object)
       expect(redux.applyMiddleware).toHaveBeenCalledWith()
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
         undefined,
@@ -105,7 +117,11 @@ describe('configureStore', async () => {
         expect.any(Function), // serializableCheck
         expect.any(Function), // actionCreatorCheck
       )
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
         undefined,
@@ -142,7 +158,11 @@ describe('configureStore', async () => {
         configureStore({ middleware: () => new Tuple(thank), reducer }),
       ).toBeInstanceOf(Object)
       expect(redux.applyMiddleware).toHaveBeenCalledWith(thank)
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
         undefined,
@@ -197,7 +217,13 @@ describe('configureStore', async () => {
         Object,
       )
       expect(redux.applyMiddleware).toHaveBeenCalled()
-      expect(composeWithDevToolsSpy).toHaveBeenCalledWith(options) // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+
+        expect(composeWithDevToolsSpy).toHaveBeenLastCalledWith(options)
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
         undefined,
@@ -210,7 +236,11 @@ describe('configureStore', async () => {
     it('calls createStore with preloadedState', () => {
       expect(configureStore({ reducer })).toBeInstanceOf(Object)
       expect(redux.applyMiddleware).toHaveBeenCalled()
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
         undefined,
@@ -241,7 +271,11 @@ describe('configureStore', async () => {
         }),
       ).toBeInstanceOf(Object)
       expect(redux.applyMiddleware).toHaveBeenCalled()
-      expect(composeWithDevToolsSpy).toHaveBeenCalled() // @remap-prod-remove-line
+      if (process.env.TEST_DIST) {
+        expect(composeWithDevToolsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(composeWithDevToolsSpy).toHaveBeenCalledOnce()
+      }
       expect(redux.createStore).toHaveBeenCalledWith(
         reducer,
         undefined,

--- a/packages/toolkit/vitest.config.mts
+++ b/packages/toolkit/vitest.config.mts
@@ -10,6 +10,14 @@ const __dirname = path.dirname(__filename)
 export default defineConfig({
   plugins: [tsconfigPaths({ root: __dirname })],
   test: {
+    alias: process.env.TEST_DIST
+      ? {
+          '@reduxjs/toolkit': new URL(
+            'node_modules/@reduxjs/toolkit',
+            import.meta.url,
+          ).pathname,
+        }
+      : undefined,
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],


### PR DESCRIPTION
## **Overview**

It seems like the new version of Vite much like Node.js allows packages to self-reference themselves, which became a problem considering how we were running the tests against the build artifact during CI. The main issue was that when running the tests against the build artifact, Vitest was prioritizing the `@reduxjs/toolkit` source files instead of the external `@reduxjs/toolkit` inside the `node_modules` folder.