### PR TITLE
Export UpdateDefinitions from toolkit/query

### DIFF
--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -31,6 +31,7 @@ export type {
   DefinitionsFromApi,
   OverrideResultType,
   TagTypesFromApi,
+  UpdateDefinitions,
 } from './endpointDefinitions'
 export { fetchBaseQuery } from './fetchBaseQuery'
 export type {


### PR DESCRIPTION
When using `enhanceEndpoints` in a library, the return type cannot be inferred because the `UpdateDefinitions` type is not exported from `@reduxjs/toolkit/query`.  This exports that type. Fixes #4492. 

The CONTRIBUTING.md file mentions needing to update the `etc/redux-toolkit.api.md` file "If you changed external-facing types". I'm not sure if that's required in this case? I wasn't able to figure out how to regenerate that file. The instructions make it sounds like it gets generated during the build process - but when I deleted the file and re-ran the build script it did not get re-generated. None of the other scripts seem to regenerate this file, either. I tried running `api-extractor` directly but get an error. Is there some other manually step that needs to be taken to generate that file? 