### PR TITLE
Preventing retries should result in the same result structure as if the retry wasn't used. 

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -65,7 +65,7 @@ export type RetryOptions = {
 )
 
 function fail(e: any): never {
-  throw Object.assign(new HandledError({ error: e }), {
+  throw Object.assign(new HandledError(e), {
     throwImmediately: true,
   })
 }


### PR DESCRIPTION
This PR fixes #3789.  Originally, by forcing the value of `HandledError` to be of type `{error: any}` instead of the full result value, the meta field would be lost. This means there would be no way to fail out of retrying but keep the result consistent as if no retry had happened.

This PR fixes what I believe to be a bug, but could be a breaking change. Alternatives could be to add an additional fail option such as `failResult`, or by exporting the `HandledError` class to be manually thrown in whatever fashion the user desires.