### PR TITLE
Pass query args to prepareHeaders function

### DIFF
--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -64,8 +64,7 @@ type FetchBaseQueryArgs = {
     api: Pick<
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
-    >,
-    args: string | FetchArgs
+    > & { args: string | FetchArgs },
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -106,7 +105,7 @@ Typically a string like `https://api.your-really-great-app.com/v1/`. If you don'
 
 _(optional)_
 
-Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors. Arguments passed to the query function is passed as the third argument in case you need those params in the context of the `prepareHeaders` function.
+Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `args`, `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
 
 You can mutate the `headers` argument directly, and returning it is optional.
 
@@ -115,12 +114,12 @@ type prepareHeaders = (
   headers: Headers,
   api: {
     getState: () => unknown
+    args: string | FetchArgs
     extra: unknown
     endpoint: string
     type: 'query' | 'mutation'
     forced: boolean | undefined
   },
-  args: string | FetchArgs
 ) => Headers | void
 ```
 
@@ -305,8 +304,8 @@ The default response handler is `"json"`, which is equivalent to the following f
 
 ```ts title="Default responseHandler"
 const defaultResponseHandler = async (res: Response) => {
-  const text = await res.text();
-  return text.length ? JSON.parse(text) : null;
+  const text = await res.text()
+  return text.length ? JSON.parse(text) : null
 }
 ```
 

--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -65,6 +65,7 @@ type FetchBaseQueryArgs = {
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
     >,
+    args: string | FetchArgs
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -105,7 +106,7 @@ Typically a string like `https://api.your-really-great-app.com/v1/`. If you don'
 
 _(optional)_
 
-Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
+Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors. Arguments passed to the query function is passed as the third argument in case you need those params in the context of the `prepareHeaders` function.
 
 You can mutate the `headers` argument directly, and returning it is optional.
 
@@ -119,6 +120,7 @@ type prepareHeaders = (
     type: 'query' | 'mutation'
     forced: boolean | undefined
   },
+  args: string | FetchArgs
 ) => Headers | void
 ```
 

--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -105,7 +105,7 @@ Typically a string like `https://api.your-really-great-app.com/v1/`. If you don'
 
 _(optional)_
 
-Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `args`, `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
+Allows you to inject headers on every request. You can specify headers at the endpoint level, but you'll typically want to set common headers like `authorization` here. As a convenience mechanism, the second argument allows you to use `getState` to access your redux store in the event you store information you'll need there such as an auth token. Additionally, it provides access to `arg`, `extra`, `endpoint`, `type`, and `forced` to unlock more granular conditional behaviors.
 
 You can mutate the `headers` argument directly, and returning it is optional.
 

--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -64,7 +64,7 @@ type FetchBaseQueryArgs = {
     api: Pick<
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
-    > & { args: string | FetchArgs },
+    > & { arg: string | FetchArgs },
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -114,7 +114,7 @@ type prepareHeaders = (
   headers: Headers,
   api: {
     getState: () => unknown
-    args: string | FetchArgs
+    arg: string | FetchArgs
     extra: unknown
     endpoint: string
     type: 'query' | 'mutation'

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -113,6 +113,7 @@ export type FetchBaseQueryArgs = {
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
     >,
+    args: string | FetchArgs
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -164,9 +165,9 @@ export type FetchBaseQueryMeta = { request: Request; response?: Response }
  * The base URL for an API service.
  * Typically in the format of https://example.com/
  *
- * @param {(headers: Headers, api: { getState: () => unknown; extra: unknown; endpoint: string; type: 'query' | 'mutation'; forced: boolean; }) => Headers} prepareHeaders
+ * @param {(headers: Headers, api: { getState: () => unknown; extra: unknown; endpoint: string; type: 'query' | 'mutation'; forced: boolean; }, args: string | FetchArgs) => Headers} prepareHeaders
  * An optional function that can be used to inject headers on requests.
- * Provides a Headers object, as well as most of the `BaseQueryApi` (`dispatch` is not available).
+ * Provides a Headers object, most of the `BaseQueryApi` (`dispatch` is not available), and the args passed into the query function.
  * Useful for setting authentication or headers that need to be set conditionally.
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Headers
@@ -212,7 +213,7 @@ export function fetchBaseQuery({
       'Warning: `fetch` is not available. Please supply a custom `fetchFn` property to use `fetchBaseQuery` on SSR environments.',
     )
   }
-  return async (arg, api) => {
+  return async (args, api) => {
     const { signal, getState, extra, endpoint, forced, type } = api
     let meta: FetchBaseQueryMeta | undefined
     let {
@@ -223,7 +224,7 @@ export function fetchBaseQuery({
       validateStatus = globalValidateStatus ?? defaultValidateStatus,
       timeout = defaultTimeout,
       ...rest
-    } = typeof arg == 'string' ? { url: arg } : arg
+    } = typeof args == 'string' ? { url: args } : args
     let config: RequestInit = {
       ...baseFetchOptions,
       signal,
@@ -238,7 +239,7 @@ export function fetchBaseQuery({
         endpoint,
         forced,
         type,
-      })) || headers
+      }, args)) || headers
 
     // Only set the content-type to json if appropriate. Will not be true for FormData, ArrayBuffer, Blob, etc.
     const isJsonifiable = (body: any) =>

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -112,8 +112,7 @@ export type FetchBaseQueryArgs = {
     api: Pick<
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
-    >,
-    args: string | FetchArgs,
+    > & { args: string | FetchArgs },
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -165,7 +164,7 @@ export type FetchBaseQueryMeta = { request: Request; response?: Response }
  * The base URL for an API service.
  * Typically in the format of https://example.com/
  *
- * @param {(headers: Headers, api: { getState: () => unknown; extra: unknown; endpoint: string; type: 'query' | 'mutation'; forced: boolean; }, args: string | FetchArgs) => Headers} prepareHeaders
+ * @param {(headers: Headers, api: { getState: () => unknown; args: string | FetchArgs; extra: unknown; endpoint: string; type: 'query' | 'mutation'; forced: boolean; }) => Headers} prepareHeaders
  * An optional function that can be used to inject headers on requests.
  * Provides a Headers object, most of the `BaseQueryApi` (`dispatch` is not available), and the args passed into the query function.
  * Useful for setting authentication or headers that need to be set conditionally.
@@ -242,17 +241,14 @@ export function fetchBaseQuery({
 
     headers = new Headers(stripUndefined(headers))
     config.headers =
-      (await prepareHeaders(
-        headers,
-        {
-          getState,
-          extra,
-          endpoint,
-          forced,
-          type,
-        },
+      (await prepareHeaders(headers, {
+        getState,
         args,
-      )) || headers
+        extra,
+        endpoint,
+        forced,
+        type,
+      })) || headers
 
     // Only set the content-type to json if appropriate. Will not be true for FormData, ArrayBuffer, Blob, etc.
     const isJsonifiable = (body: any) =>

--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -112,7 +112,7 @@ export type FetchBaseQueryArgs = {
     api: Pick<
       BaseQueryApi,
       'getState' | 'extra' | 'endpoint' | 'type' | 'forced'
-    > & { args: string | FetchArgs },
+    > & { arg: string | FetchArgs },
   ) => MaybePromise<Headers | void>
   fetchFn?: (
     input: RequestInfo,
@@ -164,9 +164,9 @@ export type FetchBaseQueryMeta = { request: Request; response?: Response }
  * The base URL for an API service.
  * Typically in the format of https://example.com/
  *
- * @param {(headers: Headers, api: { getState: () => unknown; args: string | FetchArgs; extra: unknown; endpoint: string; type: 'query' | 'mutation'; forced: boolean; }) => Headers} prepareHeaders
+ * @param {(headers: Headers, api: { getState: () => unknown; arg: string | FetchArgs; extra: unknown; endpoint: string; type: 'query' | 'mutation'; forced: boolean; }) => Headers} prepareHeaders
  * An optional function that can be used to inject headers on requests.
- * Provides a Headers object, most of the `BaseQueryApi` (`dispatch` is not available), and the args passed into the query function.
+ * Provides a Headers object, most of the `BaseQueryApi` (`dispatch` is not available), and the arg passed into the query function.
  * Useful for setting authentication or headers that need to be set conditionally.
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Headers
@@ -212,7 +212,7 @@ export function fetchBaseQuery({
       'Warning: `fetch` is not available. Please supply a custom `fetchFn` property to use `fetchBaseQuery` on SSR environments.',
     )
   }
-  return async (args, api) => {
+  return async (arg, api) => {
     const { getState, extra, endpoint, forced, type } = api
     let meta: FetchBaseQueryMeta | undefined
     let {
@@ -223,7 +223,7 @@ export function fetchBaseQuery({
       validateStatus = globalValidateStatus ?? defaultValidateStatus,
       timeout = defaultTimeout,
       ...rest
-    } = typeof args == 'string' ? { url: args } : args
+    } = typeof arg == 'string' ? { url: arg } : arg
 
     let abortController: AbortController | undefined,
       signal = api.signal
@@ -243,7 +243,7 @@ export function fetchBaseQuery({
     config.headers =
       (await prepareHeaders(headers, {
         getState,
-        args,
+        arg,
         extra,
         endpoint,
         forced,

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -850,6 +850,48 @@ describe('fetchBaseQuery', () => {
       expect(_forced).toBe(true)
       expect(_extra).toBe(fakeAuth0Client)
     })
+
+    test('prepareHeaders provides args', async () => {
+      let _args
+
+      const baseQuery = fetchBaseQuery({
+        baseUrl,
+        fetchFn: fetchFn as any,
+        prepareHeaders: (headers, _api, args) => {
+          _args = args
+
+          return headers
+        },
+      })
+
+      const fakeAuth0Client = {
+        getTokenSilently: async () => 'fakeToken',
+      }
+
+      const doRequest = async () => {
+        const abortController = new AbortController()
+        return baseQuery(
+          { url: '/echo' },
+          {
+            signal: abortController.signal,
+            abort: (reason) =>
+              // @ts-ignore
+              abortController.abort(reason),
+            dispatch: storeRef.store.dispatch,
+            getState: storeRef.store.getState,
+            extra: fakeAuth0Client,
+            type: 'query',
+            forced: true,
+            endpoint: 'someEndpointName',
+          },
+          {},
+        )
+      }
+
+      await doRequest()
+
+      expect(_args!.url).toBe('/echo')
+    })
   })
 
   test('can pass `headers` into `fetchBaseQuery`', async () => {

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -799,17 +799,17 @@ describe('fetchBaseQuery', () => {
     })
 
     test('prepareHeaders provides extra api information for getState, extra, endpoint, type and forced', async () => {
-      let _getState, _args: any, _extra, _endpoint, _type, _forced
+      let _getState, _arg: any, _extra, _endpoint, _type, _forced
 
       const baseQuery = fetchBaseQuery({
         baseUrl,
         fetchFn: fetchFn as any,
         prepareHeaders: (
           headers,
-          { getState, args, extra, endpoint, type, forced },
+          { getState, arg, extra, endpoint, type, forced },
         ) => {
           _getState = getState
-          _args = args
+          _arg = arg
           _endpoint = endpoint
           _type = type
           _forced = forced
@@ -846,7 +846,7 @@ describe('fetchBaseQuery', () => {
       await doRequest()
 
       expect(_getState).toBeDefined()
-      expect(_args!.url).toBe('/echo')
+      expect(_arg!.url).toBe('/echo')
       expect(_endpoint).toBe('someEndpointName')
       expect(_type).toBe('query')
       expect(_forced).toBe(true)

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -799,16 +799,17 @@ describe('fetchBaseQuery', () => {
     })
 
     test('prepareHeaders provides extra api information for getState, extra, endpoint, type and forced', async () => {
-      let _getState, _extra, _endpoint, _type, _forced
+      let _getState, _args, _extra, _endpoint, _type, _forced
 
       const baseQuery = fetchBaseQuery({
         baseUrl,
         fetchFn: fetchFn as any,
         prepareHeaders: (
           headers,
-          { getState, extra, endpoint, type, forced },
+          { getState, args, extra, endpoint, type, forced },
         ) => {
           _getState = getState
+          _args = args
           _endpoint = endpoint
           _type = type
           _forced = forced
@@ -845,52 +846,11 @@ describe('fetchBaseQuery', () => {
       await doRequest()
 
       expect(_getState).toBeDefined()
+      expect(_args!.url).toBe('/echo')
       expect(_endpoint).toBe('someEndpointName')
       expect(_type).toBe('query')
       expect(_forced).toBe(true)
       expect(_extra).toBe(fakeAuth0Client)
-    })
-
-    test('prepareHeaders provides args', async () => {
-      let _args: any
-
-      const baseQuery = fetchBaseQuery({
-        baseUrl,
-        fetchFn: fetchFn as any,
-        prepareHeaders: (headers, _api, args) => {
-          _args = args
-
-          return headers
-        },
-      })
-
-      const fakeAuth0Client = {
-        getTokenSilently: async () => 'fakeToken',
-      }
-
-      const doRequest = async () => {
-        const abortController = new AbortController()
-        return baseQuery(
-          { url: '/echo' },
-          {
-            signal: abortController.signal,
-            abort: (reason) =>
-              // @ts-ignore
-              abortController.abort(reason),
-            dispatch: storeRef.store.dispatch,
-            getState: storeRef.store.getState,
-            extra: fakeAuth0Client,
-            type: 'query',
-            forced: true,
-            endpoint: 'someEndpointName',
-          },
-          {},
-        )
-      }
-
-      await doRequest()
-
-      expect(_args!.url).toBe('/echo')
     })
   })
 

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -799,7 +799,7 @@ describe('fetchBaseQuery', () => {
     })
 
     test('prepareHeaders provides extra api information for getState, extra, endpoint, type and forced', async () => {
-      let _getState, _args, _extra, _endpoint, _type, _forced
+      let _getState, _args: any, _extra, _endpoint, _type, _forced
 
       const baseQuery = fetchBaseQuery({
         baseUrl,

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -852,7 +852,7 @@ describe('fetchBaseQuery', () => {
     })
 
     test('prepareHeaders provides args', async () => {
-      let _args
+      let _args: any
 
       const baseQuery = fetchBaseQuery({
         baseUrl,


### PR DESCRIPTION
Closes #4238

Passes args in the query function to the `prepareHeaders` call as the third argument.  

In the base fetch function, I renamed the first argument from `arg` to `args` to make it consistent with the name in the types and docs.