### PR TITLE
Fix incorrect handling of query parameters with values 0 or empty str…

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -448,7 +448,11 @@ export async function generateApi(
         const encodedValue =
           encodeQueryParams && param.param?.in === 'query'
             ? factory.createConditionalExpression(
-                value,
+                factory.createBinaryExpression(
+                  value,
+                  ts.SyntaxKind.ExclamationEqualsToken,
+                  factory.createNull()
+                ),
                 undefined,
                 factory.createCallExpression(factory.createIdentifier('encodeURIComponent'), undefined, [
                   factory.createCallExpression(factory.createIdentifier('String'), undefined, [value]),

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -242,7 +242,7 @@ describe('option encodeQueryParams', () => {
     });
 
     expect(api).toMatch(
-      /params:\s*{\s*\n\s*status:\s*queryArg\.status\s*\?\s*encodeURIComponent\(\s*String\(queryArg\.status\)\s*\)\s*:\s*undefined\s*,?\s*\n\s*}/s
+      /params:\s*{\s*\n\s*status:\s*queryArg\.status\s*!=\s*null\s*\?\s*encodeURIComponent\(\s*String\(queryArg\.status\)\s*\)\s*:\s*undefined\s*,?\s*\n\s*}/s
     );
   });
 


### PR DESCRIPTION
fixes #4781

The generated code in RTK Query's CodeGeneration is modified as follows when `encodeQueryParams` is set to `true`:

Before:
```ts
queryArg.status
  ? encodeURIComponent(String(queryArg.status))
  : undefined,
```

After:
```ts
queryArg.status != null
  ? encodeURIComponent(String(queryArg.status))
  : undefined,
```