### PR TITLE
Export hook options types for RTK Query hooks

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -538,7 +538,7 @@ export type TypedUseQueryState<
 >
 
 /**
- * @public
+ * @internal
  */
 export type UseQueryStateOptions<
   D extends QueryDefinition<any, any, any, any>,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -203,6 +203,19 @@ export type UseQuerySubscriptionOptions = SubscriptionOptions & {
 }
 
 /**
+ * Provides a way to reference the options accepted by the `useQuerySubscription`
+ * hook in userland code.
+ *
+ * Unlike other `Typed*` wrappers, this type has no generic parameters since
+ * {@linkcode UseQuerySubscriptionOptions} does not depend on a specific query
+ * definition.
+ *
+ * @since 2.2.8
+ * @public
+ */
+export type TypedUseQuerySubscriptionOptions = UseQuerySubscriptionOptions
+
+/**
  * A React hook that automatically triggers fetches of data from an endpoint, and 'subscribes' the component to the cached data.
  *
  * The query arg is used as a cache key. Changing the query arg will tell the hook to re-fetch the data if it does not exist in the cache already.
@@ -525,7 +538,7 @@ export type TypedUseQueryState<
 >
 
 /**
- * @internal
+ * @public
  */
 export type UseQueryStateOptions<
   D extends QueryDefinition<any, any, any, any>,
@@ -1336,6 +1349,30 @@ export type UseMutationStateOptions<
   selectFromResult?: MutationStateSelector<R, D>
   fixedCacheKey?: string
 }
+
+/**
+ * Provides a way to define a "pre-typed" version of
+ * {@linkcode UseMutationStateOptions} with specific options for a given mutation.
+ *
+ * @template ResultType - The type of the result `data` returned by the mutation.
+ * @template QueryArg - The type of the argument passed into the mutation.
+ * @template BaseQuery - The type of the base query function being used.
+ * @template SelectedResult - The type of the selected result returned by the __`selectFromResult`__ function.
+ *
+ * @since 2.2.8
+ * @public
+ */
+export type TypedUseMutationStateOptions<
+  ResultType,
+  QueryArg,
+  BaseQuery extends BaseQueryFn,
+  SelectedResult extends Record<string, any> = MutationResultSelectorResult<
+    MutationDefinition<QueryArg, BaseQuery, string, ResultType, string>
+  >,
+> = UseMutationStateOptions<
+  MutationDefinition<QueryArg, BaseQuery, string, ResultType, string>,
+  SelectedResult
+>
 
 export type UseMutationStateResult<
   D extends MutationDefinition<any, any, any, any>,

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -38,9 +38,8 @@ export type {
   TypedUseInfiniteQuerySubscription,
   TypedUseInfiniteQueryState,
   TypedLazyInfiniteQueryTrigger,
-  UseQuerySubscriptionOptions,
-  UseQueryStateOptions,
-  UseMutationStateOptions,
+  TypedUseQuerySubscriptionOptions,
+  TypedUseMutationStateOptions,
 } from './buildHooks'
 export { UNINITIALIZED_VALUE } from './constants'
 export { createApi, reactHooksModule, reactHooksModuleName }

--- a/packages/toolkit/src/query/react/index.ts
+++ b/packages/toolkit/src/query/react/index.ts
@@ -38,6 +38,9 @@ export type {
   TypedUseInfiniteQuerySubscription,
   TypedUseInfiniteQueryState,
   TypedLazyInfiniteQueryTrigger,
+  UseQuerySubscriptionOptions,
+  UseQueryStateOptions,
+  UseMutationStateOptions,
 } from './buildHooks'
 export { UNINITIALIZED_VALUE } from './constants'
 export { createApi, reactHooksModule, reactHooksModuleName }


### PR DESCRIPTION
## Summary

Exports `UseQuerySubscriptionOptions`, `UseQueryStateOptions`, and `UseMutationStateOptions` from `@reduxjs/toolkit/query/react` to allow users to directly reference these types without using `Parameters<T>` utility type workaround.

## Motivation

Currently, when building wrapper hooks that accept the same options as RTK Query hooks (`useQuery`, `useLazyQuery`, `useMutation`), developers must use the `Parameters` utility type to extract the options type, which is verbose and less discoverable:

```ts
// Current workaround
options?: Parameters<TypedUseQuery<...>>[1]
```

With these types exported, it becomes much cleaner:

```ts
// After this change
options?: UseQuerySubscriptionOptions & UseQueryStateOptions<...>
```

## Changes

- Added exports for `UseQuerySubscriptionOptions`, `UseQueryStateOptions`, and `UseMutationStateOptions` in `/packages/toolkit/src/query/react/index.ts`

## Test Plan

- TypeScript compilation succeeds
- Existing tests pass
- Types are properly exported and accessible to consumers

Fixes #5172