### PR TITLE
docs: fix minor typos in configureStore docs

### DIFF
--- a/docs/api/configureStore.mdx
+++ b/docs/api/configureStore.mdx
@@ -182,7 +182,7 @@ Where you wish to add onto or customize the default enhancers, you may pass a ca
 Example: `enhancers: (defaultEnhancers) => defaultEnhancers.prepend(offline)` will result in a final setup
 of `[offline, applyMiddleware, devToolsExtension]`.
 
-For more details on how the `enhancer` parameter works and the list of enhancers that are added by default, see the [`getDefaultEnhancers` docs page](./getDefaultEnhancers).
+For more details on how the `enhancers` parameter works and the list of enhancers that are added by default, see the [`getDefaultEnhancers` docs page](./getDefaultEnhancers).
 
 :::caution Middleware
 
@@ -194,7 +194,7 @@ If you don't use `getDefaultEnhancers` and instead return an array, the `applyMi
 // warns - middleware customised but not included in final enhancers
 configureStore({
   reducer,
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger)
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
   enhancers: [offline(offlineConfig)],
 })
 


### PR DESCRIPTION
## Summary
Fix a couple of small doc issues in `configureStore` docs:
- Use the correct option name (`enhancers` instead of `enhancer`) when referring to the parameter.
- Fix a missing comma in a code snippet to make it copy/paste valid.

No behavior changes — docs-only.

## Test plan
Docs-only change.
- Verified the updated sentences and snippet in `docs/api/configureStore.mdx`.
