### PR TITLE
Add the `TypedUseQueryStateOptions` helper type

### DIFF
--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -78,6 +78,9 @@ export function getRequestStatusFlags(status: QueryStatus): RequestStatusFlags {
   } as any
 }
 
+/**
+ * @public
+ */
 export type SubscriptionOptions = {
   /**
    * How frequently to automatically re-fetch data (in milliseconds). Defaults to `0` (off).

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -436,6 +436,52 @@ export type UseQueryStateOptions<
  * This is particularly useful for setting default query behaviors such as
  * refetching strategies, which can be overridden as needed.
  *
+ * @example
+ * <caption>#### __Create a `useQuery` hook with default options__</caption>
+ *
+ * ```ts
+ * import type {
+ *   SubscriptionOptions,
+ *   TypedUseQueryStateOptions,
+ * } from '@reduxjs/toolkit/query/react'
+ * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+ *
+ * type Post = {
+ *   id: number
+ *   name: string
+ * }
+ *
+ * const api = createApi({
+ *   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+ *   tagTypes: ['Post'],
+ *   endpoints: (build) => ({
+ *     getPosts: build.query<Post[], void>({
+ *       query: () => 'posts',
+ *     }),
+ *   }),
+ * })
+ *
+ * const { useGetPostsQuery } = api
+ *
+ * export const useGetPostsQueryWithDefaults = <
+ *   SelectedResult extends Record<string, any>,
+ * >(
+ *   overrideOptions: TypedUseQueryStateOptions<
+ *     Post[],
+ *     void,
+ *     ReturnType<typeof fetchBaseQuery>,
+ *     SelectedResult
+ *   > &
+ *     SubscriptionOptions,
+ * ) =>
+ *   useGetPostsQuery(undefined, {
+ *     // Insert default options here
+ *
+ *     refetchOnMountOrArgChange: true,
+ *     refetchOnFocus: true,
+ *     ...overrideOptions,
+ *   })
+ * ```
  *
  * @template ResultType - The type of the result `data` returned by the query.
  * @template QueryArg - The type of the argument passed into the query.

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -430,6 +430,30 @@ export type UseQueryStateOptions<
   selectFromResult?: QueryStateSelector<R, D>
 }
 
+/**
+ * Allows you to define a "pre-typed" version of
+ * {@linkcode UseQueryStateOptions} for a specific query.
+ *
+ * @template ResultType - The type of the data returned by the query.
+ * @template QueryArg - The type of the argument passed to the query.
+ * @template BaseQuery - The type of the base query function used by the query.
+ * @template SelectedResult - The type of the selected result returned by __`selectFromResult`__.
+ *
+ * @since 2.7.8
+ * @public
+ */
+export type TypedUseQueryStateOptions<
+  ResultType,
+  QueryArg,
+  BaseQuery extends BaseQueryFn,
+  SelectedResult extends Record<string, any> = UseQueryStateDefaultResult<
+    QueryDefinition<QueryArg, BaseQuery, string, ResultType, string>
+  >,
+> = UseQueryStateOptions<
+  QueryDefinition<QueryArg, BaseQuery, string, ResultType, string>,
+  SelectedResult
+>
+
 export type UseQueryStateResult<
   _ extends QueryDefinition<any, any, any, any>,
   R,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -431,13 +431,16 @@ export type UseQueryStateOptions<
 }
 
 /**
- * Allows you to define a "pre-typed" version of
- * {@linkcode UseQueryStateOptions} for a specific query.
+ * Provides a way to define a "pre-typed" version of
+ * {@linkcode UseQueryStateOptions} with specific options for a given query.
+ * This is particularly useful for setting default query behaviors such as
+ * refetching strategies, which can be overridden as needed.
  *
- * @template ResultType - The type of the data returned by the query.
- * @template QueryArg - The type of the argument passed to the query.
- * @template BaseQuery - The type of the base query function used by the query.
- * @template SelectedResult - The type of the selected result returned by __`selectFromResult`__.
+ *
+ * @template ResultType - The type of the result `data` returned by the query.
+ * @template QueryArg - The type of the argument passed into the query.
+ * @template BaseQuery - The type of the base query function being used.
+ * @template SelectedResult - The type of the selected result returned by the __`selectFromResult`__ function.
  *
  * @since 2.7.8
  * @public

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -357,6 +357,9 @@ export type TypedUseQueryState<
   QueryDefinition<QueryArg, BaseQuery, string, ResultType, string>
 >
 
+/**
+ * @internal
+ */
 export type UseQueryStateOptions<
   D extends QueryDefinition<any, any, any, any>,
   R extends Record<string, any>,

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -26,6 +26,7 @@ export type {
   TypedUseQuery,
   TypedUseQuerySubscription,
   TypedUseLazyQuerySubscription,
+  TypedUseQueryStateOptions,
 } from './buildHooks'
 export { UNINITIALIZED_VALUE } from './constants'
 export { createApi, reactHooksModule, reactHooksModuleName }

--- a/packages/toolkit/src/query/tests/unionTypes.test-d.ts
+++ b/packages/toolkit/src/query/tests/unionTypes.test-d.ts
@@ -1,6 +1,8 @@
+import type { UseQueryStateOptions } from '@internal/query/react/buildHooks'
 import type { SerializedError } from '@reduxjs/toolkit'
 import type {
   FetchBaseQueryError,
+  QueryDefinition,
   TypedUseMutationResult,
   TypedUseQueryHookResult,
   TypedUseQueryState,
@@ -13,6 +15,7 @@ import type {
   TypedMutationTrigger,
   TypedUseQuerySubscription,
   TypedUseQuery,
+  TypedUseQueryStateOptions,
 } from '@reduxjs/toolkit/query/react'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
@@ -774,6 +777,23 @@ describe('"Typed" helper types', () => {
     expectTypeOf<
       TypedUseQueryStateResult<string, void, typeof baseQuery, { x: boolean }>
     >().toEqualTypeOf(result)
+  })
+
+  test('useQueryState options', () => {
+    expectTypeOf<
+      TypedUseQueryStateOptions<string, void, typeof baseQuery>
+    >().toMatchTypeOf<
+      Parameters<typeof api.endpoints.getTest.useQueryState>[1]
+    >()
+
+    expectTypeOf<
+      UseQueryStateOptions<
+        QueryDefinition<void, typeof baseQuery, string, string>,
+        { x: boolean }
+      >
+    >().toEqualTypeOf<
+      TypedUseQueryStateOptions<string, void, typeof baseQuery, { x: boolean }>
+    >()
   })
 
   test('useQuerySubscription', () => {


### PR DESCRIPTION
## **This PR**:

- [X] Adds **`TypedUseQueryStateOptions`** helper type which Provides a way to define a "pre-typed" version of **`UseQueryStateOptions`**.
- [X] Marks the **`UseQueryStateOptions`** type with an **`@internal`** JSDoc tag.
- [X] Marks the **`SubscriptionOptions`** type with a **`@public`** JSDoc tag.
- [X] Adds type tests for **`TypedUseQueryStateOptions`**.
- [X] Resolves #4600.