### PR TITLE
chore(toolkit): remove unnecessary `areErrorsEqual` function

### DIFF
--- a/packages/toolkit/vitest.setup.ts
+++ b/packages/toolkit/vitest.setup.ts
@@ -5,46 +5,6 @@ vi.stubGlobal('fetch', nodeFetch)
 vi.stubGlobal('Request', Request)
 vi.stubGlobal('Headers', Headers)
 
-/**
- * Compares two values to determine if they are instances of {@linkcode Error}
- * and have the same {@linkcode Error.name | name}
- * and {@linkcode Error.message | message} properties.
- *
- * @param actualError - The actual error to compare.
- * @param expectedError - The expected error to compare against.
- * @returns `true` if both values are instances of {@linkcode Error} and have the same {@linkcode Error.name | name} and {@linkcode Error.message | message}.
- *
- * @example
- * <caption>#### __Pass: The actual error is an instance of `TypeError` with the same `message` ✔️__</caption>
- *
- * ```ts
- * expect(consoleErrorSpy).toHaveBeenLastCalledWith(
- *   TypeError('endpointDefinition.queryFn is not a function'),
- * )
- * ```
- *
- * @example
- * <caption>#### __Fail: The actual error is a `TypeError`, which is more specific than the expected generic `Error` ❌__</caption>
- *
- * ```ts
- * expect(consoleErrorSpy).toHaveBeenLastCalledWith(
- *   Error('endpointDefinition.queryFn is not a function'),
- * )
- * ```
- *
- * @internal
- */
-const areErrorsEqual = (actualError: unknown, expectedError: unknown) => {
-  if (actualError instanceof Error && expectedError instanceof Error) {
-    return (
-      actualError.name === expectedError.name &&
-      actualError.message === expectedError.message
-    )
-  }
-}
-
-expect.addEqualityTesters([areErrorsEqual])
-
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'error' })
 })


### PR DESCRIPTION
# **Overview**

[**`vitest`**](https://vitest.dev) already internally uses an error-comparison helper, [**`isErrorEqual`**](https://github.com/vitest-dev/vitest/blob/89cbdaea3f86e699c8e46ee52b08204cbc8bf345/packages/expect/src/jest-utils.ts#L261C1-L290C2), so our local **`areErrorsEqual`** equality-tester is redundant.

[**`isErrorEqual`**](https://github.com/vitest-dev/vitest/blob/89cbdaea3f86e699c8e46ee52b08204cbc8bf345/packages/expect/src/jest-utils.ts#L261C1-L290C2) was introduced upstream in [**vitest-dev/vitest#5876**](https://github.com/vitest-dev/vitest/pull/5876) and covers our use case (including correctly differentiating error *types*). With the current version of [**`vitest`**](https://vitest.dev), the tests fail if we swap (for example) a **`TypeError`** for an **`Error`**, which matches the behavior we want and confirms we can safely remove **`areErrorsEqual`** without changing test intent.

# **This PR**:

- [X] Removes the unnecessary **`areErrorsEqual`** equality-tester.

## **Additional Notes**

- Partially related to [**this comment**](https://github.com/reduxjs/redux-toolkit/pull/5206/changes#r2718753084) in #5206.

