### PR TITLE
feat(baseQuery): expose queryCacheKey in baseQuery

### DIFF
--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -91,6 +91,7 @@ export const { useGetPokemonByNameQuery } = pokemonApi
   - `endpoint` - The name of the endpoint.
   - `type` - Type of request (`query` or `mutation`).
   - `forced` - Indicates if a query has been forced.
+  - `queryCacheKey`- The computed query cache key
 - `extraOptions` - The value of the optional `extraOptions` property provided for a given endpoint
 
 #### baseQuery function signature

--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -91,7 +91,7 @@ export const { useGetPokemonByNameQuery } = pokemonApi
   - `endpoint` - The name of the endpoint.
   - `type` - Type of request (`query` or `mutation`).
   - `forced` - Indicates if a query has been forced.
-  - `queryCacheKey`- The computed query cache key
+  - `queryCacheKey`- The computed query cache key.
 - `extraOptions` - The value of the optional `extraOptions` property provided for a given endpoint
 
 #### baseQuery function signature

--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -18,6 +18,10 @@ export interface BaseQueryApi {
    * invalidated queries.
    */
   forced?: boolean
+  /**
+   * Only available for queries: the cache key that was used to store the query result
+   */
+  queryCacheKey?: string
 }
 
 export type QueryReturnValue<T = unknown, E = unknown, M = unknown> =

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -381,6 +381,7 @@ export function buildThunks<
         type: arg.type,
         forced:
           arg.type === 'query' ? isForcedQuery(arg, getState()) : undefined,
+        queryCacheKey: arg.type === 'query' ? arg.queryCacheKey : undefined,
       }
 
       const forceQueryFn =

--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -314,6 +314,7 @@ describe('endpoint definition typings', () => {
       getState: expect.any(Function),
       signal: expect.any(Object),
       type: expect.any(String),
+      queryCacheKey: expect.any(String),
     }
     beforeEach(() => {
       baseQuery.mockClear()
@@ -355,6 +356,7 @@ describe('endpoint definition typings', () => {
             abort: expect.any(Function),
             forced: expect.any(Boolean),
             type: expect.any(String),
+            queryCacheKey: expect.any(String),
           },
           undefined,
         ],
@@ -368,6 +370,7 @@ describe('endpoint definition typings', () => {
             abort: expect.any(Function),
             forced: expect.any(Boolean),
             type: expect.any(String),
+            queryCacheKey: expect.any(String),
           },
           undefined,
         ],
@@ -499,8 +502,24 @@ describe('endpoint definition typings', () => {
       expect(baseQuery.mock.calls).toEqual([
         ['modified1', commonBaseQueryApi, undefined],
         ['modified2', commonBaseQueryApi, undefined],
-        ['modified1', { ...commonBaseQueryApi, forced: undefined }, undefined],
-        ['modified2', { ...commonBaseQueryApi, forced: undefined }, undefined],
+        [
+          'modified1',
+          {
+            ...commonBaseQueryApi,
+            forced: undefined,
+            queryCacheKey: undefined,
+          },
+          undefined,
+        ],
+        [
+          'modified2',
+          {
+            ...commonBaseQueryApi,
+            forced: undefined,
+            queryCacheKey: undefined,
+          },
+          undefined,
+        ],
       ])
     })
 


### PR DESCRIPTION
- Add `queryCacheKey` to `BaseQueryApi` typings
- Expose query cache key to the `baseQuery` api context
- Write tests to ensure correct typings and for ensuring matching keys between thunk dispatches and baseQuery 

closes #4615 