### PR TITLE
chore: ignore `test-results` folder in publish-ci examples

### DIFF
--- a/examples/publish-ci/cra4/.gitignore
+++ b/examples/publish-ci/cra4/.gitignore
@@ -33,3 +33,5 @@ typesversions
 !.yarn/versions
 .pnp.*
 *.tgz
+
+/test-results/

--- a/examples/publish-ci/cra5/.gitignore
+++ b/examples/publish-ci/cra5/.gitignore
@@ -33,3 +33,5 @@ typesversions
 !.yarn/versions
 .pnp.*
 *.tgz
+
+/test-results/

--- a/examples/publish-ci/next/.gitignore
+++ b/examples/publish-ci/next/.gitignore
@@ -47,3 +47,5 @@ typesversions
 !.yarn/versions
 .pnp.*
 *.tgz
+
+/test-results/

--- a/examples/publish-ci/vite/.gitignore
+++ b/examples/publish-ci/vite/.gitignore
@@ -35,3 +35,5 @@ typesversions
 !.yarn/versions
 .pnp.*
 *.tgz
+
+/test-results/


### PR DESCRIPTION
## Summary

[**`@playwright/test`**](https://playwright.dev/docs/test-configuration#test-output-directory)
writes its per-run artifacts (traces, screenshots, videos) to a
**`test-results/`** directory by default. This folder was not ignored in the
**`publish-ci`** example projects, so running the Playwright e2e tests locally
left untracked output cluttering `git status`. This PR ignores it across all
four examples.

## Changes

- Add **`/test-results/`** to the **`.gitignore`** of the **`cra4`**, **`cra5`**,
  **`next`**, and **`vite`** examples under **`examples/publish-ci`**.

## Related

- Follow-up to the Playwright e2e fixes in [**#5310**](https://github.com/reduxjs/redux-toolkit/pull/5310)
