### PR TITLE
Read `window.rAF` later to allow fake timers to work correctly

### DIFF
--- a/packages/toolkit/src/autoBatchEnhancer.ts
+++ b/packages/toolkit/src/autoBatchEnhancer.ts
@@ -15,13 +15,6 @@ const createQueueWithTimer = (timeout: number) => {
   }
 }
 
-// requestAnimationFrame won't exist in SSR environments.
-// Fall back to a vague approximation just to keep from erroring.
-const rAF =
-  typeof window !== 'undefined' && window.requestAnimationFrame
-    ? window.requestAnimationFrame
-    : createQueueWithTimer(10)
-
 export type AutoBatchOptions =
   | { type: 'tick' }
   | { type: 'timer'; timeout: number }
@@ -66,7 +59,10 @@ export const autoBatchEnhancer =
       options.type === 'tick'
         ? queueMicrotask
         : options.type === 'raf'
-          ? rAF
+          ? // requestAnimationFrame won't exist in SSR environments. Fall back to a vague approximation just to keep from erroring.
+            typeof window !== 'undefined' && window.requestAnimationFrame
+            ? window.requestAnimationFrame
+            : createQueueWithTimer(10)
           : options.type === 'callback'
             ? options.queueNotification
             : createQueueWithTimer(options.timeout)


### PR DESCRIPTION
This fixes issue https://github.com/reduxjs/redux-toolkit/issues/4693 by reading window.requestAnimationFrame within the autoBatchEnhancer function instead of in the top-level module scope. This ensures that we use the fake version of requestAnimationFrame if jest is using fake timers.