### PR TITLE
Rework infinite query forced checks

### DIFF
--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -633,11 +633,18 @@ export function buildThunks<
           getState(),
           arg.queryCacheKey,
         )?.data as InfiniteData<unknown, unknown> | undefined
-        // Don't want to use `isForcedQuery` here, because that
-        // includes `refetchOnMountOrArgChange`.
+
+        // When the arg changes or the user forces a refetch,
+        // we don't include the `direction` flag. This lets us distinguish
+        // between actually refetching with a forced query, vs just fetching
+        // the next page.
+        const isForcedQueryNeedingRefetch = // arg.forceRefetch
+          isForcedQuery(arg, getState()) &&
+          !(arg as InfiniteQueryThunkArg<any>).direction
         const existingData = (
-          arg.forceRefetch || !cachedData ? blankData : cachedData
+          isForcedQueryNeedingRefetch || !cachedData ? blankData : cachedData
         ) as InfiniteData<unknown, unknown>
+
 
         // If the thunk specified a direction and we do have at least one page,
         // fetch the next or previous page


### PR DESCRIPTION
Previously in #4795 , I had made tweaks to the infinite query fetching logic to fix broken behavior (would not fetch next pages if the API definition had `refetchOnMountOrArgChange: true`).  I did so by altering the logic to fall back to an empty infinite data set, using an internal `arg.forceRefetch` flag instead of `isForcedQuery()`.

@agusterodin reported some more problems with similar scenarios in https://github.com/reduxjs/redux-toolkit/pull/4744#issuecomment-2606221573.  I did some investigating and concluded that this change resulted in a logic mismatch. We triggered an actual run of the thunk because `condition` used `isForcedQuery`, but we _didn't_ use `isForcedQuery` to determine whether to use cached data or start fresh.  That led to a refetch of the pages, but appended to the _existing_ copy of the pages, resulting in duplicates.

After further tinkering, I ended up with `isForcedQuery() && !arg.direction`, as we don't pass in a `direction` flag when the hook switches to a different arg.  That appears to handle both "can fetch with `refetchOnMountOrArgChange` active" and "does not duplicate the entries on refetch".

As for the other reported issue, where an arg change + refetch is quickly followed by a `fetchNextPage()` call: it looks like React Query intentionally cancels an in-flight query in that case.  It seems like the refetch sequence continues, but I think that promise gets ignored.  So, the additional page request goes out right away.

It _might_ be possible to mimic that behavior with RTKQ, but our internal logic is different enough it's a bit trickier.  Given that, I'm going to skip trying to match that edge case for now.