### PR TITLE
fix: incorrect position of keepUnusedDataFor for two scenarios

### DIFF
--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -482,6 +482,8 @@ By default, this function will take the query arguments, sort object keys where 
 
 [summary](docblock://query/createApi.ts?token=CreateApiOptions.keepUnusedDataFor)
 
+[examples](docblock://query/createApi.ts?token=CreateApiOptions.keepUnusedDataFor)
+
 ### `refetchOnMountOrArgChange`
 
 [summary](docblock://query/createApi.ts?token=CreateApiOptions.refetchOnMountOrArgChange)
@@ -684,7 +686,7 @@ Overrides the api-wide definition of `keepUnusedDataFor` for this endpoint only.
 
 [summary](docblock://query/createApi.ts?token=CreateApiOptions.keepUnusedDataFor)
 
-[examples](docblock://query/createApi.ts?token=CreateApiOptions.keepUnusedDataFor)
+[examples](docblock://query/core/buildMiddleware/cacheCollection.ts?token=CacheCollectionQueryExtraOptions)
 
 ### `serializeQueryArgs`
 

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -21,6 +21,30 @@ function isObjectEmpty(obj: Record<any, any>) {
   return true
 }
 
+/**
+ * @example
+   * ```ts
+   * // codeblock-meta title="keepUnusedDataFor example"
+   * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+   * interface Post {
+   *   id: number
+   *   name: string
+   * }
+   * type PostsResponse = Post[]
+   *
+   * const api = createApi({
+   *   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+   *   endpoints: (build) => ({
+   *     getPosts: build.query<PostsResponse, void>({
+   *       query: () => 'posts',
+   *       // highlight-start
+   *       keepUnusedDataFor: 5
+   *       // highlight-end
+   *     })
+   *   })
+   * })
+   * ```
+ */
 export type CacheCollectionQueryExtraOptions = {
   /**
    * Overrides the api-wide definition of `keepUnusedDataFor` for this endpoint only. _(This value is in seconds.)_

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -109,9 +109,9 @@ export interface CreateApiOptions<
   /**
    * Defaults to `60` _(this value is in seconds)_. This is how long RTK Query will keep your data cached for **after** the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
    *
+   * @example
    * ```ts
    * // codeblock-meta title="keepUnusedDataFor example"
-   *
    * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
    * interface Post {
    *   id: number
@@ -124,11 +124,11 @@ export interface CreateApiOptions<
    *   endpoints: (build) => ({
    *     getPosts: build.query<PostsResponse, void>({
    *       query: () => 'posts',
-   *       // highlight-start
-   *       keepUnusedDataFor: 5
-   *       // highlight-end
    *     })
    *   })
+   *   // highlight-start
+   *   keepUnusedDataFor: 5
+   *   // highlight-end
    * })
    * ```
    */

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -36,6 +36,7 @@ const config: Config = {
                     'query/endpointDefinitions.ts',
                     'query/react/index.ts',
                     'query/react/ApiProvider.tsx',
+                    'query/core/buildMiddleware/cacheCollection.ts',
                   ],
                 },
               },


### PR DESCRIPTION
As we can put keepUnusedDataFor in both `createApi` and `endpoints` level hence we need to correct examples for each of the use case.

Due to the [constraint from remark-typescript-tools](https://github.com/phryneas/remark-typescript-tools/issues/4), I am not able to have nested identifier in a Typescript type hence I put the example on the outermost level which I think no harm