### PR TITLE
Fix window SSR breakage

### DIFF
--- a/packages/toolkit/src/query/core/setupListeners.ts
+++ b/packages/toolkit/src/query/core/setupListeners.ts
@@ -83,8 +83,7 @@ export function setupListeners(
     }
 
     if (!initialized) {
-      const WINDOW = window
-      if (typeof WINDOW !== 'undefined' && !!WINDOW.addEventListener) {
+      if (typeof window !== 'undefined' && window.addEventListener) {
         const handlers = {
           [FOCUS]: handleFocus,
           [VISIBILITYCHANGE]: handleVisibilityChange,
@@ -95,9 +94,9 @@ export function setupListeners(
         function updateListeners(add: boolean) {
           Object.entries(handlers).forEach(([event, handler]) => {
             if (add) {
-              WINDOW.addEventListener(event, handler, false)
+              window.addEventListener(event, handler, false)
             } else {
-              WINDOW.removeEventListener(event, handler)
+              window.removeEventListener(event, handler)
             }
           })
         }


### PR DESCRIPTION
This PR:

- Reverts the `window` accesses from #5129 , which broke behavior in SSR