### PR TITLE
feature: add cli to exports

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -147,4 +147,4 @@ jobs:
           name: package
 
       - name: Run are-the-types-wrong
-        run: yarn dlx @arethetypeswrong/cli@latest ./package.tgz --format table
+        run: yarn dlx @arethetypeswrong/cli@latest ./package.tgz --format table --exclude-entrypoints cli

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ typesversions
 *.tgz
 
 tsconfig.vitest-temp.json
+
+# node version manager files
+.node-version
+.nvmrc

--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -84,6 +84,17 @@ const api = await generateEndpoints({
 })
 ```
 
+#### With Node.js Child process
+
+```ts no-transpile title="bin/openapi-codegen.ts"
+import { exec } from 'node:child_process'
+
+const cliPath = require.resolve('@rtk-query/codegen-openapi/cli')
+
+// you can also use esbuild-runner (esr) or ts-node instead of tsx
+exec(`tsx ${cliPath} config.ts`)
+```
+
 ### Config file options
 
 #### Simple usage

--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -18,7 +18,8 @@
         "types": "./lib/index.d.ts",
         "default": "./lib/index.js"
       }
-    }
+    },
+    "./cli": "./lib/bin/cli.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes https://github.com/reduxjs/redux-toolkit/issues/4976

exposes the cli in exports to be able to programmatically resolve the path at runtime and updates docs.

ie. *bin/openapi-codegen.ts*
```typescript
import { exec } from 'node:child_process'

const cliPath = require.resolve('@rtk-query/codegen-openapi/cli')

// you can also use esbuild-runner (esr) or ts-node instead of tsx
exec(`tsx ${cliPath} config.ts`)
```