### PR TITLE
Fix updateQueryData for infinite queries

### DIFF
--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -154,6 +154,19 @@ export type QueryKeys<Definitions extends EndpointDefinitions> = {
     ? K
     : never
 }[keyof Definitions]
+
+export type InfiniteQueryKeys<Definitions extends EndpointDefinitions> = {
+  [K in keyof Definitions]: Definitions[K] extends InfiniteQueryDefinition<
+    any,
+    any,
+    any,
+    any,
+    any
+  >
+    ? K
+    : never
+}[keyof Definitions]
+
 export type MutationKeys<Definitions extends EndpointDefinitions> = {
   [K in keyof Definitions]: Definitions[K] extends MutationDefinition<
     any,

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -121,7 +121,7 @@ export type QueryActionCreatorResult<
 export type InfiniteQueryActionCreatorResult<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
 > = Promise<InfiniteQueryResultSelectorResult<D>> & {
-  arg: QueryArgFrom<D>
+  arg: InfiniteQueryArgFrom<D>
   requestId: string
   subscriptionOptions: SubscriptionOptions | undefined
   abort(): void

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -344,7 +344,7 @@ export const buildCacheLifecycleHandler: InternalHandlerBuilder = ({
             mwApi.dispatch(
               api.util.updateQueryData(
                 endpointName as never,
-                originalArgs,
+                originalArgs as never,
                 updateRecipe,
               ),
             )

--- a/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -476,7 +476,7 @@ export const buildQueryLifecycleHandler: InternalHandlerBuilder = ({
                 mwApi.dispatch(
                   api.util.updateQueryData(
                     endpointName as never,
-                    originalArgs,
+                    originalArgs as never,
                     updateRecipe,
                   ),
                 )

--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -29,6 +29,9 @@ import type {
 } from './apiState'
 import { QueryStatus } from './apiState'
 import type {
+  AllQueryKeys,
+  QueryArgFromAnyQueryDefinition,
+  DataFromAnyQueryDefinition,
   InfiniteQueryThunk,
   MutationThunk,
   QueryThunk,
@@ -64,11 +67,11 @@ import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
  */
 export type NormalizedQueryUpsertEntry<
   Definitions extends EndpointDefinitions,
-  EndpointName extends QueryKeys<Definitions>,
+  EndpointName extends AllQueryKeys<Definitions>,
 > = {
   endpointName: EndpointName
-  arg: QueryArgFrom<Definitions[EndpointName]>
-  value: ResultTypeFrom<Definitions[EndpointName]>
+  arg: QueryArgFromAnyQueryDefinition<Definitions, EndpointName>
+  value: DataFromAnyQueryDefinition<Definitions, EndpointName>
 }
 
 /**
@@ -89,7 +92,7 @@ export type ProcessedQueryUpsertEntry = {
  * A typesafe representation of a util action creator that accepts cache entry descriptions to upsert
  */
 export type UpsertEntries<Definitions extends EndpointDefinitions> = (<
-  EndpointNames extends Array<QueryKeys<Definitions>>,
+  EndpointNames extends Array<AllQueryKeys<Definitions>>,
 >(
   entries: [
     ...{

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -6,6 +6,7 @@ import type {
   ThunkDispatch,
   UnknownAction,
 } from '@reduxjs/toolkit'
+import util from 'util'
 import type { Patch } from 'immer'
 import { isDraftable, produceWithPatches } from 'immer'
 import type { Api, ApiContext } from '../apiTypes'
@@ -198,11 +199,11 @@ export type PatchQueryDataThunk<
   updateProvided?: boolean,
 ) => ThunkAction<void, PartialState, any, UnknownAction>
 
-type AllQueryKeys<Definitions extends EndpointDefinitions> =
+export type AllQueryKeys<Definitions extends EndpointDefinitions> =
   | QueryKeys<Definitions>
   | InfiniteQueryKeys<Definitions>
 
-type QueryArgFromAnyQueryDefinition<
+export type QueryArgFromAnyQueryDefinition<
   Definitions extends EndpointDefinitions,
   EndpointName extends AllQueryKeys<Definitions>,
 > =
@@ -218,7 +219,7 @@ type QueryArgFromAnyQueryDefinition<
       ? QueryArgFrom<Definitions[EndpointName]>
       : never
 
-type DataFromAnyQueryDefinition<
+export type DataFromAnyQueryDefinition<
   Definitions extends EndpointDefinitions,
   EndpointName extends AllQueryKeys<Definitions>,
 > =
@@ -237,7 +238,7 @@ type DataFromAnyQueryDefinition<
       ? ResultTypeFrom<Definitions[EndpointName]>
       : unknown
 
-type UpsertThunkResult<
+export type UpsertThunkResult<
   Definitions extends EndpointDefinitions,
   EndpointName extends AllQueryKeys<Definitions>,
 > =

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -19,8 +19,10 @@ import type {
   AssertTagTypes,
   EndpointDefinition,
   EndpointDefinitions,
+  InfiniteQueryArgFrom,
   InfiniteQueryDefinition,
   MutationDefinition,
+  PageParamFrom,
   QueryArgFrom,
   QueryDefinition,
   ResultTypeFrom,
@@ -40,6 +42,7 @@ import type {
   InfiniteQueryConfigOptions,
   QueryCacheKey,
   InfiniteQueryDirection,
+  InfiniteQueryKeys,
 } from './apiState'
 import { QueryStatus } from './apiState'
 import type {
@@ -194,13 +197,39 @@ export type PatchQueryDataThunk<
   updateProvided?: boolean,
 ) => ThunkAction<void, PartialState, any, UnknownAction>
 
+type AllQueryKeys<Definitions extends EndpointDefinitions> =
+  | QueryKeys<Definitions>
+  | InfiniteQueryKeys<Definitions>
+
 export type UpdateQueryDataThunk<
   Definitions extends EndpointDefinitions,
   PartialState,
-> = <EndpointName extends QueryKeys<Definitions>>(
+> = <EndpointName extends AllQueryKeys<Definitions>>(
   endpointName: EndpointName,
-  arg: QueryArgFrom<Definitions[EndpointName]>,
-  updateRecipe: Recipe<ResultTypeFrom<Definitions[EndpointName]>>,
+  // TODO Find a way to deduplicate this ugly conditional type
+  arg: Definitions[EndpointName] extends InfiniteQueryDefinition<
+    any,
+    any,
+    any,
+    any,
+    any
+  >
+    ? InfiniteQueryArgFrom<Definitions[EndpointName]>
+    : QueryArgFrom<Definitions[EndpointName]>,
+  updateRecipe: Recipe<
+    Definitions[EndpointName] extends InfiniteQueryDefinition<
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+      ? InfiniteData<
+          ResultTypeFrom<Definitions[EndpointName]>,
+          PageParamFrom<Definitions[EndpointName]>
+        >
+      : ResultTypeFrom<Definitions[EndpointName]>
+  >,
   updateProvided?: boolean,
 ) => ThunkAction<PatchCollection, PartialState, any, UnknownAction>
 

--- a/packages/toolkit/src/query/tests/infiniteQueries.test.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test.ts
@@ -523,14 +523,14 @@ describe('Infinite queries', () => {
     )
 
     const res1 = storeRef.store.dispatch(
-      pokemonApi.endpoints.getInfinitePokemon.initiate('fire', {}),
+      pokemonApiWithRefetch.endpoints.getInfinitePokemon.initiate('fire', {}),
     )
 
     const entry1InitialLoad = await res1
     checkResultData(entry1InitialLoad, [[{ id: '0', name: 'Pokemon 0' }]])
 
     const res2 = storeRef.store.dispatch(
-      pokemonApi.endpoints.getInfinitePokemon.initiate('fire', {
+      pokemonApiWithRefetch.endpoints.getInfinitePokemon.initiate('fire', {
         direction: 'forward',
       }),
     )
@@ -540,5 +540,33 @@ describe('Infinite queries', () => {
       [{ id: '0', name: 'Pokemon 0' }],
       [{ id: '1', name: 'Pokemon 1' }],
     ])
+  })
+
+  test('Works with cache manipulation utils', async () => {
+    const res1 = storeRef.store.dispatch(
+      pokemonApi.endpoints.getInfinitePokemon.initiate('fire', {}),
+    )
+
+    const entry1InitialLoad = await res1
+    checkResultData(entry1InitialLoad, [[{ id: '0', name: 'Pokemon 0' }]])
+
+    storeRef.store.dispatch(
+      pokemonApi.util.updateQueryData('getInfinitePokemon', 'fire', (draft) => {
+        draft.pages.push([{ id: '1', name: 'Pokemon 1' }])
+        draft.pageParams.push(1)
+      }),
+    )
+
+    const entry1Updated = pokemonApi.endpoints.getInfinitePokemon.select(
+      'fire',
+    )(storeRef.store.getState())
+
+    expect(entry1Updated.data).toEqual({
+      pages: [
+        [{ id: '0', name: 'Pokemon 0' }],
+        [{ id: '1', name: 'Pokemon 1' }],
+      ],
+      pageParams: [0, 1],
+    })
   })
 })

--- a/packages/toolkit/src/query/tests/infiniteQueries.test.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test.ts
@@ -557,9 +557,8 @@ describe('Infinite queries', () => {
       }),
     )
 
-    const entry1Updated = pokemonApi.endpoints.getInfinitePokemon.select(
-      'fire',
-    )(storeRef.store.getState())
+    const selectFire = pokemonApi.endpoints.getInfinitePokemon.select('fire')
+    const entry1Updated = selectFire(storeRef.store.getState())
 
     expect(entry1Updated.data).toEqual({
       pages: [
@@ -577,18 +576,49 @@ describe('Infinite queries', () => {
     )
 
     const entry2InitialLoad = await res2
-    const entry2Updated = pokemonApi.endpoints.getInfinitePokemon.select(
-      'water',
-    )(storeRef.store.getState())
-
-    console.log(
-      'entry2Updated',
-      util.inspect(entry2Updated, { depth: Infinity }),
-    )
+    const selectWater = pokemonApi.endpoints.getInfinitePokemon.select('water')
+    const entry2Updated = selectWater(storeRef.store.getState())
 
     expect(entry2Updated.data).toEqual({
       pages: [[{ id: '2', name: 'Pokemon 2' }]],
       pageParams: [2],
+    })
+
+    storeRef.store.dispatch(
+      pokemonApi.util.upsertQueryEntries([
+        {
+          endpointName: 'getInfinitePokemon',
+          arg: 'air',
+          value: {
+            pages: [[{ id: '3', name: 'Pokemon 3' }]],
+            pageParams: [3],
+          },
+        },
+      ]),
+    )
+
+    const selectAir = pokemonApi.endpoints.getInfinitePokemon.select('air')
+    const entry3Initial = selectAir(storeRef.store.getState())
+
+    expect(entry3Initial.data).toEqual({
+      pages: [[{ id: '3', name: 'Pokemon 3' }]],
+      pageParams: [3],
+    })
+
+    await storeRef.store.dispatch(
+      pokemonApi.endpoints.getInfinitePokemon.initiate('air', {
+        direction: 'forward',
+      }),
+    )
+
+    const entry3Updated = selectAir(storeRef.store.getState())
+
+    expect(entry3Updated.data).toEqual({
+      pages: [
+        [{ id: '3', name: 'Pokemon 3' }],
+        [{ id: '4', name: 'Pokemon 4' }],
+      ],
+      pageParams: [3, 4],
     })
   })
 })

--- a/packages/toolkit/src/query/tests/infiniteQueries.test.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test.ts
@@ -568,5 +568,27 @@ describe('Infinite queries', () => {
       ],
       pageParams: [0, 1],
     })
+
+    const res2 = storeRef.store.dispatch(
+      pokemonApi.util.upsertQueryData('getInfinitePokemon', 'water', {
+        pages: [[{ id: '2', name: 'Pokemon 2' }]],
+        pageParams: [2],
+      }),
+    )
+
+    const entry2InitialLoad = await res2
+    const entry2Updated = pokemonApi.endpoints.getInfinitePokemon.select(
+      'water',
+    )(storeRef.store.getState())
+
+    console.log(
+      'entry2Updated',
+      util.inspect(entry2Updated, { depth: Infinity }),
+    )
+
+    expect(entry2Updated.data).toEqual({
+      pages: [[{ id: '2', name: 'Pokemon 2' }]],
+      pageParams: [2],
+    })
   })
 })


### PR DESCRIPTION
This PR:

- Updates `upsertQueryData` / `updateQueryData` / `upsertQueryEntries` to work with infinite queries at both the types and runtime level