### PR TITLE
Allow infinite query invalidation and promise checks

### DIFF
--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -58,10 +58,12 @@ import { buildSelectors } from './buildSelectors'
 import type { SliceActions, UpsertEntries } from './buildSlice'
 import { buildSlice } from './buildSlice'
 import type {
+  AllQueryKeys,
   BuildThunksApiEndpointInfiniteQuery,
   BuildThunksApiEndpointMutation,
   BuildThunksApiEndpointQuery,
   PatchQueryDataThunk,
+  QueryArgFromAnyQueryDefinition,
   UpdateQueryDataThunk,
   UpsertQueryDataThunk,
 } from './buildThunks'
@@ -167,9 +169,9 @@ export interface ApiModules<
        *
        * See https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering for details.
        */
-      getRunningQueryThunk<EndpointName extends QueryKeys<Definitions>>(
+      getRunningQueryThunk<EndpointName extends AllQueryKeys<Definitions>>(
         endpointName: EndpointName,
-        arg: QueryArgFrom<Definitions[EndpointName]>,
+        arg: QueryArgFromAnyQueryDefinition<Definitions, EndpointName>,
       ): ThunkWithReturnValue<
         | QueryActionCreatorResult<
             Definitions[EndpointName] & { type: 'query' }

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -594,7 +594,13 @@ export interface InfiniteQueryExtraOptions<
     CacheCollectionQueryExtraOptions {
   type: DefinitionType.infinitequery
 
-  providesTags?: never
+  providesTags?: ResultDescription<
+    TagTypes,
+    ResultType,
+    QueryArg,
+    BaseQueryError<BaseQuery>,
+    BaseQueryMeta<BaseQuery>
+  >
   /**
    * Not to be used. A query should not invalidate tags in the cache.
    */


### PR DESCRIPTION
This PR:

- Updates the infinite query endpoint definition to allow `providesTags`
- Adds a test that verifies that an infinite query gets refetched after a mutation invalidates it, and that the query promise thunks work as expected
- Adds a test for polling behavior