### PR TITLE
docs: fix createAction type guard typo

### DIFF
--- a/docs/api/createAction.mdx
+++ b/docs/api/createAction.mdx
@@ -114,7 +114,7 @@ This has different uses:
 
 This `match` method is a [TypeScript type guard](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) and can be used to discriminate the `payload` type of an action.
 
-This behavior can be particularly useful when used in custom middlewares, where manual casts might be neccessary otherwise.
+This behavior can be particularly useful when used in custom middlewares, where manual casts might be necessary otherwise.
 
 ```ts
 import { createAction } from '@reduxjs/toolkit'


### PR DESCRIPTION
## Summary

- Fixes a typo in the `createAction` API docs by changing `neccessary` to `necessary`.

## Related issue

- N/A (minor documentation typo fix)

## Guideline alignment

- https://github.com/reduxjs/redux-toolkit/blob/master/CONTRIBUTING.md

## Validation

- `git diff --check`
- No tests added; documentation-only change.
