### PR TITLE
Update Immer to v11 for better update performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ tsconfig.vitest-temp.json
 # node version manager files
 .node-version
 .nvmrc
+
+# Assorted local docs
+docs/dev-plans
+# Perf protobufs
+*.pb.gz

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -261,7 +261,7 @@
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
     "@standard-schema/utils": "^0.3.0",
-    "immer": "^10.2.0",
+    "immer": "^11.0.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
     "reselect": "^5.1.0"

--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -11,13 +11,6 @@ import { executeReducerBuilderCallback } from './mapBuilders'
 import type { NoInfer, TypeGuard } from './tsHelpers'
 import { freezeDraftable } from './utils'
 
-// Immer 10.2 defaults to still using strict iteration (specifically
-// `Reflect.ownKeys()` for symbols support). However, we assume that
-// Redux users are not using symbols as state keys, so we'll override
-// this to prefer `Object.keys()` instead, as it provides a ~10% speedup.
-// If users do need symbol support, they can call `setUseStrictIteration(true)` themselves.
-setUseStrictIteration(false)
-
 /**
  * Defines a mapping from action types to corresponding action object shapes.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,7 +7695,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.23.2"
     eslint-plugin-react-hooks: "npm:^4.2.0"
     fs-extra: "npm:^9.1.0"
-    immer: "npm:^10.2.0"
+    immer: "npm:^11.0.0"
     invariant: "npm:^2.2.4"
     jsdom: "npm:^25.0.1"
     json-stringify-safe: "npm:^5.0.1"
@@ -18728,10 +18728,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "immer@npm:10.2.0"
-  checksum: 10/d73e218c8f8ffbb39f9290dfafa478b94af73403dcf26b5672eef35233bb30f09ffe231f8a78a6c9cb442968510edd89e851776ec90a5ddfa82cee6db6b35137
+"immer@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "immer@npm:11.0.0"
+  checksum: 10/d79824edac56741986d80f091fcec00330e7fa4406a82f9e6bb30997c2674c468afe5196750456fc592c7e40cf903d968e04f8035efc9f26c073b5ed2b52462f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

- Bumps our Immer dep to https://github.com/immerjs/immer/releases/tag/v11.0.0 to pick up the architectural performance rewrites I've done there