### PR TITLE
Feature: Expose HTTP resolver options

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -108,6 +108,7 @@ interface SimpleUsage {
     | Array<string | RegExp | EndpointMatcherFunction>
   endpointOverrides?: EndpointOverrides[]
   flattenArg?: boolean
+  httpResolverOptions?: SwaggerParser.HTTPResolverOptions
 }
 
 export type EndpointMatcherFunction = (
@@ -165,6 +166,27 @@ const config: ConfigFile = {
     },
     './src/store/pet.ts': {
       filterEndpoints: [/pet/i],
+    },
+  },
+}
+```
+
+#### Custom HTTP resolver options
+
+If you need to customize the HTTP request issued to your server, you user the `httpResolverOptions` option. This object is passed directly to the `SwaggerParser` instance that fetches the OpenAPI schema.
+
+For example, you can pass custom headers or set a custom request timeout.
+
+```ts no-transpile title="openapi-config.ts"
+const config: ConfigFile = {
+  schemaFile: 'https://petstore3.swagger.io/api/v3/openapi.json',
+  apiFile: './src/store/emptyApi.ts',
+  outputFile: './src/store/petApi.ts',
+  httpResolverOptions: {
+    timeout: 30_000,
+    headers: {
+      Accept: 'application/json',
+      Authorization: 'Basic cmVkdXgtdG9vbGtpdDppcy1ncmVhdA==',
     },
   },
 }

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -92,9 +92,10 @@ export async function generateApi(
     flattenArg = false,
     useEnumType = false,
     mergeReadWriteOnly = false,
+    httpResolverOptions,
   }: GenerationOptions
 ) {
-  const v3Doc = await getV3Doc(spec);
+  const v3Doc = await getV3Doc(spec, httpResolverOptions);
 
   const apiGen = new ApiGenerator(v3Doc, {
     unionUndefined,

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -1,3 +1,4 @@
+import type SwaggerParser from '@apidevtools/swagger-parser';
 import type { OpenAPIV3 } from 'openapi-types';
 
 export type OperationDefinition = {
@@ -77,6 +78,10 @@ export interface CommonOptions {
    * `true` will not generate separate types for read-only and write-only properties.
    */
   mergeReadWriteOnly?: boolean;
+  /**
+   * HTTPResolverOptions object that is passed to the SwaggerParser bundle function.
+   */
+  httpResolverOptions?: SwaggerParser.HTTPResolverOptions;
 }
 
 export type TextMatcher = string | RegExp | (string | RegExp)[];

--- a/packages/rtk-query-codegen-openapi/src/utils/getV3Doc.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/getV3Doc.ts
@@ -3,9 +3,18 @@ import type { OpenAPIV3 } from 'openapi-types';
 // @ts-ignore
 import converter from 'swagger2openapi';
 
-export async function getV3Doc(spec: string): Promise<OpenAPIV3.Document> {
-  const doc = await SwaggerParser.bundle(spec);
+export async function getV3Doc(
+  spec: string,
+  httpResolverOptions?: SwaggerParser.HTTPResolverOptions
+): Promise<OpenAPIV3.Document> {
+  const doc = await SwaggerParser.bundle(spec, {
+    resolve: {
+      http: httpResolverOptions,
+    },
+  });
+
   const isOpenApiV3 = 'openapi' in doc && doc.openapi.startsWith('3');
+
   if (isOpenApiV3) {
     return doc as OpenAPIV3.Document;
   } else {


### PR DESCRIPTION
Allow passing `httpResolverOptions` in `ConfigFile`.

Closes #4521
Closes #3468