### PR TITLE
Keep `isSuccess` consistent when refetching after an error

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -934,12 +934,13 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       !hasData &&
       isFetching
 
-    // isSuccess = true when data is present.
+    // isSuccess = true when data is present and we're not refetching after an error.
     // That includes cases where the _current_ item is either actively
     // fetching or about to fetch due to an uninitialized entry.
     const isSuccess =
       currentState.isSuccess ||
-      ((isFetching || currentState.isUninitialized) && hasData)
+      (hasData &&
+        ((isFetching && !lastResult?.isError) || currentState.isUninitialized))
 
     return {
       ...currentState,


### PR DESCRIPTION
This PR:

- Makes a further tweak to the logic for calculating `isSuccess`, such that we don't flip from `false` to `true` temporarily when refetching after an error

Fixes #4240 

## Investigation

Per #4240, if you have a sequence where:

- The initial fetch succeeds
- The first refetch fails
- You run a second refetch that also fails

the observed behavior is:

```js
      [
        // Initial renders
        { id: 1, isFetching: true, isSuccess: false, isError: false },
        { id: 1, isFetching: true, isSuccess: false, isError: false },
        // Data is returned
        { id: 1, isFetching: false, isSuccess: true, isError: false },
        // Started first refetch
        { id: 1, isFetching: true, isSuccess: true, isError: false },
        // First refetch errored
        { id: 1, isFetching: false, isSuccess: false, isError: true },
        // Started second refetch <-------- `isSuccess` flips true here!
        { id: 1, isFetching: true, isSuccess: true, isError: false },
        // Second refetch errored
        { id: 1, isFetching: false, isSuccess: false, isError: true },
      ]
```

The issue is that `isSuccess` was `false` when the first refetch settled, but then flips to `true` when we start the second refetch. This does seem unintuitive and buggy.

Similar to #4731 , I think the logic for calculating `isSuccess` isn't sufficient. In this case:

- We know the _current_ cache entry is not in a success state because it's fetching
- we _are_ fetching and we do technically have cached data...
- but we know that the _last_ request actually failed

Given that, I think the right thing to do is include `&& !lastResult?.isError`, leaving us with:

```ts
    const isSuccess =
      currentState.isSuccess ||
      (hasData &&
        ((isFetching && !lastResult?.isError) || currentState.isUninitialized))
```

I see that flip the second refetch case to stay with `isSuccess: false` as I'd hope.