### PR TITLE
fix: allow setting `CaseReducerWithPrepare` action types

### DIFF
--- a/packages/toolkit/src/createSlice.ts
+++ b/packages/toolkit/src/createSlice.ts
@@ -284,14 +284,17 @@ export type CaseReducerDefinition<
  *
  * @public
  */
-export type CaseReducerWithPrepare<State, Action extends PayloadAction> = {
+export type CaseReducerWithPrepare<
+  State,
+  Action extends PayloadAction<any, string, any, any>,
+> = {
   reducer: CaseReducer<State, Action>
   prepare: PrepareAction<Action['payload']>
 }
 
 export interface CaseReducerWithPrepareDefinition<
   State,
-  Action extends PayloadAction,
+  Action extends PayloadAction<any, string, any, any>,
 > extends CaseReducerWithPrepare<State, Action>,
     ReducerDefinition<ReducerType.reducerWithPrepare> {}
 

--- a/packages/toolkit/src/tests/createSlice.test-d.ts
+++ b/packages/toolkit/src/tests/createSlice.test-d.ts
@@ -8,6 +8,7 @@ import type {
   ActionReducerMapBuilder,
   AsyncThunk,
   CaseReducer,
+  CaseReducerWithPrepare,
   PayloadAction,
   PayloadActionCreator,
   Reducer,
@@ -15,7 +16,6 @@ import type {
   SerializedError,
   SliceCaseReducers,
   ThunkDispatch,
-  UnknownAction,
   ValidateSliceCaseReducers,
 } from '@reduxjs/toolkit'
 import {
@@ -991,5 +991,23 @@ describe('type tests', () => {
       creators: { asyncThunk: { [Symbol()]: createAsyncThunk } },
     })
     buildCreateSlice({ creators: { asyncThunk: asyncThunkCreator } })
+  })
+
+  test('wrapping create reducer creators should be possible', () => {
+    const highOrderCreateCaseReducerWithPrepare = <S>(
+      creator: ReducerCreators<S>,
+    ): CaseReducerWithPrepare<S, PayloadAction<S, string, any, any>> =>
+      creator.preparedReducer(
+        (p: S) => ({ payload: p }),
+        (state, action) => action.payload,
+      )
+
+    createSlice({
+      name: 'test',
+      initialState: 0,
+      reducers: (creators) => ({
+        increment: highOrderCreateCaseReducerWithPrepare(creators),
+      }),
+    })
   })
 })


### PR DESCRIPTION
Hi, I noticed a type error when implementing a function that returns a `CaseReducerWithPrepare` and found a fix for it. Hope it looks good to you! I'll attach the original error I met in the file changes comment.
