### PR TITLE
Improve JSDoc comments in `@rtk-query/codegen-openapi`

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -38,77 +38,76 @@ export interface CommonOptions {
    */
   schemaFile: string;
   /**
-   * defaults to "api"
+   * @default "api"
    */
   apiImport?: string;
   /**
-   * defaults to "enhancedApi"
+   * @default "enhancedApi"
    */
   exportName?: string;
   /**
-   * defaults to "ApiArg"
+   * @default "ApiArg"
    */
   argSuffix?: string;
   /**
-   * defaults to "ApiResponse"
+   * @default "ApiResponse"
    */
   responseSuffix?: string;
   /**
-   * defaults to empty
+   * @default ""
    */
   operationNameSuffix?: string;
   /**
-   * defaults to `false`
    * `true` will generate hooks for queries and mutations, but no lazyQueries
+   * @default false
    */
   hooks?: boolean | { queries: boolean; lazyQueries: boolean; mutations: boolean };
   /**
-   * defaults to false
    * `true` will generate a union type for `undefined` properties like: `{ id?: string | undefined }` instead of `{ id?: string }`
+   * @default false
    */
   unionUndefined?: boolean;
   /**
-   * defaults to false
    * `true` will result in all generated endpoints having `providesTags`/`invalidatesTags` declarations for the `tags` of their respective operation definition
+   * @default false
    * @see https://redux-toolkit.js.org/rtk-query/usage/code-generation for more information
    */
   tag?: boolean;
   /**
-   * defaults to false
    * `true` will add `encodeURIComponent` to the generated path parameters
+   * @default false
    */
   encodePathParams?: boolean;
   /**
-   * defaults to false
    * `true` will add `encodeURIComponent` to the generated query parameters
+   * @default false
    */
   encodeQueryParams?: boolean;
   /**
-   * defaults to false
    * `true` will "flatten" the arg so that you can do things like `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`
+   * @default false
    */
   flattenArg?: boolean;
   /**
-   * default to false
    * If set to `true`, the default response type will be included in the generated code for all endpoints.
+   * @default false
    * @see https://swagger.io/docs/specification/describing-responses/#default
    */
   includeDefault?: boolean;
   /**
-   * default to false
    * `true` will not generate separate types for read-only and write-only properties.
+   * @default false
    */
   mergeReadWriteOnly?: boolean;
   /**
-   *
    * HTTPResolverOptions object that is passed to the SwaggerParser bundle function.
    */
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions;
 
   /**
-   * defaults to undefined
    * If present the given file will be used as prettier config when formatting the generated code. If undefined the default prettier config
    * resolution mechanism will be used.
+   * @default undefined
    */
   prettierConfigFile?: string;
 }
@@ -128,8 +127,8 @@ export interface OutputFileOptions extends Partial<CommonOptions> {
   filterEndpoints?: EndpointMatcher;
   endpointOverrides?: EndpointOverrides[];
   /**
-   * defaults to false
    * If passed as true it will generate TS enums instead of union of strings
+   * @default false
    */
   useEnumType?: boolean;
 }


### PR DESCRIPTION
I wasn't that happy with the way the default values for fields in the codegen types rendered in my IDE. After some small tweaks to the JSDoc comments, it looks much better.

Before:

<img width="320" height="250" alt="image" src="https://github.com/user-attachments/assets/84e0be85-50a4-453c-8c78-cb499b352f25" />

After:

<img width="321" height="253" alt="image" src="https://github.com/user-attachments/assets/bcac082b-652c-4cb2-bed7-834c815a3eaf" />
