### PR TITLE
Speed up type checking by explicitly annotating some type parameter variances

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -135,13 +135,14 @@ export interface QueryCacheLifecycleApi<
 > extends QueryBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,
     CacheLifecyclePromises<ResultType, BaseQueryMeta<BaseQuery>> {}
 
-export type MutationCacheLifecycleApi<
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  ResultType,
-  ReducerPath extends string = string,
-> = MutationBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath> &
+export interface MutationCacheLifecycleApi<
+  in QueryArg,
+  in BaseQuery extends BaseQueryFn,
+  out ResultType,
+  in ReducerPath extends string = string,
+> extends MutationBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,
   CacheLifecyclePromises<ResultType, BaseQueryMeta<BaseQuery>>
+  {}
 
 export type CacheLifecycleQueryExtraOptions<
   ResultType,

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -51,12 +51,12 @@ export interface QueryBaseLifecycleApi<
   updateCachedData(updateRecipe: Recipe<ResultType>): PatchCollection
 }
 
-export type MutationBaseLifecycleApi<
+export interface MutationBaseLifecycleApi<
   QueryArg,
   BaseQuery extends BaseQueryFn,
   ResultType,
   ReducerPath extends string = string,
-> = LifecycleApi<ReducerPath> & {
+> extends LifecycleApi<ReducerPath> {
   /**
    * Gets the current value of this cache entry.
    */
@@ -70,7 +70,7 @@ export type MutationBaseLifecycleApi<
   >
 }
 
-type LifecycleApi<ReducerPath extends string = string> = {
+type LifecycleApi<in ReducerPath extends string = string> = {
   /**
    * The dispatch method for the store
    */

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -52,10 +52,10 @@ export interface QueryBaseLifecycleApi<
 }
 
 export interface MutationBaseLifecycleApi<
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  ResultType,
-  ReducerPath extends string = string,
+  in QueryArg,
+  in BaseQuery extends BaseQueryFn,
+  in ResultType,
+  in ReducerPath extends string = string,
 > extends LifecycleApi<ReducerPath> {
   /**
    * Gets the current value of this cache entry.

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -89,7 +89,10 @@ type LifecycleApi<ReducerPath extends string = string> = {
   requestId: string
 }
 
-type CacheLifecyclePromises<ResultType = unknown, MetaType = unknown> = {
+type CacheLifecyclePromises<
+  out ResultType = unknown,
+  out MetaType = unknown,
+> = {
   /**
    * Promise that will resolve with the first value for this cache key.
    * This allows you to `await` until an actual value is in cache.
@@ -125,10 +128,10 @@ type CacheLifecyclePromises<ResultType = unknown, MetaType = unknown> = {
 }
 
 export interface QueryCacheLifecycleApi<
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  ResultType,
-  ReducerPath extends string = string,
+  in QueryArg,
+  in BaseQuery extends BaseQueryFn,
+  out ResultType,
+  in ReducerPath extends string = string,
 > extends QueryBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,
     CacheLifecyclePromises<ResultType, BaseQueryMeta<BaseQuery>> {}
 

--- a/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -202,8 +202,8 @@ export type QueryLifecycleMutationExtraOptions<
 export interface QueryLifecycleApi<
   QueryArg,
   BaseQuery extends BaseQueryFn,
-  ResultType,
-  ReducerPath extends string = string,
+  out ResultType,
+  in ReducerPath extends string = string,
 > extends QueryBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,
     QueryLifecyclePromises<ResultType, BaseQuery> {}
 

--- a/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -200,8 +200,8 @@ export type QueryLifecycleMutationExtraOptions<
 }
 
 export interface QueryLifecycleApi<
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
+  in QueryArg,
+  in BaseQuery extends BaseQueryFn,
   out ResultType,
   in ReducerPath extends string = string,
 > extends QueryBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,

--- a/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/queryLifecycle.ts
@@ -207,13 +207,13 @@ export interface QueryLifecycleApi<
 > extends QueryBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,
     QueryLifecyclePromises<ResultType, BaseQuery> {}
 
-export type MutationLifecycleApi<
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  ResultType,
-  ReducerPath extends string = string,
-> = MutationBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath> &
-  QueryLifecyclePromises<ResultType, BaseQuery>
+export interface MutationLifecycleApi<
+  in QueryArg,
+  in BaseQuery extends BaseQueryFn,
+  out ResultType,
+  in ReducerPath extends string = string,
+> extends MutationBaseLifecycleApi<QueryArg, BaseQuery, ResultType, ReducerPath>,
+  QueryLifecyclePromises<ResultType, BaseQuery> {}
 
 /**
  * Provides a way to define a strongly-typed version of

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -1061,14 +1061,14 @@ export type InfiniteQueryDefinition<
       RawResultType
     >
 
-type MutationTypes<
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  TagTypes extends string,
-  ResultType,
-  ReducerPath extends string = string,
-  RawResultType extends BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
-> = BaseEndpointTypes<QueryArg, BaseQuery, ResultType, RawResultType> & {
+export interface  MutationTypes<
+  in out QueryArg,
+  out BaseQuery extends BaseQueryFn,
+  out TagTypes extends string,
+  in out ResultType,
+  out ReducerPath extends string = string,
+  out RawResultType extends BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
+> extends BaseEndpointTypes<QueryArg, BaseQuery, ResultType, RawResultType> {
   /**
    * The endpoint definition type. To be used with some internal generic types.
    * @example

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -65,8 +65,8 @@ export type SchemaFailureConverter<BaseQuery extends BaseQueryFn> = (
 export type EndpointDefinitionWithQuery<
   QueryArg,
   BaseQuery extends BaseQueryFn,
-  ResultType,
-  RawResultType extends BaseQueryResult<BaseQuery>,
+  out ResultType,
+  out RawResultType extends BaseQueryResult<BaseQuery>,
 > = {
   /**
    * `query` can be a function that returns either a `string` or an `object` which is passed to your `baseQuery`. If you are using [fetchBaseQuery](./fetchBaseQuery), this can return either a `string` or an `object` of properties in `FetchArgs`. If you use your own custom [`baseQuery`](../../rtk-query/usage/customizing-queries), you can customize this behavior to your liking.
@@ -566,12 +566,13 @@ type QueryTypes<
  * @public
  */
 export interface QueryExtraOptions<
-  TagTypes extends string,
-  ResultType,
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  ReducerPath extends string = string,
-  RawResultType extends BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
+  out TagTypes extends string,
+  in out ResultType,
+  in out QueryArg,
+  out BaseQuery extends BaseQueryFn,
+  out ReducerPath extends string = string,
+  out RawResultType extends
+    BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
 > extends CacheLifecycleQueryExtraOptions<
       ResultType,
       QueryArg,
@@ -872,13 +873,14 @@ export type InfiniteQueryTypes<
 }
 
 export interface InfiniteQueryExtraOptions<
-  TagTypes extends string,
-  ResultType,
-  QueryArg,
-  PageParam,
-  BaseQuery extends BaseQueryFn,
-  ReducerPath extends string = string,
-  RawResultType extends BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
+  out TagTypes extends string,
+  in out ResultType,
+  in out QueryArg,
+  in out PageParam,
+  out BaseQuery extends BaseQueryFn,
+  out ReducerPath extends string = string,
+  out RawResultType extends
+    BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
 > extends CacheLifecycleInfiniteQueryExtraOptions<
       InfiniteData<ResultType, PageParam>,
       QueryArg,
@@ -1089,12 +1091,13 @@ type MutationTypes<
  * @public
  */
 export interface MutationExtraOptions<
-  TagTypes extends string,
-  ResultType,
-  QueryArg,
-  BaseQuery extends BaseQueryFn,
-  ReducerPath extends string = string,
-  RawResultType extends BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
+  out TagTypes extends string,
+  in out ResultType,
+  in out QueryArg,
+  out BaseQuery extends BaseQueryFn,
+  out ReducerPath extends string = string,
+  out RawResultType extends
+    BaseQueryResult<BaseQuery> = BaseQueryResult<BaseQuery>,
 > extends CacheLifecycleMutationExtraOptions<
       ResultType,
       QueryArg,
@@ -1262,11 +1265,11 @@ export function isAnyQueryDefinition(
   return isQueryDefinition(e) || isInfiniteQueryDefinition(e)
 }
 
-export type EndpointBuilder<
-  BaseQuery extends BaseQueryFn,
-  TagTypes extends string,
-  ReducerPath extends string,
-> = {
+export interface EndpointBuilder<
+  out BaseQuery extends BaseQueryFn,
+  out TagTypes extends string,
+  out ReducerPath extends string,
+> {
   /**
    * An endpoint definition that retrieves data, and may provide tags to the cache.
    *

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -1,6 +1,7 @@
 // This must remain here so that the `mangleErrors.cjs` build script
 // does not have to import this into each source file it rewrites.
 import { formatProdErrorMessage } from '@reduxjs/toolkit'
+import type { MutationBaseLifecycleApi } from './core/buildMiddleware/cacheLifecycle'
 
 export type {
   CombinedState,
@@ -104,3 +105,9 @@ export type {
 } from './tsHelpers'
 
 export { NamedSchemaError } from './standardSchema'
+
+// This is for type portability when using interfaces that we don't want to expose
+// interfaces are sometimes preferred over type aliases for faster type inference
+export declare namespace RTKInternalDoNotUse {
+  export { MutationBaseLifecycleApi }
+}

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -1,7 +1,9 @@
 // This must remain here so that the `mangleErrors.cjs` build script
 // does not have to import this into each source file it rewrites.
 import { formatProdErrorMessage } from '@reduxjs/toolkit'
-import type { MutationBaseLifecycleApi } from './core/buildMiddleware/cacheLifecycle'
+import type { MutationBaseLifecycleApi, MutationCacheLifecycleApi } from './core/buildMiddleware/cacheLifecycle'
+import type { MutationTypes } from './endpointDefinitions'
+import type { MutationLifecycleApi } from './core/buildMiddleware'
 
 export type {
   CombinedState,
@@ -108,6 +110,9 @@ export { NamedSchemaError } from './standardSchema'
 
 // This is for type portability when using interfaces that we don't want to expose
 // interfaces are sometimes preferred over type aliases for faster type inference
-export declare namespace RTKInternalDoNotUse {
-  export { MutationBaseLifecycleApi }
+export {
+  MutationBaseLifecycleApi as RTKInternalDoNotUseMutationBaseLifecycleApi,
+  MutationCacheLifecycleApi as RTKInternalDoNotUseMutationCacheLifecycleApi,
+  MutationLifecycleApi as RTKInternalDoNotUseMutationLifecycleApi,
+  MutationTypes as RTKInternalDoNotUseMutationTypes
 }


### PR DESCRIPTION
# Why
In certain cases, type inference could be slow and reach typescript depth limits. Eg https://github.com/reduxjs/redux-toolkit/issues/3214

# How
By using typescript performance tracing on some examples from the above issue, I've manged to track down the slowness to checking the variances of various type parameters.
I used TypeSlayer's Type search to find the types where the variance was checked, and using the result data from the performance trace, I filled in the variances.

Since not all types of variance can be marked explicitly, I skipped some of them or added a different specifier. Eg `in` for bivariant.
I'm not 100% sure if this is correct, but many combinations produced type errors in various places, so based on my current understanding a wrong variance would cause type errors elsewhere.
I'm also not sure if this catches all common occurrences of this issue as I was using very simple examples. I will test for robustness + effectiveness by running the changes through a proprietary project and reporting the results.

I'm also not sure if this is the ideal way to solve this problem, I'd assume that there are other simplifications one could make to the types that would result in the built-in variance checking to get faster, but I couldn't find those and don't know enough about what's slow in the current version to do that


I think this could be a breaking change for some users:
- in some cases the reduced type complexity will surface existing type issues that were too complex to discover before
- In some cases the variants might cause a different breakage in client code => I'm hoping that the tests sufficiently account for this

# What
- Change `EndpointBuilder` from a type alias to an interface
- Add `in` `out` or `in out` variance specifiers to some type properties
