### PR TITLE
Add ability to reset lazy query hooks

### DIFF
--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -28,6 +28,7 @@ export type {
   TypedUseQuerySubscription,
   TypedUseLazyQuerySubscription,
   TypedUseQueryStateOptions,
+  TypedUseLazyQueryStateResult,
 } from './buildHooks'
 export { UNINITIALIZED_VALUE } from './constants'
 export { createApi, reactHooksModule, reactHooksModuleName }

--- a/packages/toolkit/src/query/tests/unionTypes.test-d.ts
+++ b/packages/toolkit/src/query/tests/unionTypes.test-d.ts
@@ -9,6 +9,7 @@ import type {
   TypedUseQueryStateResult,
   TypedUseQuerySubscriptionResult,
   TypedLazyQueryTrigger,
+  TypedUseLazyQueryStateResult,
   TypedUseLazyQuery,
   TypedUseLazyQuerySubscription,
   TypedUseMutation,
@@ -820,7 +821,7 @@ describe('"Typed" helper types', () => {
     >().toMatchTypeOf(trigger)
 
     expectTypeOf<
-      TypedUseQueryHookResult<string, void, typeof baseQuery>
+      TypedUseLazyQueryStateResult<string, void, typeof baseQuery>
     >().toMatchTypeOf(result)
   })
 
@@ -834,7 +835,12 @@ describe('"Typed" helper types', () => {
     >().toMatchTypeOf(trigger)
 
     expectTypeOf<
-      TypedUseQueryHookResult<string, void, typeof baseQuery, { x: boolean }>
+      TypedUseLazyQueryStateResult<
+        string,
+        void,
+        typeof baseQuery,
+        { x: boolean }
+      >
     >().toMatchTypeOf(result)
   })
 


### PR DESCRIPTION
Having another go at addressing #2055 since #2133 has been stale for quite a while now.
Implements the suggestion from https://github.com/reduxjs/redux-toolkit/pull/2133#issuecomment-1173164762

I have tried to follow a similar approach to the way the `reset` method has been implemented for the `useMutation` hook. I am new to this codebase so please let me know if something does not makes sense! 