### PR TITLE
fix: include lodash in rtk-query-codegen-openapi dependencies

### DIFF
--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.2",
     "commander": "^6.2.0",
+    "lodash": "^4.17.21",
     "oazapfts": "^6.0.2",
     "prettier": "^3.2.5",
     "semver": "^7.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,6 +8206,7 @@ __metadata:
     esbuild: "npm:~0.17"
     esbuild-runner: "npm:^2.2.1"
     husky: "npm:^4.3.6"
+    lodash: "npm:^4.17.21"
     msw: "npm:^2.1.5"
     node-fetch: "npm:^3.3.2"
     oazapfts: "npm:^6.0.2"


### PR DESCRIPTION
`camelCase` from `lodash` is being imported in the rtk-query-codegen-openapi package here

https://github.com/reduxjs/redux-toolkit/blob/75b4f698e1c58efa6b19096abe5850da0a431da0/packages/rtk-query-codegen-openapi/src/generate.ts#L1

But only the type definitions for lodash are installed as a devDependency of that package

https://github.com/reduxjs/redux-toolkit/blob/75b4f698e1c58efa6b19096abe5850da0a431da0/packages/rtk-query-codegen-openapi/package.json#L41

We're relying on a phantom dependency to be available via the hoisting of node_modules. This is a problem for downstream consumers who may disable the default hoisting behavior of npm / yarn. 

This MR just adds lodash as a direct dependency of rtk-query-codegen-openapi . I just installed the same version as the installed phantom dependency, `4.17.21` and added a caret to match the other dependencies currently in the package