### PR TITLE
fix: allow interface-based type guards as listener matcher

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test-d.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test-d.ts
@@ -13,6 +13,7 @@ import {
   createAction,
   createListenerMiddleware,
   createSlice,
+  isAnyOf,
   isFluxStandardAction,
 } from '@reduxjs/toolkit'
 
@@ -305,6 +306,27 @@ describe('type tests', () => {
         },
       }),
     )
+  })
+
+  test('matcher works with interface-based custom type guards', () => {
+    interface ExtraAction extends Action {
+      payload: number
+    }
+
+    function isExtraAction(action: any): action is ExtraAction {
+      return (
+        isFluxStandardAction(action) && typeof action.payload === 'number'
+      )
+    }
+
+    const matcher = isAnyOf(isExtraAction)
+
+    startListening({
+      matcher,
+      effect: (action, listenerApi) => {
+        expectTypeOf(action).toMatchTypeOf<ExtraAction>()
+      },
+    })
   })
 
   test('Can create a pre-typed middleware', () => {

--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -465,7 +465,7 @@ export type AddListenerOverloads<
   ): Return
 
   /** Accepts an RTK matcher function, such as `incrementByAmount.match` */
-  <MatchFunctionType extends MatchFunction<UnknownAction>>(
+  <MatchFunctionType extends MatchFunction<Action>>(
     options: {
       actionCreator?: never
       type?: never


### PR DESCRIPTION
Fixes #4641

I basically just implemented the fix Ben mentioned in the thread and added a test.

The `matcher` overload in `AddListenerOverloads` constrained `MatchFunctionType` to `MatchFunction<UnknownAction>`. Since `UnknownAction` has an index signature (`[extraProps: string]: unknown`) and TypeScript interfaces don't implicitly satisfy index signatures, passing a matcher built from an interface-based type guard (e.g. `isAnyOf(isCustomGuard)` where the guard narrows to `interface Foo extends Action`) produced a type error.

Added a type test in `listenerMiddleware.test-d.ts` that defines an interface-based `ExtraAction`, creates a type guard, wraps it with `isAnyOf`, and passes it as a matcher to `startListening`. Full test suite passes (1300 tests, no type errors).