### PR TITLE
Keep isSuccess: true when switching infinite query cache entries

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1650,8 +1650,13 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       (!lastResult || lastResult.isLoading || lastResult.isUninitialized) &&
       !hasData &&
       isFetching
-    // isSuccess = true when data is present
-    const isSuccess = currentState.isSuccess || (isFetching && hasData)
+    // isSuccess = true when data is present and we're not refetching after an error.
+    // That includes cases where the _current_ item is either actively
+    // fetching or about to fetch due to an uninitialized entry.
+    const isSuccess =
+      currentState.isSuccess ||
+      (hasData &&
+        ((isFetching && !lastResult?.isError) || currentState.isUninitialized))
 
     return {
       ...currentState,

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -2441,6 +2441,62 @@ describe('hooks tests', () => {
       expect(numRequests).toBe(1)
     })
 
+    test('`isSuccess` does not flash false on subsequent infinite queries', async () => {
+      const storeRef = setupApiStore(pokemonApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      type LoadingState = {
+        arg: string
+        isFetching: boolean
+        isSuccess: boolean
+      }
+      const loadingHistory: LoadingState[] = []
+
+      function PokemonList({ arg }: { arg: string }) {
+        const queryRes = pokemonApi.useGetInfinitePokemonInfiniteQuery(arg)
+
+        useEffect(() => {
+          const { isFetching, isSuccess } = queryRes
+          loadingHistory.push({ arg, isFetching, isSuccess })
+        }, [arg, queryRes])
+
+        return (
+          <div data-testid="data">
+            {queryRes.status === QueryStatus.fulfilled && arg}
+          </div>
+        )
+      }
+
+      let { rerender } = render(<PokemonList arg="fire" />, {
+        wrapper: storeRef.wrapper,
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('data').textContent).toBe('fire'),
+      )
+
+      rerender(<PokemonList arg="water" />)
+
+      await waitFor(() =>
+        expect(screen.getByTestId('data').textContent).toBe('water'),
+      )
+
+      expect(loadingHistory).toEqual([
+        // Initial render(s)
+        { arg: 'fire', isFetching: true, isSuccess: false },
+        { arg: 'fire', isFetching: true, isSuccess: false },
+        // Data returned
+        { arg: 'fire', isFetching: false, isSuccess: true },
+        // Arg changed, there's an uninitialized cache entry.
+        // IMPORTANT: `isSuccess` should not be false here.
+        // We have valid data already for the old item.
+        { arg: 'water', isFetching: true, isSuccess: true },
+        { arg: 'water', isFetching: true, isSuccess: true },
+        { arg: 'water', isFetching: false, isSuccess: true },
+      ])
+    })
+
     test.each([
       ['skip token', true],
       ['skip option', false],


### PR DESCRIPTION
Fixes #5265


Updates `infiniteQueryStatePreSelector` to match the existing `queryStatePreSelector` logic for deriving `isSuccess`. When switching to a new arg that has an uninitialized cache entry, `isSuccess` now stays `true` if valid data exists from the previous entry.
