### PR TITLE
ci: declare explicit read-only token permissions for test workflows

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -8,6 +8,10 @@ defaults:
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   changes:
     name: Check for changes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches: [master]
   pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
 defaults:
   run:
     working-directory: ./packages/toolkit


### PR DESCRIPTION
## Summary\n- add explicit workflow permissions to two CI workflows currently relying on implicit defaults\n\n### Updated workflows\n- `.github/workflows/test-codegen.yml`\n- `.github/workflows/tests.yml`\n\n## Permissions\n- `contents: read`\n- `pull-requests: read`\n\n## Why\nThese workflows are read-only CI jobs (checkout, path filtering, build/test). Declaring permissions explicitly follows least-privilege guidance and documents intended access.\n\n## Notes\n- configuration-only change\n- no test logic changed\n