### PR TITLE
ci: fix Playwright e2e tests in publish-ci examples

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,6 +336,10 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
         run: yarn build
 
+      - name: playwright install
+        if: matrix.example == 'next' || matrix.example == 'vite' || matrix.example == 'cra4' || matrix.example == 'cra5'
+        run: yarn exec playwright install --with-deps chromium
+
       - name: Run test step
         run: yarn test
 

--- a/examples/publish-ci/cra4/package.json
+++ b/examples/publish-ci/cra4/package.json
@@ -41,7 +41,7 @@
     "workerDirectory": "public"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -49,7 +49,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3"

--- a/examples/publish-ci/cra4/yarn.lock
+++ b/examples/publish-ci/cra4/yarn.lock
@@ -2049,19 +2049,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "@playwright/test@npm:1.31.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/e82cfc959bba9f1bf62bf35b1845df6bf0235ccd179520373ec668da8b94b660c2c5422a27b4e3e6e48dabe9abd39caa1bc9a9bd70474d6911f370a78822f1f4
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -11887,23 +11882,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.2":
-  version: 1.31.2
-  resolution: "playwright-core@npm:1.31.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/dc5c0b80f6bc02ae197123da315ba713494607653c8f9c8e675c727cf6b6e5dd0c21ccae4e29ec1244b147cf913b194a0733ba97384685620e155edb664b9d3b
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "playwright@npm:1.31.2"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.2"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3ca8060bf768c9ddeb012cc8979e0adb5a2ff44d5aa337ae9f6c13d7ccd26b29b90a12485c23137f71cdc74b0ebac4b67865c4d4029baf539def19b276ef9b59
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -13920,7 +13919,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rtk-esm-cra@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -13930,7 +13929,6 @@ __metadata:
     "@types/react": "npm:^18.0.26"
     "@types/react-dom": "npm:^18.0.10"
     msw: "npm:^1.3.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/examples/publish-ci/cra5/package.json
+++ b/examples/publish-ci/cra5/package.json
@@ -41,7 +41,7 @@
     "workerDirectory": "public"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -49,7 +49,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3"

--- a/examples/publish-ci/cra5/yarn.lock
+++ b/examples/publish-ci/cra5/yarn.lock
@@ -2329,19 +2329,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.1
-  resolution: "@playwright/test@npm:1.31.1"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.1"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/8a58aa1c492c4e87a8f68ccf80d6e38ae43123bbd73182bc6c59e1f87edc7df6ca14a40c04cb1305cddebd38145dda86112c4c21dcdc8b2d80edf836abeab2ff
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -10551,23 +10546,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.1":
-  version: 1.31.1
-  resolution: "playwright-core@npm:1.31.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/89139fc8387adf7d113b5bd3ad266edd5a2966b59e115680b7705edf56f378583838b0a14e4daef4192baa96833e1303d6019b4ce276668bc65623e959b08e3e
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.1
-  resolution: "playwright@npm:1.31.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.1"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/e70b54ac34aa5a97ac9053e41c49960a3db1ac439a2fb7bc76252b6e70c795a1973b14ba698c5e428931f498bc8f66ff6f4eff6bbfe0904c0953bf7bafdec089
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -12294,7 +12293,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rtk-esm-cra@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -12304,7 +12303,6 @@ __metadata:
     "@types/react": "npm:^18.0.26"
     "@types/react-dom": "npm:^18.0.10"
     msw: "npm:^1.3.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/examples/publish-ci/next/package.json
+++ b/examples/publish-ci/next/package.json
@@ -18,7 +18,7 @@
     "react-redux": "^9.0.0-rc.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -26,7 +26,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3"

--- a/examples/publish-ci/next/yarn.lock
+++ b/examples/publish-ci/next/yarn.lock
@@ -235,19 +235,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "@playwright/test@npm:1.31.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/e82cfc959bba9f1bf62bf35b1845df6bf0235ccd179520373ec668da8b94b660c2c5422a27b4e3e6e48dabe9abd39caa1bc9a9bd70474d6911f370a78822f1f4
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -2553,23 +2548,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.2":
-  version: 1.31.2
-  resolution: "playwright-core@npm:1.31.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/dc5c0b80f6bc02ae197123da315ba713494607653c8f9c8e675c727cf6b6e5dd0c21ccae4e29ec1244b147cf913b194a0733ba97384685620e155edb664b9d3b
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "playwright@npm:1.31.2"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.2"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3ca8060bf768c9ddeb012cc8979e0adb5a2ff44d5aa337ae9f6c13d7ccd26b29b90a12485c23137f71cdc74b0ebac4b67865c4d4029baf539def19b276ef9b59
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -2846,7 +2845,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -2857,7 +2856,6 @@ __metadata:
     "@types/react-dom": "npm:^18.0.10"
     msw: "npm:^1.3.2"
     next: "npm:^13.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"

--- a/examples/publish-ci/vite/package.json
+++ b/examples/publish-ci/vite/package.json
@@ -18,7 +18,7 @@
     "react-redux": "^9.0.0-rc.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
@@ -27,7 +27,6 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^5",
-    "playwright": "^1.31.1",
     "prettier": "^3.2.5",
     "serve": "^14.2.0",
     "typescript": "^5.9.3",

--- a/examples/publish-ci/vite/yarn.lock
+++ b/examples/publish-ci/vite/yarn.lock
@@ -622,19 +622,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "@playwright/test@npm:1.31.2"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.31.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/e82cfc959bba9f1bf62bf35b1845df6bf0235ccd179520373ec668da8b94b660c2c5422a27b4e3e6e48dabe9abd39caa1bc9a9bd70474d6911f370a78822f1f4
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -3277,23 +3272,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.31.2":
-  version: 1.31.2
-  resolution: "playwright-core@npm:1.31.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
-    playwright: cli.js
-  checksum: 10/dc5c0b80f6bc02ae197123da315ba713494607653c8f9c8e675c727cf6b6e5dd0c21ccae4e29ec1244b147cf913b194a0733ba97384685620e155edb664b9d3b
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.31.1":
-  version: 1.31.2
-  resolution: "playwright@npm:1.31.2"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
-    playwright-core: "npm:1.31.2"
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10/3ca8060bf768c9ddeb012cc8979e0adb5a2ff44d5aa337ae9f6c13d7ccd26b29b90a12485c23137f71cdc74b0ebac4b67865c4d4029baf539def19b276ef9b59
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -3658,7 +3657,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rtk-esm-vite-normal@workspace:."
   dependencies:
-    "@playwright/test": "npm:^1.31.1"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.0-rc.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.4.0"
@@ -3669,7 +3668,6 @@ __metadata:
     "@types/react-dom": "npm:^18.0.10"
     "@vitejs/plugin-react": "npm:^5"
     msw: "npm:^1.3.2"
-    playwright: "npm:^1.31.1"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"


### PR DESCRIPTION
## Summary

The **`cra4`**, **`cra5`**, **`next`**, and **`vite`** examples each depended on both [**`@playwright/test`**](https://www.npmjs.com/package/@playwright/test) and a standalone [**`playwright`**](https://www.npmjs.com/package/playwright), whose versions could drift and fight over the Chromium build, breaking the [**`test-published-artifact`**](.github/workflows/tests.yml) CI job. This PR consolidates each example to a single Playwright dependency.

## Changes

- Bump [**`@playwright/test`**](https://www.npmjs.com/package/@playwright/test) from **`^1.31.1`** to **`^1.60.0`** and drop the redundant standalone [**`playwright`**](https://www.npmjs.com/package/playwright) devDependency in the **`cra4`**, **`cra5`**, **`next`**, and **`vite`** examples under [**`examples/publish-ci`**](examples/publish-ci/), with matching [**`yarn.lock`**](examples/publish-ci/vite/yarn.lock) updates.
- Add an explicit [**`playwright install --with-deps chromium`**](.github/workflows/tests.yml#L338) step (gated on the **`next`**, **`vite`**, **`cra4`**, and **`cra5`** matrix examples) so the required Chromium build is present before the test step runs.

## Related

- [**microsoft/playwright#29930**](https://github.com/microsoft/playwright/issues/29930)
- [**microsoft/playwright#33673**](https://github.com/microsoft/playwright/issues/33673)