### PR TITLE
Implement infinite query status flags

### DIFF
--- a/errors.json
+++ b/errors.json
@@ -38,5 +38,7 @@
   "36": "When using custom hooks for context, all  hooks need to be provided: .\\nHook  was either not provided or not a function.",
   "37": "Warning: Middleware for RTK-Query API at reducerPath \"\" has not been added to the store.\n    You must add the middleware for RTK-Query to function correctly!",
   "38": "Cannot refetch a query that has not been started yet.",
-  "39": "called \\`injectEndpoints\\` to override already-existing endpointName  without specifying \\`overrideExisting: true\\`"
+  "39": "called \\`injectEndpoints\\` to override already-existing endpointName  without specifying \\`overrideExisting: true\\`",
+  "40": "maxPages for endpoint '' must be a number greater than 0",
+  "41": "getPreviousPageParam for endpoint '' must be a function if maxPages is used"
 }

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -238,6 +238,8 @@ export type QuerySubState<
     }
 >
 
+export type InfiniteQueryDirection = 'forward' | 'backward'
+
 export type InfiniteQuerySubState<
   D extends BaseEndpointDefinition<any, any, any>,
 > =
@@ -249,7 +251,7 @@ export type InfiniteQuerySubState<
         isFetchingNextPage?: boolean
         isFetchingPreviousPage?: boolean
         param?: PageParamFrom<D>
-        direction?: 'forward' | 'backward'
+        direction?: InfiniteQueryDirection
       }
     : never
 

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -201,13 +201,6 @@ type BaseQuerySubState<
    * Time that the latest query was fulfilled
    */
   fulfilledTimeStamp?: number
-  /**
-   * Infinite Query Specific substate properties
-   */
-  hasNextPage?: boolean
-  hasPreviousPage?: boolean
-  direction?: 'forward' | 'backward'
-  param?: QueryArgFrom<D>
 }
 
 export type QuerySubState<
@@ -245,12 +238,6 @@ export type InfiniteQuerySubState<
 > =
   D extends InfiniteQueryDefinition<any, any, any, any, any>
     ? QuerySubState<D, InfiniteData<ResultTypeFrom<D>, PageParamFrom<D>>> & {
-        // TODO: These shouldn't be optional
-        hasNextPage?: boolean
-        hasPreviousPage?: boolean
-        isFetchingNextPage?: boolean
-        isFetchingPreviousPage?: boolean
-        param?: PageParamFrom<D>
         direction?: InfiniteQueryDirection
       }
     : never

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -24,6 +24,7 @@ import { countObjectKeys, getOrInsert, isNotNullish } from '../utils'
 import type {
   InfiniteData,
   InfiniteQueryConfigOptions,
+  InfiniteQueryDirection,
   SubscriptionOptions,
 } from './apiState'
 import type {
@@ -73,7 +74,7 @@ export type StartInfiniteQueryActionCreatorOptions<
   subscribe?: boolean
   forceRefetch?: boolean | number
   subscriptionOptions?: SubscriptionOptions
-  direction?: 'forward' | 'backward'
+  direction?: InfiniteQueryDirection
   [forceQueryFnSymbol]?: () => QueryReturnValue
   param?: unknown
   previous?: boolean

--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -1,6 +1,7 @@
 import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import type {
   EndpointDefinitions,
+  InfiniteQueryArgFrom,
   InfiniteQueryDefinition,
   MutationDefinition,
   QueryArgFrom,
@@ -108,7 +109,7 @@ type InfiniteQueryResultSelectorFactory<
   Definition extends InfiniteQueryDefinition<any, any, any, any, any>,
   RootState,
 > = (
-  queryArg: QueryArgFrom<Definition> | SkipToken,
+  queryArg: InfiniteQueryArgFrom<Definition> | SkipToken,
 ) => (state: RootState) => InfiniteQueryResultSelectorResult<Definition>
 
 export type InfiniteQueryResultSelectorResult<

--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -13,6 +13,8 @@ import type {
 import { expandTagDescription } from '../endpointDefinitions'
 import { flatten, isNotNullish } from '../utils'
 import type {
+  InfiniteData,
+  InfiniteQueryConfigOptions,
   InfiniteQuerySubState,
   MutationSubState,
   QueryCacheKey,
@@ -26,6 +28,7 @@ import { QueryStatus, getRequestStatusFlags } from './apiState'
 import { getMutationCacheKey } from './buildSlice'
 import type { createSelector as _createSelector } from './rtkImports'
 import { createNextState } from './rtkImports'
+import { getNextPageParam, getPreviousPageParam } from './buildThunks'
 
 export type SkipToken = typeof skipToken
 /**
@@ -112,9 +115,20 @@ type InfiniteQueryResultSelectorFactory<
   queryArg: InfiniteQueryArgFrom<Definition> | SkipToken,
 ) => (state: RootState) => InfiniteQueryResultSelectorResult<Definition>
 
+export type InfiniteQueryResultFlags = {
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  isFetchingNextPage: boolean
+  isFetchingPreviousPage: boolean
+  isFetchNextPageError: boolean
+  isFetchPreviousPageError: boolean
+}
+
 export type InfiniteQueryResultSelectorResult<
   Definition extends InfiniteQueryDefinition<any, any, any, any, any>,
-> = InfiniteQuerySubState<Definition> & RequestStatusFlags
+> = InfiniteQuerySubState<Definition> &
+  RequestStatusFlags &
+  InfiniteQueryResultFlags
 
 type MutationResultSelectorFactory<
   Definition extends MutationDefinition<any, any, any, any>,
@@ -231,7 +245,52 @@ export function buildSelectors<
       const finalSelectQuerySubState =
         queryArgs === skipToken ? selectSkippedQuery : selectQuerySubstate
 
-      return createSelector(finalSelectQuerySubState, withRequestFlags)
+      const { infiniteQueryOptions } = endpointDefinition
+
+      function withInfiniteQueryResultFlags<T extends { status: QueryStatus }>(
+        substate: T,
+      ): T & RequestStatusFlags & InfiniteQueryResultFlags {
+        const infiniteSubstate = substate as InfiniteQuerySubState<any>
+        const fetchDirection = infiniteSubstate.direction
+        const stateWithRequestFlags = {
+          ...infiniteSubstate,
+          ...getRequestStatusFlags(substate.status),
+        }
+
+        const { isLoading, isError } = stateWithRequestFlags
+
+        const isFetchNextPageError = isError && fetchDirection === 'forward'
+        const isFetchingNextPage = isLoading && fetchDirection === 'forward'
+
+        const isFetchPreviousPageError =
+          isError && fetchDirection === 'backward'
+        const isFetchingPreviousPage =
+          isLoading && fetchDirection === 'backward'
+
+        const hasNextPage = getHasNextPage(
+          infiniteQueryOptions,
+          stateWithRequestFlags.data,
+        )
+        const hasPreviousPage = getHasPreviousPage(
+          infiniteQueryOptions,
+          stateWithRequestFlags.data,
+        )
+
+        return {
+          ...stateWithRequestFlags,
+          hasNextPage,
+          hasPreviousPage,
+          isFetchingNextPage,
+          isFetchingPreviousPage,
+          isFetchNextPageError,
+          isFetchPreviousPageError,
+        }
+      }
+
+      return createSelector(
+        finalSelectQuerySubState,
+        withInfiniteQueryResultFlags,
+      )
     }) as InfiniteQueryResultSelectorFactory<any, RootState>
   }
 
@@ -315,5 +374,21 @@ export function buildSelectors<
           entry.status !== QueryStatus.uninitialized,
       )
       .map((entry) => entry.originalArgs)
+  }
+
+  function getHasNextPage(
+    options: InfiniteQueryConfigOptions<any, any>,
+    data?: InfiniteData<unknown, unknown>,
+  ): boolean {
+    if (!data) return false
+    return getNextPageParam(options, data) != null
+  }
+
+  function getHasPreviousPage(
+    options: InfiniteQueryConfigOptions<any, any>,
+    data?: InfiniteData<unknown, unknown>,
+  ): boolean {
+    if (!data || !options.getPreviousPageParam) return false
+    return getPreviousPageParam(options, data) != null
   }
 }

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -39,6 +39,7 @@ import type {
   InfiniteData,
   InfiniteQueryConfigOptions,
   QueryCacheKey,
+  InfiniteQueryDirection,
 } from './apiState'
 import { QueryStatus } from './apiState'
 import type {
@@ -131,7 +132,7 @@ export type InfiniteQueryThunkArg<
     endpointName: string
     param: unknown
     previous?: boolean
-    direction?: 'forward' | 'backward'
+    direction?: InfiniteQueryDirection
   }
 
 type MutationThunkArg = {

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -647,31 +647,6 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     }
   }
 
-  function getNextPageParam(
-    options: InfiniteQueryConfigOptions<unknown, unknown>,
-    { pages, pageParams }: InfiniteData<unknown, unknown>,
-  ): unknown | undefined {
-    const lastIndex = pages.length - 1
-    return options.getNextPageParam(
-      pages[lastIndex],
-      pages,
-      pageParams[lastIndex],
-      pageParams,
-    )
-  }
-
-  function getPreviousPageParam(
-    options: InfiniteQueryConfigOptions<unknown, unknown>,
-    { pages, pageParams }: InfiniteData<unknown, unknown>,
-  ): unknown | undefined {
-    return options.getPreviousPageParam?.(
-      pages[0],
-      pages,
-      pageParams[0],
-      pageParams,
-    )
-  }
-
   function isForcedQuery(
     arg: QueryThunkArg,
     state: RootState<any, string, ReducerPath>,
@@ -891,6 +866,31 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     patchQueryData,
     buildMatchThunkActions,
   }
+}
+
+export function getNextPageParam(
+  options: InfiniteQueryConfigOptions<unknown, unknown>,
+  { pages, pageParams }: InfiniteData<unknown, unknown>,
+): unknown | undefined {
+  const lastIndex = pages.length - 1
+  return options.getNextPageParam(
+    pages[lastIndex],
+    pages,
+    pageParams[lastIndex],
+    pageParams,
+  )
+}
+
+export function getPreviousPageParam(
+  options: InfiniteQueryConfigOptions<unknown, unknown>,
+  { pages, pageParams }: InfiniteData<unknown, unknown>,
+): unknown | undefined {
+  return options.getPreviousPageParam?.(
+    pages[0],
+    pages,
+    pageParams[0],
+    pageParams,
+  )
 }
 
 export function calculateProvidedByThunk(

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -63,6 +63,7 @@ import { UNINITIALIZED_VALUE } from './constants'
 import type { ReactHooksModuleOptions } from './module'
 import { useStableQueryArgs } from './useSerializedStableValue'
 import { useShallowStableValue } from './useShallowStableValue'
+import { InfiniteQueryDirection } from '../core/apiState'
 
 // Copy-pasted from React-Redux
 const canUseDOM = () =>
@@ -786,7 +787,7 @@ export type LazyInfiniteQueryTrigger<
    */
   (
     arg: QueryArgFrom<D>,
-    direction: 'forward' | 'backward',
+    direction: InfiniteQueryDirection,
   ): InfiniteQueryActionCreatorResult<D>
 }
 

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1768,7 +1768,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         Definitions
       >
       const dispatch = useDispatch<ThunkDispatch<any, any, UnknownAction>>()
-      const subscriptionSelectorsRef = useRef<SubscriptionSelectors>()
+      const subscriptionSelectorsRef = useRef<
+        SubscriptionSelectors | undefined
+      >(undefined)
       if (!subscriptionSelectorsRef.current) {
         const returnedValue = dispatch(
           api.internalActions.internal_getRTKQSubscriptions(),
@@ -1809,7 +1811,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       const lastRenderHadSubscription = useRef(false)
 
-      const promiseRef = useRef<InfiniteQueryActionCreatorResult<any>>()
+      const promiseRef = useRef<
+        InfiniteQueryActionCreatorResult<any> | undefined
+      >(undefined)
 
       let { queryCacheKey, requestId } = promiseRef.current || {}
 
@@ -1933,7 +1937,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       type ApiRootState = Parameters<ReturnType<typeof select>>[0]
 
-      const lastValue = useRef<any>()
+      const lastValue = useRef<any>(undefined)
 
       const selectDefaultResult: Selector<ApiRootState, any, [any]> = useMemo(
         () =>

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -890,7 +890,10 @@ export type UseInfiniteQuery<
   arg: InfiniteQueryArgFrom<D> | SkipToken,
   options?: UseInfiniteQuerySubscriptionOptions<D> &
     UseInfiniteQueryStateOptions<D, R>,
-) => UseInfiniteQueryHookResult<D, R>
+) => UseInfiniteQueryHookResult<D, R> & {
+  fetchNextPage: () => InfiniteQueryActionCreatorResult<D>
+  fetchPreviousPage: () => InfiniteQueryActionCreatorResult<D>
+}
 
 export type UseInfiniteQueryState<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
@@ -898,7 +901,6 @@ export type UseInfiniteQueryState<
   arg: QueryArgFrom<D> | SkipToken,
   options?: UseInfiniteQueryStateOptions<D, R>,
 ) => UseInfiniteQueryStateResult<D, R>
-
 export type TypedUseInfiniteQueryState<
   ResultType,
   QueryArg,
@@ -1040,9 +1042,6 @@ type UseInfiniteQueryStateBaseResult<
   hasPreviousPage: false
   isFetchingNextPage: false
   isFetchingPreviousPage: false
-
-  fetchNextPage: () => Promise<InfiniteQueryActionCreatorResult<D>>
-  fetchPreviousPage: () => Promise<InfiniteQueryActionCreatorResult<D>>
 }
 
 type UseInfiniteQueryStateDefaultResult<
@@ -1347,12 +1346,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     // isSuccess = true when data is present
     const isSuccess = currentState.isSuccess || (isFetching && hasData)
 
-    const isFetchingNextPage =
-      isFetching && currentState.direction === 'forward'
-
-    const isFetchingPreviousPage =
-      isFetching && currentState.direction === 'backward'
-
     return {
       ...currentState,
       data,
@@ -1360,8 +1353,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       isFetching,
       isLoading,
       isSuccess,
-      isFetchingNextPage,
-      isFetchingPreviousPage,
     } as UseInfiniteQueryStateDefaultResult<any>
   }
 

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1782,7 +1782,7 @@ describe('hooks tests', () => {
       )
     })
 
-    test.only('useInfiniteQuery fetchNextPage Trigger', async () => {
+    test('useInfiniteQuery fetchNextPage Trigger', async () => {
       const storeRef = setupApiStore(pokemonApi, undefined, {
         withoutTestLifecycles: true,
       })

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -36,6 +36,7 @@ import type { SyncScreen } from '@testing-library/react-render-stream/pure'
 import { createRenderStream } from '@testing-library/react-render-stream/pure'
 import { HttpResponse, http } from 'msw'
 import { useEffect, useState } from 'react'
+import type { InfiniteQueryResultFlags } from '../core/buildSelectors'
 
 // Just setup a temporary in-memory counter for tests that `getIncrementedAmount`.
 // This can be used to test how many renders happen due to data changes or
@@ -1781,7 +1782,7 @@ describe('hooks tests', () => {
       )
     })
 
-    test('useInfiniteQuery fetchNextPage Trigger', async () => {
+    test.only('useInfiniteQuery fetchNextPage Trigger', async () => {
       const storeRef = setupApiStore(pokemonApi, undefined, {
         withoutTestLifecycles: true,
       })
@@ -1796,6 +1797,26 @@ describe('hooks tests', () => {
         //console.log('queries', queries, storeRef.store.getState().api.queries)
 
         expect(queries).toBe(count)
+      }
+
+      const checkEntryFlags = (
+        arg: string,
+        expectedFlags: Partial<InfiniteQueryResultFlags>,
+      ) => {
+        const selector = pokemonApi.endpoints.getInfinitePokemon.select(arg)
+        const entry = selector(storeRef.store.getState())
+
+        const actualFlags: InfiniteQueryResultFlags = {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          isFetchingNextPage: false,
+          isFetchingPreviousPage: false,
+          isFetchNextPageError: false,
+          isFetchPreviousPageError: false,
+          ...expectedFlags,
+        }
+
+        expect(entry).toMatchObject(actualFlags)
       }
 
       const checkPageRows = (
@@ -1836,30 +1857,64 @@ describe('hooks tests', () => {
 
       const utils = render(<PokemonList />, { wrapper: storeRef.wrapper })
       checkNumQueries(1)
+      checkEntryFlags('fire', {})
       await waitForFetch(true)
       checkNumQueries(1)
       checkPageRows(getCurrentRender().withinDOM, 'fire', [0])
+      checkEntryFlags('fire', {
+        hasNextPage: true,
+      })
 
       fireEvent.click(screen.getByTestId('nextPage'), {})
+      checkEntryFlags('fire', {
+        hasNextPage: true,
+        isFetchingNextPage: true,
+      })
       await waitForFetch()
       checkPageRows(getCurrentRender().withinDOM, 'fire', [0, 1])
+      checkEntryFlags('fire', {
+        hasNextPage: true,
+      })
 
       fireEvent.click(screen.getByTestId('nextPage'))
       await waitForFetch()
       checkPageRows(getCurrentRender().withinDOM, 'fire', [0, 1, 2])
 
       utils.rerender(<PokemonList arg="water" initialPageParam={3} />)
+      checkEntryFlags('water', {})
       await waitForFetch(true)
       checkNumQueries(2)
       checkPageRows(getCurrentRender().withinDOM, 'water', [3])
+      checkEntryFlags('water', {
+        hasNextPage: true,
+        hasPreviousPage: true,
+      })
 
       fireEvent.click(screen.getByTestId('nextPage'))
+      checkEntryFlags('water', {
+        hasNextPage: true,
+        hasPreviousPage: true,
+        isFetchingNextPage: true,
+      })
       await waitForFetch()
       checkPageRows(getCurrentRender().withinDOM, 'water', [3, 4])
+      checkEntryFlags('water', {
+        hasNextPage: true,
+        hasPreviousPage: true,
+      })
 
       fireEvent.click(screen.getByTestId('prevPage'))
+      checkEntryFlags('water', {
+        hasNextPage: true,
+        hasPreviousPage: true,
+        isFetchingPreviousPage: true,
+      })
       await waitForFetch()
       checkPageRows(getCurrentRender().withinDOM, 'water', [2, 3, 4])
+      checkEntryFlags('water', {
+        hasNextPage: true,
+        hasPreviousPage: true,
+      })
     })
   })
 

--- a/packages/toolkit/src/query/tests/infiniteQueries.test.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test.ts
@@ -140,7 +140,7 @@ describe('Infinite queries', () => {
     process.env.NODE_ENV = 'test'
   })
 
-  test.only('Basic infinite query behavior', async () => {
+  test('Basic infinite query behavior', async () => {
     const checkFlags = (
       value: unknown,
       expectedFlags: Partial<InfiniteQueryResultFlags>,


### PR DESCRIPTION
This PR:

- Extracts `'forward' | 'backward'` as `InfiniteQueryDirection`
- Fixes TS issues from the React 19 update after rebase
- Fixes a type mismatch with infinite query endpoint selectors
- Implements the various `has*` and `isFetching*` status flags for infinite query selector results