### PR TITLE
feat(toolkit)!: switch to native `NoInfer` utility type

### DIFF
--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -1,14 +1,9 @@
 import type { Draft } from 'immer'
-import {
-  createNextState,
-  isDraft,
-  isDraftable,
-  setUseStrictIteration,
-} from './immerImports'
 import type { Action, Reducer, UnknownAction } from 'redux'
+import { createNextState, isDraft, isDraftable } from './immerImports'
 import type { ActionReducerMapBuilder } from './mapBuilders'
 import { executeReducerBuilderCallback } from './mapBuilders'
-import type { NoInfer, TypeGuard } from './tsHelpers'
+import type { TypeGuard } from './tsHelpers'
 import { freezeDraftable } from './utils'
 
 /**

--- a/packages/toolkit/src/query/apiTypes.ts
+++ b/packages/toolkit/src/query/apiTypes.ts
@@ -1,6 +1,6 @@
 import type { UnknownAction } from '@reduxjs/toolkit'
 import type { BaseQueryFn } from './baseQueryTypes'
-import type { CombinedState, CoreModule, QueryKeys } from './core'
+import type { CombinedState, CoreModule } from './core/index'
 import type { ApiModules } from './core/module'
 import type { CreateApiOptions } from './createApi'
 import type {
@@ -9,11 +9,7 @@ import type {
   EndpointDefinitions,
   UpdateDefinitions,
 } from './endpointDefinitions'
-import type {
-  NoInfer,
-  UnionToIntersection,
-  WithRequiredProp,
-} from './tsHelpers'
+import type { UnionToIntersection, WithRequiredProp } from './tsHelpers'
 
 export type ModuleName = keyof ApiModules<any, any, any, any>
 

--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -1,12 +1,10 @@
-import {
-  getEndpointDefinition,
-  type Api,
-  type ApiContext,
-  type Module,
-  type ModuleName,
-} from './apiTypes'
-import type { CombinedState } from './core/apiState'
-import type { BaseQueryArg, BaseQueryFn } from './baseQueryTypes'
+import type { UnknownAction } from '@reduxjs/toolkit'
+import { weakMapMemoize } from 'reselect'
+import type { Api, ApiContext, Module, ModuleName } from './apiTypes'
+import { getEndpointDefinition } from './apiTypes'
+import type { BaseQueryFn } from './baseQueryTypes'
+import type { CombinedState } from './core/index'
+import { nanoid } from './core/rtkImports'
 import type { SerializeQueryArgs } from './defaultSerializeQueryArgs'
 import { defaultSerializeQueryArgs } from './defaultSerializeQueryArgs'
 import type {
@@ -17,17 +15,11 @@ import type {
   SchemaType,
 } from './endpointDefinitions'
 import {
-  DefinitionType,
   ENDPOINT_INFINITEQUERY,
   ENDPOINT_MUTATION,
   ENDPOINT_QUERY,
   isInfiniteQueryDefinition,
-  isQueryDefinition,
 } from './endpointDefinitions'
-import { nanoid } from './core/rtkImports'
-import type { UnknownAction } from '@reduxjs/toolkit'
-import type { NoInfer } from './tsHelpers'
-import { weakMapMemoize } from 'reselect'
 
 export interface CreateApiOptions<
   BaseQuery extends BaseQueryFn,

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -99,7 +99,6 @@ export type { SerializeQueryArgs } from './defaultSerializeQueryArgs'
 
 export type {
   Id as TSHelpersId,
-  NoInfer as TSHelpersNoInfer,
   Override as TSHelpersOverride,
 } from './tsHelpers'
 

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -7,7 +7,6 @@ import type {
 import type {
   Api,
   ApiContext,
-  ApiEndpointInfiniteQuery,
   ApiEndpointMutation,
   ApiEndpointQuery,
   BaseQueryFn,
@@ -36,11 +35,17 @@ import type {
   SkipToken,
   SubscriptionOptions,
   TSHelpersId,
-  TSHelpersNoInfer,
   TSHelpersOverride,
 } from '@reduxjs/toolkit/query'
-import { QueryStatus, skipToken } from './rtkqImports'
 import type { DependencyList } from 'react'
+import type { InfiniteQueryDirection } from '../core/apiState'
+import type { StartInfiniteQueryActionCreator } from '../core/buildInitiate'
+import type { SubscriptionSelectors } from '../core/buildMiddleware/index'
+import type { InfiniteData } from '../core/index'
+import { isInfiniteQueryDefinition } from '../endpointDefinitions'
+import type { UninitializedValue } from './constants'
+import { UNINITIALIZED_VALUE } from './constants'
+import type { ReactHooksModuleOptions } from './module'
 import {
   useCallback,
   useDebugValue,
@@ -51,17 +56,9 @@ import {
   useState,
 } from './reactImports'
 import { shallowEqual } from './reactReduxImports'
-
-import type { SubscriptionSelectors } from '../core/buildMiddleware/index'
-import type { InfiniteData, InfiniteQueryConfigOptions } from '../core/index'
-import type { UninitializedValue } from './constants'
-import { UNINITIALIZED_VALUE } from './constants'
-import type { ReactHooksModuleOptions } from './module'
+import { QueryStatus, skipToken } from './rtkqImports'
 import { useStableQueryArgs } from './useSerializedStableValue'
 import { useShallowStableValue } from './useShallowStableValue'
-import type { InfiniteQueryDirection } from '../core/apiState'
-import { isInfiniteQueryDefinition } from '../endpointDefinitions'
-import type { StartInfiniteQueryActionCreator } from '../core/buildInitiate'
 
 // Copy-pasted from React-Redux
 const canUseDOM = () =>
@@ -688,7 +685,7 @@ export type TypedUseQueryStateOptions<
 export type UseQueryStateResult<
   _ extends QueryDefinition<any, any, any, any>,
   R,
-> = TSHelpersNoInfer<R>
+> = R
 
 /**
  * Helper type to manually type the result
@@ -701,7 +698,7 @@ export type TypedUseQueryStateResult<
   R = UseQueryStateDefaultResult<
     QueryDefinition<QueryArg, BaseQuery, string, ResultType, string>
   >,
-> = TSHelpersNoInfer<R>
+> = R
 
 type UseQueryStateBaseResult<D extends QueryDefinition<any, any, any, any>> =
   QuerySubState<D> & {
@@ -957,19 +954,17 @@ export type TypedInfiniteQueryStateSelector<
   QueryArg,
   PageParam,
   BaseQuery extends BaseQueryFn,
-  SelectedResult extends Record<
-    string,
-    any
-  > = UseInfiniteQueryStateDefaultResult<
-    InfiniteQueryDefinition<
-      QueryArg,
-      PageParam,
-      BaseQuery,
-      string,
-      ResultType,
-      string
-    >
-  >,
+  SelectedResult extends Record<string, any> =
+    UseInfiniteQueryStateDefaultResult<
+      InfiniteQueryDefinition<
+        QueryArg,
+        PageParam,
+        BaseQuery,
+        string,
+        ResultType,
+        string
+      >
+    >,
 > = InfiniteQueryStateSelector<
   SelectedResult,
   InfiniteQueryDefinition<
@@ -1203,19 +1198,17 @@ export type TypedUseInfiniteQueryStateOptions<
   QueryArg,
   PageParam,
   BaseQuery extends BaseQueryFn,
-  SelectedResult extends Record<
-    string,
-    any
-  > = UseInfiniteQueryStateDefaultResult<
-    InfiniteQueryDefinition<
-      QueryArg,
-      PageParam,
-      BaseQuery,
-      string,
-      ResultType,
-      string
-    >
-  >,
+  SelectedResult extends Record<string, any> =
+    UseInfiniteQueryStateDefaultResult<
+      InfiniteQueryDefinition<
+        QueryArg,
+        PageParam,
+        BaseQuery,
+        string,
+        ResultType,
+        string
+      >
+    >,
 > = UseInfiniteQueryStateOptions<
   InfiniteQueryDefinition<
     QueryArg,
@@ -1231,7 +1224,7 @@ export type TypedUseInfiniteQueryStateOptions<
 export type UseInfiniteQueryStateResult<
   D extends InfiniteQueryDefinition<any, any, any, any, any>,
   R = UseInfiniteQueryStateDefaultResult<D>,
-> = TSHelpersNoInfer<R>
+> = R
 
 export type TypedUseInfiniteQueryStateResult<
   ResultType,
@@ -1381,7 +1374,7 @@ export type TypedUseMutationStateOptions<
 export type UseMutationStateResult<
   D extends MutationDefinition<any, any, any, any>,
   R,
-> = TSHelpersNoInfer<R> & {
+> = R & {
   originalArgs?: QueryArgFrom<D>
   /**
    * Resets the hook state to its initial `uninitialized` state.

--- a/packages/toolkit/src/query/tsHelpers.ts
+++ b/packages/toolkit/src/query/tsHelpers.ts
@@ -29,8 +29,6 @@ export type HasRequiredProps<T, True, False> =
 
 export type OptionalIfAllPropsOptional<T> = HasRequiredProps<T, T, T | never>
 
-export type NoInfer<T> = [T][T extends any ? 0 : never]
-
 export type NonUndefined<T> = T extends undefined ? never : T
 
 export type UnwrapPromise<T> = T extends PromiseLike<infer V> ? V : T

--- a/packages/toolkit/src/tsHelpers.ts
+++ b/packages/toolkit/src/tsHelpers.ts
@@ -158,15 +158,6 @@ export type ExtractStateExtensions<E> =
         >
       : never
 
-/**
- * Helper type. Passes T out again, but boxes it in a way that it cannot
- * "widen" the type by accident if it is a generic that should be inferred
- * from elsewhere.
- *
- * @internal
- */
-export type NoInfer<T> = [T][T extends any ? 0 : never]
-
 export type NonUndefined<T> = T extends undefined ? never : T
 
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &


### PR DESCRIPTION
## **This PR**:

- [x] Switches to the native [**`NoInfer`**](https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype) utility type, introduced in [**TypeScript v5.4**](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4), which aligns with our minimum supported TypeScript version.
- [x] Resolves #5204.