### PR TITLE
Implement a util function to batch-upsert cache entries

### DIFF
--- a/docs/rtk-query/api/created-api/api-slice-utils.mdx
+++ b/docs/rtk-query/api/created-api/api-slice-utils.mdx
@@ -197,6 +197,86 @@ dispatch(
 patchCollection.undo()
 ```
 
+### `upsertQueryEntries`
+
+A standard Redux action creator that accepts an array of individual cache entry descriptions, and immediately upserts them into the store. This is designed to efficiently bulk-insert many entries at once.
+
+#### Signature
+
+```ts no-transpile
+/**
+ * A typesafe single entry to be upserted into the cache
+ */
+export type NormalizedQueryUpsertEntry<
+  Definitions extends EndpointDefinitions,
+  EndpointName extends QueryKeys<Definitions>,
+> = {
+  endpointName: EndpointName
+  arg: QueryArgFrom<Definitions[EndpointName]>
+  value: ResultTypeFrom<Definitions[EndpointName]>
+}
+
+const upsertQueryEntries = (entries: NormalizedQueryUpsertEntry[]) =>
+  PayloadAction<NormalizedQueryUpsertEntry[]>
+```
+
+- **Parameters**
+  - `entries`: an array of objects that contain the data needed to upsert individual cache entries:
+    - `endpointName`: the name of the endpoint, such as `"getPokemon"`
+    - `arg`: the full query key argument needed to identify this cache entry, such as `"pikachu"` (same as you would pass to a `useQuery` hook or `api.endpoints.someEndpoint.select()`)
+    - `value`: the data to be upserted into this cache entry, exactly as formatted.
+
+#### Description
+
+This method is designed as a more efficient approach to bulk-inserting many entries at once than many individual calls to `upsertQueryData`. As a comparison:
+
+- `upsertQueryData`:
+  - upserts one cache entry at a time
+  - Is async
+  - Dispatches 2 separate actions, `pending` and `fulfilled`
+  - Runs the `transformResponse` callback if defined for that endpoint, as well as the `merge` callback if defined
+- `upsertQueryEntries`:
+  - upserts many cache entries at once, and they may be for any combination of endpoints defined in the API
+  - Is a single synchronous action
+  - Does _not_ run `transformResponse`, so the provided `value` fields must already be in the final format expected for that endpoint. However, it will still run the `merge` callback if defined
+
+Currently, this method has two main use cases. The first is prefilling the cache with data retrieved from storage on app startup. The second is to act as a "pseudo-normalization" tool. [RTK Query is _not_ a "normalized" cache](../../usage/cache-behavior.mdx#no-normalized-or-de-duplicated-cache). However, there are times when you may want to prefill other cache entries with the contents of another endpoint, such as taking the results of a `getPosts` list endpoint response and prefilling the individual `getPost(id)` endpoint cache entries.
+
+If no cache entry for that cache key exists, a cache entry will be created and the data added. If a cache entry already exists, this will _overwrite_ the existing cache entry data.
+
+If dispatched while an actual request is in progress, both the upsert and request will be handled as soon as they resolve, resulting in a "last result wins" update behavior.
+
+#### Example
+
+```ts no-transpile
+const api = createApi({
+  endpoints: (build) => ({
+    getPosts: build.query<Post[], void>({
+      query: () => '/posts',
+      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+        const res = await queryFulfilled
+        const posts = res.data
+
+        // Pre-fill the individual post entries with the results
+        // from the list endpoint query
+        const entries = dispatch(
+          api.util.upsertQueryEntries(
+            posts.map((post) => ({
+              endpointName: 'getPost',
+              arg: { id: post.id },
+              value: post,
+            })),
+          ),
+        )
+      },
+    }),
+    getPost: build.query<Post, Pick<Post, 'id'>>({
+      query: (post) => `post/${post.id}`,
+    }),
+  }),
+})
+```
+
 ### `prefetch`
 
 #### Signature

--- a/docs/rtk-query/api/created-api/api-slice-utils.mdx
+++ b/docs/rtk-query/api/created-api/api-slice-utils.mdx
@@ -42,11 +42,12 @@ interface PatchCollection {
 }
 ```
 
-- **Parameters**
-  - `endpointName`: a string matching an existing endpoint name
-  - `arg`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
-  - `updateRecipe`: an Immer `produce` callback that can apply changes to the cached state
-  - `updateProvided`: a boolean indicating whether the endpoint's provided tags should be re-calculated based on the updated cache. Defaults to `false`.
+#### Parameters
+
+- `endpointName`: a string matching an existing endpoint name
+- `arg`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
+- `updateRecipe`: an Immer `produce` callback that can apply changes to the cached state
+- `updateProvided`: a boolean indicating whether the endpoint's provided tags should be re-calculated based on the updated cache. Defaults to `false`.
 
 #### Description
 
@@ -123,10 +124,11 @@ const upsertQueryData = <T>(endpointName: string, arg: any, newEntryData: T) =>
   ThunkAction<Promise<CacheEntry<T>>, PartialState, any, UnknownAction>
 ```
 
-- **Parameters**
-  - `endpointName`: a string matching an existing endpoint name
-  - `arg`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
-  - `newEntryValue`: the value to be written into the corresponding cache entry's `data` field
+#### Parameters
+
+- `endpointName`: a string matching an existing endpoint name
+- `arg`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
+- `newEntryValue`: the value to be written into the corresponding cache entry's `data` field
 
 #### Description
 
@@ -161,11 +163,12 @@ const patchQueryData = (
 ) => ThunkAction<void, PartialState, any, UnknownAction>;
 ```
 
-- **Parameters**
-  - `endpointName`: a string matching an existing endpoint name
-  - `arg`: a cache key, used to determine which cached dataset needs to be updated
-  - `patches`: an array of patches (or inverse patches) to apply to cached state. These would typically be obtained from the result of dispatching [`updateQueryData`](#updatequerydata)
-  - `updateProvided`: a boolean indicating whether the endpoint's provided tags should be re-calculated based on the updated cache. Defaults to `false`.
+#### Parameters
+
+- `endpointName`: a string matching an existing endpoint name
+- `arg`: a cache key, used to determine which cached dataset needs to be updated
+- `patches`: an array of patches (or inverse patches) to apply to cached state. These would typically be obtained from the result of dispatching [`updateQueryData`](#updatequerydata)
+- `updateProvided`: a boolean indicating whether the endpoint's provided tags should be re-calculated based on the updated cache. Defaults to `false`.
 
 #### Description
 
@@ -220,11 +223,12 @@ const upsertQueryEntries = (entries: NormalizedQueryUpsertEntry[]) =>
   PayloadAction<NormalizedQueryUpsertEntry[]>
 ```
 
-- **Parameters**
-  - `entries`: an array of objects that contain the data needed to upsert individual cache entries:
-    - `endpointName`: the name of the endpoint, such as `"getPokemon"`
-    - `arg`: the full query key argument needed to identify this cache entry, such as `"pikachu"` (same as you would pass to a `useQuery` hook or `api.endpoints.someEndpoint.select()`)
-    - `value`: the data to be upserted into this cache entry, exactly as formatted.
+#### Parameters
+
+- `entries`: an array of objects that contain the data needed to upsert individual cache entries:
+  - `endpointName`: the name of the endpoint, such as `"getPokemon"`
+  - `arg`: the full query key argument needed to identify this cache entry, such as `"pikachu"` (same as you would pass to a `useQuery` hook or `api.endpoints.someEndpoint.select()`)
+  - `value`: the data to be upserted into this cache entry, exactly as formatted.
 
 #### Description
 
@@ -259,7 +263,7 @@ const api = createApi({
 
         // Pre-fill the individual post entries with the results
         // from the list endpoint query
-        const entries = dispatch(
+        dispatch(
           api.util.upsertQueryEntries(
             posts.map((post) => ({
               endpointName: 'getPost',
@@ -290,13 +294,13 @@ const prefetch = (endpointName: string, arg: any, options: PrefetchOptions) =>
   ThunkAction<void, any, any, UnknownAction>
 ```
 
-- **Parameters**
+#### Parameters
 
-  - `endpointName`: a string matching an existing endpoint name
-  - `args`: a cache key, used to determine which cached dataset needs to be updated
-  - `options`: options to determine whether the request should be sent for a given situation:
-    - `ifOlderThan`: if specified, only runs the query if the difference between `new Date()` and the last`fulfilledTimeStamp` is greater than the given value (in seconds)
-    - `force`: if `true`, it will ignore the `ifOlderThan` value if it is set and the query will be run even if it exists in the cache.
+- `endpointName`: a string matching an existing endpoint name
+- `args`: a cache key, used to determine which cached dataset needs to be updated
+- `options`: options to determine whether the request should be sent for a given situation:
+  - `ifOlderThan`: if specified, only runs the query if the difference between `new Date()` and the last`fulfilledTimeStamp` is greater than the given value (in seconds)
+  - `force`: if `true`, it will ignore the `ifOlderThan` value if it is set and the query will be run even if it exists in the cache.
 
 #### Description
 
@@ -327,12 +331,13 @@ function selectInvalidatedBy(
 }>
 ```
 
-- **Parameters**
-  - `state`: the root state
-  - `tags`: a readonly array of invalidated tags, where the provided `TagDescription` is one of the strings provided to the [`tagTypes`](../createApi.mdx#tagtypes) property of the api. e.g.
-    - `[TagType]`
-    - `[{ type: TagType }]`
-    - `[{ type: TagType, id: number | string }]`
+#### Parameters
+
+- `state`: the root state
+- `tags`: a readonly array of invalidated tags, where the provided `TagDescription` is one of the strings provided to the [`tagTypes`](../createApi.mdx#tagtypes) property of the api. e.g.
+  - `[TagType]`
+  - `[{ type: TagType }]`
+  - `[{ type: TagType, id: number | string }]`
 
 #### Description
 
@@ -373,11 +378,12 @@ const invalidateTags = (
 })
 ```
 
-- **Parameters**
-  - `tags`: an array of tags to be invalidated, where the provided `TagType` is one of the strings provided to the [`tagTypes`](../createApi.mdx#tagtypes) property of the api. e.g.
-    - `[TagType]`
-    - `[{ type: TagType }]`
-    - `[{ type: TagType, id: number | string }]`
+#### Parameters
+
+- `tags`: an array of tags to be invalidated, where the provided `TagType` is one of the strings provided to the [`tagTypes`](../createApi.mdx#tagtypes) property of the api. e.g.
+  - `[TagType]`
+  - `[{ type: TagType }]`
+  - `[{ type: TagType, id: number | string }]`
 
 #### Description
 
@@ -411,9 +417,10 @@ function selectCachedArgsForQuery(
 ): Array<QueryArg>
 ```
 
-- **Parameters**
-  - `state`: the root state
-  - `queryName`: a string matching an existing query endpoint name
+#### Parameters
+
+- `state`: the root state
+- `queryName`: a string matching an existing query endpoint name
 
 #### Description
 

--- a/docs/rtk-query/api/created-api/api-slice-utils.mdx
+++ b/docs/rtk-query/api/created-api/api-slice-utils.mdx
@@ -23,12 +23,14 @@ Some of the TS types on this page are pseudocode to illustrate intent, as the ac
 
 ### `updateQueryData`
 
+A Redux thunk action creator that, when dispatched, creates and applies a set of JSON diff/patch objects to the current state. This immediately updates the Redux state with those changes.
+
 #### Signature
 
 ```ts no-transpile
 const updateQueryData = (
   endpointName: string,
-  args: any,
+  arg: any,
   updateRecipe: (draft: Draft<CachedState>) => void,
   updateProvided?: boolean,
 ) => ThunkAction<PatchCollection, PartialState, any, AnyAction>
@@ -42,21 +44,19 @@ interface PatchCollection {
 
 - **Parameters**
   - `endpointName`: a string matching an existing endpoint name
-  - `args`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
+  - `arg`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
   - `updateRecipe`: an Immer `produce` callback that can apply changes to the cached state
   - `updateProvided`: a boolean indicating whether the endpoint's provided tags should be re-calculated based on the updated cache. Defaults to `false`.
 
 #### Description
 
-A Redux thunk action creator that, when dispatched, creates and applies a set of JSON diff/patch objects to the current state. This immediately updates the Redux state with those changes.
-
 The thunk action creator accepts three arguments: the name of the endpoint we are updating (such as `'getPost'`), any relevant query arguments, and a callback function. The callback receives an Immer-wrapped `draft` of the current state, and may modify the draft to match the expected results after the mutation completes successfully.
 
 The thunk returns an object containing `{patches: Patch[], inversePatches: Patch[], undo: () => void}`. The `patches` and `inversePatches` are generated using Immer's [`produceWithPatches` method](https://immerjs.github.io/immer/patches).
 
-This is typically used as the first step in implementing optimistic updates. The generated `inversePatches` can be used to revert the updates by calling `dispatch(patchQueryData(endpointName, args, inversePatches))`. Alternatively, the `undo` method can be called directly to achieve the same effect.
+This is typically used as the first step in implementing optimistic updates. The generated `inversePatches` can be used to revert the updates by calling `dispatch(patchQueryData(endpointName, arg, inversePatches))`. Alternatively, the `undo` method can be called directly to achieve the same effect.
 
-Note that the first two arguments (`endpointName` and `args`) are used to determine which existing cache entry to update. If no existing cache entry is found, the `updateRecipe` callback will not run.
+Note that the first two arguments (`endpointName` and `arg`) are used to determine which existing cache entry to update. If no existing cache entry is found, the `updateRecipe` callback will not run.
 
 #### Example 1
 
@@ -69,7 +69,7 @@ const patchCollection = dispatch(
 ```
 
 In the example above, `'getPosts'` is provided for the `endpointName`, and `undefined` is provided
-for `args`. This will match a query cache key of `'getPosts(undefined)'`.
+for `arg`. This will match a query cache key of `'getPosts(undefined)'`.
 
 i.e. it will match a cache entry that may have been created via any of the following calls:
 
@@ -96,7 +96,7 @@ const patchCollection = dispatch(
 ```
 
 In the example above, `'getPostById'` is provided for the `endpointName`, and `1` is provided
-for `args`. This will match a query cache key of `'getPostById(1)'`.
+for `arg`. This will match a query cache key of `'getPostById(1)'`.
 
 i.e. it will match a cache entry that may have been created via any of the following calls:
 
@@ -114,27 +114,27 @@ dispatch(api.endpoints.getPostById.initiate(1, { ...options }))
 
 ### `upsertQueryData`
 
+A Redux thunk action creator that, when dispatched, acts as an artificial API request to upsert a value into the cache.
+
 #### Signature
 
 ```ts no-transpile
-const upsertQueryData = <T>(endpointName: string, args: any, newEntryData: T) =>
+const upsertQueryData = <T>(endpointName: string, arg: any, newEntryData: T) =>
   ThunkAction<Promise<CacheEntry<T>>, PartialState, any, UnknownAction>
 ```
 
 - **Parameters**
   - `endpointName`: a string matching an existing endpoint name
-  - `args`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
+  - `arg`: an argument matching that used for a previous query call, used to determine which cached dataset needs to be updated
   - `newEntryValue`: the value to be written into the corresponding cache entry's `data` field
 
 #### Description
-
-A Redux thunk action creator that, when dispatched, acts as an artificial API request to upsert a value into the cache.
 
 The thunk action creator accepts three arguments: the name of the endpoint we are updating (such as `'getPost'`), the appropriate query arg values to construct the desired cache key, and the data to upsert.
 
 If no cache entry for that cache key exists, a cache entry will be created and the data added. If a cache entry already exists, this will _overwrite_ the existing cache entry data.
 
-The thunk executes _asynchronously_, and returns a promise that resolves when the store has been updated.
+The thunk executes _asynchronously_, and returns a promise that resolves when the store has been updated. This includes executing the `transformResponse` callback if defined for that endpoint.
 
 If dispatched while an actual request is in progress, both the upsert and request will be handled as soon as they resolve, resulting in a "last result wins" update behavior.
 
@@ -148,12 +148,14 @@ await dispatch(
 
 ### `patchQueryData`
 
+A Redux thunk action creator that, when dispatched, applies a JSON diff/patch array to the cached data for a given query result. This immediately updates the Redux state with those changes.
+
 #### Signature
 
 ```ts no-transpile
 const patchQueryData = (
   endpointName: string,
-  args: any
+  arg: any
   patches: Patch[],
   updateProvided?: boolean
 ) => ThunkAction<void, PartialState, any, UnknownAction>;
@@ -161,13 +163,11 @@ const patchQueryData = (
 
 - **Parameters**
   - `endpointName`: a string matching an existing endpoint name
-  - `args`: a cache key, used to determine which cached dataset needs to be updated
+  - `arg`: a cache key, used to determine which cached dataset needs to be updated
   - `patches`: an array of patches (or inverse patches) to apply to cached state. These would typically be obtained from the result of dispatching [`updateQueryData`](#updatequerydata)
   - `updateProvided`: a boolean indicating whether the endpoint's provided tags should be re-calculated based on the updated cache. Defaults to `false`.
 
 #### Description
-
-A Redux thunk action creator that, when dispatched, applies a JSON diff/patch array to the cached data for a given query result. This immediately updates the Redux state with those changes.
 
 The thunk action creator accepts three arguments: the name of the endpoint we are updating (such as `'getPost'`), the appropriate query arg values to construct the desired cache key, and a JSON diff/patch array as produced by Immer's `produceWithPatches`.
 
@@ -279,6 +279,8 @@ const api = createApi({
 
 ### `prefetch`
 
+A Redux thunk action creator that can be used to manually trigger pre-fetching of data.
+
 #### Signature
 
 ```ts no-transpile
@@ -298,8 +300,6 @@ const prefetch = (endpointName: string, arg: any, options: PrefetchOptions) =>
 
 #### Description
 
-A Redux thunk action creator that can be used to manually trigger pre-fetching of data.
-
 The thunk action creator accepts three arguments: the name of the endpoint we are updating (such as `'getPost'`), any relevant query arguments, and a set of options used to determine if the data actually should be re-fetched based on cache staleness.
 
 React Hooks users will most likely never need to use this directly, as the `usePrefetch` hook will dispatch the thunk action creator result internally as needed when you call the prefetching function supplied by the hook.
@@ -311,6 +311,8 @@ dispatch(api.util.prefetch('getPosts', undefined, { force: true }))
 ```
 
 ### `selectInvalidatedBy`
+
+A selector function that can select query parameters to be invalidated.
 
 #### Signature
 
@@ -333,8 +335,6 @@ function selectInvalidatedBy(
     - `[{ type: TagType, id: number | string }]`
 
 #### Description
-
-A function that can select query parameters to be invalidated.
 
 The function accepts two arguments
 
@@ -360,6 +360,8 @@ const entries = api.util.selectInvalidatedBy(state, [
 
 ### `invalidateTags`
 
+A Redux action creator that can be used to manually invalidate cache tags for [automated re-fetching](../../usage/automated-refetching.mdx).
+
 #### Signature
 
 ```ts no-transpile
@@ -378,8 +380,6 @@ const invalidateTags = (
     - `[{ type: TagType, id: number | string }]`
 
 #### Description
-
-A Redux action creator that can be used to manually invalidate cache tags for [automated re-fetching](../../usage/automated-refetching.mdx).
 
 The action creator accepts one argument: the cache tags to be invalidated. It returns an action with those tags as a payload, and the corresponding `invalidateTags` action type for the api.
 
@@ -400,6 +400,8 @@ dispatch(
 
 ### `selectCachedArgsForQuery`
 
+A selector function that can select arguments for currently cached queries.
+
 #### Signature
 
 ```ts no-transpile
@@ -414,8 +416,6 @@ function selectCachedArgsForQuery(
   - `queryName`: a string matching an existing query endpoint name
 
 #### Description
-
-A function that can select arguments for currently cached queries.
 
 The function accepts two arguments
 

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -63,7 +63,7 @@ export type NormalizedQueryUpsertEntry<
   EndpointName extends QueryKeys<Definitions>,
 > = {
   endpointName: EndpointName
-  args: QueryArgFrom<Definitions[EndpointName]>
+  arg: QueryArgFrom<Definitions[EndpointName]>
   value: ResultTypeFrom<Definitions[EndpointName]>
 }
 
@@ -72,8 +72,8 @@ export type NormalizedQueryUpsertEntry<
  */
 type NormalizedQueryUpsertEntryPayload = {
   endpointName: string
-  args: any
-  value: any
+  arg: unknown
+  value: unknown
 }
 
 export type ProcessedQueryUpsertEntry = {
@@ -313,14 +313,14 @@ export function buildSlice({
         prepare: (payload: NormalizedQueryUpsertEntryPayload[]) => {
           const queryDescriptions: ProcessedQueryUpsertEntry[] = payload.map(
             (entry) => {
-              const { endpointName, args, value } = entry
+              const { endpointName, arg, value } = entry
               const endpointDefinition = definitions[endpointName]
               const queryDescription: QueryThunkArg = {
                 type: 'query',
                 endpointName: endpointName,
-                originalArgs: entry.args,
+                originalArgs: entry.arg,
                 queryCacheKey: serializeQueryArgs({
-                  queryArgs: args,
+                  queryArgs: arg,
                   endpointDefinition,
                   endpointName,
                 }),

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -47,7 +47,7 @@ import type {
   BuildSelectorsApiEndpointQuery,
 } from './buildSelectors'
 import { buildSelectors } from './buildSelectors'
-import type { SliceActions } from './buildSlice'
+import type { SliceActions, UpsertEntries } from './buildSlice'
 import { buildSlice } from './buildSlice'
 import type {
   BuildThunksApiEndpointMutation,
@@ -320,6 +320,9 @@ export interface ApiModules<
        * ```
        */
       resetApiState: SliceActions['resetApiState']
+
+      upsertEntries: UpsertEntries<Definitions>
+
       /**
        * A Redux action creator that can be used to manually invalidate cache tags for [automated re-fetching](../../usage/automated-refetching.mdx).
        *
@@ -527,6 +530,7 @@ export const coreModule = ({
       context,
       queryThunk,
       mutationThunk,
+      serializeQueryArgs,
       reducerPath,
       assertTagType,
       config: {
@@ -545,6 +549,7 @@ export const coreModule = ({
       upsertQueryData,
       prefetch,
       resetApiState: sliceActions.resetApiState,
+      upsertEntries: sliceActions.cacheEntriesUpserted as any,
     })
     safeAssign(api.internalActions, sliceActions)
 

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -150,7 +150,7 @@ export interface ApiModules<
     util: {
       /**
        * A thunk that (if dispatched) will return a specific running query, identified
-       * by `endpointName` and `args`.
+       * by `endpointName` and `arg`.
        * If that query is not running, dispatching the thunk will result in `undefined`.
        *
        * Can be used to await a specific query triggered in any way,
@@ -160,7 +160,7 @@ export interface ApiModules<
        */
       getRunningQueryThunk<EndpointName extends QueryKeys<Definitions>>(
         endpointName: EndpointName,
-        args: QueryArgFrom<Definitions[EndpointName]>,
+        arg: QueryArgFrom<Definitions[EndpointName]>,
       ): ThunkWithReturnValue<
         | QueryActionCreatorResult<
             Definitions[EndpointName] & { type: 'query' }
@@ -237,9 +237,9 @@ export interface ApiModules<
        *
        * The thunk executes _synchronously_, and returns an object containing `{patches: Patch[], inversePatches: Patch[], undo: () => void}`. The `patches` and `inversePatches` are generated using Immer's [`produceWithPatches` method](https://immerjs.github.io/immer/patches).
        *
-       * This is typically used as the first step in implementing optimistic updates. The generated `inversePatches` can be used to revert the updates by calling `dispatch(patchQueryData(endpointName, args, inversePatches))`. Alternatively, the `undo` method can be called directly to achieve the same effect.
+       * This is typically used as the first step in implementing optimistic updates. The generated `inversePatches` can be used to revert the updates by calling `dispatch(patchQueryData(endpointName, arg, inversePatches))`. Alternatively, the `undo` method can be called directly to achieve the same effect.
        *
-       * Note that the first two arguments (`endpointName` and `args`) are used to determine which existing cache entry to update. If no existing cache entry is found, the `updateRecipe` callback will not run.
+       * Note that the first two arguments (`endpointName` and `arg`) are used to determine which existing cache entry to update. If no existing cache entry is found, the `updateRecipe` callback will not run.
        *
        * @example
        *

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -321,7 +321,7 @@ export interface ApiModules<
        */
       resetApiState: SliceActions['resetApiState']
 
-      upsertEntries: UpsertEntries<Definitions>
+      upsertQueryEntries: UpsertEntries<Definitions>
 
       /**
        * A Redux action creator that can be used to manually invalidate cache tags for [automated re-fetching](../../usage/automated-refetching.mdx).
@@ -549,7 +549,7 @@ export const coreModule = ({
       upsertQueryData,
       prefetch,
       resetApiState: sliceActions.resetApiState,
-      upsertEntries: sliceActions.cacheEntriesUpserted as any,
+      upsertQueryEntries: sliceActions.cacheEntriesUpserted as any,
     })
     safeAssign(api.internalActions, sliceActions)
 

--- a/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
@@ -1,4 +1,5 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
+import { createAction } from '@reduxjs/toolkit'
 import {
   actionsReducer,
   hookWaitFor,
@@ -15,6 +16,8 @@ interface Post {
 
 const baseQuery = vi.fn()
 beforeEach(() => baseQuery.mockReset())
+
+const postAddedAction = createAction<string>('postAdded')
 
 const api = createApi({
   baseQuery: (...args: any[]) => {
@@ -64,6 +67,18 @@ const api = createApi({
           },
         }
       },
+    }),
+    postWithSideEffect: build.query<Post, string>({
+      query: (id) => `post/${id}`,
+      providesTags: ['Post'],
+      async onCacheEntryAdded(arg, api) {
+        // Verify that lifecycle promise resolution works
+        const res = await api.cacheDataLoaded
+
+        // and leave a side effect we can check in the test
+        api.dispatch(postAddedAction(res.data.id))
+      },
+      keepUnusedDataFor: 0.01,
     }),
   }),
 })
@@ -331,47 +346,86 @@ describe('upsertQueryData', () => {
 })
 
 describe('upsertEntries', () => {
-  test('Upserts many entries at once', async () => {
-    const posts: Post[] = [
-      {
-        id: '1',
-        contents: 'A',
-        title: 'A',
-      },
-      {
-        id: '2',
-        contents: 'B',
-        title: 'B',
-      },
-      {
-        id: '3',
-        contents: 'C',
-        title: 'C',
-      },
-    ]
+  const posts: Post[] = [
+    {
+      id: '1',
+      contents: 'A',
+      title: 'A',
+    },
+    {
+      id: '2',
+      contents: 'B',
+      title: 'B',
+    },
+    {
+      id: '3',
+      contents: 'C',
+      title: 'C',
+    },
+  ]
 
-    storeRef.store.dispatch(
-      api.util.upsertEntries([
-        {
-          endpointName: 'getPosts',
-          args: undefined,
-          value: posts,
-        },
-        ...posts.map((post) => ({
-          endpointName: 'post' as const,
-          args: post.id,
-          value: post,
-        })),
-      ]),
-    )
+  const entriesAction = api.util.upsertEntries([
+    {
+      endpointName: 'getPosts',
+      args: undefined,
+      value: posts,
+    },
+    ...posts.map((post) => ({
+      endpointName: 'postWithSideEffect' as const,
+      args: post.id,
+      value: post,
+    })),
+  ])
+
+  test('Upserts many entries at once', async () => {
+    storeRef.store.dispatch(entriesAction)
 
     const state = storeRef.store.getState()
 
     expect(api.endpoints.getPosts.select()(state).data).toBe(posts)
 
-    expect(api.endpoints.post.select('1')(state).data).toBe(posts[0])
-    expect(api.endpoints.post.select('2')(state).data).toBe(posts[1])
-    expect(api.endpoints.post.select('3')(state).data).toBe(posts[2])
+    expect(api.endpoints.postWithSideEffect.select('1')(state).data).toBe(
+      posts[0],
+    )
+    expect(api.endpoints.postWithSideEffect.select('2')(state).data).toBe(
+      posts[1],
+    )
+    expect(api.endpoints.postWithSideEffect.select('3')(state).data).toBe(
+      posts[2],
+    )
+  })
+
+  test('Triggers cache lifecycles and side effects', async () => {
+    storeRef.store.dispatch(entriesAction)
+
+    // Tricky timing. The cache data promises will be resolved
+    // in microtasks, so we just need any async delay here.
+    await delay(1)
+
+    const state = storeRef.store.getState()
+
+    // onCacheEntryAdded should have run for each post,
+    // including cache data being resolved
+    for (const post of posts) {
+      const matchingSideEffectAction = state.actions.find(
+        (action) => postAddedAction.match(action) && action.payload === post.id,
+      )
+      expect(matchingSideEffectAction).toBeTruthy()
+    }
+
+    expect(api.endpoints.postWithSideEffect.select('1')(state).data).toBe(
+      posts[0],
+    )
+
+    // The cache data should be removed after the keepUnusedDataFor time,
+    // so wait longer than that
+    await delay(20)
+
+    const stateAfter = storeRef.store.getState()
+
+    expect(api.endpoints.postWithSideEffect.select('1')(stateAfter).data).toBe(
+      undefined,
+    )
   })
 })
 

--- a/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
@@ -345,7 +345,7 @@ describe('upsertQueryData', () => {
   })
 })
 
-describe('upsertEntries', () => {
+describe('upsertQueryEntries', () => {
   const posts: Post[] = [
     {
       id: '1',
@@ -364,15 +364,15 @@ describe('upsertEntries', () => {
     },
   ]
 
-  const entriesAction = api.util.upsertEntries([
+  const entriesAction = api.util.upsertQueryEntries([
     {
       endpointName: 'getPosts',
-      args: undefined,
+      arg: undefined,
       value: posts,
     },
     ...posts.map((post) => ({
       endpointName: 'postWithSideEffect' as const,
-      args: post.id,
+      arg: post.id,
       value: post,
     })),
   ])


### PR DESCRIPTION
This PR:

- Extracts the current reducer logic for writing `pending` and `fulfilled` cache entries into reusable helper functions
- Implements a new `util.upsertEntries` action creator + reducer that accepts an array of `{endpointName, arg, value}` entries, and upserts those into the cache, overwriting any prior entries

### Use Cases

One use case might be just preloading some data into the cache programmatically.

The other main use case I'm thinking of is a pseudo-normalization approach, ala #4106 and #4073.  

Say you have a `getPosts` endpoint and it returns the usual array.  RTKQ won't deduplicate individual objects across multiple endpoints, so if you then try to access `getPost("2")`, we have to make that request separately.  

It seems very reasonable to want to take the response contents from the `getPosts` query, and prepopulate all of the corresponding individual `getPost` cache entries.

We have `upsertQueryData`, which relies on the entire async thunk lifecycle, and like the rest of our utils it only does a single entry at a time.  That's always felt too limiting, both in terms of possibly wanting to update many cache entries at once, and performance due to the number of actions that would have to get dispatched.

### Status

This is the first seemingly-working implementation.  Thanks to @EskiMojo14 the external types seem to work (ie, `{endpointName: 'getPost'}` correctly expects to go along with `{arg: string, value: Post}`).  I threw in one POC unit test 

### Perf

Per #4106, doing this by calling the `apiSlice.reducer()` with a separate faked action for each item was still relatively slow - 1500ms for 1000 items (as compared to the abominably slow 6000ms for 1000 items using individual `upsertQueryData` calls).

In a quick local test, a single `dispatch(api.util.upsertEntries())` call with 1000 separate `getPost` entries was only 31ms.  That's because we only called the reducer once, so we did all that work inside a single Immer call.  That should reduce the perf overhead significantly.

### Plans

The starting point would be to just ship this util action creator as-is, and users would manually dispatch that in `onQueryStarted` after the response resolves.

I can also imagine a new `upsertCacheEntries` option to make this more of a first-class citizen, which would look roughly like `(data: T) => NormalizedQueryUpsertEntry[]`.

I'm sure there's edge cases here. For example, `merge` expects `baseQueryMeta`, and since we aren't even using a real request here, we don't have that. Right now I'm faking it with an empty object. I could imagine a `merge` function actually expecting a real value instead.