### PR TITLE
fixing naming in docs to match the actual definition in apiState

### DIFF
--- a/docs/rtk-query/api/created-api/hooks.mdx
+++ b/docs/rtk-query/api/created-api/hooks.mdx
@@ -335,7 +335,7 @@ type UseMutationResult<T> = {
   data?: T // Returned result if present
   error?: unknown // Error result if present
   endpointName?: string // The name of the given endpoint for the mutation
-  fulfilledTimestamp?: number // Timestamp for when the mutation was completed
+  fulfilledTimeStamp?: number // Timestamp for when the mutation was completed
 
   // Derived request status booleans
   isUninitialized: boolean // Mutation has not been fired yet


### PR DESCRIPTION
There is a mismatch in Timestamp vs TimeStamp in the docs. Currently naming convention TimeStamp with a capital S is used everywhere in the project however in the docs we see fulfilledTimestamp when in the API the actual definition is fulfilledTimeStamp. Changing the docs to match the API.

Note: I checked if other places had the same issues this is the only one i could find