### PR TITLE
fix(codegen): narrow `generateEndpoints` return type

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/index.ts
+++ b/packages/rtk-query-codegen-openapi/src/index.ts
@@ -8,6 +8,14 @@ export type { ConfigFile } from './types';
 
 const require = createRequire(__filename);
 
+export async function generateEndpoints(
+  options: Omit<GenerationOptions, 'outputFile'> & { outputFile?: never }
+): Promise<string>;
+
+export async function generateEndpoints(
+  options: Omit<GenerationOptions, 'outputFile'> & Required<Pick<GenerationOptions, 'outputFile'>>
+): Promise<void>;
+
 export async function generateEndpoints(options: GenerationOptions): Promise<string | void> {
   const schemaLocation = options.schemaFile;
 

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test-d.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test-d.ts
@@ -1,0 +1,31 @@
+import { generateEndpoints } from '@rtk-query/codegen-openapi';
+import * as path from 'node:path';
+
+const withoutOutputFile = {
+  apiFile: './fixtures/emptyApi.ts',
+  schemaFile: path.join(__dirname, 'fixtures', 'petstore.json'),
+};
+
+const withOutputFile = {
+  apiFile: './fixtures/emptyApi.ts',
+  outputFile: './test/tmp/out.ts',
+  schemaFile: path.join(__dirname, 'fixtures', 'petstore.json'),
+};
+
+describe('generateEndpoints return type narrowing', () => {
+  test('narrows to Promise<string> when outputFile is omitted', () => {
+    expectTypeOf(generateEndpoints(withoutOutputFile)).toEqualTypeOf<Promise<string>>();
+
+    expectTypeOf(generateEndpoints(withoutOutputFile)).resolves.toBeString();
+
+    expectTypeOf(generateEndpoints).toBeCallableWith(withoutOutputFile).returns.resolves.toBeString();
+  });
+
+  test('narrows to Promise<void> when outputFile is provided', () => {
+    expectTypeOf(generateEndpoints(withOutputFile)).toEqualTypeOf<Promise<void>>();
+
+    expectTypeOf(generateEndpoints(withOutputFile)).resolves.toBeVoid();
+
+    expectTypeOf(generateEndpoints).toBeCallableWith(withOutputFile).returns.resolves.toBeVoid();
+  });
+});

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -933,3 +933,26 @@ describe('esmExtensions option', () => {
     expect(content).toContain("import { api } from '../../fixtures/emptyApi'");
   });
 });
+
+describe('generateEndpoints return type narrowing', () => {
+  const schemaFile = resolve(__dirname, 'fixtures', 'petstore.json');
+
+  test('returns a string when outputFile is omitted', async () => {
+    const result = await generateEndpoints({
+      apiFile: './fixtures/emptyApi.ts',
+      schemaFile,
+    });
+
+    expect(result).toBeTypeOf('string');
+  });
+
+  test('returns void when outputFile is provided', async () => {
+    const result = await generateEndpoints({
+      apiFile: './fixtures/emptyApi.ts',
+      outputFile: './test/tmp/out.ts',
+      schemaFile,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/rtk-query-codegen-openapi/vitest.config.mts
+++ b/packages/rtk-query-codegen-openapi/vitest.config.mts
@@ -1,23 +1,42 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
-
-// No __dirname under Node ESM
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import packageJson from './package.json' with { type: 'json' };
 
 export default defineConfig({
-  plugins: [tsconfigPaths({ projects: ['./tsconfig.json'] })],
+  plugins: [
+    tsconfigPaths({
+      configNames: ['tsconfig.json'],
+      projects: ['./tsconfig.json'],
+      root: import.meta.dirname,
+    }),
+  ],
+
+  root: import.meta.dirname,
+
   test: {
+    name: {
+      label: packageJson.name,
+    },
+
     alias: process.env.TEST_DIST
       ? {
-          '@rtk-query/codegen-openapi': path.join(__dirname, '../..', 'node_modules/@rtk-query/codegen-openapi'),
+          '@rtk-query/codegen-openapi': path.join(import.meta.dirname, '..', '..', 'node_modules', packageJson.name),
         }
       : undefined,
+
+    dir: path.join(import.meta.dirname, 'test'),
+    root: import.meta.dirname,
     testTimeout: 10_000,
+
+    typecheck: {
+      enabled: true,
+      tsconfig: path.join(import.meta.dirname, 'tsconfig.json'),
+    },
+
     pool: 'forks',
     globals: true,
     setupFiles: ['./test/vitest.setup.ts'],
+    watch: false,
   },
 });


### PR DESCRIPTION
## Summary

- [X] Follow-up to the [**suggestion**](https://github.com/reduxjs/redux-toolkit/pull/5174/changes#r2657784481) by @issy in #5174.
- [X] Adds function overloads to **`generateEndpoints`** so the return type narrows based on whether **`outputFile`** is provided:
  - Without **`outputFile`** → **`Promise<string>`**
  - With **`outputFile`** → **`Promise<void>`**

This eliminates the need for manual type assertions like **`await generateEndpoints(...) as string`** in consumer code.