### PR TITLE
docs: fix getDefaultEnhancers typo

### DIFF
--- a/docs/api/configureStore.mdx
+++ b/docs/api/configureStore.mdx
@@ -217,7 +217,7 @@ Note that if using TypeScript, the `middleware` option is required to be provide
 :::
 
 :::note Tuple
-TypeScript users are required to use a `Tuple` instance (if not using a `getDefaultEnhancer` result, which is already a `Tuple`), for better inference.
+TypeScript users are required to use a `Tuple` instance (if not using a `getDefaultEnhancers` result, which is already a `Tuple`), for better inference.
 
 ```ts no-transpile
 import { configureStore, Tuple } from '@reduxjs/toolkit'


### PR DESCRIPTION
## Summary
Fix a typo in the `configureStore` docs where `getDefaultEnhancer` (singular) was referenced instead of the correct `getDefaultEnhancers` (plural).