### PR TITLE
fix(rtk-query): `useQuery` hook does not refetch after `resetApiState`

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1661,8 +1661,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       skipPollingIfUnfocused,
     })
 
-    const lastRenderHadSubscription = useRef(false)
-
     const initialPageParam = (rest as UseInfiniteQuerySubscriptionOptions<any>)
       .initialPageParam
     const stableInitialPageParam = useShallowStableValue(initialPageParam)
@@ -1686,11 +1684,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     }
 
     const subscriptionRemoved =
-      !currentRenderHasSubscription && lastRenderHadSubscription.current
-
-    usePossiblyImmediateEffect(() => {
-      lastRenderHadSubscription.current = currentRenderHasSubscription
-    })
+      !currentRenderHasSubscription && promiseRef.current !== undefined
 
     usePossiblyImmediateEffect((): void | undefined => {
       if (subscriptionRemoved) {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -903,7 +903,7 @@ describe('hooks tests', () => {
         })
       })
 
-      test('reset after unmount/remount', async () => {
+      test('hook should not be stuck loading post resetApiState after re-render', async () => {
         const user = userEvent.setup()
 
         function QueryComponent() {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -902,6 +902,71 @@ describe('hooks tests', () => {
           status: 'uninitialized',
         })
       })
+
+      test('reset after unmount/remount', async () => {
+        const user = userEvent.setup()
+
+        function QueryComponent() {
+          const { isLoading, data } = api.endpoints.getUser.useQuery(1)
+
+          if (isLoading) {
+            return <p>Loading...</p>
+          }
+
+          return <p>{data?.name}</p>
+        }
+
+        function Wrapper() {
+          const [open, setOpen] = useState(true)
+
+          const handleRerender = () => {
+            setOpen(false)
+            setTimeout(() => {
+              setOpen(true)
+            }, 1000)
+          }
+
+          const handleReset = () => {
+            storeRef.store.dispatch(api.util.resetApiState())
+          }
+
+          return (
+            <>
+              <button onClick={handleRerender} aria-label="Rerender component">
+                Rerender
+              </button>
+              {open ? (
+                <div>
+                  <button onClick={handleReset} aria-label="Reset API state">
+                    Reset
+                  </button>
+
+                  <QueryComponent />
+                </div>
+              ) : null}
+            </>
+          )
+        }
+
+        render(<Wrapper />, { wrapper: storeRef.wrapper })
+
+        await user.click(
+          screen.getByRole('button', { name: /Rerender component/i }),
+        )
+        await waitFor(() => {
+          expect(screen.getByText('Timmy')).toBeTruthy()
+        })
+
+        await user.click(
+          screen.getByRole('button', { name: /reset api state/i }),
+        )
+        await waitFor(() => {
+          expect(screen.queryByText('Loading...')).toBeNull()
+        })
+        await waitFor(() => {
+          expect(screen.getByText('Timmy')).toBeTruthy()
+        })
+      })
     })
 
     test('useQuery refetch method returns a promise that resolves with the result', async () => {

--- a/packages/toolkit/src/query/tests/createApi.test.ts
+++ b/packages/toolkit/src/query/tests/createApi.test.ts
@@ -1181,7 +1181,7 @@ describe('timeout behavior', () => {
       http.get(
         'https://example.com/success',
         async () => {
-          await delay(10)
+          await delay(50)
           return HttpResponse.json({ value: 'failed' }, { status: 500 })
         },
         { once: true },


### PR DESCRIPTION
This PR fixes #3778 

Problem:
- The current implementation uses a `lastRenderHadSubscription` ref to track if the last render had a subscription. However, this ref can become out of sync with the actual subscription state, causing failed refetches, which lead to missing data and eventually stuck loading states.

Solution:
- We now use `promiseRef.current` to check if there was a previous subscription, as it is sufficient to track the subscription state. This removes redundant logic and ensures correct behavior.