### PR TITLE
Add duplicate middleware dev check to configureStore

### DIFF
--- a/docs/api/configureStore.mdx
+++ b/docs/api/configureStore.mdx
@@ -65,6 +65,11 @@ interface ConfigureStoreOptions<
   devTools?: boolean | DevToolsOptions
 
   /**
+   * Whether to check for duplicate middleware instances. Defaults to `true`.
+   */
+  duplicateMiddlewareCheck?: boolean
+
+  /**
    * The initial state, same as Redux's createStore.
    * You may optionally specify it to hydrate the state
    * from the server in universal apps, or to restore a previously serialized
@@ -139,6 +144,12 @@ If this is a boolean, it will be used to indicate whether `configureStore` shoul
 If it is an object, then the DevTools Extension will be enabled, and the options object will be passed to `composeWithDevtools()`. See
 the DevTools Extension docs for [`EnhancerOptions`](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md) for
 a list of the specific options that are available.
+
+Defaults to `true`.
+
+### `duplicateMiddlewareCheck`
+
+If enabled, the store will check the final middleware array to see if there are any duplicate middleware references. This will catch issues like accidentally adding the same RTK Query API middleware twice (such as adding both the base API middleware and an injected API middleware, which are actually the exact same function reference).
 
 Defaults to `true`.
 

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -67,6 +67,11 @@ export interface ConfigureStoreOptions<
   devTools?: boolean | DevToolsOptions
 
   /**
+   * Whether to check for duplicate middleware instances. Defaults to `true`.
+   */
+  duplicateMiddlewareCheck?: boolean
+
+  /**
    * The initial state, same as Redux's createStore.
    * You may optionally specify it to hydrate the state
    * from the server in universal apps, or to restore a previously serialized
@@ -128,6 +133,7 @@ export function configureStore<
     reducer = undefined,
     middleware,
     devTools = true,
+    duplicateMiddlewareCheck = true,
     preloadedState = undefined,
     enhancers = undefined,
   } = options || {}
@@ -174,6 +180,18 @@ export function configureStore<
     throw new Error(
       'each middleware provided to configureStore must be a function',
     )
+  }
+
+  if (process.env.NODE_ENV !== 'production' && duplicateMiddlewareCheck) {
+    let middlewareReferences = new Set<Middleware<any, S>>()
+    finalMiddleware.forEach((middleware) => {
+      if (middlewareReferences.has(middleware)) {
+        throw new Error(
+          'Duplicate middleware found. Ensure that each middleware is only included once',
+        )
+      }
+      middlewareReferences.add(middleware)
+    })
   }
 
   let finalCompose = compose

--- a/packages/toolkit/src/tests/configureStore.test.ts
+++ b/packages/toolkit/src/tests/configureStore.test.ts
@@ -1,5 +1,5 @@
 import * as DevTools from '@internal/devtoolsExtension'
-import type { StoreEnhancer } from '@reduxjs/toolkit'
+import type { Middleware, StoreEnhancer } from '@reduxjs/toolkit'
 import { Tuple } from '@reduxjs/toolkit'
 import type * as Redux from 'redux'
 import { vi } from 'vitest'
@@ -127,6 +127,37 @@ describe('configureStore', async () => {
         undefined,
         expect.any(Function),
       )
+    })
+  })
+
+  describe('given any middleware', () => {
+    const exampleMiddleware: Middleware<any, any> = () => (next) => (action) =>
+      next(action)
+    it('throws an error by default if there are duplicate middleware', () => {
+      const makeStore = () => {
+        return configureStore({
+          reducer,
+          middleware: (gDM) =>
+            gDM().concat(exampleMiddleware, exampleMiddleware),
+        })
+      }
+
+      expect(makeStore).toThrowError(
+        'Duplicate middleware found. Ensure that each middleware is only included once',
+      )
+    })
+
+    it('does not throw a duplicate middleware error if duplicateMiddlewareCheck is disabled', () => {
+      const makeStore = () => {
+        return configureStore({
+          reducer,
+          middleware: (gDM) =>
+            gDM().concat(exampleMiddleware, exampleMiddleware),
+          duplicateMiddlewareCheck: false,
+        })
+      }
+
+      expect(makeStore).not.toThrowError()
     })
   })
 


### PR DESCRIPTION
This PR:

- Adds a new dev mode check to `configureStore` that throws an error if duplicate middleware references are found
- Adds a new `duplicateMiddlewareCheck` option to `configureStore` to control that behavior

Per issues like #4349 , apparently some folks have managed to accidentally add the same middleware to the store twice (and specifically, the same RTKQ middleware, like `gDM().concat(baseApi.middleware, injectedApi.middleware)`... which is wrong because those are the exact same object and middleware references).  

Adding a trivial `Set` + reference checks seems to catch that.

I don't think this is common enough to be a major problem, but it was easy enough to throw this check in and add tests + docs, so why not.