### PR TITLE
Re-export `setGlobalDevModeChecks` from `reselect`

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -15,6 +15,7 @@ export {
   createSelector,
   createSelectorCreator,
   lruMemoize,
+  setGlobalDevModeChecks,
   weakMapMemoize,
 } from 'reselect'
 export type { Selector, OutputSelector } from 'reselect'


### PR DESCRIPTION
Resolves #4681.

I tried to update the API report file `etc/redux-toolkit.api.md` as suggested by the contribution guide but it didn't work, is that maybe broken? Seems like that report hasn't been updated in a while.

EDIT: Ah yes it was acknowledged [here](https://github.com/reduxjs/redux-toolkit/pull/4519#issuecomment-2249140044).