### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -83,6 +83,19 @@ yarn add react-redux
 ```
 
   </TabItem>
+  <TabItem value="deno" label="deno">
+
+```bash
+deno add @reduxjs/toolkit
+```
+
+If you need React bindings:
+
+```bash
+deno add react-redux
+```
+
+  </TabItem>
 </Tabs>
 
 The package includes a precompiled ESM build that can be used as a [`<script type="module">` tag](https://unpkg.com/@reduxjs/toolkit/dist/redux-toolkit.browser.mjs) directly in the browser.


### PR DESCRIPTION
👋 Bartek from the Deno team here. Thanks for Redux Toolkit.

The "Getting Started" install section has npm and yarn tabs. This adds a Deno tab in parity (covering both `@reduxjs/toolkit` and the `react-redux` bindings), since Deno is a drop-in replacement for npm these days:

```bash
deno add @reduxjs/toolkit
```

Docs-only change. Happy to adjust wording or placement.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
