### PR TITLE
Fix potential subscription leakage in SSR environments

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -13,27 +13,27 @@ export type ReferenceCacheCollection = never
 
 /**
  * @example
-   * ```ts
-   * // codeblock-meta title="keepUnusedDataFor example"
-   * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-   * interface Post {
-   *   id: number
-   *   name: string
-   * }
-   * type PostsResponse = Post[]
-   *
-   * const api = createApi({
-   *   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-   *   endpoints: (build) => ({
-   *     getPosts: build.query<PostsResponse, void>({
-   *       query: () => 'posts',
-   *       // highlight-start
-   *       keepUnusedDataFor: 5
-   *       // highlight-end
-   *     })
-   *   })
-   * })
-   * ```
+ * ```ts
+ * // codeblock-meta title="keepUnusedDataFor example"
+ * import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+ * interface Post {
+ *   id: number
+ *   name: string
+ * }
+ * type PostsResponse = Post[]
+ *
+ * const api = createApi({
+ *   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+ *   endpoints: (build) => ({
+ *     getPosts: build.query<PostsResponse, void>({
+ *       query: () => 'posts',
+ *       // highlight-start
+ *       keepUnusedDataFor: 5
+ *       // highlight-end
+ *     })
+ *   })
+ * })
+ * ```
  */
 export type CacheCollectionQueryExtraOptions = {
   /**
@@ -64,8 +64,6 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
   const { removeQueryResult, unsubscribeQueryResult, cacheEntriesUpserted } =
     api.internalActions
 
-  const runningQueries = internalState.runningQueries.get(mwApi.dispatch)!
-
   const canTriggerUnsubscribe = isAnyOf(
     unsubscribeQueryResult.match,
     queryThunk.fulfilled,
@@ -80,8 +78,7 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
     }
 
     const hasSubscriptions = subscriptions.size > 0
-    const isRunning = runningQueries?.[queryCacheKey] !== undefined
-    return hasSubscriptions || isRunning
+    return hasSubscriptions
   }
 
   const currentRemovalTimeouts: QueryStateMeta<TimeoutId> = {}

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -45,7 +45,7 @@ export function buildMiddleware<
   ReducerPath extends string,
   TagTypes extends string,
 >(input: BuildMiddlewareInput<Definitions, ReducerPath, TagTypes>) {
-  const { reducerPath, queryThunk, api, context, internalState } = input
+  const { reducerPath, queryThunk, api, context, getInternalState } = input
   const { apiUid } = context
 
   const actions = {
@@ -72,6 +72,8 @@ export function buildMiddleware<
     ThunkDispatch<any, any, UnknownAction>
   > = (mwApi) => {
     let initialized = false
+
+    const internalState = getInternalState(mwApi.dispatch)
 
     const builderArgs = {
       ...(input as any as BuildMiddlewareInput<

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -47,18 +47,12 @@ export interface InternalMiddlewareState {
   currentSubscriptions: SubscriptionInternalState
   currentPolls: Map<string, QueryPollState>
   runningQueries: Map<
-    Dispatch,
-    Record<
-      string,
-      | QueryActionCreatorResult<any>
-      | InfiniteQueryActionCreatorResult<any>
-      | undefined
-    >
+    string,
+    | QueryActionCreatorResult<any>
+    | InfiniteQueryActionCreatorResult<any>
+    | undefined
   >
-  runningMutations: Map<
-    Dispatch,
-    Record<string, MutationActionCreatorResult<any> | undefined>
-  >
+  runningMutations: Map<string, MutationActionCreatorResult<any> | undefined>
 }
 
 export interface SubscriptionSelectors {
@@ -84,7 +78,7 @@ export interface BuildMiddlewareInput<
     endpointName: string,
     queryArgs: any,
   ) => (dispatch: Dispatch) => QueryActionCreatorResult<any> | undefined
-  internalState: InternalMiddlewareState
+  getInternalState: (dispatch: Dispatch) => InternalMiddlewareState
 }
 
 export type SubMiddlewareApi = MiddlewareAPI<

--- a/packages/toolkit/src/query/utils/isNotNullish.ts
+++ b/packages/toolkit/src/query/utils/isNotNullish.ts
@@ -1,3 +1,7 @@
 export function isNotNullish<T>(v: T | null | undefined): v is T {
   return v != null
 }
+
+export function filterNullishValues<T>(map?: Map<any, T>) {
+  return [...(map?.values() ?? [])].filter(isNotNullish) as NonNullable<T>[]
+}


### PR DESCRIPTION
This PR:

- Fixes a bug caused by #5064 that could allow some active subscription entries to leak when the same RTKQ middleware definition is used with multiple stores.
- Fixes another issue where the `isRunning` value in `anySubscriptionsRemaining` was always `false`, because it tried to access the `runningQueries` map too early and there was no per-store lookup table of promises yet

Fixes #5110 

## Background

In #5064 , I rewrote RTKQ's internals to improve perf.  As part of that, I hoisted the `InternalMiddlewareState` object out of `buildMiddleware` and into `core/module.ts` (part of `createApi`), so that both the middleware and the thunks could access the same subscription data directly.

Redux middleware are factory functions for closures.  When `createStore` is called, it executes the outermost middleware function, which creates a closure scoped to just that store instance.  When the `InternalMiddlewareState` object was being created there, this was fine - every store would get its own `InternalMiddlewareState`.

When I moved that instantiation up to `createApi`, though, now that value is outside the scope of the middleware, and thus outside the lifetime of a given store.  If multiple stores use the same RTKQ middleware definition, they each create their own unique middleware _instance_, but those middleware instances are all sharing the same `InternalMiddlewareState` reference.

To be clear, this doesn't appear to have leaked any actual cache data - just that there were subscriptions of some kind, with RTKQ's internal cache entry IDs.  

This PR resolves that by using the same technique we did for thunk promises - a `WeakMap<Dispatch, Thing>` that ensures we cache the value on a per-store basis.  In fact, since the `runningQueries/Mutations` maps were already on the `InternalMiddlewareState`, we're really just moving the `Dispatch` keying up one level, which simplifies a few other checks.

I found I'd caused another issue in #5064 in the process.  I had tried to save `const runningQueries = internalState.runningQueries.get(dispatch)` at the top of `cacheCollection.ts`, and then use it in `anySubscriptionsRemaining`.  When I made my fixes for this issue, a single test in `buildHooks.test.tsx` failed, indicating some subscriptions weren't getting cleaned up.  After a lot of investigation, I finally realized that the problem was the `isRunning` check itself.  I added logging to the pre-fix logic and found that `runningQueries` itself was always `undefined`... because we only inserted the per-store lookup table whenever we had active running promises.  Since we were trying to read that at the start of the middleware, there was no lookup table for this store yet.  My fix accidentally uncovered that broken logic.

It turns out that with the various other changes we've had, the `isRunning` check in `anySubscriptionsRemaining` isn't even needed!  I removed it and all the tests passed, with both the pre- and post-fix subscription handling.  I actually _don't_ have a full explanation for that right now, but also it's late and my mind's kinda fried :)

