### PR TITLE
Improve duplicate middleware error and save build output

### DIFF
--- a/errors.json
+++ b/errors.json
@@ -40,5 +40,6 @@
   "38": "Cannot refetch a query that has not been started yet.",
   "39": "called \\`injectEndpoints\\` to override already-existing endpointName  without specifying \\`overrideExisting: true\\`",
   "40": "maxPages for endpoint '' must be a number greater than 0",
-  "41": "getPreviousPageParam for endpoint '' must be a function if maxPages is used"
+  "41": "getPreviousPageParam for endpoint '' must be a function if maxPages is used",
+  "42": "Duplicate middleware references found when creating the store. Ensure that each middleware is only included once."
 }

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -187,7 +187,7 @@ export function configureStore<
     finalMiddleware.forEach((middleware) => {
       if (middlewareReferences.has(middleware)) {
         throw new Error(
-          'Duplicate middleware found. Ensure that each middleware is only included once',
+          'Duplicate middleware references found when creating the store. Ensure that each middleware is only included once.',
         )
       }
       middlewareReferences.add(middleware)

--- a/packages/toolkit/src/query/tests/injectEndpoints.test.tsx
+++ b/packages/toolkit/src/query/tests/injectEndpoints.test.tsx
@@ -115,7 +115,7 @@ describe('injectEndpoints', () => {
       })
 
     expect(makeStore).toThrowError(
-      'Duplicate middleware found. Ensure that each middleware is only included once',
+      'Duplicate middleware references found when creating the store. Ensure that each middleware is only included once.',
     )
   })
 })

--- a/packages/toolkit/src/tests/configureStore.test.ts
+++ b/packages/toolkit/src/tests/configureStore.test.ts
@@ -143,7 +143,7 @@ describe('configureStore', async () => {
       }
 
       expect(makeStore).toThrowError(
-        'Duplicate middleware found. Ensure that each middleware is only included once',
+        'Duplicate middleware references found when creating the store. Ensure that each middleware is only included once.',
       )
     })
 


### PR DESCRIPTION
- Improved the duplicate middleware error message to be clearer
- Actually included it in `errors.json` for inclusion in the errors page