### PR TITLE
Add the `TypedQueryStateSelector` helper type

### DIFF
--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -88,6 +88,9 @@ export type BaseQueryError<BaseQuery extends BaseQueryFn> = Exclude<
   { error?: undefined }
 >['error']
 
+/**
+ * @public
+ */
 export type BaseQueryArg<T extends (arg: any, ...args: any[]) => any> =
   T extends (arg: infer A, ...args: any[]) => any ? A : any
 

--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -63,6 +63,9 @@ export type BaseQueryEnhancer<
   NonNullable<BaseQueryMeta<BaseQuery>>
 >
 
+/**
+ * @public
+ */
 export type BaseQueryResult<BaseQuery extends BaseQueryFn> =
   UnwrapPromise<ReturnType<BaseQuery>> extends infer Unwrapped
     ? Unwrapped extends { data: any }

--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -74,6 +74,9 @@ export type BaseQueryMeta<BaseQuery extends BaseQueryFn> = UnwrapPromise<
   ReturnType<BaseQuery>
 >['meta']
 
+/**
+ * @public
+ */
 export type BaseQueryError<BaseQuery extends BaseQueryFn> = Exclude<
   UnwrapPromise<ReturnType<BaseQuery>>,
   { error?: undefined }

--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -70,6 +70,9 @@ export type BaseQueryResult<BaseQuery extends BaseQueryFn> =
       : never
     : never
 
+/**
+ * @public
+ */
 export type BaseQueryMeta<BaseQuery extends BaseQueryFn> = UnwrapPromise<
   ReturnType<BaseQuery>
 >['meta']

--- a/packages/toolkit/src/query/baseQueryTypes.ts
+++ b/packages/toolkit/src/query/baseQueryTypes.ts
@@ -94,5 +94,8 @@ export type BaseQueryError<BaseQuery extends BaseQueryFn> = Exclude<
 export type BaseQueryArg<T extends (arg: any, ...args: any[]) => any> =
   T extends (arg: infer A, ...args: any[]) => any ? A : any
 
+/**
+ * @public
+ */
 export type BaseQueryExtraOptions<BaseQuery extends BaseQueryFn> =
   Parameters<BaseQuery>[2]

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -231,6 +231,10 @@ export type FullTagDescription<TagType> = {
   id?: number | string
 }
 export type TagDescription<TagType> = TagType | FullTagDescription<TagType>
+
+/**
+ * @public
+ */
 export type ResultDescription<
   TagTypes extends string,
   ResultType,

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -34,6 +34,7 @@ export type {
   DefinitionType,
   DefinitionsFromApi,
   OverrideResultType,
+  ResultDescription,
   TagTypesFromApi,
   UpdateDefinitions,
 } from './endpointDefinitions'

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -15,6 +15,7 @@ export type { Api, ApiContext, Module } from './apiTypes'
 
 export type {
   BaseQueryApi,
+  BaseQueryArg,
   BaseQueryEnhancer,
   BaseQueryError,
   BaseQueryFn,

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -18,6 +18,7 @@ export type {
   BaseQueryArg,
   BaseQueryEnhancer,
   BaseQueryError,
+  BaseQueryExtraOptions,
   BaseQueryFn,
   BaseQueryMeta,
   BaseQueryResult,

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -19,6 +19,7 @@ export type {
   BaseQueryError,
   BaseQueryFn,
   BaseQueryMeta,
+  BaseQueryResult,
   QueryReturnValue,
 } from './baseQueryTypes'
 export type {

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -16,6 +16,7 @@ export type { Api, ApiContext, Module } from './apiTypes'
 export type {
   BaseQueryApi,
   BaseQueryEnhancer,
+  BaseQueryError,
   BaseQueryFn,
   QueryReturnValue
 } from './baseQueryTypes'

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -18,7 +18,8 @@ export type {
   BaseQueryEnhancer,
   BaseQueryError,
   BaseQueryFn,
-  QueryReturnValue
+  BaseQueryMeta,
+  QueryReturnValue,
 } from './baseQueryTypes'
 export type {
   BaseEndpointDefinition,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -327,6 +327,9 @@ export type TypedUseLazyQuerySubscription<
   QueryDefinition<QueryArg, BaseQuery, string, ResultType, string>
 >
 
+/**
+ * @internal
+ */
 export type QueryStateSelector<
   R extends Record<string, any>,
   D extends QueryDefinition<any, any, any, any>,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -333,6 +333,119 @@ export type QueryStateSelector<
 > = (state: UseQueryStateDefaultResult<D>) => R
 
 /**
+ * Provides a way to define a strongly-typed version of
+ * {@linkcode QueryStateSelector} for use with a specific query.
+ * This is useful for scenarios where you want to create a "pre-typed"
+ * {@linkcode UseQueryStateOptions.selectFromResult | selectFromResult}
+ * function.
+ *
+ * @example
+ * <caption>#### __Create a strongly-typed `selectFromResult` selector function__</caption>
+ *
+ * ```tsx
+ * import type { TypedQueryStateSelector } from '@reduxjs/toolkit/query/react'
+ * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+ *
+ * type Post = {
+ *   id: number
+ *   title: string
+ * }
+ *
+ * type PostsApiResponse = {
+ *   posts: Post[]
+ *   total: number
+ *   skip: number
+ *   limit: number
+ * }
+ *
+ * type QueryArgument = number | undefined
+ *
+ * type BaseQueryFunction = ReturnType<typeof fetchBaseQuery>
+ *
+ * type SelectedResult = Pick<PostsApiResponse, 'posts'>
+ *
+ * const postsApiSlice = createApi({
+ *   baseQuery: fetchBaseQuery({ baseUrl: 'https://dummyjson.com/posts' }),
+ *   reducerPath: 'postsApi',
+ *   tagTypes: ['Posts'],
+ *   endpoints: (build) => ({
+ *     getPosts: build.query<PostsApiResponse, QueryArgument>({
+ *       query: (limit = 5) => `?limit=${limit}&select=title`,
+ *     }),
+ *   }),
+ * })
+ *
+ * const { useGetPostsQuery } = postsApiSlice
+ *
+ * function PostById({ id }: { id: number }) {
+ *   const { post } = useGetPostsQuery(undefined, {
+ *     selectFromResult: (state) => ({
+ *       post: state.data?.posts.find((post) => post.id === id),
+ *     }),
+ *   })
+ *
+ *   return <li>{post?.title}</li>
+ * }
+ *
+ * const EMPTY_ARRAY: Post[] = []
+ *
+ * const typedSelectFromResult: TypedQueryStateSelector<
+ *   PostsApiResponse,
+ *   QueryArgument,
+ *   BaseQueryFunction,
+ *   SelectedResult
+ * > = (state) => ({ posts: state.data?.posts ?? EMPTY_ARRAY })
+ *
+ * function PostsList() {
+ *   const { posts } = useGetPostsQuery(undefined, {
+ *     selectFromResult: typedSelectFromResult,
+ *   })
+ *
+ *   return (
+ *     <div>
+ *       <ul>
+ *         {posts.map((post) => (
+ *           <PostById key={post.id} id={post.id} />
+ *         ))}
+ *       </ul>
+ *     </div>
+ *   )
+ * }
+ * ```
+ *
+ * @template ResultType - The type of the result `data` returned by the query.
+ * @template QueryArgumentType - The type of the argument passed into the query.
+ * @template BaseQueryFunctionType - The type of the base query function being used.
+ * @template SelectedResultType - The type of the selected result returned by the __`selectFromResult`__ function.
+ *
+ * @since 2.7.9
+ * @public
+ */
+export type TypedQueryStateSelector<
+  ResultType,
+  QueryArgumentType,
+  BaseQueryFunctionType extends BaseQueryFn,
+  SelectedResultType extends Record<string, any> = UseQueryStateDefaultResult<
+    QueryDefinition<
+      QueryArgumentType,
+      BaseQueryFunctionType,
+      string,
+      ResultType,
+      string
+    >
+  >,
+> = QueryStateSelector<
+  SelectedResultType,
+  QueryDefinition<
+    QueryArgumentType,
+    BaseQueryFunctionType,
+    string,
+    ResultType,
+    string
+  >
+>
+
+/**
  * A React hook that reads the request status and cached data from the Redux store. The component will re-render as the loading status changes and the data becomes available.
  *
  * Note that this hook does not trigger fetching new data. For that use-case, see [`useQuery`](#usequery) or [`useQuerySubscription`](#usequerysubscription).

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -22,6 +22,7 @@ export type {
   TypedUseLazyQuery,
   TypedUseMutation,
   TypedMutationTrigger,
+  TypedQueryStateSelector,
   TypedUseQueryState,
   TypedUseQuery,
   TypedUseQuerySubscription,


### PR DESCRIPTION
## **This PR**:

- [X] Adds the **`TypedQueryStateSelector`** helper type which Provides a way to define a "pre-typed" version of **`QueryStateSelector`** (related to #4554).
- [X] Marks the **`QueryStateSelector`** type with an **`@internal`** JSDoc tag.
- [X] Adds type tests for the newly added **`TypedQueryStateSelector`** type.
- [X] Exports the following types and marks them with a **`@public`** JSDoc tag:
  - [X] **`BaseQueryArg`**.
  - [X] **`BaseQueryError`** (related to #4554).
  - [X] **`BaseQueryExtraOptions`**.
  - [X] **`BaseQueryMeta`** (related to #4554).
  - [X] **`BaseQueryResult`**.
  - [X] **`ResultDescription`** (related to #4554).
- [X] Resolves **#4554**.
