### PR TITLE
fix(combineSlices): scope stateProxyMap per instance to prevent cross-instance proxy collisions

### DIFF
--- a/packages/toolkit/src/combineSlices.ts
+++ b/packages/toolkit/src/combineSlices.ts
@@ -62,9 +62,8 @@ export type InjectConfig = {
 export interface CombinedSliceReducer<
   InitialState,
   DeclaredState extends InitialState = InitialState,
-  PreloadedState extends Partial<
-    Record<keyof PreloadedState, any>
-  > = Partial<DeclaredState>,
+  PreloadedState extends Partial<Record<keyof PreloadedState, any>> =
+    Partial<DeclaredState>,
 > extends Reducer<DeclaredState, UnknownAction, PreloadedState> {
   /**
    * Provide a type for slices that will be injected lazily.
@@ -354,9 +353,8 @@ const ORIGINAL_STATE = Symbol.for('rtk-state-proxy-original')
 
 const isStateProxy = (value: any) => !!value && !!value[ORIGINAL_STATE]
 
-const stateProxyMap = new WeakMap<object, object>()
-
 const createStateProxy = <State extends object>(
+  stateProxyMap: WeakMap<object, object>,
   state: State,
   reducerMap: Partial<Record<PropertyKey, Reducer>>,
   initialStateCache: Record<PropertyKey, unknown>,
@@ -411,6 +409,7 @@ export function combineSlices<Slices extends Array<AnySliceLike | ReducerMap>>(
   Id<InitialState<Slices>>,
   Partial<Id<InitialPreloadedState<Slices>>>
 > {
+  const stateProxyMap = new WeakMap<object, object>()
   const reducerMap = Object.fromEntries(getReducers(slices))
 
   const getReducer = () =>
@@ -472,6 +471,7 @@ export function combineSlices<Slices extends Array<AnySliceLike | ReducerMap>>(
       return function selector(state: State, ...args: Args) {
         return selectorFn(
           createStateProxy(
+            stateProxyMap,
             selectState ? selectState(state as any, ...args) : state,
             reducerMap,
             initialStateCache,

--- a/packages/toolkit/src/tests/combineSlices.test.ts
+++ b/packages/toolkit/src/tests/combineSlices.test.ts
@@ -212,4 +212,38 @@ describe('combineSlices', () => {
       expect(counter2).toBe(selectCounter(beforeInject))
     })
   })
+  it('uses separate proxy caches for separate combineSlices instances', () => {
+    // Two independent combineSlices() with no initial slices both use the
+    // module-level noopReducer, which returns the same `emptyObject` reference
+    // as their initial state. If stateProxyMap were module-level (shared), the
+    // second instance's selector would get the first instance's proxy and
+    // return the wrong initial value for its injected reducer.
+    const xReducer1 = createReducer('from-reducer1', () => {})
+    const xReducer2 = createReducer('from-reducer2', () => {})
+
+    const reducer1 = combineSlices()
+    const reducer2 = combineSlices()
+
+    // Capture the pre-injection state (emptyObject from noopReducer).
+    // Both empty instances share the same emptyObject reference.
+    const preInjectionState = reducer1(undefined, dummyAction())
+
+    const injected1 = reducer1.inject({
+      reducerPath: 'x' as const,
+      reducer: xReducer1,
+    })
+    const injected2 = reducer2.inject({
+      reducerPath: 'x' as const,
+      reducer: xReducer2,
+    })
+
+    const select1x = injected1.selector((state) => state.x)
+    const select2x = injected2.selector((state) => state.x)
+
+    // preInjectionState lacks 'x', so the selector must fall back to the
+    // injected reducer's initial state. Each instance should use its own
+    // reducerMap, not the other instance's.
+    expect(select1x(preInjectionState)).toBe('from-reducer1')
+    expect(select2x(preInjectionState)).toBe('from-reducer2')
+  })
 })


### PR DESCRIPTION
## Problem

`combineSlices.ts` declares `stateProxyMap` at module level:

```ts
const stateProxyMap = new WeakMap<object, object>()
```

This WeakMap is shared across **all** `combineSlices()` instances. The module-level `noopReducer` always returns the same `emptyObject` constant as initial state when no slices are given, so two empty `combineSlices()` calls both produce the **same object reference** as their initial state.

When a selector from instance A is called first with that shared state, a proxy is cached in the module-level `stateProxyMap` keyed by the state reference. A subsequent selector call from instance B with the same state reference retrieves the **cached proxy from instance A**, which closes over instance A's `reducerMap` and `initialStateCache` — so instance B's injected reducer's initial value is never consulted and the wrong value is returned.

```ts
const reducer1 = combineSlices()
const reducer2 = combineSlices()

// Both return the same  reference (noopReducer)
const preState = reducer1(undefined, { type: '@@INIT' })

reducer1.inject({ reducerPath: 'x', reducer: () => 'A' })
reducer2.inject({ reducerPath: 'x', reducer: () => 'B' })

const sel1 = reducer1.selector(s => s.x)
const sel2 = reducer2.selector(s => s.x)

sel1(preState) // 'A'  ✓
sel2(preState) // 'A'  ✗  — should be 'B'
```

## Fix

Move `stateProxyMap` inside `combineSlices` (one WeakMap per instance) and thread it as an explicit parameter through `createStateProxy`.  Each instance now has an isolated proxy cache, so selecting against a shared state object from a different instance creates a fresh proxy with the correct `reducerMap` and `initialStateCache`.

## Testing

A new unit test in `combineSlices.test.ts` reproduces the bug (fails without this fix, passes with it).  All 88 existing test files continue to pass.

> AI-assisted fix