### PR TITLE
docs: fix persistence typo in RTK Query docs

### DIFF
--- a/docs/rtk-query/usage/persistence-and-rehydration.mdx
+++ b/docs/rtk-query/usage/persistence-and-rehydration.mdx
@@ -25,7 +25,7 @@ should be used in browsers to define cache behavior.
 Persisting and rehydrating an api slice might always leave the user with very stale data if the user
 has not visited the page for some time.
 Nonetheless, in environments like Native Apps, where there is no browser cache to take care of this,
-persistance might still be a viable option.
+persistence might still be a viable option.
 
 :::
 


### PR DESCRIPTION
## Summary
- fix "persistance" to "persistence" in the RTK Query persistence and rehydration docs

## Related issue
- N/A (trivial docs fix)

## Guideline alignment
- Follows [CONTRIBUTING.md](https://github.com/reduxjs/redux-toolkit/blob/master/CONTRIBUTING.md): single-file docs-only change with no behavior impact

## Validation
- Not run (documentation-only change)
