### PR TITLE
fix(types): ensure non-undefined `data` on isSuccess with `exactOptionalPropertyTypes`

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -718,44 +718,58 @@ type UseQueryStateBaseResult<D extends QueryDefinition<any, any, any, any>> =
     isError: false
   }
 
+type UseQueryStateUninitialized<D extends QueryDefinition<any, any, any, any>> =
+  TSHelpersOverride<
+    Extract<UseQueryStateBaseResult<D>, { status: QueryStatus.uninitialized }>,
+    { isUninitialized: true }
+  >
+
+type UseQueryStateLoading<D extends QueryDefinition<any, any, any, any>> =
+  TSHelpersOverride<
+    UseQueryStateBaseResult<D>,
+    { isLoading: true; isFetching: boolean; data: undefined }
+  >
+
+type UseQueryStateSuccessFetching<
+  D extends QueryDefinition<any, any, any, any>,
+> = TSHelpersOverride<
+  UseQueryStateBaseResult<D>,
+  {
+    isSuccess: true
+    isFetching: true
+    error: undefined
+  } & {
+    data: ResultTypeFrom<D>
+  } & Required<Pick<UseQueryStateBaseResult<D>, 'fulfilledTimeStamp'>>
+>
+
+type UseQueryStateSuccessNotFetching<
+  D extends QueryDefinition<any, any, any, any>,
+> = TSHelpersOverride<
+  UseQueryStateBaseResult<D>,
+  {
+    isSuccess: true
+    isFetching: false
+    error: undefined
+  } & {
+    data: ResultTypeFrom<D>
+    currentData: ResultTypeFrom<D>
+  } & Required<Pick<UseQueryStateBaseResult<D>, 'fulfilledTimeStamp'>>
+>
+
+type UseQueryStateError<D extends QueryDefinition<any, any, any, any>> =
+  TSHelpersOverride<
+    UseQueryStateBaseResult<D>,
+    { isError: true } & Required<Pick<UseQueryStateBaseResult<D>, 'error'>>
+  >
+
 type UseQueryStateDefaultResult<D extends QueryDefinition<any, any, any, any>> =
   TSHelpersId<
-    | TSHelpersOverride<
-        Extract<
-          UseQueryStateBaseResult<D>,
-          { status: QueryStatus.uninitialized }
-        >,
-        { isUninitialized: true }
-      >
-    | TSHelpersOverride<
-        UseQueryStateBaseResult<D>,
-        | { isLoading: true; isFetching: boolean; data: undefined }
-        | ({
-            isSuccess: true
-            isFetching: true
-            error: undefined
-          } & {
-            data: ResultTypeFrom<D>
-          } & Required<
-            Pick<UseQueryStateBaseResult<D>, 'fulfilledTimeStamp'>
-          >)
-        | ({
-            isSuccess: true
-            isFetching: false
-            error: undefined
-          } & {
-            data: ResultTypeFrom<D>
-            currentData: ResultTypeFrom<D>
-          } & Required<
-            Pick<
-              UseQueryStateBaseResult<D>,
-              'fulfilledTimeStamp'
-            >
-          >)
-        | ({ isError: true } & Required<
-            Pick<UseQueryStateBaseResult<D>, 'error'>
-          >)
-      >
+    | UseQueryStateUninitialized<D>
+    | UseQueryStateLoading<D>
+    | UseQueryStateSuccessFetching<D>
+    | UseQueryStateSuccessNotFetching<D>
+    | UseQueryStateError<D>
   > & {
     /**
      * @deprecated Included for completeness, but discouraged.


### PR DESCRIPTION
Fixes #5086 

fix(types): ensure non-undefined `data` on isSuccess with exactOptionalPropertyTypes

When TypeScript `exactOptionalPropertyTypes: true` is enabled, `UseQueryStateDefaultResult`
could infer `data` as `undefined` even on `isSuccess` branches. This patch explicitly sets
`data: ResultTypeFrom<D>` (and `currentData: ResultTypeFrom<D>` when `!isFetching`)
to provide correct type narrowing while keeping `isLoading` as `data: undefined`.

- Replace Required<Pick<..., 'data'>> with explicit `data: ResultTypeFrom<D>`
- Keep `data: undefined` only on `isLoading` branch
- Make `currentData` required on `isSuccess && !isFetching` 
- Preserve `fulfilledTimeStamp`/`error` constraints

<img width="639" height="815" alt="image" src="https://github.com/user-attachments/assets/08b48ba3-6e7f-450f-88e7-d2529e2aedd6" />
