### PR TITLE
docs: fix reusing wording in RTK Query comments

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -706,7 +706,7 @@ export type TypedUseQueryStateResult<
 type UseQueryStateBaseResult<D extends QueryDefinition<any, any, any, any>> =
   QuerySubState<D> & {
     /**
-     * Where `data` tries to hold data as much as possible, also re-using
+     * Where `data` tries to hold data as much as possible, also reusing
      * data from the last arguments passed into the hook, this property
      * will always contain the received data from the query, for the current query arguments.
      */
@@ -1264,7 +1264,7 @@ type UseInfiniteQueryStateBaseResult<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
 > = InfiniteQuerySubState<D> & {
   /**
-   * Where `data` tries to hold data as much as possible, also re-using
+   * Where `data` tries to hold data as much as possible, also reusing
    * data from the last arguments passed into the hook, this property
    * will always contain the received data from the query, for the current query arguments.
    */


### PR DESCRIPTION
## Summary

Fix the RTK Query hook comments by changing `re-using` to `reusing` in two matching comment blocks.

## Related issue

N/A, trivial comment wording fix.

## Guideline alignment

Single-file, non-behavioral wording change kept narrowly scoped.

## Validation/testing note

Not run; comment-only change.