### PR TITLE
fix(entityAdapter): pre-merge same-ID updates in sorted adapter's updateMany

### DIFF
--- a/packages/toolkit/src/entities/sorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/sorted_state_adapter.ts
@@ -129,7 +129,27 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     let appliedUpdates = false
     let replacedIds = false
 
-    for (let update of updates) {
+    // Pre-merge all updates that target the same entity ID so that later
+    // changes always win for every field—including `id`.  Without this step,
+    // the first rename moves the entity to a new key; a subsequent update that
+    // still targets the original key finds nothing and is silently dropped,
+    // producing results inconsistent with the unsorted adapter.
+    const updatesPerEntity: { [id: string]: Update<T, Id> } = {}
+    for (const update of updates) {
+      // Only collect updates for entities that currently exist (same guard
+      // used by the unsorted adapter).
+      if (update.id in (state.entities as Record<Id, T>)) {
+        updatesPerEntity[update.id] = {
+          id: update.id,
+          changes: {
+            ...updatesPerEntity[update.id]?.changes,
+            ...update.changes,
+          },
+        }
+      }
+    }
+
+    for (const update of Object.values(updatesPerEntity) as Update<T, Id>[]) {
       const entity: T | undefined = (state.entities as Record<Id, T>)[update.id]
       if (!entity) {
         continue

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -414,6 +414,29 @@ describe('Sorted State Adapter', () => {
       },
     })
   })
+  it("doesn't break when multiple renames of one item occur (consistent with unsorted adapter)", () => {
+    const withA = adapter.addOne(state, { id: 'a', title: 'First' })
+
+    const withUpdates = adapter.updateMany(withA, [
+      { id: 'a', changes: { id: 'b' } },
+      { id: 'a', changes: { id: 'c' } },
+    ])
+
+    const { ids, entities } = withUpdates
+
+    /*
+      The sorted adapter must behave identically to the unsorted adapter for
+      multiple renames of the same entity in one updateMany call.
+      The last-applied change wins; all intermediate IDs must be absent.
+    */
+    expect(ids.length).toBe(1)
+    expect(ids).toEqual(['c'])
+    expect(entities.a).toBeFalsy()
+    expect(entities.b).toBeFalsy()
+    expect(entities.c).toBeTruthy()
+    expect(entities.c).toEqual({ id: 'c', title: 'First' })
+  })
+
 
   it('should let you add one entity to the state with upsert()', () => {
     const withOneEntity = adapter.upsertOne(state, TheGreatGatsby)


### PR DESCRIPTION
## Problem

Closes #5322

When `updateMany` is called on a sorted entity adapter with multiple updates that all target the **same entity ID**, and an earlier update in the list changes that entity's ID, the remaining updates are silently dropped.

**Root cause:** `updateManyMutably` in `sorted_state_adapter.ts` applies updates one-by-one. As soon as the first update renames entity `'a'` → `'b'`, the entry at `state.entities['a']` is removed. Every subsequent update in the call that still references `'a'` finds no matching entity and is skipped.

By contrast, the **unsorted** adapter first pre-merges all updates for the same entity ID into a single combined update (last-write-wins per field), then applies that merged result once. The sorted adapter lacked this deduplication step.

## Fix

Added a pre-merge loop in `sorted_state_adapter.ts`'s `updateManyMutably` — identical in shape to the `updatesPerEntity` pattern already used in `unsorted_state_adapter.ts`:

```ts
// Before applying, merge all updates that share the same entity ID
const updatesPerEntity: { [id: string]: Update<T, Id> } = {}
for (const update of updates) {
  if (update.id in (state.entities as Record<Id, T>)) {
    updatesPerEntity[update.id] = {
      id: update.id,
      changes: {
        ...updatesPerEntity[update.id]?.changes,
        ...update.changes,
      },
    }
  }
}
// Apply the merged updates
for (const update of Object.values(updatesPerEntity) as Update<T, Id>[]) { ... }
```

The apply loop itself is unchanged — only the pre-merge step is new.

## Verification

New test added to `sorted_state_adapter.test.ts` (mirrors the existing test in `unsorted_state_adapter.test.ts`):

```ts
it("doesn't break when multiple renames of one item occur (consistent with unsorted adapter)", () => {
  const withA = adapter.addOne(state, { id: 'a', title: 'First' })

  const withUpdates = adapter.updateMany(withA, [
    { id: 'a', changes: { id: 'b' } },  // rename a → b
    { id: 'a', changes: { id: 'c' } },  // rename a → c (last wins)
  ])

  expect(withUpdates.ids).toEqual(['c'])              // was ['b'] before fix
  expect(withUpdates.entities['c']).toEqual(...)     // was undefined before fix
  expect(withUpdates.entities['b']).toBeUndefined()  // was defined before fix
})
```

All 53 tests in `sorted_state_adapter.test.ts` pass (was 1 failing before the fix). The full entity test suite (7 files, 115 tests) passes without regressions.