### PR TITLE
Split "encodeParams" into "encodePathParams" and "encodeQueryParams"

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -444,14 +444,21 @@ export async function generateApi(
 
       const properties = parameters.map((param) => {
         const value = isFlatArg ? rootObject : accessProperty(rootObject, param.name);
-        return createPropertyAssignment(
-          param.originalName,
+
+        const encodedValue =
           encodeQueryParams && param.param?.in === 'query'
-            ? factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [
-                factory.createCallExpression(factory.createIdentifier('String'), undefined, [value]),
-              ])
-            : value
-        );
+            ? factory.createConditionalExpression(
+                value,
+                undefined,
+                factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [
+                  factory.createCallExpression(factory.createIdentifier('String'), undefined, [value]),
+                ]),
+                undefined,
+                factory.createIdentifier('undefined')
+              )
+            : value;
+
+        return createPropertyAssignment(param.originalName, encodedValue);
       });
 
       return factory.createPropertyAssignment(

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -75,9 +75,14 @@ export interface CommonOptions {
   tag?: boolean;
   /**
    * defaults to false
-   * `true` will add `encodeURIComponent` to the generated query params
+   * `true` will add `encodeURIComponent` to the generated path parameters
    */
-  encodeParams?: boolean;
+  encodePathParams?: boolean;
+  /**
+   * defaults to false
+   * `true` will add `encodeURIComponent` to the generated query parameters
+   */
+  encodeQueryParams?: boolean;
   /**
    * defaults to false
    * `true` will "flatten" the arg so that you can do things like `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -174,20 +174,12 @@ describe('endpoint overrides', () => {
   });
 });
 
-describe('option encodeParams', () => {
+describe('option encodePathParams', () => {
   const config = {
     apiFile: './fixtures/emptyApi.ts',
     schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
-    encodeParams: true,
+    encodePathParams: true,
   };
-
-  it('should encode query parameters', async () => {
-    const api = await generateEndpoints({
-      ...config,
-      filterEndpoints: ['findPetsByStatus'],
-    });
-    expect(api).toContain('status: encodeURIComponent(String(queryArg.status))');
-  });
 
   it('should encode path parameters', async () => {
     const api = await generateEndpoints({
@@ -196,6 +188,14 @@ describe('option encodeParams', () => {
     });
     // eslint-disable-next-line no-template-curly-in-string
     expect(api).toContain('`/store/order/${encodeURIComponent(String(queryArg.orderId))}`');
+  });
+
+  it('should not encode query parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['findPetsByStatus'],
+    });
+    expect(api).toContain('status: queryArg.status');
   });
 
   it('should not encode body parameters', async () => {
@@ -217,15 +217,57 @@ describe('option encodeParams', () => {
     expect(api).toContain('`/store/order/${encodeURIComponent(String(queryArg))}`');
   });
 
-  it('should not encode parameters when encodeParams is false', async () => {
+  it('should not encode path parameters when encodePathParams is false', async () => {
     const api = await generateEndpoints({
       ...config,
-      encodeParams: false,
+      encodePathParams: false,
+      filterEndpoints: ['findPetsByStatus', 'getOrderById'],
+    });
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(api).toContain('`/store/order/${queryArg.orderId}`');
+  });
+});
+
+describe('option encodeQueryParams', () => {
+  const config = {
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    encodeQueryParams: true,
+  };
+
+  it('should encode query parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['findPetsByStatus'],
+    });
+    expect(api).toContain('status: encodeURIComponent(String(queryArg.status))');
+  });
+
+  it('should not encode path parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['getOrderById'],
+    });
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(api).toContain('`/store/order/${queryArg.orderId}`');
+  });
+
+  it('should not encode body parameters', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      filterEndpoints: ['addPet'],
+    });
+    expect(api).toContain('body: queryArg.pet');
+    expect(api).not.toContain('body: encodeURIComponent(String(queryArg.pet))');
+  });
+
+  it('should not encode query parameters when encodeQueryParams is false', async () => {
+    const api = await generateEndpoints({
+      ...config,
+      encodeQueryParams: false,
       filterEndpoints: ['findPetsByStatus', 'getOrderById'],
     });
     expect(api).toContain('status: queryArg.status');
-    // eslint-disable-next-line no-template-curly-in-string
-    expect(api).toContain('`/store/order/${queryArg.orderId}`');
   });
 });
 

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -235,12 +235,15 @@ describe('option encodeQueryParams', () => {
     encodeQueryParams: true,
   };
 
-  it('should encode query parameters', async () => {
+  it('should conditionally encode query parameters', async () => {
     const api = await generateEndpoints({
       ...config,
       filterEndpoints: ['findPetsByStatus'],
     });
-    expect(api).toContain('status: encodeURIComponent(String(queryArg.status))');
+
+    expect(api).toMatch(
+      /params:\s*{\s*\n\s*status:\s*queryArg\.status\s*\?\s*encodeURIComponent\(\s*String\(queryArg\.status\)\s*\)\s*:\s*undefined\s*,?\s*\n\s*}/s
+    );
   });
 
   it('should not encode path parameters', async () => {


### PR DESCRIPTION
## Overview

This PR splits the `encodeParams` option introduced in https://github.com/reduxjs/redux-toolkit/pull/4568 into `encodePathParams` and `encodeQueryParams` so users can customize the code generator output according to their specific needs and existing backend infrastructure.

When `encodeQueryParams` is enabled, the query parameters are conditionally encoded to prevent sending `undefined` parameters to the endpoint. This is particularly useful when certain query parameters are optional and should not be included in the request if they are not defined.

### Example output with `encodeQueryParams`

```typescript
const injectedRtkApi = api.injectEndpoints({
  endpoints: (build) => ({
    findPetsByStatus: build.query<
      FindPetsByStatusApiResponse,
      FindPetsByStatusApiArg
    >({
      query: (queryArg) => ({
        url: `/pet/findByStatus`,
        params: {
          status: queryArg.status
            ? encodeURIComponent(String(queryArg.status))
            : undefined,
        },
      }),
    }),
  }),
  overrideExisting: false,
});
```