### PR TITLE
feat!: rename `RootState` type to `ApiRootState`

### DIFF
--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -719,7 +719,7 @@ _(optional, only for query endpoints)_
 type forceRefetch = (params: {
   currentArg: QueryArg | undefined
   previousArg: QueryArg | undefined
-  state: RootState<any, any, string>
+  state: ApiRootState<any, any, string>
   endpointState?: QuerySubState<any>
 }) => boolean
 ```

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -370,7 +370,19 @@ export type MutationState<D extends EndpointDefinitions> = {
   [requestId: string]: MutationSubState<D[string]> | undefined
 }
 
-export type RootState<
+/**
+ * Get the root state type for an RTK Query API slice.
+ *
+ * **Note**: This type was previously named **`RootState`**.
+ *
+ * @template Definitions - Endpoint definitions for the API.
+ * @template TagTypes - Tag types used by the API.
+ * @template ReducerPath - The **`reducerPath`** key the API reducer is mounted under.
+ *
+ * @since 3.0.0
+ * @public
+ */
+export type ApiRootState<
   Definitions extends EndpointDefinitions,
   TagTypes extends string,
   ReducerPath extends string,

--- a/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheLifecycle.ts
@@ -9,7 +9,7 @@ import type {
   DefinitionType,
 } from '../../endpointDefinitions'
 import { isAnyQueryDefinition } from '../../endpointDefinitions'
-import type { QueryCacheKey, RootState } from '../apiState'
+import type { QueryCacheKey, ApiRootState } from '../apiState'
 import type {
   MutationResultSelectorResult,
   QueryResultSelectorResult,
@@ -78,7 +78,7 @@ type LifecycleApi<ReducerPath extends string = string> = {
   /**
    * A method to get the current state
    */
-  getState(): RootState<any, any, ReducerPath>
+  getState(): ApiRootState<any, any, ReducerPath>
   /**
    * `extra` as provided as `thunk.extraArgument` to the `configureStore` `getDefaultMiddleware` option.
    */

--- a/packages/toolkit/src/query/core/buildMiddleware/index.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/index.ts
@@ -8,7 +8,7 @@ import type {
   EndpointDefinitions,
   FullTagDescription,
 } from '../../endpointDefinitions'
-import type { QueryStatus, QuerySubState, RootState } from '../apiState'
+import type { QueryStatus, QuerySubState, ApiRootState } from '../apiState'
 import type { QueryThunkArg } from '../buildThunks'
 import { createAction, isAction } from '../rtkImports'
 import { buildBatchedActionsHandler } from './batchActions'
@@ -68,7 +68,7 @@ export function buildMiddleware<
 
   const middleware: Middleware<
     {},
-    RootState<Definitions, string, ReducerPath>,
+    ApiRootState<Definitions, string, ReducerPath>,
     ThunkDispatch<any, any, UnknownAction>
   > = (mwApi) => {
     let initialized = false

--- a/packages/toolkit/src/query/core/buildMiddleware/types.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/types.ts
@@ -16,7 +16,7 @@ import type {
 import type {
   QueryStatus,
   QuerySubState,
-  RootState,
+  ApiRootState,
   SubscriptionInternalState,
   SubscriptionState,
 } from '../apiState'
@@ -83,7 +83,7 @@ export interface BuildMiddlewareInput<
 
 export type SubMiddlewareApi = MiddlewareAPI<
   ThunkDispatch<any, any, UnknownAction>,
-  RootState<EndpointDefinitions, string, string>
+  ApiRootState<EndpointDefinitions, string, string>
 >
 
 export interface BuildSubMiddlewareInput
@@ -99,7 +99,7 @@ export interface BuildSubMiddlewareInput
   selectors: AllSelectors
   mwApi: MiddlewareAPI<
     ThunkDispatch<any, any, UnknownAction>,
-    RootState<EndpointDefinitions, string, string>
+    ApiRootState<EndpointDefinitions, string, string>
   >
 }
 
@@ -107,7 +107,7 @@ export type SubMiddlewareBuilder = (
   input: BuildSubMiddlewareInput,
 ) => Middleware<
   {},
-  RootState<EndpointDefinitions, string, string>,
+  ApiRootState<EndpointDefinitions, string, string>,
   ThunkDispatch<any, any, UnknownAction>
 >
 
@@ -116,7 +116,7 @@ type MwNext = Parameters<ReturnType<Middleware>>[0]
 export type ApiMiddlewareInternalHandler<Return = void> = (
   action: Action,
   mwApi: SubMiddlewareApi & { next: MwNext },
-  prevState: RootState<EndpointDefinitions, string, string>,
+  prevState: ApiRootState<EndpointDefinitions, string, string>,
 ) => Return
 
 export type InternalHandlerBuilder<ReturnType = void> = (

--- a/packages/toolkit/src/query/core/buildSelectors.ts
+++ b/packages/toolkit/src/query/core/buildSelectors.ts
@@ -23,7 +23,7 @@ import type {
   QueryState,
   QuerySubState,
   RequestStatusFlags,
-  RootState as _RootState,
+  ApiRootState as _RootState,
   QueryStatus,
 } from './apiState'
 import { STATUS_UNINITIALIZED, getRequestStatusFlags } from './apiState'

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -42,7 +42,7 @@ import {
 import { HandledError } from '../HandledError'
 import type { UnwrapPromise } from '../tsHelpers'
 import type {
-  RootState,
+  ApiRootState,
   QueryKeys,
   QuerySubstateIdentifier,
   InfiniteData,
@@ -355,7 +355,7 @@ export function buildThunks<
   catchSchemaFailure: SchemaFailureConverter<BaseQuery> | undefined
   skipSchemaValidation: boolean | SchemaType[] | undefined
 }) {
-  type State = RootState<any, string, ReducerPath>
+  type State = ApiRootState<any, string, ReducerPath>
 
   const patchQueryData: PatchQueryDataThunk<EndpointDefinitions, State> =
     (endpointName, arg, patches, updateProvided) => (dispatch, getState) => {
@@ -377,7 +377,7 @@ export function buildThunks<
 
       const newValue = api.endpoints[endpointName].select(arg)(
         // Work around TS 4.1 mismatch
-        getState() as RootState<any, any, any>,
+        getState() as ApiRootState<any, any, any>,
       )
 
       const providedTags = calculateProvidedBy(
@@ -411,7 +411,7 @@ export function buildThunks<
 
       const currentState = endpointDefinition.select(arg)(
         // Work around TS 4.1 mismatch
-        getState() as RootState<any, any, any>,
+        getState() as ApiRootState<any, any, any>,
       )
 
       const ret: PatchCollection = {
@@ -494,7 +494,7 @@ export function buildThunks<
   const executeEndpoint: AsyncThunkPayloadCreator<
     ThunkResult,
     QueryThunkArg | MutationThunkArg | InfiniteQueryThunkArg<any>,
-    ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
+    ThunkApiMetaConfig & { state: ApiRootState<any, string, ReducerPath> }
   > = async (
     arg,
     {
@@ -884,7 +884,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
 
   function isForcedQuery(
     arg: QueryThunkArg,
-    state: RootState<any, string, ReducerPath>,
+    state: ApiRootState<any, string, ReducerPath>,
   ) {
     const requestState = selectors.selectQueryEntry(state, arg.queryCacheKey)
     const baseFetchOnMountOrArgChange =
@@ -910,7 +910,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
     const generatedQueryThunk = createAsyncThunk<
       ThunkResult,
       ThunkArgType,
-      ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
+      ThunkApiMetaConfig & { state: ApiRootState<any, string, ReducerPath> }
     >(`${reducerPath}/executeQuery`, executeEndpoint, {
       getPendingMeta({ arg }) {
         const endpointDefinition = endpointDefinitions[arg.endpointName]
@@ -1003,7 +1003,7 @@ In the case of an unhandled error, no tags will be "provided" or "invalidated".`
   const mutationThunk = createAsyncThunk<
     ThunkResult,
     MutationThunkArg,
-    ThunkApiMetaConfig & { state: RootState<any, string, ReducerPath> }
+    ThunkApiMetaConfig & { state: ApiRootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeMutation`, executeEndpoint, {
     getPendingMeta() {
       return addShouldAutoBatch({ startedTimeStamp: Date.now() })

--- a/packages/toolkit/src/query/core/index.ts
+++ b/packages/toolkit/src/query/core/index.ts
@@ -13,7 +13,7 @@ export type {
   QueryCacheKey,
   QueryKeys,
   QuerySubState,
-  RootState,
+  ApiRootState,
   SubscriptionOptions,
 } from './apiState'
 export type {

--- a/packages/toolkit/src/query/core/module.ts
+++ b/packages/toolkit/src/query/core/module.ts
@@ -34,7 +34,7 @@ import type {
   CombinedState,
   MutationKeys,
   QueryKeys,
-  RootState,
+  ApiRootState,
 } from './apiState'
 import type {
   BuildInitiateApiEndpointMutation,
@@ -157,7 +157,7 @@ export interface ApiModules<
      */
     middleware: Middleware<
       {},
-      RootState<Definitions, string, ReducerPath>,
+      ApiRootState<Definitions, string, ReducerPath>,
       ThunkDispatch<any, any, UnknownAction>
     >
     /**
@@ -274,7 +274,7 @@ export interface ApiModules<
        */
       updateQueryData: UpdateQueryDataThunk<
         Definitions,
-        RootState<Definitions, string, ReducerPath>
+        ApiRootState<Definitions, string, ReducerPath>
       >
 
       /**
@@ -298,7 +298,7 @@ export interface ApiModules<
        */
       upsertQueryData: UpsertQueryDataThunk<
         Definitions,
-        RootState<Definitions, string, ReducerPath>
+        ApiRootState<Definitions, string, ReducerPath>
       >
       /**
        * A Redux thunk that applies a JSON diff/patch array to the cached data for a given query result. This immediately updates the Redux state with those changes.
@@ -328,7 +328,7 @@ export interface ApiModules<
        */
       patchQueryData: PatchQueryDataThunk<
         Definitions,
-        RootState<Definitions, string, ReducerPath>
+        ApiRootState<Definitions, string, ReducerPath>
       >
 
       /**
@@ -381,7 +381,7 @@ export interface ApiModules<
        * Can be used for mutations that want to do optimistic updates instead of invalidating a set of tags, but don't know exactly what they need to update.
        */
       selectInvalidatedBy: (
-        state: RootState<Definitions, string, ReducerPath>,
+        state: ApiRootState<Definitions, string, ReducerPath>,
         tags: ReadonlyArray<TagDescription<TagTypes> | null | undefined>,
       ) => Array<{
         endpointName: string
@@ -395,7 +395,7 @@ export interface ApiModules<
        * Can be used for mutations that want to do optimistic updates instead of invalidating a set of tags, but don't know exactly what they need to update.
        */
       selectCachedArgsForQuery: <QueryName extends AllQueryKeys<Definitions>>(
-        state: RootState<Definitions, string, ReducerPath>,
+        state: ApiRootState<Definitions, string, ReducerPath>,
         queryName: QueryName,
       ) => Array<QueryArgFromAnyQuery<Definitions[QueryName]>>
     }

--- a/packages/toolkit/src/query/endpointDefinitions.ts
+++ b/packages/toolkit/src/query/endpointDefinitions.ts
@@ -25,7 +25,7 @@ import type {
   InfiniteData,
   InfiniteQueryConfigOptions,
   QuerySubState,
-  RootState,
+  ApiRootState,
 } from './core/index'
 import type { SerializeQueryArgs } from './defaultSerializeQueryArgs'
 import type { NEVER } from './fakeBaseQuery'
@@ -855,7 +855,7 @@ export interface QueryExtraOptions<
   forceRefetch?(params: {
     currentArg: QueryArg | undefined
     previousArg: QueryArg | undefined
-    state: RootState<any, any, string>
+    state: ApiRootState<any, any, string>
     endpointState?: QuerySubState<any>
   }): boolean
 

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -7,7 +7,7 @@ export type {
   QueryCacheKey,
   QueryKeys,
   QuerySubState,
-  RootState,
+  ApiRootState,
   SubscriptionOptions,
 } from './core/apiState'
 export { QueryStatus } from './core/apiState'

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -30,7 +30,7 @@ import type {
   QueryResultSelectorResult,
   QuerySubState,
   ResultTypeFrom,
-  RootState,
+  ApiRootState,
   SerializeQueryArgs,
   SkipToken,
   SubscriptionOptions,
@@ -1839,11 +1839,11 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       >
       const stableArg = useStableQueryArgs(skip ? skipToken : arg)
 
-      type ApiRootState = Parameters<ReturnType<typeof select>>[0]
+      type RootStateType = Parameters<ReturnType<typeof select>>[0]
 
       const lastValue = useRef<any>(undefined)
 
-      const selectDefaultResult: Selector<ApiRootState, any, [any]> = useMemo(
+      const selectDefaultResult: Selector<RootStateType, any, [any]> = useMemo(
         () =>
           // Normally ts-ignores are bad and should be avoided, but we're
           // already casting this selector to be `Selector<any>` anyway,
@@ -1853,8 +1853,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
             [
               // @ts-ignore
               select(stableArg),
-              (_: ApiRootState, lastResult: any) => lastResult,
-              (_: ApiRootState) => stableArg,
+              (_: RootStateType, lastResult: any) => lastResult,
+              (_: RootStateType) => stableArg,
             ],
             // `preSelector` is a union of the standard/infinite query pre-selectors.
             // `tsc` attributes the resulting overload error to the `createSelector` call
@@ -1871,7 +1871,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         [select, stableArg],
       )
 
-      const querySelector: Selector<ApiRootState, any, [any]> = useMemo(
+      const querySelector: Selector<RootStateType, any, [any]> = useMemo(
         () =>
           selectFromResult
             ? createSelector([selectDefaultResult], selectFromResult, {
@@ -1882,12 +1882,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       )
 
       const currentState = useSelector(
-        (state: RootState<Definitions, any, any>) =>
+        (state: ApiRootState<Definitions, any, any>) =>
           querySelector(state, lastValue.current),
         shallowEqual,
       )
 
-      const store = useStore<RootState<Definitions, any, any>>()
+      const store = useStore<ApiRootState<Definitions, any, any>>()
       const newLastValue = selectDefaultResult(
         store.getState(),
         lastValue.current,
@@ -2243,7 +2243,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         [fixedCacheKey, promise, select],
       )
       const mutationSelector = useMemo(
-        (): Selector<RootState<Definitions, any, any>, any> =>
+        (): Selector<ApiRootState<Definitions, any, any>, any> =>
           selectFromResult
             ? createSelector([selectDefaultResult], selectFromResult)
             : selectDefaultResult,

--- a/packages/toolkit/src/query/tests/queryLifecycle.test-d.tsx
+++ b/packages/toolkit/src/query/tests/queryLifecycle.test-d.tsx
@@ -1,9 +1,9 @@
 import type { PatchCollection, Recipe } from '@internal/query/core/buildThunks'
 import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit'
 import type {
+  ApiRootState,
   FetchBaseQueryError,
   FetchBaseQueryMeta,
-  RootState,
   TypedMutationOnQueryStarted,
   TypedQueryOnQueryStarted,
 } from '@reduxjs/toolkit/query'
@@ -213,7 +213,7 @@ describe('type tests', () => {
         expectTypeOf(extra).toBeUnknown()
 
         expectTypeOf(getState).toEqualTypeOf<
-          () => RootState<any, any, 'postsApi'>
+          () => ApiRootState<any, any, 'postsApi'>
         >()
 
         expectTypeOf(requestId).toBeString()
@@ -325,7 +325,7 @@ describe('type tests', () => {
         expectTypeOf(extra).toBeUnknown()
 
         expectTypeOf(getState).toEqualTypeOf<
-          () => RootState<any, any, 'postsApi'>
+          () => ApiRootState<any, any, 'postsApi'>
         >()
 
         expectTypeOf(requestId).toBeString()


### PR DESCRIPTION
# **This PR**:

- [X] Renames the public **`RootState`** type to **`ApiRootState`**.
- [X] Resolves #4530.

> [!CAUTION]
> This PR introduces a **breaking change**.

---

> [!NOTE]
> **`ApiRootState`** was initially suggested by @markerikson. Feedback on the naming choice is welcome.