### PR TITLE
Only run `transformResponse` when a `query` is used

### DIFF
--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -510,10 +510,7 @@ export function buildThunks<
       endpointDefinition
 
     try {
-      let transformResponse = getTransformCallbackForEndpoint(
-        endpointDefinition,
-        'transformResponse',
-      )
+      let transformResponse: TransformCallback = defaultTransformResponse
 
       const baseQueryApi = {
         signal,
@@ -587,6 +584,13 @@ export function buildThunks<
           // upsertQueryData relies on this to pass in the user-provided value
           result = forceQueryFn()
         } else if (endpointDefinition.query) {
+          // We should only run `transformResponse` when the endpoint has a `query` method,
+          // and we're not doing an `upsertQueryData`.
+          transformResponse = getTransformCallbackForEndpoint(
+            endpointDefinition,
+            'transformResponse',
+          )
+
           result = await baseQuery(
             endpointDefinition.query(finalQueryArg as any),
             baseQueryApi,


### PR DESCRIPTION
This PR:

- Fixes the logic in `executeEndpoint` to only run a provided `transformResponse` callback when the endpoint's `query` method is used, _not_ when there's an `upsertQueryData` call or a `queryFn` field.

This fixes a regression introduced in #4738 as part of the thunk restructuring to enable infinite queries.

Fixes #4940