### PR TITLE
Simplify `useRef<T | undefined>(undefined)` usages in RTK Query hooks

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1703,10 +1703,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     >
     const dispatch = useDispatch<ThunkDispatch<any, any, UnknownAction>>()
 
-    // TODO: Change this to `useRef<SubscriptionSelectors>(undefined)` after upgrading to React 19.
-    const subscriptionSelectorsRef = useRef<SubscriptionSelectors | undefined>(
-      undefined,
-    )
+    const subscriptionSelectorsRef = useRef<SubscriptionSelectors>(undefined)
 
     if (!subscriptionSelectorsRef.current) {
       const returnedValue = dispatch(
@@ -1745,10 +1742,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     ).refetchCachedPages
     const stableRefetchCachedPages = useShallowStableValue(refetchCachedPages)
 
-    /**
-     * @todo Change this to `useRef<QueryActionCreatorResult<any>>(undefined)` after upgrading to React 19.
-     */
-    const promiseRef = useRef<T | undefined>(undefined)
+    const promiseRef = useRef<T>(undefined)
 
     let { queryCacheKey, requestId } = promiseRef.current || {}
 
@@ -1961,13 +1955,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       const [arg, setArg] = useState<any>(UNINITIALIZED_VALUE)
 
-      // TODO: Change this to `useRef<QueryActionCreatorResult<any>>(undefined)` after upgrading to React 19.
-      /**
-       * @todo Change this to `useRef<QueryActionCreatorResult<any>>(undefined)` after upgrading to React 19.
-       */
-      const promiseRef = useRef<QueryActionCreatorResult<any> | undefined>(
-        undefined,
-      )
+      const promiseRef = useRef<QueryActionCreatorResult<any>>(undefined)
 
       const stableSubscriptionOptions = useShallowStableValue({
         refetchOnReconnect,


### PR DESCRIPTION
## Summary

Resolves the maintainer `TODO`/`@todo` comments in `packages/toolkit/src/query/react/buildHooks.ts` that asked to simplify the `useRef<T | undefined>(undefined)` pattern once the React 19 `useRef` typings became available:

- `// TODO: Change this to useRef<SubscriptionSelectors>(undefined) after upgrading to React 19.`
- `@todo Change this to useRef<QueryActionCreatorResult<any>>(undefined) after upgrading to React 19.`
- `// TODO: Change this to useRef<QueryActionCreatorResult<any>>(undefined) after upgrading to React 19.`

These collapse the explicit `useRef<T | undefined>(undefined)` calls to the single-argument `useRef<T>(undefined)` form, removing the now-unnecessary `| undefined` in the type argument and the wrapped multi-line calls (-15/+3).

Note: at the `useQuerySubscriptionCommonImpl` site the ref is generic over `T extends QueryActionCreatorResult<any> | InfiniteQueryActionCreatorResult<any>`, so it is simplified to `useRef<T>(undefined)` (rather than the literal `useRef<QueryActionCreatorResult<any>>(undefined)` from the comment, which predates that generalization and would drop the infinite-query case).

## Why this is safe now

The precondition is met without affecting the still-supported React 18 peer range (`^16.9.0 || ^17.0.0 || ^18 || ^19`): `@types/react@18.3.31` backported the single-argument `useRef<T>(undefined)` overload, so the simplified form type-checks identically under both type-test lanes.

The resulting `.current` type is unchanged: `useRef<T>(undefined)` and `useRef<T | undefined>(undefined)` both produce a mutable ref whose `current` is `T | undefined`.

## Verification

`type-tests` (`tsc -p tsconfig.test.json --noEmit`) pass under both CI type lanes:

- React 19: `@types/react@19.2.14` — pass
- React 18: `@types/react@18.3.31` — pass (matching CI's `^18` lane)

`buildHooks` unit + typecheck suite: 69 passed.
