### PR TITLE
chore: update `@arethetypeswrong/cli` to `0.18.3` to fix CI failure

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -147,4 +147,4 @@ jobs:
           name: package
 
       - name: Run are-the-types-wrong
-        run: yarn dlx @arethetypeswrong/cli@0.18.2 ./package.tgz --format table --exclude-entrypoints cli
+        run: yarn attw ./package.tgz --format table --exclude-entrypoints cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,6 +336,10 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
         run: yarn build
 
+      - name: playwright install
+        if: matrix.example == 'next' || matrix.example == 'vite' || matrix.example == 'cra4' || matrix.example == 'cra5'
+        run: yarn exec playwright install --with-deps chromium
+
       - name: Run test step
         run: yarn test
 

--- a/examples/publish-ci/cra4/package.json
+++ b/examples/publish-ci/cra4/package.json
@@ -41,7 +41,7 @@
     "workerDirectory": "public"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -49,7 +49,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3"

--- a/examples/publish-ci/cra4/yarn.lock
+++ b/examples/publish-ci/cra4/yarn.lock
@@ -2049,19 +2049,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "@playwright/test@npm:1.31.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/e82cfc959bba9f1bf62bf35b1845df6bf0235ccd179520373ec668da8b94b660c2c5422a27b4e3e6e48dabe9abd39caa1bc9a9bd70474d6911f370a78822f1f4
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -11887,23 +11882,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.2":
-  version: 1.31.2
-  resolution: "playwright-core@npm:1.31.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/dc5c0b80f6bc02ae197123da315ba713494607653c8f9c8e675c727cf6b6e5dd0c21ccae4e29ec1244b147cf913b194a0733ba97384685620e155edb664b9d3b
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "playwright@npm:1.31.2"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.2"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3ca8060bf768c9ddeb012cc8979e0adb5a2ff44d5aa337ae9f6c13d7ccd26b29b90a12485c23137f71cdc74b0ebac4b67865c4d4029baf539def19b276ef9b59
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -13920,7 +13919,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rtk-esm-cra@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -13930,7 +13929,6 @@ __metadata:
     "@types/react": "npm:^18.0.26"
     "@types/react-dom": "npm:^18.0.10"
     msw: "npm:^1.3.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/examples/publish-ci/cra5/package.json
+++ b/examples/publish-ci/cra5/package.json
@@ -41,7 +41,7 @@
     "workerDirectory": "public"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -49,7 +49,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3"

--- a/examples/publish-ci/cra5/yarn.lock
+++ b/examples/publish-ci/cra5/yarn.lock
@@ -2329,19 +2329,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.1
-  resolution: "@playwright/test@npm:1.31.1"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.1"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/8a58aa1c492c4e87a8f68ccf80d6e38ae43123bbd73182bc6c59e1f87edc7df6ca14a40c04cb1305cddebd38145dda86112c4c21dcdc8b2d80edf836abeab2ff
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -10551,23 +10546,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.1":
-  version: 1.31.1
-  resolution: "playwright-core@npm:1.31.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/89139fc8387adf7d113b5bd3ad266edd5a2966b59e115680b7705edf56f378583838b0a14e4daef4192baa96833e1303d6019b4ce276668bc65623e959b08e3e
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.1
-  resolution: "playwright@npm:1.31.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.1"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/e70b54ac34aa5a97ac9053e41c49960a3db1ac439a2fb7bc76252b6e70c795a1973b14ba698c5e428931f498bc8f66ff6f4eff6bbfe0904c0953bf7bafdec089
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -12294,7 +12293,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rtk-esm-cra@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -12304,7 +12303,6 @@ __metadata:
     "@types/react": "npm:^18.0.26"
     "@types/react-dom": "npm:^18.0.10"
     msw: "npm:^1.3.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/examples/publish-ci/next/package.json
+++ b/examples/publish-ci/next/package.json
@@ -18,7 +18,7 @@
     "react-redux": "^9.0.0-rc.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -26,7 +26,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3"

--- a/examples/publish-ci/next/yarn.lock
+++ b/examples/publish-ci/next/yarn.lock
@@ -235,19 +235,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "@playwright/test@npm:1.31.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/e82cfc959bba9f1bf62bf35b1845df6bf0235ccd179520373ec668da8b94b660c2c5422a27b4e3e6e48dabe9abd39caa1bc9a9bd70474d6911f370a78822f1f4
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -2553,23 +2548,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.2":
-  version: 1.31.2
-  resolution: "playwright-core@npm:1.31.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/dc5c0b80f6bc02ae197123da315ba713494607653c8f9c8e675c727cf6b6e5dd0c21ccae4e29ec1244b147cf913b194a0733ba97384685620e155edb664b9d3b
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "playwright@npm:1.31.2"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.2"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3ca8060bf768c9ddeb012cc8979e0adb5a2ff44d5aa337ae9f6c13d7ccd26b29b90a12485c23137f71cdc74b0ebac4b67865c4d4029baf539def19b276ef9b59
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -2846,7 +2845,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -2857,7 +2856,6 @@ __metadata:
     "@types/react-dom": "npm:^18.0.10"
     msw: "npm:^1.3.2"
     next: "npm:^13.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/examples/publish-ci/vite/package.json
+++ b/examples/publish-ci/vite/package.json
@@ -18,7 +18,7 @@
     "react-redux": "^9.0.0-rc.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -27,7 +27,6 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^5",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3",

--- a/examples/publish-ci/vite/yarn.lock
+++ b/examples/publish-ci/vite/yarn.lock
@@ -622,19 +622,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "@playwright/test@npm:1.31.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/e82cfc959bba9f1bf62bf35b1845df6bf0235ccd179520373ec668da8b94b660c2c5422a27b4e3e6e48dabe9abd39caa1bc9a9bd70474d6911f370a78822f1f4
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -3277,23 +3272,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.2":
-  version: 1.31.2
-  resolution: "playwright-core@npm:1.31.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/dc5c0b80f6bc02ae197123da315ba713494607653c8f9c8e675c727cf6b6e5dd0c21ccae4e29ec1244b147cf913b194a0733ba97384685620e155edb664b9d3b
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "playwright@npm:1.31.2"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.2"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3ca8060bf768c9ddeb012cc8979e0adb5a2ff44d5aa337ae9f6c13d7ccd26b29b90a12485c23137f71cdc74b0ebac4b67865c4d4029baf539def19b276ef9b59
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -3658,7 +3657,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rtk-esm-vite-normal@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -3669,7 +3668,6 @@ __metadata:
     "@types/react-dom": "npm:^18.0.10"
     "@vitejs/plugin-react": "npm:^5"
     msw: "npm:^1.3.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -50,6 +50,7 @@
     "!skills/_artifacts"
   ],
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.3",
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -184,7 +184,7 @@
     }
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.3",
     "@babel/core": "^7.24.8",
     "@babel/helper-module-imports": "^7.24.7",
     "@microsoft/api-extractor": "^7.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,11 +355,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@arethetypeswrong/cli@npm:^0.18.2":
-  version: 0.18.2
-  resolution: "@arethetypeswrong/cli@npm:0.18.2"
+"@arethetypeswrong/cli@npm:^0.18.3":
+  version: 0.18.3
+  resolution: "@arethetypeswrong/cli@npm:0.18.3"
   dependencies:
-    "@arethetypeswrong/core": "npm:0.18.2"
+    "@arethetypeswrong/core": "npm:0.18.3"
     chalk: "npm:^4.1.2"
     cli-table3: "npm:^0.6.3"
     commander: "npm:^10.0.1"
@@ -367,24 +367,24 @@ __metadata:
     marked-terminal: "npm:^7.1.0"
     semver: "npm:^7.5.4"
   bin:
-    attw: dist/index.js
-  checksum: 10/8b4506edeb37d58f15e347302df68981c5aefecce973e746026d46370bb560c1ebc05ef8a38eba3102881df4cd3c901961186e3df41077efca4e58adffd455a1
+    attw: ./dist/index.js
+  checksum: 10/37cc112b31b3467df5156f02f689cacb82db21549aafb6ee8fa9802c9ab9904d0e21924d445713b49423b0d696a933e7a4fe30962e48eb20e952f1b039136b99
   languageName: node
   linkType: hard
 
-"@arethetypeswrong/core@npm:0.18.2":
-  version: 0.18.2
-  resolution: "@arethetypeswrong/core@npm:0.18.2"
+"@arethetypeswrong/core@npm:0.18.3":
+  version: 0.18.3
+  resolution: "@arethetypeswrong/core@npm:0.18.3"
   dependencies:
     "@andrewbranch/untar.js": "npm:^1.0.3"
     "@loaderkit/resolve": "npm:^1.0.2"
     cjs-module-lexer: "npm:^1.2.3"
-    fflate: "npm:^0.8.2"
+    fflate: "npm:^0.8.3"
     lru-cache: "npm:^11.0.1"
     semver: "npm:^7.5.4"
     typescript: "npm:5.6.1-rc"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10/9c3edeb8e09e572682e37f55bd523d0dad45388232d31fa1d8875f7f5c414a184070c2bb6d0c8f254dfce4ed9248da373d549ecdeaa571a0cfff04c387c94cf1
+  checksum: 10/7ae9b9c63fa12c4608f7ba737783fc0504346c27f86bb08b6aff10a02d81bbb2bff68d942a668e8d7595a76aa78cc3ad2d9b8d156e524092483266be560aa0fc
   languageName: node
   linkType: hard
 
@@ -7750,7 +7750,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@reduxjs/toolkit@workspace:packages/toolkit"
   dependencies:
-    "@arethetypeswrong/cli": "npm:^0.18.2"
+    "@arethetypeswrong/cli": "npm:^0.18.3"
     "@babel/core": "npm:^7.24.8"
     "@babel/helper-module-imports": "npm:^7.24.7"
     "@microsoft/api-extractor": "npm:^7.13.2"
@@ -8361,6 +8361,7 @@ __metadata:
   resolution: "@rtk-query/codegen-openapi@workspace:packages/rtk-query-codegen-openapi"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.1"
+    "@arethetypeswrong/cli": "npm:^0.18.3"
     "@babel/core": "npm:^7.12.10"
     "@babel/preset-env": "npm:^7.12.11"
     "@babel/preset-typescript": "npm:^7.12.7"
@@ -17099,10 +17100,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "fflate@npm:0.8.2"
-  checksum: 10/2bd26ba6d235d428de793c6a0cd1aaa96a06269ebd4e21b46c8fd1bd136abc631acf27e188d47c3936db090bf3e1ede11d15ce9eae9bffdc4bfe1b9dc66ca9cb
+"fflate@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10/6ebf528dc9c56e78e715eac615b009b25dc33e15c1920b11ebba44e6d76181c647756a81a23e19247907496b93aa99928514c53090579a65109e026ac2824aa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump **`@arethetypeswrong/cli`** from **`0.18.2`** to **`0.18.3`** in **`@reduxjs/toolkit`**
- Add **`@arethetypeswrong/cli@0.18.3`** as a dev dependency to **`@rtk-query/codegen-openapi`**
- Switch CI from **`yarn dlx @arethetypeswrong/cli@0.18.2`** to **`yarn attw`** (uses the installed version)

Related: [**arethetypeswrong/arethetypeswrong.github.io#258**](https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258), [**101arrowz/fflate#258**](https://github.com/101arrowz/fflate/issues/258)
Upstream fix: [**arethetypeswrong/arethetypeswrong.github.io#261**](https://github.com/arethetypeswrong/arethetypeswrong.github.io/pull/261), released in [**`@arethetypeswrong/core@0.18.3`**](https://github.com/arethetypeswrong/arethetypeswrong.github.io/releases/tag/%40arethetypeswrong%2Fcore%400.18.3)

Depends on #5310.
