### PR TITLE
Abort pending requests if the cache entry is removed

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -1,6 +1,7 @@
 import type {
   Action,
   AsyncThunkAction,
+  Dispatch,
   Middleware,
   MiddlewareAPI,
   ThunkAction,
@@ -54,6 +55,10 @@ export interface BuildMiddlewareInput<
   api: Api<any, Definitions, ReducerPath, TagTypes>
   assertTagType: AssertTagTypes
   selectors: AllSelectors
+  getRunningQueryThunk: (
+    endpointName: string,
+    queryArgs: any,
+  ) => (dispatch: Dispatch) => QueryActionCreatorResult<any> | undefined
 }
 
 export type SubMiddlewareApi = MiddlewareAPI<

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -618,20 +618,6 @@ export const coreModule = ({
     })
     safeAssign(api.internalActions, sliceActions)
 
-    const { middleware, actions: middlewareActions } = buildMiddleware({
-      reducerPath,
-      context,
-      queryThunk,
-      mutationThunk,
-      infiniteQueryThunk,
-      api,
-      assertTagType,
-      selectors,
-    })
-    safeAssign(api.util, middlewareActions)
-
-    safeAssign(api, { reducer: reducer as any, middleware })
-
     const {
       buildInitiateQuery,
       buildInitiateInfiniteQuery,
@@ -655,6 +641,21 @@ export const coreModule = ({
       getRunningQueryThunk,
       getRunningQueriesThunk,
     })
+
+    const { middleware, actions: middlewareActions } = buildMiddleware({
+      reducerPath,
+      context,
+      queryThunk,
+      mutationThunk,
+      infiniteQueryThunk,
+      api,
+      assertTagType,
+      selectors,
+      getRunningQueryThunk,
+    })
+    safeAssign(api.util, middlewareActions)
+
+    safeAssign(api, { reducer: reducer as any, middleware })
 
     return {
       name: coreModuleName,


### PR DESCRIPTION
This PR:

- Updates the RTKQ internals to rearrange the API instance setup in `module.ts` so that `buildInitiate()` is called before `buildMiddleware()`, and then makes `getRunningQueryThunk` available to `buildMiddleware`
- Updates `cacheCollection.ts` to:
  - Ignore any subscription entries with a `"_running"` postfix when checking if there's still an active subscription to that cache entry.  Those indicate a pending request, not a full subscription, and can exist even if there are 0 true subscribers (ref: #3709 , #3706 )
  - Only run `handleUnsubscribe()` if there's still an actual cache entry at that time
  - When we do remove the cache entry, first check if there's a running query, and if so call `.abort()` on it
- We already expose the abort signal into the `retryCondition` callback, via `extraArgs.baseQueryApi.signal`.  Added a test to verify it gets marked as aborted if we have aborted the in-flight request.

Fixes #4942 