### PR TITLE
docs: fix duplicate word 'the' in Next.js usage documentation

### DIFF
--- a/docs/usage/nextjs.mdx
+++ b/docs/usage/nextjs.mdx
@@ -85,7 +85,7 @@ We'll use that approach for this guide.
 
 ## Initial Setup
 
-Similar to the the [RTK TypeScript Tutorial](../tutorials/typescript.md), we need to create a file for the Redux store, as well as the inferred `RootState` and `AppDispatch` types.
+Similar to the [RTK TypeScript Tutorial](../tutorials/typescript.md), we need to create a file for the Redux store, as well as the inferred `RootState` and `AppDispatch` types.
 
 However, Next's multi-page architecture requires some differences from that single-page app setup.
 


### PR DESCRIPTION
## Summary

Fixed typo in documentation where the word 'the' was duplicated.

## Changes

- Fixed: 'the the current' → 'the current'

## Test Plan

- Documentation renders correctly
- No functionality changes