### PR TITLE
fix(query): prevent `onQueryStarted` from triggering at end-of-list

### DIFF
--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -971,6 +971,25 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
           return false
         }
 
+        if (direction && isInfiniteQueryDefinition(endpointDefinition)) {
+          const cachedData = requestState?.data as
+            | InfiniteData<unknown, unknown>
+            | undefined
+          if (cachedData?.pages.length) {
+            const { infiniteQueryOptions } = endpointDefinition
+            const pageParamFn =
+              direction === 'forward' ? getNextPageParam : getPreviousPageParam
+            const nextParam = pageParamFn(
+              infiniteQueryOptions,
+              cachedData,
+              currentArg,
+            )
+            if (nextParam == null) {
+              return false
+            }
+          }
+        }
+
         return true
       },
       dispatchConditionRejection: true,

--- a/packages/toolkit/src/query/tests/infiniteQueries.test.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test.ts
@@ -981,6 +981,145 @@ describe('Infinite queries', () => {
     expect(onQueryStartedCallCount).toBe(3)
   })
 
+  test('fetchPreviousPage does not trigger onQueryStarted when hasPreviousPage is false', async () => {
+    let onQueryStartedCallCount = 0
+
+    const api = createApi({
+      baseQuery: fakeBaseQuery(),
+      endpoints: (build) => ({
+        list: build.infiniteQuery<string, void, number>({
+          infiniteQueryOptions: {
+            initialPageParam: 0,
+            getNextPageParam: (lastPage, allPages) => allPages.length,
+            getPreviousPageParam: () => undefined,
+          },
+          queryFn: async ({ pageParam }) => ({ data: `page-${pageParam}` }),
+          onQueryStarted: async () => {
+            onQueryStartedCallCount++
+          },
+        }),
+      }),
+    })
+
+    const storeRef = setupApiStore(api, undefined, {
+      withoutTestLifecycles: true,
+    })
+
+    await storeRef.store.dispatch(api.endpoints.list.initiate())
+    expect(onQueryStartedCallCount).toBe(1)
+
+    await storeRef.store.dispatch(
+      api.endpoints.list.initiate(undefined, { direction: 'backward' }),
+    )
+    expect(onQueryStartedCallCount).toBe(1)
+  })
+
+  test('end-of-list skip does not set error state', async () => {
+    const api = createApi({
+      baseQuery: fakeBaseQuery(),
+      endpoints: (build) => ({
+        list: build.infiniteQuery<string, void, number>({
+          infiniteQueryOptions: {
+            initialPageParam: 0,
+            getNextPageParam: (lastPage, allPages) =>
+              allPages.length < 2 ? allPages.length : undefined,
+          },
+          queryFn: async ({ pageParam }) => ({ data: `page-${pageParam}` }),
+        }),
+      }),
+    })
+
+    const storeRef = setupApiStore(api, undefined, {
+      withoutTestLifecycles: true,
+    })
+
+    await storeRef.store.dispatch(api.endpoints.list.initiate())
+    await storeRef.store.dispatch(
+      api.endpoints.list.initiate(undefined, { direction: 'forward' }),
+    )
+
+    await storeRef.store.dispatch(
+      api.endpoints.list.initiate(undefined, { direction: 'forward' }),
+    )
+
+    const selector = api.endpoints.list.select()(storeRef.store.getState())
+
+    expect(selector.isFetchingNextPage).toBe(false)
+    expect(selector.isError).toBe(false)
+    expect(selector.error).toBeUndefined()
+    expect(selector.data?.pages).toHaveLength(2)
+  })
+
+  test('fetchNextPage skips when getNextPageParam returns null', async () => {
+    let onQueryStartedCallCount = 0
+
+    const api = createApi({
+      baseQuery: fakeBaseQuery(),
+      endpoints: (build) => ({
+        list: build.infiniteQuery<string, void, number>({
+          infiniteQueryOptions: {
+            initialPageParam: 0,
+            getNextPageParam: () => null as number | null | undefined,
+          },
+          queryFn: async ({ pageParam }) => ({ data: `page-${pageParam}` }),
+          onQueryStarted: async () => {
+            onQueryStartedCallCount++
+          },
+        }),
+      }),
+    })
+
+    const storeRef = setupApiStore(api, undefined, {
+      withoutTestLifecycles: true,
+    })
+
+    await storeRef.store.dispatch(api.endpoints.list.initiate())
+    expect(onQueryStartedCallCount).toBe(1)
+
+    await storeRef.store.dispatch(
+      api.endpoints.list.initiate(undefined, { direction: 'forward' }),
+    )
+    expect(onQueryStartedCallCount).toBe(1)
+  })
+
+  test('fetchNextPage works with falsy but valid pageParam', async () => {
+    let fetchCount = 0
+
+    const api = createApi({
+      baseQuery: fakeBaseQuery(),
+      endpoints: (build) => ({
+        list: build.infiniteQuery<string, void, number>({
+          infiniteQueryOptions: {
+            initialPageParam: 1,
+            getNextPageParam: (lastPage, allPages, lastPageParam) =>
+              lastPageParam > 0 ? lastPageParam - 1 : undefined,
+          },
+          queryFn: async ({ pageParam }) => {
+            fetchCount++
+            return { data: `page-${pageParam}` }
+          },
+        }),
+      }),
+    })
+
+    const storeRef = setupApiStore(api, undefined, {
+      withoutTestLifecycles: true,
+    })
+
+    await storeRef.store.dispatch(api.endpoints.list.initiate())
+    expect(fetchCount).toBe(1)
+
+    await storeRef.store.dispatch(
+      api.endpoints.list.initiate(undefined, { direction: 'forward' }),
+    )
+    expect(fetchCount).toBe(2)
+
+    await storeRef.store.dispatch(
+      api.endpoints.list.initiate(undefined, { direction: 'forward' }),
+    )
+    expect(fetchCount).toBe(2)
+  })
+
   test('Can use transformResponse', async () => {
     type PokemonPage = { items: Pokemon[]; page: number }
     const pokemonApi = createApi({


### PR DESCRIPTION
Fixes #5167

## Summary

When `fetchNextPage()` or `fetchPreviousPage()` is called at end-of-list (when `getNextPageParam`/`getPreviousPageParam` returns `undefined`), the thunk was still executing and triggering `onQueryStarted` with stale cached data.

To solve the problem added an early bail-out in the thunk's `condition` function -> to check if the next/previous page actually exists before processing any action.

## Changes

- Added direction check in `buildThunks.ts` condition function
- Added test case for the fix
- Updated existing test expectation (removed `isFetchingPreviousPage: true` when no previous page exists)

## Test

- yarn test
- yarn type-tests
- yarn eslint
