### PR TITLE
Add "includeDefault" option to rtkq-codegen-openapi

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -30,8 +30,8 @@ import { factory } from './utils/factory';
 const generatedApiName = 'injectedRtkApi';
 const v3DocCache: Record<string, OpenAPIV3.Document> = {};
 
-function defaultIsDataResponse(code: string) {
-  if (code === 'default') {
+function defaultIsDataResponse(code: string, includeDefault: boolean) {
+  if (includeDefault && code === 'default') {
     return true;
   }
   const parsedCode = Number(code);
@@ -112,6 +112,7 @@ export async function generateApi(
     unionUndefined,
     encodeParams = false,
     flattenArg = false,
+    includeDefault = false,
     useEnumType = false,
     mergeReadWriteOnly = false,
     httpResolverOptions,
@@ -253,7 +254,9 @@ export async function generateApi(
                 factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
             ] as const
         )
-        .filter(([status, response]) => isDataResponse(status, apiGen.resolve(response), responses || {}))
+        .filter(([status, response]) =>
+          isDataResponse(status, includeDefault, apiGen.resolve(response), responses || {})
+        )
         .filter(([_1, _2, type]) => type !== keywordType.void)
         .map(([code, response, type]) =>
           ts.addSyntheticLeadingComment(

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -24,6 +24,7 @@ export type GenerationOptions = Id<
     Optional<OutputFileOptions, 'outputFile'> & {
       isDataResponse?(
         code: string,
+        includeDefault: boolean,
         response: OpenAPIV3.ResponseObject,
         allResponses: OpenAPIV3.ResponsesObject
       ): boolean;
@@ -82,6 +83,12 @@ export interface CommonOptions {
    * `true` will "flatten" the arg so that you can do things like `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`
    */
   flattenArg?: boolean;
+  /**
+   * default to false
+   * If set to `true`, the default response type will be included in the generated code for all endpoints.
+   * @see https://swagger.io/docs/specification/describing-responses/#default
+   */
+  includeDefault?: boolean;
   /**
    * default to false
    * `true` will not generate separate types for read-only and write-only properties.

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
@@ -167,7 +167,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -414,7 +414,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -167,7 +167,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -414,7 +414,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse = /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -714,8 +714,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1125,8 +1124,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1404,8 +1402,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1702,8 +1699,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -1986,8 +1982,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -2262,8 +2257,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -2757,8 +2751,7 @@ export type DeleteOrderV2ApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserV2ApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserV2ApiResponse = unknown;
 export type CreateUserV2ApiArg = {
   /** Created user object */
   user: User;
@@ -3385,8 +3378,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;
@@ -3787,8 +3779,7 @@ export type DeleteOrderApiArg = {
   /** ID of the order that needs to be deleted */
   orderId: number;
 };
-export type CreateUserApiResponse =
-  /** status default successful operation */ User;
+export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
   user: User;

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -26,10 +26,11 @@ test('calling without `outputFile` returns the generated api', async () => {
   expect(api).toMatchSnapshot();
 });
 
-test('should set response type for request with default response type', async () => {
+test('should include default response type in request when includeDefault is set to true', async () => {
   const api = await generateEndpoints({
     apiFile: './fixtures/emptyApi.ts',
     schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    includeDefault: true,
   });
   // eslint-disable-next-line no-template-curly-in-string
   expect(api).toMatch(/export type CreateUserApiResponse =[\s\S/*]+status default successful operation[\s/*]+User;/);


### PR DESCRIPTION
## Overview

This PR adds a new `includeDefault` option to the Redux Toolkit Query (RTKQ) OpenAPI code generator. When enabled, this option includes the default response type in the generated code for all endpoints, as defined in the OpenAPI schema.

The `includeDefault` option is disabled by default because the default response type typically represents an error response (see [OpenAPI documentation on default responses](https://swagger.io/docs/specification/describing-responses/#default)). Enabling it by default could break existing code if types are not narrowed correctly.