### PR TITLE
Allow passing meta to retry.fail, and passing baseQuery to ensure types match

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['20.x']
-        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
+        ts: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/docs/rtk-query/usage/customizing-queries.mdx
+++ b/docs/rtk-query/usage/customizing-queries.mdx
@@ -636,7 +636,7 @@ const staggeredBaseQueryWithBailOut = retry(
     // bail out of re-tries immediately if unauthorized,
     // because we know successive re-retries would be redundant
     if (result.error?.status === 401) {
-      retry.fail(result.error)
+      retry.fail(result.error, result.meta)
     }
 
     return result

--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -5,6 +5,7 @@ import type {
   BaseQueryError,
   BaseQueryExtraOptions,
   BaseQueryFn,
+  BaseQueryMeta,
 } from './baseQueryTypes'
 import type { FetchBaseQueryError } from './fetchBaseQuery'
 import { HandledError } from './HandledError'
@@ -64,8 +65,11 @@ export type RetryOptions = {
     }
 )
 
-function fail(e: any): never {
-  throw Object.assign(new HandledError({ error: e }), {
+function fail<BaseQuery extends BaseQueryFn = BaseQueryFn>(
+  e: BaseQueryError<BaseQuery>,
+  meta?: BaseQueryMeta<BaseQuery>,
+): never {
+  throw Object.assign(new HandledError({ error: e, meta }), {
     throwImmediately: true,
   })
 }

--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -66,10 +66,10 @@ export type RetryOptions = {
 )
 
 function fail<BaseQuery extends BaseQueryFn = BaseQueryFn>(
-  e: BaseQueryError<BaseQuery>,
+  error: BaseQueryError<BaseQuery>,
   meta?: BaseQueryMeta<BaseQuery>,
 ): never {
-  throw Object.assign(new HandledError({ error: e, meta }), {
+  throw Object.assign(new HandledError({ error, meta }), {
     throwImmediately: true,
   })
 }


### PR DESCRIPTION
Alternative fix to #3789, compared to #4721 which would be a breaking change.

This makes the change non-breaking, and also allows providing the baseQuery as a type parameter to retry.fail for correct error and meta type checking.

Meta parameter being optional is fine as the meta property in QueryReturnValue is also optional.