### PR TITLE
Fix serializeQueryTags type

### DIFF
--- a/packages/toolkit/etc/rtk-query-react.api.md
+++ b/packages/toolkit/etc/rtk-query-react.api.md
@@ -159,7 +159,7 @@ export interface CreateApiOptions<
   refetchOnFocus?: boolean
   refetchOnMountOrArgChange?: boolean | number
   refetchOnReconnect?: boolean
-  serializeQueryArgs?: SerializeQueryArgs<BaseQueryArg<BaseQuery>>
+  serializeQueryArgs?: SerializeQueryArgs<unknown>
   tagTypes?: readonly TagTypes[]
 }
 

--- a/packages/toolkit/etc/rtk-query.api.md
+++ b/packages/toolkit/etc/rtk-query.api.md
@@ -145,7 +145,7 @@ export interface CreateApiOptions<
   refetchOnFocus?: boolean
   refetchOnMountOrArgChange?: boolean | number
   refetchOnReconnect?: boolean
-  serializeQueryArgs?: SerializeQueryArgs<BaseQueryArg<BaseQuery>>
+  serializeQueryArgs?: SerializeQueryArgs<unknown>
   structuralSharing?: boolean
   tagTypes?: readonly TagTypes[]
 }

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -92,7 +92,7 @@ export interface CreateApiOptions<
   /**
    * Accepts a custom function if you have a need to change the creation of cache keys for any reason.
    */
-  serializeQueryArgs?: SerializeQueryArgs<BaseQueryArg<BaseQuery>>
+  serializeQueryArgs?: SerializeQueryArgs<unknown>
   /**
    * Endpoints are just a set of operations that you want to perform against your server. You define them as an object using the builder syntax. There are two basic endpoint types: [`query`](../../rtk-query/usage/queries) and [`mutation`](../../rtk-query/usage/mutations).
    */


### PR DESCRIPTION
This PR

- [x]  Fixes type of **serializeQueryArgs** in **CreateApiOptions**.
- [x]  Updates corresponding type in **rtk-query-react.api.md**.
- [x]  Updates corresponding type in **rtk-query.api.md**.
- [x] Resolves https://github.com/reduxjs/redux-toolkit/issues/4657.