### PR TITLE
call `initiate` to refetch queries from middleware

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -24,6 +24,7 @@ import type {
   InternalMiddlewareState,
 } from './types'
 import { buildWindowEventHandler } from './windowEventHandling'
+import type { ApiEndpointQuery } from '../module'
 export type { ReferenceCacheCollection } from './cacheCollection'
 export type {
   MutationCacheLifecycleApi,
@@ -146,17 +147,10 @@ export function buildMiddleware<
       QuerySubState<any>,
       { status: QueryStatus.uninitialized }
     >,
-    queryCacheKey: string,
-    override: Partial<QueryThunkArg> = {},
   ) {
-    return queryThunk({
-      type: 'query',
-      endpointName: querySubState.endpointName,
-      originalArgs: querySubState.originalArgs,
+    return (input.api.endpoints[querySubState.endpointName] as ApiEndpointQuery<any, any>).initiate(querySubState.originalArgs as any, {
       subscribe: false,
       forceRefetch: true,
-      queryCacheKey: queryCacheKey as any,
-      ...override,
     })
   }
 }

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -122,7 +122,7 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
               }),
             )
           } else if (querySubState.status !== QueryStatus.uninitialized) {
-            mwApi.dispatch(refetchQuery(querySubState, queryCacheKey))
+            mwApi.dispatch(refetchQuery(querySubState))
           }
         }
       }

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -78,7 +78,7 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
       pollingInterval: lowestPollingInterval,
       timeout: setTimeout(() => {
         if (state.config.focused || !skipPollingIfUnfocused) {
-          api.dispatch(refetchQuery(querySubState, queryCacheKey))
+          api.dispatch(refetchQuery(querySubState))
         }
         startNextPoll({ queryCacheKey }, api)
       }, lowestPollingInterval),

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -3,6 +3,7 @@ import type {
   AsyncThunkAction,
   Middleware,
   MiddlewareAPI,
+  ThunkAction,
   ThunkDispatch,
   UnknownAction,
 } from '@reduxjs/toolkit'
@@ -23,6 +24,7 @@ import type {
   QueryThunkArg,
   ThunkResult,
 } from '../buildThunks'
+import type { QueryActionCreatorResult } from '../buildInitiate'
 
 export type QueryStateMeta<T> = Record<string, undefined | T>
 export type TimeoutId = ReturnType<typeof setTimeout>
@@ -62,10 +64,8 @@ export interface BuildSubMiddlewareInput
     querySubState: Exclude<
       QuerySubState<any>,
       { status: QueryStatus.uninitialized }
-    >,
-    queryCacheKey: string,
-    override?: Partial<QueryThunkArg>,
-  ): AsyncThunkAction<ThunkResult, QueryThunkArg, {}>
+    >
+  ): ThunkAction<QueryActionCreatorResult<any>, any, any, UnknownAction>
   isThisApiSliceAction: (action: Action) => boolean
 }
 

--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -58,7 +58,7 @@ export const buildWindowEventHandler: InternalHandlerBuilder = ({
               }),
             )
           } else if (querySubState.status !== QueryStatus.uninitialized) {
-            api.dispatch(refetchQuery(querySubState, queryCacheKey))
+            api.dispatch(refetchQuery(querySubState))
           }
         }
       }


### PR DESCRIPTION
This should fix #4650 

Previously, middleware-initiated refetches would directly call the thunk, not `initiate`. While that was probably more performant, that meant that the running thunk would not be tracked in `runningQueries`, which meant that a subsequent call to `initiate` could not latch onto the currently-running thunk, and would return the stale value.

It also meant that there were running queries that were not visible to `getRunningQueriesThunk`/`getRunningQueryThunk`.