### PR TITLE
add docusaurus-plugin-copy-page-button

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -186,6 +186,7 @@ const config: Config = {
     // },
   } satisfies ThemeConfig,
   plugins: [
+    'docusaurus-plugin-copy-page-button',
     [
       '@dipakparmar/docusaurus-plugin-umami',
       {

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "@getcanary/web": "^1.0.12",
     "@mdx-js/react": "^3.1.1",
     "classnames": "^2.2.6",
-    "docusaurus-plugin-copy-page-button": "^0.5.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-lite-youtube-embed": "^2.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
     "@getcanary/web": "^1.0.12",
     "@mdx-js/react": "^3.1.1",
     "classnames": "^2.2.6",
+    "docusaurus-plugin-copy-page-button": "^0.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-lite-youtube-embed": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15179,13 +15179,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-copy-page-button@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "docusaurus-plugin-copy-page-button@npm:0.5.1"
+"docusaurus-plugin-copy-page-button@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.8.0"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
     react: ^18.0.0 || ^19.0.0
-  checksum: 10/efab016c1513019376ee866bc4c2db2b97b12138c5d209b3feaf635d98830a20d3956e00a5a7a611aa0b76de8e96dfd1e194c074b81e456585a2fea6aca06ab3
+  checksum: 10/b99e445c942ec29ee2d9458c601c2ec91411dc5b21990ad7e32c9d2cb388a1b1849d162008b053b16d109d856241b486525555bb1bddc94065fb83e0546b50e6
   languageName: node
   linkType: hard
 
@@ -33482,7 +33482,7 @@ __metadata:
     "@types/node": "npm:^25.5.0"
     "@types/react": "npm:^19.2.14"
     classnames: "npm:^2.2.6"
-    docusaurus-plugin-copy-page-button: "npm:^0.5.1"
+    docusaurus-plugin-copy-page-button: "npm:^0.8.0"
     netlify-plugin-cache: "npm:^1.0.3"
     prettier: "npm:^3.2.5"
     react: "npm:^19.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15179,6 +15179,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docusaurus-plugin-copy-page-button@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.5.1"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10/efab016c1513019376ee866bc4c2db2b97b12138c5d209b3feaf635d98830a20d3956e00a5a7a611aa0b76de8e96dfd1e194c074b81e456585a2fea6aca06ab3
+  languageName: node
+  linkType: hard
+
 "dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
@@ -33472,6 +33482,7 @@ __metadata:
     "@types/node": "npm:^25.5.0"
     "@types/react": "npm:^19.2.14"
     classnames: "npm:^2.2.6"
+    docusaurus-plugin-copy-page-button: "npm:^0.5.1"
     netlify-plugin-cache: "npm:^1.0.3"
     prettier: "npm:^3.2.5"
     react: "npm:^19.0.0"


### PR DESCRIPTION
This PR
adds docusaurus-plugin-copy-page-button to website/package.json
adds the plugin string to plugins in website/docusaurus.config.ts
puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for RTK specifically:
RTK Query, createSlice, listener middleware all have a lot of subtle nuance per page. the typical "I want to ask claude about this" flow is reading a docs page → wanting to drop just that page in for context. this saves the selection-and-cleanup step.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on Ethereum execution-apis, Sui, Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, Cardano, and Arbitrum docs. listed in the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button (~10k installs/mo)