### PR TITLE
Add types for autogenerated infinite query hooks

### DIFF
--- a/packages/toolkit/src/query/react/namedHooks.ts
+++ b/packages/toolkit/src/query/react/namedHooks.ts
@@ -3,8 +3,14 @@ import type {
   EndpointDefinitions,
   MutationDefinition,
   QueryDefinition,
+  InfiniteQueryDefinition,
 } from '@reduxjs/toolkit/query'
-import type { UseLazyQuery, UseMutation, UseQuery } from './buildHooks'
+import type {
+  UseInfiniteQuery,
+  UseLazyQuery,
+  UseMutation,
+  UseQuery,
+} from './buildHooks'
 
 type QueryHookNames<Definitions extends EndpointDefinitions> = {
   [K in keyof Definitions as Definitions[K] extends {
@@ -26,6 +32,16 @@ type LazyQueryHookNames<Definitions extends EndpointDefinitions> = {
   >
 }
 
+type InfiniteQueryHookNames<Definitions extends EndpointDefinitions> = {
+  [K in keyof Definitions as Definitions[K] extends {
+    type: DefinitionType.infinitequery
+  }
+    ? `use${Capitalize<K & string>}InfiniteQuery`
+    : never]: UseInfiniteQuery<
+    Extract<Definitions[K], InfiniteQueryDefinition<any, any, any, any, any>>
+  >
+}
+
 type MutationHookNames<Definitions extends EndpointDefinitions> = {
   [K in keyof Definitions as Definitions[K] extends {
     type: DefinitionType.mutation
@@ -39,4 +55,5 @@ type MutationHookNames<Definitions extends EndpointDefinitions> = {
 export type HooksWithUniqueNames<Definitions extends EndpointDefinitions> =
   QueryHookNames<Definitions> &
     LazyQueryHookNames<Definitions> &
+    InfiniteQueryHookNames<Definitions> &
     MutationHookNames<Definitions>

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1764,7 +1764,7 @@ describe('hooks tests', () => {
         isUninitialized,
         fetchNextPage,
         fetchPreviousPage,
-      } = api.endpoints.getInfinitePokemon.useInfiniteQuery(arg, {
+      } = api.useGetInfinitePokemonInfiniteQuery(arg, {
         initialPageParam,
       })
 

--- a/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
@@ -53,6 +53,8 @@ describe('Infinite queries', () => {
       .parameter(0)
       .toBeString()
 
+    expectTypeOf(pokemonApi.useGetInfinitePokemonInfiniteQuery).toBeFunction()
+
     const res = storeRef.store.dispatch(
       pokemonApi.endpoints.getInfinitePokemon.initiate('fire', {}),
     )


### PR DESCRIPTION
This PR:

- Updates the TS types for autogenerated root-level hook fields to include the infinite query hooks

The integration PR was already generating the fields at runtime, just had to add the types.