### PR TITLE
Byte-shave and deduplicate infinite query implementation

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'feature/infinite-query-integration'
 permissions:
   pull-requests: write
 jobs:

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -98,7 +98,7 @@ type StartQueryActionCreator<
 
 // placeholder type which
 // may attempt to derive the list of args to query in pagination
-type StartInfiniteQueryActionCreator<
+export type StartInfiniteQueryActionCreator<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
 > = (
   arg: InfiniteQueryArgFrom<D>,

--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -76,11 +76,11 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
   function hasPendingRequests(
     state: CombinedState<EndpointDefinitions, string, string>,
   ) {
-    for (const key in state.queries) {
-      if (state.queries[key]?.status === QueryStatus.pending) return true
-    }
-    for (const key in state.mutations) {
-      if (state.mutations[key]?.status === QueryStatus.pending) return true
+    const { queries, mutations } = state
+    for (const cacheRecord of [queries, mutations]) {
+      for (const key in cacheRecord) {
+        if (cacheRecord[key]?.status === QueryStatus.pending) return true
+      }
     }
     return false
   }

--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -1,4 +1,8 @@
-import type { QuerySubstateIdentifier, Subscribers } from '../apiState'
+import type {
+  QueryCacheKey,
+  QuerySubstateIdentifier,
+  Subscribers,
+} from '../apiState'
 import { QueryStatus } from '../apiState'
 import type {
   QueryStateMeta,
@@ -47,6 +51,20 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
     if (api.util.resetApiState.match(action)) {
       clearPolls()
     }
+  }
+
+  function getCacheEntrySubscriptions(
+    queryCacheKey: QueryCacheKey,
+    api: SubMiddlewareApi,
+  ) {
+    const state = api.getState()[reducerPath]
+    const querySubState = state.queries[queryCacheKey]
+    const subscriptions = internalState.currentSubscriptions[queryCacheKey]
+
+    if (!querySubState || querySubState.status === QueryStatus.uninitialized)
+      return
+
+    return subscriptions
   }
 
   function startNextPoll(

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -26,6 +26,7 @@ import type {
   ThunkResult,
 } from '../buildThunks'
 import type { QueryActionCreatorResult } from '../buildInitiate'
+import type { AllSelectors } from '../buildSelectors'
 
 export type QueryStateMeta<T> = Record<string, undefined | T>
 export type TimeoutId = ReturnType<typeof setTimeout>
@@ -52,6 +53,7 @@ export interface BuildMiddlewareInput<
   infiniteQueryThunk: InfiniteQueryThunk<any>
   api: Api<any, Definitions, ReducerPath, TagTypes>
   assertTagType: AssertTagTypes
+  selectors: AllSelectors
 }
 
 export type SubMiddlewareApi = MiddlewareAPI<
@@ -69,6 +71,7 @@ export interface BuildSubMiddlewareInput
     >,
   ): ThunkAction<QueryActionCreatorResult<any>, any, any, UnknownAction>
   isThisApiSliceAction: (action: Action) => boolean
+  selectors: AllSelectors
 }
 
 export type SubMiddlewareBuilder = (

--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -238,6 +238,11 @@ export function buildSelectors<
     ) => T & RequestStatusFlags,
   ) {
     return (queryArgs: any) => {
+      // Avoid calling serializeQueryArgs if the arg is skipToken
+      if (queryArgs === skipToken) {
+        return createSelector(selectSkippedQuery, combiner)
+      }
+
       const serializedArgs = serializeQueryArgs({
         queryArgs,
         endpointDefinition,
@@ -245,10 +250,8 @@ export function buildSelectors<
       })
       const selectQuerySubstate = (state: RootState) =>
         selectQueryEntry(state, serializedArgs) ?? defaultQuerySubState
-      const finalSelectQuerySubState =
-        queryArgs === skipToken ? selectSkippedQuery : selectQuerySubstate
 
-      return createSelector(finalSelectQuerySubState, combiner)
+      return createSelector(selectQuerySubstate, combiner)
     }
   }
 

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -462,9 +462,9 @@ export function buildThunks<
   const getTransformCallbackForEndpoint = (
     endpointDefinition: EndpointDefinition<any, any, any, any>,
     transformFieldName: 'transformResponse' | 'transformErrorResponse',
-  ) => {
+  ): TransformCallback => {
     return endpointDefinition.query && endpointDefinition[transformFieldName]
-      ? endpointDefinition[transformFieldName]
+      ? endpointDefinition[transformFieldName]!
       : defaultTransformResponse
   }
 

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -6,7 +6,6 @@ import type {
   ThunkDispatch,
   UnknownAction,
 } from '@reduxjs/toolkit'
-import util from 'util'
 import type { Patch } from 'immer'
 import { isDraftable, produceWithPatches } from 'immer'
 import type { Api, ApiContext } from '../apiTypes'
@@ -297,6 +296,21 @@ export type PatchCollection = {
   undo: () => void
 }
 
+type TransformCallback = (
+  baseQueryReturnValue: unknown,
+  meta: unknown,
+  arg: unknown,
+) => any
+
+export const addShouldAutoBatch = <T extends Record<string, any>>(
+  arg: T = {} as T,
+): T & { [SHOULD_AUTOBATCH]: true } => {
+  return {
+    ...arg,
+    [SHOULD_AUTOBATCH]: true,
+  }
+}
+
 export function buildThunks<
   BaseQuery extends BaseQueryFn,
   ReducerPath extends string,
@@ -446,6 +460,15 @@ export function buildThunks<
       return res
     }
 
+  const getTransformCallbackForEndpoint = (
+    endpointDefinition: EndpointDefinition<any, any, any, any>,
+    transformFieldName: 'transformResponse' | 'transformErrorResponse',
+  ) => {
+    return endpointDefinition.query && endpointDefinition[transformFieldName]
+      ? endpointDefinition[transformFieldName]
+      : defaultTransformResponse
+  }
+
   // The generic async payload function for all of our thunks
   const executeEndpoint: AsyncThunkPayloadCreator<
     ThunkResult,
@@ -466,14 +489,8 @@ export function buildThunks<
     const endpointDefinition = endpointDefinitions[arg.endpointName]
 
     try {
-      let transformResponse: (
-        baseQueryReturnValue: any,
-        meta: any,
-        arg: any,
-      ) => any =
-        endpointDefinition.query && endpointDefinition.transformResponse
-          ? endpointDefinition.transformResponse
-          : defaultTransformResponse
+      let transformResponse: TransformCallback =
+        getTransformCallbackForEndpoint(endpointDefinition, 'transformResponse')
 
       const baseQueryApi = {
         signal,
@@ -509,7 +526,6 @@ export function buildThunks<
 
         const pageResponse = await executeRequest(param)
 
-        // TODO Get maxPages from endpoint config
         const addTo = previous ? addToStart : addToEnd
 
         return {
@@ -526,6 +542,7 @@ export function buildThunks<
         finalQueryArg: unknown,
       ): Promise<QueryReturnValue> {
         let result: QueryReturnValue
+        const { extraOptions } = endpointDefinition
 
         if (forceQueryFn) {
           // upsertQueryData relies on this to pass in the user-provided value
@@ -534,19 +551,14 @@ export function buildThunks<
           result = await baseQuery(
             endpointDefinition.query(finalQueryArg),
             baseQueryApi,
-            endpointDefinition.extraOptions as any,
+            extraOptions as any,
           )
         } else {
           result = await endpointDefinition.queryFn(
             finalQueryArg,
             baseQueryApi,
-            endpointDefinition.extraOptions as any,
-            (arg) =>
-              baseQuery(
-                arg,
-                baseQueryApi,
-                endpointDefinition.extraOptions as any,
-              ),
+            extraOptions as any,
+            (arg) => baseQuery(arg, baseQueryApi, extraOptions as any),
           )
         }
 
@@ -657,7 +669,7 @@ export function buildThunks<
           // Fetch remaining pages
           for (let i = 1; i < totalPages; i++) {
             const param = getNextPageParam(
-              endpointDefinition.infiniteQueryOptions,
+              infiniteQueryOptions,
               result.data as InfiniteData<unknown, unknown>,
             )
             result = await fetchPage(
@@ -675,22 +687,21 @@ export function buildThunks<
       }
 
       // console.log('Final result: ', transformedData)
-      return fulfillWithValue(finalQueryReturnValue.data, {
-        fulfilledTimeStamp: Date.now(),
-        baseQueryMeta: finalQueryReturnValue.meta,
-        [SHOULD_AUTOBATCH]: true,
-      })
+      return fulfillWithValue(
+        finalQueryReturnValue.data,
+        addShouldAutoBatch({
+          fulfilledTimeStamp: Date.now(),
+          baseQueryMeta: finalQueryReturnValue.meta,
+        }),
+      )
     } catch (error) {
       let catchedError = error
       if (catchedError instanceof HandledError) {
-        let transformErrorResponse: (
-          baseQueryReturnValue: any,
-          meta: any,
-          arg: any,
-        ) => any =
-          endpointDefinition.query && endpointDefinition.transformErrorResponse
-            ? endpointDefinition.transformErrorResponse
-            : defaultTransformResponse
+        let transformErrorResponse: TransformCallback =
+          getTransformCallbackForEndpoint(
+            endpointDefinition,
+            'transformErrorResponse',
+          )
 
         try {
           return rejectWithValue(
@@ -699,7 +710,7 @@ export function buildThunks<
               catchedError.meta,
               arg.originalArgs,
             ),
-            { baseQueryMeta: catchedError.meta, [SHOULD_AUTOBATCH]: true },
+            addShouldAutoBatch({ baseQueryMeta: catchedError.meta }),
           )
         } catch (e) {
           catchedError = e
@@ -743,116 +754,84 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     return false
   }
 
-  const queryThunk = createAsyncThunk<
-    ThunkResult,
-    QueryThunkArg,
-    ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
-  >(`${reducerPath}/executeQuery`, executeEndpoint, {
-    getPendingMeta() {
-      return { startedTimeStamp: Date.now(), [SHOULD_AUTOBATCH]: true }
-    },
-    condition(queryThunkArgs, { getState }) {
-      const state = getState()
-
-      const requestState =
-        state[reducerPath]?.queries?.[queryThunkArgs.queryCacheKey]
-      const fulfilledVal = requestState?.fulfilledTimeStamp
-      const currentArg = queryThunkArgs.originalArgs
-      const previousArg = requestState?.originalArgs
-      const endpointDefinition =
-        endpointDefinitions[queryThunkArgs.endpointName]
-
-      // Order of these checks matters.
-      // In order for `upsertQueryData` to successfully run while an existing request is in flight,
-      /// we have to check for that first, otherwise `queryThunk` will bail out and not run at all.
-      if (isUpsertQuery(queryThunkArgs)) {
-        return true
-      }
-
-      // Don't retry a request that's currently in-flight
-      if (requestState?.status === 'pending') {
-        return false
-      }
-
-      // if this is forced, continue
-      if (isForcedQuery(queryThunkArgs, state)) {
-        return true
-      }
-
-      if (
-        isQueryDefinition(endpointDefinition) &&
-        endpointDefinition?.forceRefetch?.({
-          currentArg,
-          previousArg,
-          endpointState: requestState,
-          state,
+  const createQueryThunk = <
+    ThunkArgType extends QueryThunkArg | InfiniteQueryThunkArg<any>,
+  >() => {
+    const generatedQueryThunk = createAsyncThunk<
+      ThunkResult,
+      ThunkArgType,
+      ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
+    >(`${reducerPath}/executeQuery`, executeEndpoint, {
+      getPendingMeta({ arg }) {
+        const endpointDefinition = endpointDefinitions[arg.endpointName]
+        return addShouldAutoBatch({
+          startedTimeStamp: Date.now(),
+          ...(isInfiniteQueryDefinition(endpointDefinition)
+            ? {
+                direction: (arg as InfiniteQueryThunkArg<any>).direction,
+              }
+            : {}),
         })
-      ) {
+      },
+      condition(queryThunkArg, { getState }) {
+        const state = getState()
+
+        const requestState = selectors.selectQueryEntry(
+          state,
+          queryThunkArg.queryCacheKey,
+        )
+        const fulfilledVal = requestState?.fulfilledTimeStamp
+        const currentArg = queryThunkArg.originalArgs
+        const previousArg = requestState?.originalArgs
+        const endpointDefinition =
+          endpointDefinitions[queryThunkArg.endpointName]
+        const direction = (queryThunkArg as InfiniteQueryThunkArg<any>)
+          .direction
+
+        // Order of these checks matters.
+        // In order for `upsertQueryData` to successfully run while an existing request is in flight,
+        /// we have to check for that first, otherwise `queryThunk` will bail out and not run at all.
+        if (isUpsertQuery(queryThunkArg)) {
+          return true
+        }
+
+        // Don't retry a request that's currently in-flight
+        if (requestState?.status === 'pending') {
+          return false
+        }
+
+        // if this is forced, continue
+        if (isForcedQuery(queryThunkArg, state)) {
+          return true
+        }
+
+        if (
+          isQueryDefinition(endpointDefinition) &&
+          endpointDefinition?.forceRefetch?.({
+            currentArg,
+            previousArg,
+            endpointState: requestState,
+            state,
+          })
+        ) {
+          return true
+        }
+
+        // Pull from the cache unless we explicitly force refetch or qualify based on time
+        if (fulfilledVal && !direction) {
+          // Value is cached and we didn't specify to refresh, skip it.
+          return false
+        }
+
         return true
-      }
+      },
+      dispatchConditionRejection: true,
+    })
+    return generatedQueryThunk
+  }
 
-      // Pull from the cache unless we explicitly force refetch or qualify based on time
-      if (fulfilledVal) {
-        // Value is cached and we didn't specify to refresh, skip it.
-        return false
-      }
-
-      return true
-    },
-    dispatchConditionRejection: true,
-  })
-
-  const infiniteQueryThunk = createAsyncThunk<
-    ThunkResult,
-    InfiniteQueryThunkArg<any>,
-    ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
-  >(`${reducerPath}/executeQuery`, executeEndpoint, {
-    getPendingMeta(queryThunkArgs) {
-      return {
-        startedTimeStamp: Date.now(),
-        [SHOULD_AUTOBATCH]: true,
-        direction: queryThunkArgs.arg.direction,
-      }
-    },
-    condition(queryThunkArgs, { getState }) {
-      const state = getState()
-
-      const requestState =
-        state[reducerPath]?.queries?.[queryThunkArgs.queryCacheKey]
-      const fulfilledVal = requestState?.fulfilledTimeStamp
-      const currentArg = queryThunkArgs.originalArgs
-      const previousArg = requestState?.originalArgs
-      const endpointDefinition =
-        endpointDefinitions[queryThunkArgs.endpointName]
-      const direction = queryThunkArgs.direction
-
-      // Order of these checks matters.
-      // In order for `upsertQueryData` to successfully run while an existing request is in flight,
-      /// we have to check for that first, otherwise `queryThunk` will bail out and not run at all.
-      // if (isUpsertQuery(queryThunkArgs)) {
-      //   return true
-      // }
-
-      // Don't retry a request that's currently in-flight
-      if (requestState?.status === 'pending') {
-        return false
-      }
-
-      // if this is forced, continue
-      if (isForcedQuery(queryThunkArgs, state)) {
-        return true
-      }
-
-      // Pull from the cache unless we explicitly force refetch or qualify based on time
-      if (fulfilledVal && !direction) {
-        // Value is cached and we didn't specify to refresh, skip it.
-        return false
-      }
-
-      return true
-    },
-    dispatchConditionRejection: true,
-  })
+  const queryThunk = createQueryThunk<QueryThunkArg>()
+  const infiniteQueryThunk = createQueryThunk<InfiniteQueryThunkArg<any>>()
 
   const mutationThunk = createAsyncThunk<
     ThunkResult,
@@ -860,7 +839,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeMutation`, executeEndpoint, {
     getPendingMeta() {
-      return { startedTimeStamp: Date.now(), [SHOULD_AUTOBATCH]: true }
+      return addShouldAutoBatch({ startedTimeStamp: Date.now() })
     },
   })
 

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -136,7 +136,6 @@ export type InfiniteQueryThunkArg<
     originalArgs: unknown
     endpointName: string
     param: unknown
-    previous?: boolean
     direction?: InfiniteQueryDirection
   }
 

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -546,6 +546,22 @@ export const coreModule = ({
       util: {},
     })
 
+    const selectors = buildSelectors({
+      serializeQueryArgs: serializeQueryArgs as any,
+      reducerPath,
+      createSelector,
+    })
+
+    const {
+      selectInvalidatedBy,
+      selectCachedArgsForQuery,
+      buildQuerySelector,
+      buildInfiniteQuerySelector,
+      buildMutationSelector,
+    } = selectors
+
+    safeAssign(api.util, { selectInvalidatedBy, selectCachedArgsForQuery })
+
     const {
       queryThunk,
       infiniteQueryThunk,
@@ -604,20 +620,6 @@ export const coreModule = ({
     safeAssign(api.util, middlewareActions)
 
     safeAssign(api, { reducer: reducer as any, middleware })
-
-    const {
-      buildQuerySelector,
-      buildInfiniteQuerySelector,
-      buildMutationSelector,
-      selectInvalidatedBy,
-      selectCachedArgsForQuery,
-    } = buildSelectors({
-      serializeQueryArgs: serializeQueryArgs as any,
-      reducerPath,
-      createSelector,
-    })
-
-    safeAssign(api.util, { selectInvalidatedBy, selectCachedArgsForQuery })
 
     const {
       buildInitiateQuery,

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -578,6 +578,7 @@ export const coreModule = ({
       api,
       serializeQueryArgs,
       assertTagType,
+      selectors,
     })
 
     const { reducer, actions: sliceActions } = buildSlice({
@@ -616,6 +617,7 @@ export const coreModule = ({
       infiniteQueryThunk,
       api,
       assertTagType,
+      selectors,
     })
     safeAssign(api.util, middlewareActions)
 

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -657,10 +657,11 @@ export const coreModule = ({
           string,
           CoreModule
         >
-        anyApi.endpoints[endpointName] ??= {} as any
+        const endpoint = (anyApi.endpoints[endpointName] ??= {} as any)
+
         if (isQueryDefinition(definition)) {
           safeAssign(
-            anyApi.endpoints[endpointName],
+            endpoint,
             {
               name: endpointName,
               select: buildQuerySelector(endpointName, definition),
@@ -671,7 +672,7 @@ export const coreModule = ({
         }
         if (isMutationDefinition(definition)) {
           safeAssign(
-            anyApi.endpoints[endpointName],
+            endpoint,
             {
               name: endpointName,
               select: buildMutationSelector(),
@@ -682,7 +683,7 @@ export const coreModule = ({
         }
         if (isInfiniteQueryDefinition(definition)) {
           safeAssign(
-            anyApi.endpoints[endpointName],
+            endpoint,
             {
               name: endpointName,
               select: buildInfiniteQuerySelector(endpointName, definition),

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1211,6 +1211,23 @@ const noPendingQueryStateSelector: QueryStateSelector<any, any> = (
   return selected
 }
 
+function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {
+  const ret: any = {}
+  keys.forEach((key) => {
+    ret[key] = obj[key]
+  })
+  return ret
+}
+
+const COMMON_HOOK_DEBUG_FIELDS = [
+  'data',
+  'status',
+  'isLoading',
+  'isSuccess',
+  'isError',
+  'error',
+] as const
+
 type GenericPrefetchThunk = (
   endpointName: any,
   arg: any,
@@ -1760,9 +1777,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           ...options,
         })
 
-        const { data, status, isLoading, isSuccess, isError, error } =
-          queryStateResults
-        useDebugValue({ data, status, isLoading, isSuccess, isError, error })
+        const debugValue = pick(queryStateResults, ...COMMON_HOOK_DEBUG_FIELDS)
+        useDebugValue(debugValue)
 
         return useMemo(
           () => ({ ...queryStateResults, ...querySubscriptionResults }),
@@ -2060,26 +2076,13 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           ...options,
         })
 
-        const {
-          data,
-          status,
-          isLoading,
-          isSuccess,
-          isError,
-          error,
-          hasNextPage,
-          hasPreviousPage,
-        } = queryStateResults
-        useDebugValue({
-          data,
-          status,
-          isLoading,
-          isSuccess,
-          isError,
-          error,
-          hasNextPage,
-          hasPreviousPage,
-        })
+        const debugValue = pick(
+          queryStateResults,
+          ...COMMON_HOOK_DEBUG_FIELDS,
+          'hasNextPage',
+          'hasPreviousPage',
+        )
+        useDebugValue(debugValue)
 
         return useMemo(
           () => ({
@@ -2153,24 +2156,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         })
       }, [dispatch, fixedCacheKey, promise, requestId])
 
-      const {
-        endpointName,
-        data,
-        status,
-        isLoading,
-        isSuccess,
-        isError,
-        error,
-      } = currentState
-      useDebugValue({
-        endpointName,
-        data,
-        status,
-        isLoading,
-        isSuccess,
-        isError,
-        error,
-      })
+      const debugValue = pick(
+        currentState,
+        ...COMMON_HOOK_DEBUG_FIELDS,
+        'endpointName',
+      )
+      useDebugValue(debugValue)
 
       const finalState = useMemo(
         () => ({ ...currentState, originalArgs, reset }),

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -65,10 +65,7 @@ import { useStableQueryArgs } from './useSerializedStableValue'
 import { useShallowStableValue } from './useShallowStableValue'
 import type { InfiniteQueryDirection } from '../core/apiState'
 import { isInfiniteQueryDefinition } from '../endpointDefinitions'
-import {
-  StartInfiniteQueryActionCreatorOptions,
-  StartInfiniteQueryActionCreator,
-} from '../core/buildInitiate'
+import { StartInfiniteQueryActionCreator } from '../core/buildInitiate'
 
 // Copy-pasted from React-Redux
 const canUseDOM = () =>
@@ -1647,7 +1644,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     useEffect(() => {
       return () => {
         promiseRef.current?.unsubscribe?.()
-        promiseRef.current = undefined
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        ;(promiseRef.current as any) = undefined
       }
     }, [promiseRef])
   }

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1340,7 +1340,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     // isFetching = true any time a request is in flight
     const isFetching = currentState.isLoading
     // isLoading = true only when loading while no data is present yet (initial load with no data in the cache)
-    const isLoading = !hasData && isFetching
+    const isLoading =
+      (!lastResult || lastResult.isLoading || lastResult.isUninitialized) &&
+      !hasData &&
+      isFetching
     // isSuccess = true when data is present
     const isSuccess = currentState.isSuccess || (isFetching && hasData)
 

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1376,7 +1376,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     )
   }
 
-  function buildQueryHooks(name: string): QueryHooks<any> {
+  function buildQueryHooks(endpointName: string): QueryHooks<any> {
     const useQuerySubscription: UseQuerySubscription<any> = (
       arg: any,
       {
@@ -1388,7 +1388,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         skipPollingIfUnfocused = false,
       } = {},
     ) => {
-      const { initiate } = api.endpoints[name] as ApiEndpointQuery<
+      const { initiate } = api.endpoints[endpointName] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
         Definitions
       >
@@ -1430,8 +1430,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         // with a case where the query args did change but the serialization doesn't,
         // and then we never try to initiate a refetch.
         defaultSerializeQueryArgs,
-        context.endpointDefinitions[name],
-        name,
+        context.endpointDefinitions[endpointName],
+        endpointName,
       )
       const stableSubscriptionOptions = useShallowStableValue({
         refetchOnReconnect,
@@ -1546,7 +1546,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       pollingInterval = 0,
       skipPollingIfUnfocused = false,
     } = {}) => {
-      const { initiate } = api.endpoints[name] as ApiEndpointQuery<
+      const { initiate } = api.endpoints[endpointName] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
         Definitions
       >
@@ -1640,15 +1640,15 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       arg: any,
       { skip = false, selectFromResult } = {},
     ) => {
-      const { select } = api.endpoints[name] as ApiEndpointQuery<
+      const { select } = api.endpoints[endpointName] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
         Definitions
       >
       const stableArg = useStableQueryArgs(
         skip ? skipToken : arg,
         serializeQueryArgs,
-        context.endpointDefinitions[name],
-        name,
+        context.endpointDefinitions[endpointName],
+        endpointName,
       )
 
       type ApiRootState = Parameters<ReturnType<typeof select>>[0]
@@ -1740,7 +1740,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     }
   }
 
-  function buildInfiniteQueryHooks(name: string): InfiniteQueryHooks<any> {
+  function buildInfiniteQueryHooks(
+    endpointName: string,
+  ): InfiniteQueryHooks<any> {
     const useInfiniteQuerySubscription: UseInfiniteQuerySubscription<any> = (
       arg: any,
       {
@@ -1754,7 +1756,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       } = {},
     ) => {
       const { initiate } = api.endpoints[
-        name
+        endpointName
       ] as unknown as ApiEndpointInfiniteQuery<
         InfiniteQueryDefinition<any, any, any, any, any>,
         Definitions
@@ -1791,8 +1793,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         // with a case where the query args did change but the serialization doesn't,
         // and then we never try to initiate a refetch.
         defaultSerializeQueryArgs,
-        context.endpointDefinitions[name],
-        name,
+        context.endpointDefinitions[endpointName],
+        endpointName,
       )
       const stableSubscriptionOptions = useShallowStableValue({
         refetchOnReconnect,
@@ -1930,7 +1932,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       { skip = false, selectFromResult } = {},
     ) => {
       const { select } = api.endpoints[
-        name
+        endpointName
       ] as unknown as ApiEndpointInfiniteQuery<
         InfiniteQueryDefinition<any, any, any, any, any>,
         Definitions
@@ -1938,8 +1940,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       const stableArg = useStableQueryArgs(
         skip ? skipToken : arg,
         serializeQueryArgs,
-        context.endpointDefinitions[name],
-        name,
+        context.endpointDefinitions[endpointName],
+        endpointName,
       )
 
       type ApiRootState = Parameters<ReturnType<typeof select>>[0]


### PR DESCRIPTION
This PR:

- Attempts to shrink the bundle size changes of the infinite query PR, by deduplicating places that were intentionally copy-pasted at the start of the PR, and doing other assorted byte-shaving tricks.

Note that some of the byte-shaving is not actually related to this PR, and could be applied to `master`.


Progress thus far, checking sizes via a Vite React app based off our default template (which has a couple normal query endpoints, but no infinite query endpoints.  Note that the size increase is still expected because none of this can tree-shake, so you pay the cost regardless of whether or not you have any infinite queries.

```
- 2.5.0:              `dist/assets/index-qfEMzmSA.js   217.68 kB │ gzip: 71.25 kB`
- integration:        `dist/assets/index-Bi_rqowG.js   224.67 kB │ gzip: 72.97 kB`
- shaving:      
  - selectors:        `dist/assets/index-DiA9FXmc.js   224.48 kB │ gzip: 72.90 kB`
  - thunks:           `dist/assets/index-BNrKdMuh.js   224.11 kB │ gzip: 72.94 kB`
  - internal:         `dist/assets/index-CWuCWuKB.js   224.03 kB │ gzip: 73.04 kB`
  - selector fix:     `dist/assets/index-ZN5C2aCU.js   224.27 kB │ gzip: 73.01 kB`
  - initiate:         `dist/assets/index-u0d7I2eW.js   223.40 kB │ gzip: 72.75 kB`
  - useSubscription:  `dist/assets/index-DI39JJ7S.js   222.60 kB │ gzip: 72.70 kB`
  - useState:         `dist/assets/index-DtQB8L8Z.js   222.24 kB │ gzip: 72.62 kB`
  - debugValue:       `dist/assets/index-Dd2yXm-V.js   222.01 kB │ gzip: 72.64 kB`
  - hook unsub:       `dist/assets/index-C8CCHuBe.js   221.88 kB │ gzip: 72.64 kB`
```

Overall, we started with +7K min on the integration branch, and I've shaved off 1.27K min of that. I think I can knock off a few hundred bytes more working on the query hooks.

### Sonda visualizations

2.5.0:

![image](https://github.com/user-attachments/assets/d074f00f-0712-4833-9095-434b3a80978d)

Integration:

![image](https://github.com/user-attachments/assets/f6cf633f-189a-43d4-bd3e-96de5e2e566b)

Through initiate deduplication:

![image](https://github.com/user-attachments/assets/cc470d05-ea90-4d8e-9334-b1a86eff0b72)

With hooks deduplicated:

![image](https://github.com/user-attachments/assets/b643eb07-6761-48b3-b40d-708b26fa9a13)


