### PR TITLE
Ignore nullish values in tag invalidations

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -48,7 +48,7 @@ export function buildMiddleware<
 
   const actions = {
     invalidateTags: createAction<
-      Array<TagTypes | FullTagDescription<TagTypes>>
+      Array<TagTypes | FullTagDescription<TagTypes> | null | undefined>
     >(`${reducerPath}/invalidateTags`),
   }
 

--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -9,7 +9,7 @@ import type {
   TagTypesFrom,
 } from '../endpointDefinitions'
 import { expandTagDescription } from '../endpointDefinitions'
-import { flatten } from '../utils'
+import { flatten, isNotNullish } from '../utils'
 import type {
   MutationSubState,
   QueryCacheKey,
@@ -205,7 +205,7 @@ export function buildSelectors<
 
   function selectInvalidatedBy(
     state: RootState,
-    tags: ReadonlyArray<TagDescription<string>>,
+    tags: ReadonlyArray<TagDescription<string> | null | undefined>,
   ): Array<{
     endpointName: string
     originalArgs: any
@@ -213,7 +213,7 @@ export function buildSelectors<
   }> {
     const apiState = state[reducerPath]
     const toInvalidate = new Set<QueryCacheKey>()
-    for (const tag of tags.map(expandTagDescription)) {
+    for (const tag of tags.filter(isNotNullish).map(expandTagDescription)) {
       const provided = apiState.provided[tag.type]
       if (!provided) {
         continue

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -350,7 +350,7 @@ export interface ApiModules<
        * ```
        */
       invalidateTags: ActionCreatorWithPayload<
-        Array<TagDescription<TagTypes>>,
+        Array<TagDescription<TagTypes> | null | undefined>,
         string
       >
 
@@ -361,7 +361,7 @@ export interface ApiModules<
        */
       selectInvalidatedBy: (
         state: RootState<Definitions, string, ReducerPath>,
-        tags: ReadonlyArray<TagDescription<TagTypes>>,
+        tags: ReadonlyArray<TagDescription<TagTypes> | null | undefined>,
       ) => Array<{
         endpointName: string
         originalArgs: any

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -242,7 +242,7 @@ export type ResultDescription<
   ErrorType,
   MetaType,
 > =
-  | ReadonlyArray<TagDescription<TagTypes>>
+  | ReadonlyArray<TagDescription<TagTypes> | undefined | null>
   | GetResultDescriptionFn<TagTypes, ResultType, QueryArg, ErrorType, MetaType>
 
 type QueryTypes<

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -29,6 +29,7 @@ import type {
   OmitFromUnion,
   UnwrapPromise,
 } from './tsHelpers'
+import { isNotNullish } from './utils'
 
 const resultType = /* @__PURE__ */ Symbol()
 const baseQuery = /* @__PURE__ */ Symbol()
@@ -224,7 +225,7 @@ export type GetResultDescriptionFn<
   error: ErrorType | undefined,
   arg: QueryArg,
   meta: MetaType,
-) => ReadonlyArray<TagDescription<TagTypes>>
+) => ReadonlyArray<TagDescription<TagTypes> | undefined | null>
 
 export type FullTagDescription<TagType> = {
   type: TagType
@@ -778,6 +779,7 @@ export function calculateProvidedBy<ResultType, QueryArg, ErrorType, MetaType>(
       queryArg,
       meta as MetaType,
     )
+      .filter(isNotNullish)
       .map(expandTagDescription)
       .map(assertTagTypes)
   }

--- a/packages/toolkit/src/query/tests/createApi.test-d.ts
+++ b/packages/toolkit/src/query/tests/createApi.test-d.ts
@@ -39,7 +39,7 @@ describe('type tests', () => {
 
     expectTypeOf(api.util.invalidateTags)
       .parameter(0)
-      .toEqualTypeOf<TagDescription<never>[]>()
+      .toEqualTypeOf<(null | undefined | TagDescription<never>)[]>()
   })
 
   describe('endpoint definition typings', () => {

--- a/packages/toolkit/src/query/tests/invalidation.test.tsx
+++ b/packages/toolkit/src/query/tests/invalidation.test.tsx
@@ -14,10 +14,10 @@ const tagTypes = [
   'giraffe',
 ] as const
 type TagTypes = (typeof tagTypes)[number]
-type Tags = TagDescription<TagTypes>[]
-
+type ProvidedTags = TagDescription<TagTypes>[] 
+type InvalidatesTags = (ProvidedTags[number] | null | undefined)[]
 /** providesTags, invalidatesTags, shouldInvalidate */
-const caseMatrix: [Tags, Tags, boolean][] = [
+const caseMatrix: [ProvidedTags, InvalidatesTags, boolean][] = [
   // *****************************
   // basic invalidation behavior
   // *****************************
@@ -39,7 +39,11 @@ const caseMatrix: [Tags, Tags, boolean][] = [
   // type + id invalidates type + id
   [[{ type: 'apple', id: 1 }], [{ type: 'apple', id: 1 }], true],
   [[{ type: 'apple', id: 1 }], [{ type: 'apple', id: 2 }], false],
-
+  // null and undefined
+  [['apple'], [null], false],
+  [['apple'], [undefined], false],
+  [['apple'], [null, 'apple'], true],
+  [['apple'], [undefined, 'apple'], true],
   // *****************************
   // test multiple values in array
   // *****************************


### PR DESCRIPTION
### Description
Closes #4644

The following public rtk query APIs now supports `undefined` or `null` tags:
- api.util.invalidateTags
- api.util.selectInvalidatedBy
- mutationDefinition.invalidateTags

### Example nullish invalidate tags in mutation definition

```ts
const api = createApi({
  baseQuery,
  tagTypes: ['Banana'],
  endpoints: (build) => ({
    getBanana: build.query<unknown, number>({
      query(id) {
        return { url: `banana/${id}` }
      },
      providesTags: ['Banana'],
    }),
    getBananas: build.query<unknown, void>({
      query() {
        return { url: 'bananas' }
      },
      providesTags: ['Banana'],
    }),
    invalidateFruit: build.mutation({
      query: (fruit?: 'Banana'  | null) => ({ url: `invalidate/fruit/${fruit || ''}` }),
      invalidatesTags(result, error, arg) {
        return [arg] // arg now can also be undefined or null
      }
    })
  }),
})
```
### api.utils.invalidateTags

```ts
store.dispatch(api.util.invalidateTags(["Bread", params?.id]))
```

### api.util.selectInvalidatedBy

```ts
store.dispatch(api.util.selectInvalidatedBy(["Bread", params?.id]))
```

### Notes
Paired with @FaberVitale 