### PR TITLE
fix(rtk-query): reset removeQueryResult entry to uninitialized instead of deleting

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -291,7 +291,14 @@ export function buildSlice({
             payload: { queryCacheKey },
           }: PayloadAction<QuerySubstateIdentifier>,
         ) {
-          delete draft[queryCacheKey]
+          const entry = draft[queryCacheKey];
+          if (entry) {
+            entry.status = STATUS_UNINITIALIZED;
+            delete entry.data;
+            delete entry.error;
+            delete entry.fulfilledTimeStamp;
+            delete entry.startedTimeStamp;
+          }
         },
         prepare: prepareAutoBatched<QuerySubstateIdentifier>(),
       },


### PR DESCRIPTION
Fixes #5300

Why
removeQueryResult currently does delete draft[queryCacheKey], which completely removes the cache entry from state. When a component resubscribes to the same query, no cache entry exists, so isLoading never transitions through the expected isUninitialized -> isLoading=true flow — breaking loading-indicator semantics.

Changes
Instead of deleting the entry, reset it to STATUS_UNINITIALIZED and clear the data, error, fulfilledTimeStamp, and startedTimeStamp fields.

Updated component: packages/toolkit/src/query/core/buildSlice.ts

Surface area
- RTK Query / Cache
- Bug fix