### PR TITLE
docs: fix `LazyInfiniteQueryTrigger` docs

### DIFF
--- a/docs/rtk-query/api/created-api/hooks.mdx
+++ b/docs/rtk-query/api/created-api/hooks.mdx
@@ -802,6 +802,43 @@ const useInfiniteQuerySubscriptionResult =
 
 [summary](docblock://query/react/buildHooks.ts?token=UseInfiniteQuerySubscription)
 
+##### `useInfiniteQuerySubscription` Signature
+
+```ts no-transpile
+type UseInfiniteQuerySubscription = (
+  arg: any | SkipToken,
+  options?: UseInfiniteQuerySubscriptionOptions,
+) => UseInfiniteQuerySubscriptionResult
+
+type UseInfiniteQuerySubscriptionOptions = {
+  skip?: boolean
+  refetchOnMountOrArgChange?: boolean | number
+  pollingInterval?: number
+  skipPollingIfUnfocused?: boolean
+  refetchOnReconnect?: boolean
+  refetchOnFocus?: boolean
+  initialPageParam?: PageParam
+  refetchCachedPages?: boolean
+}
+
+type UseInfiniteQuerySubscriptionResult = {
+  trigger: (arg: any, direction: 'forward' | 'backward') => InfiniteQueryActionCreatorResult
+  refetch: (options?: { refetchCachedPages?: boolean }) => InfiniteQueryActionCreatorResult
+  fetchNextPage: () => InfiniteQueryActionCreatorResult
+  fetchPreviousPage: () => InfiniteQueryActionCreatorResult
+}
+```
+
+- **Parameters**
+  - `arg`: The query argument passed to the infinite query endpoint.
+  - `options`: A set of options that control the fetching behavior of the hook.
+- **Returns**
+  - An object containing:
+  - `trigger`: manually fetches a page in the given direction for the current cache entry
+  - `refetch`: refetches the infinite query
+  - `fetchNextPage`: fetches the next page
+  - `fetchPreviousPage`: fetches the previous page
+
 ### `useLazyQuerySubscription`
 
 ```ts title="Accessing a useLazyQuerySubscription hook" no-transpile

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -798,19 +798,19 @@ export type LazyInfiniteQueryTrigger<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
 > = {
   /**
-   * Triggers a lazy query.
+   * Triggers an infinite query fetch in the given direction.
    *
-   * By default, this will start a new request even if there is already a value in the cache.
-   * If you want to use the cache value and only start a request if there is no cache value, set the second argument to `true`.
+   * Pass the endpoint argument as the first parameter and either `'forward'` or `'backward'`
+   * as the second parameter to fetch the next or previous page from the current cache entry.
    *
    * @remarks
-   * If you need to access the error or success payload immediately after a lazy query, you can chain .unwrap().
+   * If you need to access the error or success payload immediately after triggering the request, you can chain `.unwrap()`.
    *
    * @example
    * ```ts
    * // codeblock-meta title="Using .unwrap with async await"
    * try {
-   *   const payload = await getUserById(1).unwrap();
+   *   const payload = await triggerPosts('fire', 'forward').unwrap();
    *   console.log('fulfilled', payload);
    * } catch (error) {
    *   console.error('rejected', error);

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -798,7 +798,7 @@ export type LazyInfiniteQueryTrigger<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
 > = {
   /**
-   * Triggers an infinite query fetch in the given direction.
+   * Triggers fetching the next or previous page of an infinite query.
    *
    * Pass the endpoint argument as the first parameter and either `'forward'` or `'backward'`
    * as the second parameter to fetch the next or previous page from the current cache entry.


### PR DESCRIPTION
## Summary
- fix the copied `LazyInfiniteQueryTrigger` docs so the second argument is documented as a direction, not `preferCacheValue`
- add an explicit `useInfiniteQuerySubscription` signature to the generated hooks docs
- keep the source JSDoc and rendered docs aligned so the incorrect description does not come back

Closes #5229