### PR TITLE
Add skip condition on endpoint definition

### DIFF
--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -955,6 +955,14 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
 
         if (
           isQueryDefinition(endpointDefinition) &&
+          endpointDefinition?.skipCondition &&
+          endpointDefinition?.skipCondition(state)
+        ) {
+          return false
+        }
+
+        if (
+          isQueryDefinition(endpointDefinition) &&
           endpointDefinition?.forceRefetch?.({
             currentArg,
             previousArg,

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -686,6 +686,18 @@ export interface QueryExtraOptions<
   invalidatesTags?: never
 
   /**
+   * Can be provided to skip the query if the condition is met.
+   *
+   * It's the equivalent of the `skip` option on the query hook but for the endpoint definition.
+   *
+   * @example
+   * ```ts
+   * skipCondition: (state) => state.user.isLoggedIn === false
+   * ```
+   */
+  skipCondition?: (state: RootState<any, string, ReducerPath>) => boolean
+
+  /**
    * Can be provided to return a custom cache key value based on the query arguments.
    *
    * This is primarily intended for cases where a non-serializable value is passed as part of the query arg object and should be excluded from the cache key.  It may also be used for cases where an endpoint should only have a single cache entry, such as an infinite loading / pagination implementation.

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -42,7 +42,7 @@ import type { InfiniteQueryDirection } from '../core/apiState'
 import type { StartInfiniteQueryActionCreator } from '../core/buildInitiate'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/index'
 import type { InfiniteData } from '../core/index'
-import { isInfiniteQueryDefinition } from '../endpointDefinitions'
+import { isInfiniteQueryDefinition, isQueryDefinition } from '../endpointDefinitions'
 import type { UninitializedValue } from './constants'
 import { UNINITIALIZED_VALUE } from './constants'
 import type { ReactHooksModuleOptions } from './module'
@@ -2060,9 +2060,17 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       },
       useQuery(arg, options) {
         const querySubscriptionResults = useQuerySubscription(arg, options)
+        const store = useStore<RootState<Definitions, any, any>>()
+
+        const endpointDefinition = context.endpointDefinitions[endpointName]
+        const shouldSkipFromCondition =
+          isQueryDefinition(endpointDefinition) &&
+          endpointDefinition?.skipCondition &&
+          endpointDefinition?.skipCondition(store.getState())
+
         const queryStateResults = useQueryState(arg, {
           selectFromResult:
-            arg === skipToken || options?.skip
+            arg === skipToken || options?.skip || shouldSkipFromCondition
               ? undefined
               : noPendingQueryStateSelector,
           ...options,


### PR DESCRIPTION
Adds a skip condition function to the endpoint definition to "skip" making the network request when returned `true`. Instead of needing to set the skip on every query hook it can be applied at a more global layer.

In order to keep `isUninitialized` set to `true`, the same way it works with `skip` on the hook, I needed to add a check for it in the useQuery hook.


Closes #4810