### PR TITLE
Add "encodeParams" option to rtkq-codegen-openapi

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -396,7 +396,9 @@ export async function generateApi(
         return createPropertyAssignment(
           param.originalName,
           encodeParams && param.param?.in === 'query'
-            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [value])
+            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [
+                factory.createCallExpression(factory.createIdentifier('String'), undefined, [value]),
+              ])
             : value
         );
       });
@@ -487,7 +489,9 @@ function generatePathExpression(
         expressions.map(([prop, literal], index) => {
           const value = isFlatArg ? rootObject : accessProperty(rootObject, prop);
           const encodedValue = encodeParams
-            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [value])
+            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [
+                factory.createCallExpression(factory.createIdentifier('String'), undefined, [value]),
+              ])
             : value;
           return factory.createTemplateSpan(
             encodedValue,

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -88,6 +88,7 @@ export async function generateApi(
     filterEndpoints,
     endpointOverrides,
     unionUndefined,
+    encodeParams = false,
     flattenArg = false,
     useEnumType = false,
     mergeReadWriteOnly = false,
@@ -356,7 +357,7 @@ export async function generateApi(
       type: isQuery ? 'query' : 'mutation',
       Response: ResponseTypeName,
       QueryArg,
-      queryFn: generateQueryFn({ operationDefinition, queryArg, isQuery, isFlatArg }),
+      queryFn: generateQueryFn({ operationDefinition, queryArg, isQuery, isFlatArg, encodeParams }),
       extraEndpointsProps: isQuery
         ? generateQueryEndpointProps({ operationDefinition })
         : generateMutationEndpointProps({ operationDefinition }),
@@ -369,11 +370,13 @@ export async function generateApi(
     queryArg,
     isFlatArg,
     isQuery,
+    encodeParams,
   }: {
     operationDefinition: OperationDefinition;
     queryArg: QueryArgDefinitions;
     isFlatArg: boolean;
     isQuery: boolean;
+    encodeParams: boolean;
   }) {
     const { path, verb } = operationDefinition;
 
@@ -386,21 +389,22 @@ export async function generateApi(
     }
 
     function createObjectLiteralProperty(parameters: QueryArgDefinition[], propertyName: string) {
-      return parameters.length === 0
-        ? undefined
-        : factory.createPropertyAssignment(
-            factory.createIdentifier(propertyName),
-            factory.createObjectLiteralExpression(
-              parameters.map(
-                (param) =>
-                  createPropertyAssignment(
-                    param.originalName,
-                    isFlatArg ? rootObject : accessProperty(rootObject, param.name)
-                  ),
-                true
-              )
-            )
-          );
+      if (parameters.length === 0) return undefined;
+
+      const properties = parameters.map((param) => {
+        const value = isFlatArg ? rootObject : accessProperty(rootObject, param.name);
+        return createPropertyAssignment(
+          param.originalName,
+          encodeParams && param.param?.in === 'query'
+            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [value])
+            : value
+        );
+      });
+
+      return factory.createPropertyAssignment(
+        factory.createIdentifier(propertyName),
+        factory.createObjectLiteralExpression(properties, true)
+      );
     }
 
     return factory.createArrowFunction(
@@ -416,7 +420,7 @@ export async function generateApi(
           [
             factory.createPropertyAssignment(
               factory.createIdentifier('url'),
-              generatePathExpression(path, pickParams('path'), rootObject, isFlatArg)
+              generatePathExpression(path, pickParams('path'), rootObject, isFlatArg, encodeParams)
             ),
             isQuery && verb.toUpperCase() === 'GET'
               ? undefined
@@ -463,7 +467,8 @@ function generatePathExpression(
   path: string,
   pathParameters: QueryArgDefinition[],
   rootObject: ts.Identifier,
-  isFlatArg: boolean
+  isFlatArg: boolean,
+  encodeParams: boolean
 ) {
   const expressions: Array<[string, string]> = [];
 
@@ -479,14 +484,18 @@ function generatePathExpression(
   return expressions.length
     ? factory.createTemplateExpression(
         factory.createTemplateHead(head),
-        expressions.map(([prop, literal], index) =>
-          factory.createTemplateSpan(
-            isFlatArg ? rootObject : accessProperty(rootObject, prop),
+        expressions.map(([prop, literal], index) => {
+          const value = isFlatArg ? rootObject : accessProperty(rootObject, prop);
+          const encodedValue = encodeParams
+            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [value])
+            : value;
+          return factory.createTemplateSpan(
+            encodedValue,
             index === expressions.length - 1
               ? factory.createTemplateTail(literal)
               : factory.createTemplateMiddle(literal)
-          )
-        )
+          );
+        })
       )
     : factory.createNoSubstitutionTemplateLiteral(head);
 }

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -64,7 +64,7 @@ export interface CommonOptions {
   tag?: boolean;
   /**
    * defaults to false
-   * `true` will generate add `encodeURIComponent` to the generated query params
+   * `true` will add `encodeURIComponent` to the generated query params
    */
   encodeParams?: boolean;
   /**

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -64,6 +64,11 @@ export interface CommonOptions {
   tag?: boolean;
   /**
    * defaults to false
+   * `true` will generate add `encodeURIComponent` to the generated query params
+   */
+  encodeParams?: boolean;
+  /**
+   * defaults to false
    * `true` will "flatten" the arg so that you can do things like `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`
    */
   flattenArg?: boolean;

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
@@ -11,10 +11,20 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({ url: \`/pet\`, method: 'POST', body: queryArg.pet }),
     }),
     findPetsByStatus: build.query<FindPetsByStatusApiResponse, FindPetsByStatusApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByStatus\`, params: { status: queryArg.status } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: {
+          status: queryArg.status,
+        },
+      }),
     }),
     findPetsByTags: build.query<FindPetsByTagsApiResponse, FindPetsByTagsApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByTags\`, params: { tags: queryArg.tags } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByTags\`,
+        params: {
+          tags: queryArg.tags,
+        },
+      }),
     }),
     getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
       query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
@@ -23,18 +33,29 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: 'POST',
-        params: { name: queryArg.name, status: queryArg.status },
+        params: {
+          name: queryArg.name,
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
-      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\`, method: 'DELETE', headers: { api_key: queryArg.apiKey } }),
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: 'DELETE',
+        headers: {
+          api_key: queryArg.apiKey,
+        },
+      }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: 'POST',
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -58,7 +79,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
@@ -234,10 +258,20 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({ url: \`/pet\`, method: 'POST', body: queryArg.pet }),
     }),
     findPetsByStatus: build.query<FindPetsByStatusApiResponse, FindPetsByStatusApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByStatus\`, params: { status: queryArg.status } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: {
+          status: queryArg.status,
+        },
+      }),
     }),
     findPetsByTags: build.query<FindPetsByTagsApiResponse, FindPetsByTagsApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByTags\`, params: { tags: queryArg.tags } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByTags\`,
+        params: {
+          tags: queryArg.tags,
+        },
+      }),
     }),
     getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
       query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
@@ -246,18 +280,29 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: 'POST',
-        params: { name: queryArg.name, status: queryArg.status },
+        params: {
+          name: queryArg.name,
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
-      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\`, method: 'DELETE', headers: { api_key: queryArg.apiKey } }),
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: 'DELETE',
+        headers: {
+          api_key: queryArg.apiKey,
+        },
+      }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: 'POST',
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -281,7 +326,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -11,10 +11,20 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({ url: \`/pet\`, method: 'POST', body: queryArg.pet }),
     }),
     findPetsByStatus: build.query<FindPetsByStatusApiResponse, FindPetsByStatusApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByStatus\`, params: { status: queryArg.status } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: {
+          status: queryArg.status,
+        },
+      }),
     }),
     findPetsByTags: build.query<FindPetsByTagsApiResponse, FindPetsByTagsApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByTags\`, params: { tags: queryArg.tags } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByTags\`,
+        params: {
+          tags: queryArg.tags,
+        },
+      }),
     }),
     getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
       query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
@@ -23,18 +33,29 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: 'POST',
-        params: { name: queryArg.name, status: queryArg.status },
+        params: {
+          name: queryArg.name,
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
-      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\`, method: 'DELETE', headers: { api_key: queryArg.apiKey } }),
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: 'DELETE',
+        headers: {
+          api_key: queryArg.apiKey,
+        },
+      }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: 'POST',
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -58,7 +79,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
@@ -234,10 +258,20 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({ url: \`/pet\`, method: 'POST', body: queryArg.pet }),
     }),
     findPetsByStatus: build.query<FindPetsByStatusApiResponse, FindPetsByStatusApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByStatus\`, params: { status: queryArg.status } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByStatus\`,
+        params: {
+          status: queryArg.status,
+        },
+      }),
     }),
     findPetsByTags: build.query<FindPetsByTagsApiResponse, FindPetsByTagsApiArg>({
-      query: (queryArg) => ({ url: \`/pet/findByTags\`, params: { tags: queryArg.tags } }),
+      query: (queryArg) => ({
+        url: \`/pet/findByTags\`,
+        params: {
+          tags: queryArg.tags,
+        },
+      }),
     }),
     getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
       query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\` }),
@@ -246,18 +280,29 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: 'POST',
-        params: { name: queryArg.name, status: queryArg.status },
+        params: {
+          name: queryArg.name,
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
-      query: (queryArg) => ({ url: \`/pet/\${queryArg.petId}\`, method: 'DELETE', headers: { api_key: queryArg.apiKey } }),
+      query: (queryArg) => ({
+        url: \`/pet/\${queryArg.petId}\`,
+        method: 'DELETE',
+        headers: {
+          api_key: queryArg.apiKey,
+        },
+      }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: 'POST',
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -281,7 +326,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -472,7 +472,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/pet/findByStatus\`,
-        params: { status: queryArg.status },
+        params: {
+          status: queryArg.status,
+        },
       }),
     }),
     findPetsByTags: build.query<
@@ -481,7 +483,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/pet/findByTags\`,
-        params: { tags: queryArg.tags },
+        params: {
+          tags: queryArg.tags,
+        },
       }),
     }),
     getPetById: build.query<GetPetByIdApiResponse, GetPetByIdApiArg>({
@@ -494,14 +498,19 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "POST",
-        params: { name: queryArg.name, status: queryArg.status },
+        params: {
+          name: queryArg.name,
+          status: queryArg.status,
+        },
       }),
     }),
     deletePet: build.mutation<DeletePetApiResponse, DeletePetApiArg>({
       query: (queryArg) => ({
         url: \`/pet/\${queryArg.petId}\`,
         method: "DELETE",
-        headers: { api_key: queryArg.apiKey },
+        headers: {
+          api_key: queryArg.apiKey,
+        },
       }),
     }),
     uploadFile: build.mutation<UploadFileApiResponse, UploadFileApiArg>({
@@ -509,7 +518,9 @@ const injectedRtkApi = api.injectEndpoints({
         url: \`/pet/\${queryArg.petId}/uploadImage\`,
         method: "POST",
         body: queryArg.body,
-        params: { additionalMetadata: queryArg.additionalMetadata },
+        params: {
+          additionalMetadata: queryArg.additionalMetadata,
+        },
       }),
     }),
     getInventory: build.query<GetInventoryApiResponse, GetInventoryApiArg>({
@@ -551,7 +562,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
     logoutUser: build.query<LogoutUserApiResponse, LogoutUserApiArg>({
@@ -755,7 +769,9 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/api/v2/\${queryArg.pathSomeName}\`,
         method: "PATCH",
-        params: { some_name: queryArg.querySomeName },
+        params: {
+          some_name: queryArg.querySomeName,
+        },
       }),
     }),
   }),
@@ -799,7 +815,10 @@ const injectedRtkApi = api.injectEndpoints({
     loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
       query: (queryArg) => ({
         url: \`/user/login\`,
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
   }),
@@ -850,7 +869,10 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/user/login\`,
         method: "GET",
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
   }),
@@ -959,7 +981,10 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/user/login\`,
         method: "GET",
-        params: { username: queryArg.username, password: queryArg.password },
+        params: {
+          username: queryArg.username,
+          password: queryArg.password,
+        },
       }),
     }),
   }),
@@ -1068,7 +1093,9 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: \`/api/v2/\${queryArg.pathSomeName}\`,
         method: "PATCH",
-        params: { some_name: queryArg.querySomeName },
+        params: {
+          some_name: queryArg.querySomeName,
+        },
       }),
     }),
   }),
@@ -1296,7 +1323,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: \`/api/v1/animals\`,
-        params: { type: queryArg["type"] },
+        params: {
+          type: queryArg["type"],
+        },
       }),
     }),
   }),
@@ -1361,7 +1390,9 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({
           url: \`/pet/findByStatus\`,
-          params: { status: queryArg.status },
+          params: {
+            status: queryArg.status,
+          },
         }),
         providesTags: ["pet"],
       }),
@@ -1371,7 +1402,9 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({
           url: \`/pet/findByTags\`,
-          params: { tags: queryArg.tags },
+          params: {
+            tags: queryArg.tags,
+          },
         }),
         providesTags: ["pet"],
       }),
@@ -1386,7 +1419,10 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: \`/pet/\${queryArg.petId}\`,
           method: "POST",
-          params: { name: queryArg.name, status: queryArg.status },
+          params: {
+            name: queryArg.name,
+            status: queryArg.status,
+          },
         }),
         invalidatesTags: ["pet"],
       }),
@@ -1394,7 +1430,9 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: \`/pet/\${queryArg.petId}\`,
           method: "DELETE",
-          headers: { api_key: queryArg.apiKey },
+          headers: {
+            api_key: queryArg.apiKey,
+          },
         }),
         invalidatesTags: ["pet"],
       }),
@@ -1403,7 +1441,9 @@ const injectedRtkApi = api
           url: \`/pet/\${queryArg.petId}/uploadImage\`,
           method: "POST",
           body: queryArg.body,
-          params: { additionalMetadata: queryArg.additionalMetadata },
+          params: {
+            additionalMetadata: queryArg.additionalMetadata,
+          },
         }),
         invalidatesTags: ["pet"],
       }),
@@ -1452,7 +1492,10 @@ const injectedRtkApi = api
       loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
         query: (queryArg) => ({
           url: \`/user/login\`,
-          params: { username: queryArg.username, password: queryArg.password },
+          params: {
+            username: queryArg.username,
+            password: queryArg.password,
+          },
         }),
         providesTags: ["user"],
       }),
@@ -1748,7 +1791,9 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({
           url: \`/pet/findByStatus\`,
-          params: { status: queryArg.status },
+          params: {
+            status: queryArg.status,
+          },
         }),
         providesTags: ["pet"],
       }),
@@ -1758,7 +1803,9 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({
           url: \`/pet/findByTags\`,
-          params: { tags: queryArg.tags },
+          params: {
+            tags: queryArg.tags,
+          },
         }),
         providesTags: ["pet"],
       }),
@@ -1773,7 +1820,10 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: \`/pet/\${queryArg.petId}\`,
           method: "POST",
-          params: { name: queryArg.name, status: queryArg.status },
+          params: {
+            name: queryArg.name,
+            status: queryArg.status,
+          },
         }),
         invalidatesTags: ["pet"],
       }),
@@ -1781,7 +1831,9 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: \`/pet/\${queryArg.petId}\`,
           method: "DELETE",
-          headers: { api_key: queryArg.apiKey },
+          headers: {
+            api_key: queryArg.apiKey,
+          },
         }),
         invalidatesTags: ["pet"],
       }),
@@ -1790,7 +1842,9 @@ const injectedRtkApi = api
           url: \`/pet/\${queryArg.petId}/uploadImage\`,
           method: "POST",
           body: queryArg.body,
-          params: { additionalMetadata: queryArg.additionalMetadata },
+          params: {
+            additionalMetadata: queryArg.additionalMetadata,
+          },
         }),
         invalidatesTags: ["pet"],
       }),
@@ -1839,7 +1893,10 @@ const injectedRtkApi = api
       loginUser: build.query<LoginUserApiResponse, LoginUserApiArg>({
         query: (queryArg) => ({
           url: \`/user/login\`,
-          params: { username: queryArg.username, password: queryArg.password },
+          params: {
+            username: queryArg.username,
+            password: queryArg.password,
+          },
         }),
         providesTags: ["user"],
       }),

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -76,6 +76,61 @@ test('endpoint overrides', async () => {
   expect(api).toMatchSnapshot('loginUser should be a mutation');
 });
 
+describe('option encodeParams', () => {
+  const config = {
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    encodeParams: true,
+  };
+
+  it('should encode query parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['findPetsByStatus'],
+    });
+    expect(api).toContain('status: encodeURIComponent(queryArg.status)');
+  });
+
+  it('should encode path parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['getOrderById'],
+    });
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(api).toContain('`/store/order/${encodeURIComponent(queryArg.orderId)}`');
+  });
+
+  it('should not encode body parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['addPet'],
+    });
+    expect(api).toContain('body: queryArg.pet');
+    expect(api).not.toContain('body: encodeURIComponent(queryArg.pet)');
+  });
+
+  it('should work correctly with flattenArg option', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      flattenArg: true,
+      filterEndpoints: ['getOrderById'],
+    });
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(api).toContain('`/store/order/${encodeURIComponent(queryArg)}`');
+  });
+
+  it('should not encode parameters when encodeParams is false', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      encodeParams: false,
+      filterEndpoints: ['findPetsByStatus', 'getOrderById'],
+    });
+    expect(api).toContain('status: queryArg.status');
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(api).toContain('`/store/order/${queryArg.orderId}`');
+  });
+});
+
 describe('option flattenArg', () => {
   const config = {
     apiFile: './fixtures/emptyApi.ts',

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -153,7 +153,7 @@ describe('option flattenArg', () => {
       ...config,
       filterEndpoints: ['findPetsByStatus'],
     });
-    expect(api).toContain('params: { status: queryArg }');
+    expect(api).toContain('status: queryArg');
     expect(api).not.toContain('export type FindPetsByStatusApiArg = {');
   });
 

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -88,7 +88,7 @@ describe('option encodeParams', () => {
       ...config,
       filterEndpoints: ['findPetsByStatus'],
     });
-    expect(api).toContain('status: encodeURIComponent(queryArg.status)');
+    expect(api).toContain('status: encodeURIComponent(String(queryArg.status))');
   });
 
   it('should encode path parameters', async () => {
@@ -97,7 +97,7 @@ describe('option encodeParams', () => {
       filterEndpoints: ['getOrderById'],
     });
     // eslint-disable-next-line no-template-curly-in-string
-    expect(api).toContain('`/store/order/${encodeURIComponent(queryArg.orderId)}`');
+    expect(api).toContain('`/store/order/${encodeURIComponent(String(queryArg.orderId))}`');
   });
 
   it('should not encode body parameters', async () => {
@@ -106,7 +106,7 @@ describe('option encodeParams', () => {
       filterEndpoints: ['addPet'],
     });
     expect(api).toContain('body: queryArg.pet');
-    expect(api).not.toContain('body: encodeURIComponent(queryArg.pet)');
+    expect(api).not.toContain('body: encodeURIComponent(String(queryArg.pet))');
   });
 
   it('should work correctly with flattenArg option', async () => {
@@ -116,7 +116,7 @@ describe('option encodeParams', () => {
       filterEndpoints: ['getOrderById'],
     });
     // eslint-disable-next-line no-template-curly-in-string
-    expect(api).toContain('`/store/order/${encodeURIComponent(queryArg)}`');
+    expect(api).toContain('`/store/order/${encodeURIComponent(String(queryArg))}`');
   });
 
   it('should not encode parameters when encodeParams is false', async () => {


### PR DESCRIPTION
## Overview

This PR introduces a new `encodeParams` option to the Redux Toolkit Query (RTKQ) OpenAPI code generator. When enabled, this option will automatically apply `encodeURIComponent` to the generated query parameters, ensuring that special characters in query strings are correctly encoded.

This feature will be useful for users who need to ensure their query parameters are URL safe, particularly in cases where special characters are commonly used.

Fixes https://github.com/reduxjs/redux-toolkit/issues/3822

## This PR:

- [x] Adds `encodeParams` option to automatically perform URL safe encoding to the generated query and path parameters
- [X] Adds test cases for `encodeParams` option
- [X] Fixes `flattenArg` test case which was not passing due to formatting