### PR TITLE
Add "createAsyncThunkCreator" with option for customizing default error serializer

### DIFF
--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -780,7 +780,7 @@ Options specified when calling `createAsyncThunk` will override options specifie
 
 An object with the following optional fields:
 
-- `serializeError(error: unknown) => GetSerializedErrorType<ThunkApiConfig>` to replace or extend the default serializer method with your own serialization logic.
+- `serializeError(error: unknown) => any` to replace the internal `miniSerializeError` method with your own serialization logic.
 - `idGenerator(arg: unknown) => string`: a function to use when generating the `requestId` for the request sequence. Defaults to use [nanoid](./otherExports.mdx/#nanoid), but you can implement your own ID generation logic.
 
 ### Return Value

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -769,3 +769,54 @@ const UsersComponent = (props: { id: string }) => {
   // render UI here
 }
 ```
+
+## `createAsyncThunkCreator`
+
+### Options
+
+An object with the following optional fields:
+
+- `serializeError(error: any, defaultSerializer: (error: any) => GetSerializedErrorType<ThunkApiConfig>) => GetSerializedErrorType<ThunkApiConfig>` to replace or extend the default internal serializer method with your own serialization logic.
+
+### Return Value
+
+`createAsyncThunkCreator` returns a Redux thunk action creator with customized options. Currently, the only option is `serializeError`.
+
+### Example
+
+```ts no-transpile
+import { createAsyncThunkCreator } from '@reduxjs/toolkit'
+
+export interface AppSerializedError extends SerializedError {
+  isAxiosError?: boolean
+}
+
+type ThunkApiConfig = {
+  state: RootState
+  serializedErrorType: AppSerializedError
+}
+
+const createAppAsyncThunkCreator = createAsyncThunkCreator<ThunkApiConfig>({
+  serializeError(error, defaultSerializer) {
+    const serializedError = defaultSerializer(error)
+    serializedError.isAxiosError = error.isAxiosError
+    return serializedError
+  },
+})
+
+function createAppAsyncThunk<
+  Returned,
+  ThunkArg = void,
+  T extends ThunkApiConfig = ThunkApiConfig,
+>(
+  typePrefix: string,
+  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, T>,
+  options?: AsyncThunkOptions<ThunkArg, T>,
+): AsyncThunk<Returned, ThunkArg, T> {
+  return createAppAsyncThunkCreator<Returned, ThunkArg, T>(
+    typePrefix,
+    payloadCreator,
+    options,
+  )
+}
+```

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -785,7 +785,7 @@ An object with the following optional fields:
 ### Example
 
 ```ts no-transpile
-import { createAsyncThunkCreator } from '@reduxjs/toolkit'
+import { createAsyncThunkCreator, SerializedError } from '@reduxjs/toolkit'
 
 export interface AppSerializedError extends SerializedError {
   isAxiosError?: boolean

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -776,7 +776,7 @@ const UsersComponent = (props: { id: string }) => {
 
 An object with the following optional fields:
 
-- `serializeError(error: any, defaultSerializer: (error: any) => GetSerializedErrorType<ThunkApiConfig>) => GetSerializedErrorType<ThunkApiConfig>` to replace or extend the default internal serializer method with your own serialization logic.
+- `serializeError(error: any, defaultSerializer: (error: any) => SerializedError) => GetSerializedErrorType<ThunkApiConfig>` to replace or extend the default internal serializer method with your own serialization logic.
 
 ### Return Value
 
@@ -798,7 +798,7 @@ type ThunkApiConfig = {
 
 const createAppAsyncThunkCreator = createAsyncThunkCreator<ThunkApiConfig>({
   serializeError(error, defaultSerializer) {
-    const serializedError = defaultSerializer(error)
+    const serializedError = defaultSerializer(error) as AppSerializedError
     serializedError.isAxiosError = error.isAxiosError
     return serializedError
   },

--- a/docs/api/createAsyncThunk.mdx
+++ b/docs/api/createAsyncThunk.mdx
@@ -772,20 +772,31 @@ const UsersComponent = (props: { id: string }) => {
 
 ## `createAsyncThunkCreator`
 
+Create a customised version of `createAsyncThunk` with defaulted options.
+
+Options specified when calling `createAsyncThunk` will override options specified in `createAsyncThunkCreator`.
+
 ### Options
 
 An object with the following optional fields:
 
-- `serializeError(error: any, defaultSerializer: (error: any) => SerializedError) => GetSerializedErrorType<ThunkApiConfig>` to replace or extend the default internal serializer method with your own serialization logic.
+- `serializeError(error: unknown) => GetSerializedErrorType<ThunkApiConfig>` to replace or extend the default serializer method with your own serialization logic.
+- `idGenerator(arg: unknown) => string`: a function to use when generating the `requestId` for the request sequence. Defaults to use [nanoid](./otherExports.mdx/#nanoid), but you can implement your own ID generation logic.
 
 ### Return Value
 
-`createAsyncThunkCreator` returns a Redux thunk action creator with customized options. Currently, the only option is `serializeError`.
+A version of `createAsyncThunk` that has options defaulted to the values provided.
 
 ### Example
 
 ```ts no-transpile
-import { createAsyncThunkCreator, SerializedError } from '@reduxjs/toolkit'
+import {
+  createAsyncThunkCreator,
+  miniSerializeError,
+  SerializedError,
+} from '@reduxjs/toolkit'
+import { isAxiosError } from 'axios'
+import { v4 as uuidv4 } from 'uuid'
 
 export interface AppSerializedError extends SerializedError {
   isAxiosError?: boolean
@@ -796,27 +807,13 @@ type ThunkApiConfig = {
   serializedErrorType: AppSerializedError
 }
 
-const createAppAsyncThunkCreator = createAsyncThunkCreator<ThunkApiConfig>({
-  serializeError(error, defaultSerializer) {
-    const serializedError = defaultSerializer(error) as AppSerializedError
-    serializedError.isAxiosError = error.isAxiosError
-    return serializedError
+export const createAppAsyncThunk = createAsyncThunkCreator<ThunkApiConfig>({
+  serializeError(error) {
+    return {
+      ...miniSerializeError(error),
+      isAxiosError: isAxiosError(error),
+    }
   },
+  idGenerator: () => uuidv4(),
 })
-
-function createAppAsyncThunk<
-  Returned,
-  ThunkArg = void,
-  T extends ThunkApiConfig = ThunkApiConfig,
->(
-  typePrefix: string,
-  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, T>,
-  options?: AsyncThunkOptions<ThunkArg, T>,
-): AsyncThunk<Returned, ThunkArg, T> {
-  return createAppAsyncThunkCreator<Returned, ThunkArg, T>(
-    typePrefix,
-    payloadCreator,
-    options,
-  )
-}
 ```

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -93,7 +93,7 @@ class FulfillWithMeta<Payload, FulfilledMeta> {
  */
 export const miniSerializeError = (value: any): SerializedError => {
   if (typeof value === 'object' && value !== null) {
-    const simpleError = {} as Record<string, string>
+    const simpleError: SerializedError = {}
     for (const property of commonProperties) {
       if (typeof value[property] === 'string') {
         simpleError[property] = value[property]

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -91,9 +91,7 @@ class FulfillWithMeta<Payload, FulfilledMeta> {
  *
  * @public
  */
-export const miniSerializeError = <ThunkApiConfig extends AsyncThunkConfig>(
-  value: any,
-): GetSerializedErrorType<ThunkApiConfig> => {
+export const miniSerializeError = (value: any): SerializedError => {
   if (typeof value === 'object' && value !== null) {
     const simpleError = {} as Record<string, string>
     for (const property of commonProperties) {
@@ -102,10 +100,10 @@ export const miniSerializeError = <ThunkApiConfig extends AsyncThunkConfig>(
       }
     }
 
-    return simpleError as GetSerializedErrorType<ThunkApiConfig>
+    return simpleError
   }
 
-  return { message: String(value) } as GetSerializedErrorType<ThunkApiConfig>
+  return { message: String(value) }
 }
 
 export type AsyncThunkConfig = {
@@ -178,14 +176,11 @@ type GetRejectedMeta<ThunkApiConfig> = ThunkApiConfig extends {
   ? RejectedMeta
   : unknown
 
-type GetSerializedErrorType<
-  ThunkApiConfig,
-  T extends SerializedError = SerializedError,
-> = ThunkApiConfig extends {
+type GetSerializedErrorType<ThunkApiConfig> = ThunkApiConfig extends {
   serializedErrorType: infer GetSerializedErrorType
 }
   ? GetSerializedErrorType
-  : T
+  : SerializedError
 
 type MaybePromise<T> = T | Promise<T> | (T extends any ? Promise<T> : never)
 
@@ -566,7 +561,7 @@ function internalCreateAsyncThunkCreator<
         return creatorOptions.serializeError(x, miniSerializeError)
       }
 
-      return miniSerializeError(x)
+      return miniSerializeError(x) as GetSerializedErrorType<ThunkApiConfig>
     }
 
     const rejected: AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig> =
@@ -788,7 +783,7 @@ function isThenable(value: any): value is PromiseLike<any> {
  */
 type ErrorSerializer<ThunkApiConfig extends AsyncThunkConfig> = (
   error: any,
-  defaultSerializer: (error: any) => GetSerializedErrorType<ThunkApiConfig>,
+  defaultSerializer: (error: any) => SerializedError,
 ) => GetSerializedErrorType<ThunkApiConfig>
 
 /**

--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -541,7 +541,7 @@ export function createAsyncThunkCreator<
     } = {
       ...creatorOptions,
       ...options,
-    }
+    } as AsyncThunkOptions<ThunkArg, ThunkApiConfig>
 
     const fulfilled: AsyncThunkFulfilledActionCreator<
       Returned,

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -121,6 +121,7 @@ export type {
 
 export {
   createAsyncThunk,
+  createAsyncThunkCreator,
   unwrapResult,
   miniSerializeError,
 } from './createAsyncThunk'

--- a/packages/toolkit/src/tests/createAsyncThunk.test-d.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test-d.ts
@@ -1,4 +1,5 @@
 import type {
+  Action,
   AsyncThunk,
   SerializedError,
   ThunkDispatch,
@@ -7,6 +8,7 @@ import type {
 import {
   configureStore,
   createAsyncThunk,
+  createAsyncThunkCreator,
   createReducer,
   createSlice,
   unwrapResult,
@@ -887,5 +889,28 @@ describe('type tests', () => {
       // could be caused by a `throw`, `abort()` or `condition` - no `rejectedMeta` in that case
       expectTypeOf(ret.meta).not.toHaveProperty('extraProp')
     }
+  })
+  test('createAsyncThunkCreator', () => {
+    const store = configureStore({
+      reducer: (state: Action[] = [], action) => [...state, action],
+    })
+
+    type RootState = ReturnType<typeof store.getState>
+    type AppDispatch = typeof store.dispatch
+
+    const createAsyncThunk = createAsyncThunkCreator<{
+      state: RootState
+      dispatch: AppDispatch
+    }>()
+
+    const thunk = createAsyncThunk(
+      'test',
+      (arg: string, { dispatch, getState }) => {
+        expectTypeOf(dispatch).toEqualTypeOf<AppDispatch>()
+        expectTypeOf(getState).toEqualTypeOf<() => RootState>()
+      },
+    )
+
+    store.dispatch(thunk('test'))
   })
 })


### PR DESCRIPTION
Adds a new `createAsyncThunkCreator` method which can be used to set the custom error serializer.

```ts
import { createAsyncThunkCreator, SerializedError } from '@reduxjs/toolkit'

export interface AppSerializedError extends SerializedError {
  isAxiosError?: boolean
}

type ThunkApiConfig = {
  state: RootState
  serializedErrorType: AppSerializedError
}

const createAppAsyncThunkCreator = createAsyncThunkCreator<ThunkApiConfig>({
  serializeError(error, defaultSerializer) {
    const serializedError = defaultSerializer(error)
    serializedError.isAxiosError = error.isAxiosError
    return serializedError
  },
})

function createAppAsyncThunk<
  Returned,
  ThunkArg = void,
  T extends ThunkApiConfig = ThunkApiConfig,
>(
  typePrefix: string,
  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, T>,
  options?: AsyncThunkOptions<ThunkArg, T>,
): AsyncThunk<Returned, ThunkArg, T> {
  return createAppAsyncThunkCreator<Returned, ThunkArg, T>(
    typePrefix,
    payloadCreator,
    options,
  )
}
```

Closes #4548 