### PR TITLE
docs: fix codemod README typo

### DIFF
--- a/packages/rtk-codemods/transforms/createSliceReducerBuilder/README.md
+++ b/packages/rtk-codemods/transforms/createSliceReducerBuilder/README.md
@@ -2,7 +2,7 @@
 
 Rewrites uses of Redux Toolkit's `createSlice` API to use the "builder callback" syntax for the `reducers` field, to make it easier to add prepared reducers and thunks inside of `createSlice`.
 
-Note that unlike the `createReducerBuilder` and `createSliceBuilder` transforms (which both were fixes for deprecated/removed overloads), this is entirely optional. You do not _need_ to apply this to an entire codebase unless you specifically want to. Otherwise, feel free to apply to to specific slice files as needed.
+Note that unlike the `createReducerBuilder` and `createSliceBuilder` transforms (which both were fixes for deprecated/removed overloads), this is entirely optional. You do not _need_ to apply this to an entire codebase unless you specifically want to. Otherwise, feel free to apply to specific slice files as needed.
 
 Should work with both JS and TS files.
 


### PR DESCRIPTION
## Summary

- Fixes a duplicate word in the `createSliceReducerBuilder` codemod README by changing `to to` to `to`.

## Related issue

- N/A (minor documentation typo fix)

## Guideline alignment

- https://github.com/reduxjs/redux-toolkit/blob/master/CONTRIBUTING.md

## Validation

- `git diff --check`
- No tests added; documentation-only change.
