### PR TITLE
Add maxPages support

### DIFF
--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -46,6 +46,7 @@ export type GetPreviousPageParamFunction<TPageParam, TQueryFnData> = (
 
 export type InfiniteQueryConfigOptions<TQueryFnData, TPageParam> = {
   initialPageParam: TPageParam
+  maxPages?: number
   /**
    * This function can be set to automatically get the previous cursor for infinite queries.
    * The result will also be used to determine the value of `hasPreviousPage`.


### PR DESCRIPTION
This PR:

- Adds `maxPages` to the `infiniteQueryOptions` definition
- Uses `maxPages` in the query thunks
- Adds runtime checks to validate that `maxPages > 0` and that `getPreviousPageParams` is supplied if `maxPages` is used