### PR TITLE
Add edit URL for documentation in Docusaurus config

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
           sidebarPath: require.resolve('./sidebars'),
           showLastUpdateTime: true,
           routeBasePath: '/',
-          editUrl: 'https://github.com/reduxjs/redux-toolkit/edit/master/docs/',
+          editUrl: 'https://github.com/reduxjs/redux-toolkit/blob/master/docs/',
           include: [
             '{api,assets,introduction,migrations,rtk-query,tutorials,usage}/**/*.{md,mdx}',
           ], // no other way to exclude node_modules

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
           sidebarPath: require.resolve('./sidebars'),
           showLastUpdateTime: true,
           routeBasePath: '/',
+          editUrl: 'https://github.com/reduxjs/redux-toolkit/edit/master/docs/',
           include: [
             '{api,assets,introduction,migrations,rtk-query,tutorials,usage}/**/*.{md,mdx}',
           ], // no other way to exclude node_modules


### PR DESCRIPTION
Include an edit URL in the Docusaurus configuration to facilitate direct editing of documentation on GitHub.

<img width="1028" height="706" alt="image" src="https://github.com/user-attachments/assets/36533163-72e6-4cff-b125-d7568bb0d035" />
