### PR TITLE
fix(types): re-exporting WritableDraft from immer

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -10,7 +10,7 @@ export {
   original,
   isDraft,
 } from 'immer'
-export type { Draft } from 'immer'
+export type { Draft, WritableDraft } from 'immer'
 export {
   createSelector,
   createSelectorCreator,


### PR DESCRIPTION
Context is in https://github.com/reduxjs/redux-toolkit/issues/5014