### PR TITLE
fix: add setTimeout fallback to raf autoBatch strategy for background tabs

### DIFF
--- a/packages/toolkit/src/autoBatchEnhancer.ts
+++ b/packages/toolkit/src/autoBatchEnhancer.ts
@@ -15,6 +15,24 @@ const createQueueWithTimer = (timeout: number) => {
   }
 }
 
+const createRafWithFallbackTimer = (
+  raf: typeof requestAnimationFrame,
+  timeout: number,
+) => {
+  return (notify: () => void) => {
+    let called = false
+    const callback = () => {
+      if (called) return
+      called = true
+      cancelAnimationFrame(rafId)
+      clearTimeout(timerId)
+      notify()
+    }
+    const rafId = raf(callback)
+    const timerId = setTimeout(callback, timeout)
+  }
+}
+
 export type AutoBatchOptions =
   | { type: 'tick' }
   | { type: 'timer'; timeout: number }
@@ -61,7 +79,7 @@ export const autoBatchEnhancer =
         : options.type === 'raf'
           ? // requestAnimationFrame won't exist in SSR environments. Fall back to a vague approximation just to keep from erroring.
             typeof window !== 'undefined' && window.requestAnimationFrame
-            ? window.requestAnimationFrame
+            ? createRafWithFallbackTimer(window.requestAnimationFrame, 100)
             : createQueueWithTimer(10)
           : options.type === 'callback'
             ? options.queueNotification

--- a/packages/toolkit/src/tests/autoBatchEnhancer.test.ts
+++ b/packages/toolkit/src/tests/autoBatchEnhancer.test.ts
@@ -208,3 +208,58 @@ describe.each(cases)(
     })
   },
 )
+
+describe('autoBatchEnhancer raf with background tab fallback', () => {
+  const rafCallbacks: FrameRequestCallback[] = []
+
+  beforeAll(() => {
+    vitest.useFakeTimers({ toFake: ['setTimeout'] })
+    vitest.stubGlobal(
+      'requestAnimationFrame',
+      vitest.fn((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      }),
+    )
+    vitest.stubGlobal('cancelAnimationFrame', vitest.fn())
+  })
+
+  afterAll(() => {
+    vitest.useRealTimers()
+    vitest.unstubAllGlobals()
+  })
+
+  beforeEach(() => {
+    subscriptionNotifications = 0
+    rafCallbacks.length = 0
+    store = makeStore({ type: 'raf' })
+    store.subscribe(() => {
+      subscriptionNotifications++
+    })
+  })
+
+  test('Notifies subscribers via setTimeout fallback when requestAnimationFrame does not fire', () => {
+    store.dispatch(incrementBatched())
+    store.dispatch(incrementBatched())
+    store.dispatch(incrementBatched())
+
+    expect(rafCallbacks.length).toBe(1)
+    expect(subscriptionNotifications).toBe(0)
+
+    vitest.advanceTimersByTime(100)
+
+    expect(subscriptionNotifications).toBe(1)
+    expect(store.getState().value).toBe(3)
+  })
+
+  test('Does not double-notify if both raf and setTimeout would fire', () => {
+    store.dispatch(incrementBatched())
+    expect(subscriptionNotifications).toBe(0)
+
+    rafCallbacks[0](performance.now())
+    expect(subscriptionNotifications).toBe(1)
+
+    vitest.advanceTimersByTime(100)
+    expect(subscriptionNotifications).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes #5051

The default `raf` autoBatch strategy now races `requestAnimationFrame` against a 100ms `setTimeout` fallback. Whichever fires first calls `notify()` and cancels the other.


Browsers don't fire `requestAnimationFrame` callbacks in background tabs (or heavily throttle them). This means batched subscriber notifications from RTK Query fetches completing in a background tab never arrive until the tab regains focus.

As identified by @phryneas in the issue thread, adding a `setTimeout` fallback ensures notifications still fire within 100ms even when RAF is suspended. In foreground tabs, RAF fires first (~16ms) and cancels the timer, so there's no behavior change.

- Added test: `setTimeout` fallback fires when RAF is suspended (simulated background tab)
- Added test: no double-notification when both RAF and `setTimeout` could fire