### PR TITLE
Use Canary for local search instead of Algolia

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -70,6 +70,7 @@ const config: Config = {
   customFields: {
     repoUrl: 'https://github.com/reduxjs/redux-toolkit',
   },
+  themes: [require.resolve('@getcanary/docusaurus-theme-search-pagefind')],
   themeConfig: {
     tableOfContents: {
       minHeadingLevel: 2,
@@ -185,11 +186,11 @@ const config: Config = {
       ],
       copyright: `Copyright © 2015–${new Date().getFullYear()} Dan Abramov and the Redux documentation authors.`,
     },
-    algolia: {
-      appId: 'CK59DFV0FC',
-      apiKey: '98e886dfbcde7f7e8ec8d7ff1c2c34c8',
-      indexName: 'redux-starter-kit',
-    },
+    // algolia: {
+    //   appId: 'CK59DFV0FC',
+    //   apiKey: '98e886dfbcde7f7e8ec8d7ff1c2c34c8',
+    //   indexName: 'redux-starter-kit',
+    // },
   } satisfies ThemeConfig,
   plugins: [
     [

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,8 @@
     "@dipakparmar/docusaurus-plugin-umami": "^2.0.6",
     "@docusaurus/core": "3.6.3",
     "@docusaurus/preset-classic": "3.6.3",
+    "@getcanary/docusaurus-theme-search-pagefind": "^1.0.2",
+    "@getcanary/web": "^1.0.12",
     "classnames": "^2.2.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5835,6 +5835,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.6.0":
+  version: 1.6.9
+  resolution: "@floating-ui/core@npm:1.6.9"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.9"
+  checksum: 10/656fcd383da17fffca2efa0635cbe3c0b835c3312949e30bd19d05bf42479f2ac22aaf336a6a31cb160621fc6f35cfc9e115e76c5cf48ba96e33474d123ced22
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.6.8":
+  version: 1.6.13
+  resolution: "@floating-ui/dom@npm:1.6.13"
+  dependencies:
+    "@floating-ui/core": "npm:^1.6.0"
+    "@floating-ui/utils": "npm:^0.2.9"
+  checksum: 10/4bb732baf3270007741bcdc91be1de767b2bb5d8b891eb838e5f1e7c4cccad998643dbdd4e8b8cec4c5d12c9898f80febc68e9793dd6e26a445283c4fb1b6a78
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@floating-ui/utils@npm:0.2.9"
+  checksum: 10/0ca786347db3dd8d9034b86d1449fabb96642788e5900cc5f2aee433cd7b243efbcd7a165bead50b004ee3f20a90ddebb6a35296fc41d43cfd361b6f01b69ffb
+  languageName: node
+  linkType: hard
+
+"@getcanary/docusaurus-theme-search-pagefind@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@getcanary/docusaurus-theme-search-pagefind@npm:1.0.2"
+  dependencies:
+    "@getcanary/web": "npm:^1.0.0"
+    cli-progress: "npm:^3.12.0"
+    micromatch: "npm:^4.0.7"
+    pagefind: "npm:^1.1.0"
+  peerDependencies:
+    "@docusaurus/core": ^2.0.0 || ^3.0.0
+    "@getcanary/web": ^1.0.0
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: 10/63b28722cdf3d2cafdc52d737b838e55be5d8f149350f60d3190c544825b55c2dde1445ef01933ad345a5821e4526db5f18cd924288f387d72796f4d191b10df
+  languageName: node
+  linkType: hard
+
+"@getcanary/web@npm:^1.0.0, @getcanary/web@npm:^1.0.12":
+  version: 1.0.12
+  resolution: "@getcanary/web@npm:1.0.12"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.6.8"
+    "@lit-labs/observers": "npm:^2.0.2"
+    "@lit/context": "npm:^1.1.2"
+    "@lit/task": "npm:^1.0.1"
+    "@xstate/store": "npm:^2.5.0"
+    best-effort-json-parser: "npm:^1.1.2"
+    lit: "npm:^3.1.4"
+    marked: "npm:^14.0.0"
+    picomatch: "npm:^4.0.2"
+  checksum: 10/7d2cddabf7f409070d47238408485ee0e8fc48de3d82eec71381ca71392f9afbd993ea23305602e64cf3100cd5ce14016b8386709b630777a83d204771b2e603
+  languageName: node
+  linkType: hard
+
 "@graphql-codegen/add@npm:^2.0.2":
   version: 2.0.2
   resolution: "@graphql-codegen/add@npm:2.0.2"
@@ -7069,6 +7129,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lit-labs/observers@npm:^2.0.2":
+  version: 2.0.5
+  resolution: "@lit-labs/observers@npm:2.0.5"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.0.0 || ^2.0.0"
+    lit-html: "npm:^3.2.0"
+  checksum: 10/4de55e32072f5825ca288c0b32b40e6805c09cd6101c345c44dfceb6bfd03cadf652dbfcd023252ebc2f7519f036d7e0f2f8fa1e58915abbc18733ed11218086
+  languageName: node
+  linkType: hard
+
+"@lit-labs/ssr-dom-shim@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.3.0"
+  checksum: 10/a15c5d145a20f367a392cff91f2091ffe54457119ac26569670bbbe32760f86d1e250f865dc1bd0604641106376776c4862a8fff9adb44f9881b510747c08680
+  languageName: node
+  linkType: hard
+
+"@lit/context@npm:^1.1.2":
+  version: 1.1.5
+  resolution: "@lit/context@npm:1.1.5"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.6.2 || ^2.1.0"
+  checksum: 10/2e1d7558358ac5e3a4e39f8d97e3b495f9441b62dbff4e9ba955596fc2d382a8414ae9dde5041f51822ea6a62628c102a131e5b28aa11a9186a43393d3e3e3e6
+  languageName: node
+  linkType: hard
+
+"@lit/reactive-element@npm:^1.0.0 || ^2.0.0, @lit/reactive-element@npm:^1.6.2 || ^2.1.0, @lit/reactive-element@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@lit/reactive-element@npm:2.1.0"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.2.0"
+  checksum: 10/c13dbc370550b8f3cbdfff3524c4bf58fbda6e91689951ca376104d95c80df96182e0b1c9480786740711f67493f50166d261c79b020eb7a4a10b6794921c790
+  languageName: node
+  linkType: hard
+
+"@lit/task@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@lit/task@npm:1.0.2"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.0.0 || ^2.0.0"
+  checksum: 10/cf834761ee5b51b76cd175eb631e2fbbe054e072ccb46b4e09de33c56fb416d87ad3565b80ba9828a196eabb96ff093b91d6642d92887adfc26c49d01c392e89
+  languageName: node
+  linkType: hard
+
 "@manaflair/redux-batch@npm:^1.0.0":
   version: 1.0.0
   resolution: "@manaflair/redux-batch@npm:1.0.0"
@@ -7589,6 +7693,41 @@ __metadata:
   version: 2.1.0
   resolution: "@open-draft/until@npm:2.1.0"
   checksum: 10/622be42950afc8e89715d0fd6d56cbdcd13e36625e23b174bd3d9f06f80e25f9adf75d6698af93bca1e1bf465b9ce00ec05214a12189b671fb9da0f58215b6f4
+  languageName: node
+  linkType: hard
+
+"@pagefind/darwin-arm64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@pagefind/darwin-arm64@npm:1.3.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@pagefind/darwin-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@pagefind/darwin-x64@npm:1.3.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pagefind/linux-arm64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@pagefind/linux-arm64@npm:1.3.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@pagefind/linux-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@pagefind/linux-x64@npm:1.3.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pagefind/windows-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@pagefind/windows-x64@npm:1.3.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -11273,6 +11412,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xstate/store@npm:^2.5.0":
+  version: 2.6.2
+  resolution: "@xstate/store@npm:2.6.2"
+  peerDependencies:
+    react: ^18.2.0 || ^19.0.0-0
+    solid-js: ^1.7.6
+  peerDependenciesMeta:
+    react:
+      optional: true
+    solid-js:
+      optional: true
+  checksum: 10/158a593e6dae0a9b9b4f593e851e8580ef6710a65ab98d8d98d5f8bba7fdbe77291e90aa18e22df8b57c9434b04095f1b14a3f2aa69668e0f26a8b8a78f590dc
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -12604,6 +12758,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"best-effort-json-parser@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "best-effort-json-parser@npm:1.1.3"
+  checksum: 10/311ed25c95c480b44e082bfee7aaeb246e462e9504a7fcec9793e000b4661a7cf93d150e863dd816dd0567585846712571b04e6a4ce67695690c89f70ebe9dbd
+  languageName: node
+  linkType: hard
+
 "bfj@npm:^7.0.2":
   version: 7.1.0
   resolution: "bfj@npm:7.1.0"
@@ -13560,6 +13721,15 @@ __metadata:
   dependencies:
     restore-cursor: "npm:^3.1.0"
   checksum: 10/2692784c6cd2fd85cfdbd11f53aea73a463a6d64a77c3e098b2b4697a20443f430c220629e1ca3b195ea5ac4a97a74c2ee411f3807abf6df2b66211fec0c0a29
+  languageName: node
+  linkType: hard
+
+"cli-progress@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "cli-progress@npm:3.12.0"
+  dependencies:
+    string-width: "npm:^4.2.3"
+  checksum: 10/a6a549919a7461f5e798b18a4a19f83154bab145d3ec73d7f3463a8db8e311388c545ace1105557760a058cc4999b7f28c9d8d24d9783ee2912befb32544d4b8
   languageName: node
   linkType: hard
 
@@ -22444,6 +22614,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lit-element@npm:4.2.0"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.2.0"
+    "@lit/reactive-element": "npm:^2.1.0"
+    lit-html: "npm:^3.3.0"
+  checksum: 10/0760140f9cf7eb71e327f04d51a41e3ae4c3fca2ddccca05fa3458d67124a2008044ef3d3812d021e2297ba8b3af7c06fa56b03860877bc09567c334b9d390ad
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^3.2.0, lit-html@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "lit-html@npm:3.3.0"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.2"
+  checksum: 10/667992d927e841d9e74cf615e3556edcdc71392953d3eaf963187b4f0159e52ec7826331a650456f1c573a461f71e6c41da36b8efacef1dffc6cce07e548d8b0
+  languageName: node
+  linkType: hard
+
+"lit@npm:^3.1.4":
+  version: 3.3.0
+  resolution: "lit@npm:3.3.0"
+  dependencies:
+    "@lit/reactive-element": "npm:^2.1.0"
+    lit-element: "npm:^4.2.0"
+    lit-html: "npm:^3.3.0"
+  checksum: 10/442b8eabd5d1b4aee0ab34db0b67d5c07a988f30d345f4a68263275acf826816ba30937bb8d5d331dc260c2127cd8953f332dcc45edbf080d61c21291cb06330
+  languageName: node
+  linkType: hard
+
 "load-tsconfig@npm:^0.2.3":
   version: 0.2.5
   resolution: "load-tsconfig@npm:0.2.5"
@@ -22938,6 +23139,15 @@ __metadata:
   peerDependencies:
     marked: ">=1 <12"
   checksum: 10/98e79d0c4597ced53f7252fe711baf729e2c8754e654d49c713e764189419e880894534fa879f0d0c12801c938bc76cf80a7b67427e2d75fd0e502d5c7b73c1b
+  languageName: node
+  linkType: hard
+
+"marked@npm:^14.0.0":
+  version: 14.1.4
+  resolution: "marked@npm:14.1.4"
+  bin:
+    marked: bin/marked.js
+  checksum: 10/e3526e7907aa1c13481d205b667a178bd372c01318439e4cd8a3d4b55e3983bccef8c17489129c6a0e31dbecb0b417deff6c27f9f16083faa4eea16a22784a86
   languageName: node
   linkType: hard
 
@@ -25691,6 +25901,32 @@ __metadata:
     registry-url: "npm:^6.0.0"
     semver: "npm:^7.3.7"
   checksum: 10/d97ce9539e1ed4aacaf7c2cb754f16afc10937fa250bd09b4d61181d2e36a30cf8a4cff2f8f831f0826b0ac01a355f26204c7e57ca0e450da6ccec3e34fc889a
+  languageName: node
+  linkType: hard
+
+"pagefind@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "pagefind@npm:1.3.0"
+  dependencies:
+    "@pagefind/darwin-arm64": "npm:1.3.0"
+    "@pagefind/darwin-x64": "npm:1.3.0"
+    "@pagefind/linux-arm64": "npm:1.3.0"
+    "@pagefind/linux-x64": "npm:1.3.0"
+    "@pagefind/windows-x64": "npm:1.3.0"
+  dependenciesMeta:
+    "@pagefind/darwin-arm64":
+      optional: true
+    "@pagefind/darwin-x64":
+      optional: true
+    "@pagefind/linux-arm64":
+      optional: true
+    "@pagefind/linux-x64":
+      optional: true
+    "@pagefind/windows-x64":
+      optional: true
+  bin:
+    pagefind: lib/runner/bin.cjs
+  checksum: 10/ccf4acbdb1ca23a11094ea5ccccaa67b2b13bf5f1243d6fe6f227318fa8875509d69ee34899dcc053acb2269cb3cce4cb6904b7cb0fee271ffeddde52d9a5fe5
   languageName: node
   linkType: hard
 
@@ -34409,6 +34645,8 @@ __metadata:
     "@docusaurus/core": "npm:3.6.3"
     "@docusaurus/faster": "npm:^3.6.3"
     "@docusaurus/preset-classic": "npm:3.6.3"
+    "@getcanary/docusaurus-theme-search-pagefind": "npm:^1.0.2"
+    "@getcanary/web": "npm:^1.0.12"
     classnames: "npm:^2.2.6"
     netlify-plugin-cache: "npm:^1.0.3"
     prettier: "npm:^3.2.5"


### PR DESCRIPTION
We've had some issues with our docs Algolia integrations over time, and in particular the React-Redux docs search isn't returning _any_ results right now.

Trying out Canary with Pagefind (which generates a "local" index on build), and it seems to work pretty well.  For comparison:

- Algolia (live):

![image](https://github.com/user-attachments/assets/8967d7a0-44ad-48f2-8ec9-26ca4d7e592a)

- Canary + Pagefind (PR preview):

![image](https://github.com/user-attachments/assets/9d95868a-5ca6-4ad1-a2fc-23b1a9de0eb1)

So not only does Canary + Pagefind seem to at least work and produce results, I think the display of search results with in-page context is actually an improvement.