### PR TITLE
Rewrite providedTags handling for better perf

### DIFF
--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -199,10 +199,7 @@ export function buildSelectors<
   function withRequestFlags<T extends { status: QueryStatus }>(
     substate: T,
   ): T & RequestStatusFlags {
-    return {
-      ...substate,
-      ...getRequestStatusFlags(substate.status),
-    }
+    return { ...substate, ...getRequestStatusFlags(substate.status) }
   }
 
   function selectApiState(rootState: RootState) {
@@ -344,7 +341,7 @@ export function buildSelectors<
     const apiState = state[reducerPath]
     const toInvalidate = new Set<QueryCacheKey>()
     for (const tag of tags.filter(isNotNullish).map(expandTagDescription)) {
-      const provided = apiState.provided[tag.type]
+      const provided = apiState.provided.tags[tag.type]
       if (!provided) {
         continue
       }

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -166,19 +166,13 @@ type MutationThunkArg = {
 export type ThunkResult = unknown
 
 export type ThunkApiMetaConfig = {
-  pendingMeta: {
-    startedTimeStamp: number
-    [SHOULD_AUTOBATCH]: true
-  }
+  pendingMeta: { startedTimeStamp: number; [SHOULD_AUTOBATCH]: true }
   fulfilledMeta: {
     fulfilledTimeStamp: number
     baseQueryMeta: unknown
     [SHOULD_AUTOBATCH]: true
   }
-  rejectedMeta: {
-    baseQueryMeta: unknown
-    [SHOULD_AUTOBATCH]: true
-  }
+  rejectedMeta: { baseQueryMeta: unknown; [SHOULD_AUTOBATCH]: true }
 }
 export type QueryThunk = AsyncThunk<
   ThunkResult,
@@ -320,10 +314,7 @@ type TransformCallback = (
 export const addShouldAutoBatch = <T extends Record<string, any>>(
   arg: T = {} as T,
 ): T & { [SHOULD_AUTOBATCH]: true } => {
-  return {
-    ...arg,
-    [SHOULD_AUTOBATCH]: true,
-  }
+  return { ...arg, [SHOULD_AUTOBATCH]: true }
 }
 
 export function buildThunks<
@@ -382,7 +373,7 @@ export function buildThunks<
       )
 
       dispatch(
-        api.internalActions.updateProvidedBy({ queryCacheKey, providedTags }),
+        api.internalActions.updateProvidedBy([{ queryCacheKey, providedTags }]),
       )
     }
 
@@ -466,9 +457,7 @@ export function buildThunks<
         ).initiate(arg, {
           subscribe: false,
           forceRefetch: true,
-          [forceQueryFnSymbol]: () => ({
-            data: value,
-          }),
+          [forceQueryFnSymbol]: () => ({ data: value }),
         }),
       ) as UpsertThunkResult<Definitions, EndpointName>
 
@@ -623,10 +612,7 @@ export function buildThunks<
           finalQueryArg,
         )
 
-        return {
-          ...result,
-          data: transformedResponse,
-        }
+        return { ...result, data: transformedResponse }
       }
 
       if (
@@ -793,9 +779,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
         return addShouldAutoBatch({
           startedTimeStamp: Date.now(),
           ...(isInfiniteQueryDefinition(endpointDefinition)
-            ? {
-                direction: (arg as InfiniteQueryThunkArg<any>).direction,
-              }
+            ? { direction: (arg as InfiniteQueryThunkArg<any>).direction }
             : {}),
         })
       },

--- a/packages/toolkit/src/query/tests/optimisticUpdates.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpdates.test.tsx
@@ -60,9 +60,7 @@ const api = createApi({
   }),
 })
 
-const storeRef = setupApiStore(api, {
-  ...actionsReducer,
-})
+const storeRef = setupApiStore(api, { ...actionsReducer })
 
 describe('basic lifecycle', () => {
   let onStart = vi.fn(),
@@ -96,9 +94,7 @@ describe('basic lifecycle', () => {
   test('success', async () => {
     const { result } = renderHook(
       () => extendedApi.endpoints.test.useMutation(),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
 
     baseQuery.mockResolvedValue('success')
@@ -119,9 +115,7 @@ describe('basic lifecycle', () => {
   test('error', async () => {
     const { result } = renderHook(
       () => extendedApi.endpoints.test.useMutation(),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
 
     baseQuery.mockRejectedValueOnce('error')
@@ -201,11 +195,7 @@ describe('updateQueryData', () => {
   test('updates (list) cache values including provided tags, undos that', async () => {
     baseQuery
       .mockResolvedValueOnce([
-        {
-          id: '3',
-          title: 'All about cheese.',
-          contents: 'TODO',
-        },
+        { id: '3', title: 'All about cheese.', contents: 'TODO' },
       ])
       .mockResolvedValueOnce(42)
     const { result } = renderHook(() => api.endpoints.listPosts.useQuery(), {
@@ -218,7 +208,7 @@ describe('updateQueryData', () => {
       provided = storeRef.store.getState().api.provided
     })
 
-    const provided3 = provided.Post['3']
+    const provided3 = provided.tags.Post['3']
 
     let returnValue!: ReturnType<ReturnType<typeof api.util.updateQueryData>>
     act(() => {
@@ -242,7 +232,7 @@ describe('updateQueryData', () => {
       provided = storeRef.store.getState().api.provided
     })
 
-    const provided4 = provided.Post['4']
+    const provided4 = provided.tags.Post['4']
 
     expect(provided4).toEqual(provided3)
 
@@ -254,7 +244,7 @@ describe('updateQueryData', () => {
       provided = storeRef.store.getState().api.provided
     })
 
-    const provided4Next = provided.Post['4']
+    const provided4Next = provided.tags.Post['4']
 
     expect(provided4Next).toEqual([])
   })
@@ -262,11 +252,7 @@ describe('updateQueryData', () => {
   test('updates (list) cache values excluding provided tags, undoes that', async () => {
     baseQuery
       .mockResolvedValueOnce([
-        {
-          id: '3',
-          title: 'All about cheese.',
-          contents: 'TODO',
-        },
+        { id: '3', title: 'All about cheese.', contents: 'TODO' },
       ])
       .mockResolvedValueOnce(42)
     const { result } = renderHook(() => api.endpoints.listPosts.useQuery(), {
@@ -301,7 +287,7 @@ describe('updateQueryData', () => {
       provided = storeRef.store.getState().api.provided
     })
 
-    const provided4 = provided.Post['4']
+    const provided4 = provided.tags.Post['4']
 
     expect(provided4).toEqual(undefined)
 
@@ -313,7 +299,7 @@ describe('updateQueryData', () => {
       provided = storeRef.store.getState().api.provided
     })
 
-    const provided4Next = provided.Post['4']
+    const provided4Next = provided.tags.Post['4']
 
     expect(provided4Next).toEqual(undefined)
   })
@@ -382,9 +368,7 @@ describe('full integration', () => {
         query: api.endpoints.post.useQuery('3'),
         mutation: api.endpoints.updatePost.useMutation(),
       }),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
     await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
 
@@ -433,9 +417,7 @@ describe('full integration', () => {
         query: api.endpoints.post.useQuery('3'),
         mutation: api.endpoints.updatePost.useMutation(),
       }),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
     await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
 

--- a/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpserts.test.tsx
@@ -41,9 +41,7 @@ const api = createApi({
   },
   tagTypes: ['Post', 'Folder'],
   endpoints: (build) => ({
-    getPosts: build.query<Post[], void>({
-      query: () => '/posts',
-    }),
+    getPosts: build.query<Post[], void>({ query: () => '/posts' }),
     post: build.query<Post, string>({
       query: (id) => `post/${id}`,
       providesTags: ['Post'],
@@ -70,13 +68,7 @@ const api = createApi({
     post2: build.query<Post, string>({
       queryFn: async (id) => {
         await delay(20)
-        return {
-          data: {
-            id,
-            title: 'All about cheese.',
-            contents: 'TODO',
-          },
-        }
+        return { data: { id, title: 'All about cheese.', contents: 'TODO' } }
       },
     }),
     postWithSideEffect: build.query<Post, string>({
@@ -123,9 +115,7 @@ const api = createApi({
   }),
 })
 
-const storeRef = setupApiStore(api, {
-  ...actionsReducer,
-})
+const storeRef = setupApiStore(api, { ...actionsReducer })
 
 describe('basic lifecycle', () => {
   let onStart = vi.fn(),
@@ -194,9 +184,7 @@ describe('basic lifecycle', () => {
   test('success', async () => {
     const { result } = renderHook(
       () => extendedApi.endpoints.test.useMutation(),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
 
     baseQuery.mockResolvedValue('success')
@@ -217,9 +205,7 @@ describe('basic lifecycle', () => {
   test('error', async () => {
     const { result } = renderHook(
       () => extendedApi.endpoints.test.useMutation(),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
 
     baseQuery.mockRejectedValueOnce('error')
@@ -298,9 +284,7 @@ describe('upsertQueryData', () => {
     // is preserved normally after the last subscriber was unmounted
     const { result, rerender } = renderHook(
       () => api.endpoints.post.useQuery('4'),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
     await hookWaitFor(() => expect(result.current.isError).toBeTruthy())
 
@@ -387,29 +371,13 @@ describe('upsertQueryData', () => {
 
 describe('upsertQueryEntries', () => {
   const posts: Post[] = [
-    {
-      id: '1',
-      contents: 'A',
-      title: 'A',
-    },
-    {
-      id: '2',
-      contents: 'B',
-      title: 'B',
-    },
-    {
-      id: '3',
-      contents: 'C',
-      title: 'C',
-    },
+    { id: '1', contents: 'A', title: 'A' },
+    { id: '2', contents: 'B', title: 'B' },
+    { id: '3', contents: 'C', title: 'C' },
   ]
 
   const entriesAction = api.util.upsertQueryEntries([
-    {
-      endpointName: 'getPosts',
-      arg: undefined,
-      value: posts,
-    },
+    { endpointName: 'getPosts', arg: undefined, value: posts },
     ...posts.map((post) => ({
       endpointName: 'postWithSideEffect' as const,
       arg: post.id,
@@ -430,7 +398,7 @@ describe('upsertQueryEntries', () => {
       )
 
       // Should have added tags
-      expect(state.api.provided.Post[post.id]).toEqual([
+      expect(state.api.provided.tags.Post[post.id]).toEqual([
         `postWithSideEffect("${post.id}")`,
       ])
     }
@@ -508,9 +476,7 @@ describe('upsertQueryEntries', () => {
       )
     }
 
-    render(<Folder />, {
-      wrapper: storeRef.wrapper,
-    })
+    render(<Folder />, { wrapper: storeRef.wrapper })
 
     await waitFor(() => {
       const { actions } = storeRef.store.getState()
@@ -551,9 +517,7 @@ describe('full integration', () => {
         query: api.endpoints.post.useQuery('3'),
         mutation: api.endpoints.updatePost.useMutation(),
       }),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
     await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
 
@@ -605,9 +569,7 @@ describe('full integration', () => {
         query: api.endpoints.post.useQuery('3'),
         mutation: api.endpoints.updatePost.useMutation(),
       }),
-      {
-        wrapper: storeRef.wrapper,
-      },
+      { wrapper: storeRef.wrapper },
     )
     await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
 


### PR DESCRIPTION
Per #4909 , our recent update to add the missing `providesTags` handling for `upsertQueryEntries` in #4872 has resulted in a significant perf regression for that use case.

The current `api.provides` state structure looks like:

![427705022-b353576e-5515-4813-9cdb-b42747a6ee63](https://github.com/user-attachments/assets/a49206d5-1c4d-4500-bea9-e4a10ffd2b92)

When we update tags for a cache key, we first need to go in and remove that cache key from all tag entries that referenced it.  Unfortunately, the existing logic is doing that via a brute-force search over _all_ existing tag > cache key arrays.  Not only is this O(n), but it's doing so by going through an Immer draft proxy, which is slower:

```ts
      updateProvidedBy: {
        reducer(
          draft,
          action: PayloadAction<{
            queryCacheKey: QueryCacheKey
            providedTags: readonly FullTagDescription<string>[]
          }>,
        ) {
          const { queryCacheKey, providedTags } = action.payload

          for (const tagTypeSubscriptions of Object.values(draft)) {
            for (const idSubscriptions of Object.values(tagTypeSubscriptions)) {
              const foundAt = idSubscriptions.indexOf(queryCacheKey)
              if (foundAt !== -1) {
                idSubscriptions.splice(foundAt, 1)
              }
            }
          }

          for (const { type, id } of providedTags) {
            const subscribedQueries = ((draft[type] ??= {})[
              id || '__internal_without_id'
            ] ??= [])
            const alreadySubscribed = subscribedQueries.includes(queryCacheKey)
            if (!alreadySubscribed) {
              subscribedQueries.push(queryCacheKey)
            }
          }
        },
```

To make things worse, the `upsertQueryEntries` handling was doing this one cache key at a time. So, when we try to insert 5000 cache entries, we do the whole "painter's algorithm" anti-pattern and iterate through 1, 2, .... 4998, 4999 different tag > cache key arrays just to _try_ to clear out any existing uses of each cache key.

This PR restructures the invalidation state to be:

```ts
export type InvalidationState<TagTypes extends string> = {
  tags: {
    [_ in TagTypes]: {
      [id: string]: Array<QueryCacheKey>
      [id: number]: Array<QueryCacheKey>
    }
  }
  keys: Record<QueryCacheKey, Array<FullTagDescription<any>>>
}
```

From there, we just save the per-cache-key array of tags in a second lookup table, which then means that deletion simplifies down to grabbing that array of tags and removing the cache key from the corresponding per-tag cache key arrays.  So, instead of iterating over the entire list of all tags, we can just grab the few specific tags and target those directly.  (To toss _two_ CS-like bits of knowledge in here, we're "trading memory for speed".)

I also updated the `upsertQueryEntries` handling for tags to try to batch together all of the entries into one nested reducer call. Didn't appear to make much of a difference, but shouldn't hurt.

In local testing, this knocked the runtime for inserting 5000 entries from 23 _seconds_ down to 90 _milliseconds_.  (Yeah.  It was that bad.)

The downside is that this _does_ change the structure of `state.api.provided`.  We've always considered that internal, so this is not a _public_ breaking change and can thus be a patch release.

Unfortunately, the Redux DevTools RTKQ display _does_ expect the existing state structure, and I've confirmed that trying to view a cache entry with this build causes the entire DevTools to crash when it accesses an undefined field due to the structure change.

So, we're going to need to update the DevTools to handle both cases and get that release out, _then_ publish this fix.

The PR preview build here can be used as a workaround in the meantime.