### PR TITLE
Make refetch after unmount a no-op

### DIFF
--- a/packages/toolkit/src/query/react/useIsMounted.ts
+++ b/packages/toolkit/src/query/react/useIsMounted.ts
@@ -1,0 +1,16 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+export function useIsMounted(): () => boolean {
+  const mountedRef = useRef(false)
+  const get = useCallback(() => mountedRef.current, [])
+
+  useLayoutEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  return get
+}

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -812,6 +812,28 @@ describe('hooks tests', () => {
       await screen.findByText('ID: 3')
     })
 
+    test('refetch does not throw an error if run after unmount', async () => {
+      let refetchFunction: () => {}
+
+      function User() {
+        const { refetch } = api.endpoints.getUser.useQuery(1)
+
+        refetchFunction = refetch
+
+        return (
+          <div>
+            <button>Refetch</button>
+          </div>
+        )
+      }
+
+      const { unmount } = render(<User />, { wrapper: storeRef.wrapper })
+
+      unmount()
+
+      expect(() => refetchFunction()).not.toThrow()
+    })
+
     test(`useQuery shouldn't call args serialization if request skipped`, async () => {
       expect(() =>
         renderHook(() => api.endpoints.queryWithDeepArg.useQuery(skipToken), {


### PR DESCRIPTION
This PR:

- Updates `refetch` to be a no-op if called after unmount. This fixes cases where it might get called after an unmount due to a debounce or similar

Fixes #4375 