### PR TITLE
fix(query): preserve sparse array length in structural sharing

### DIFF
--- a/packages/toolkit/src/query/tests/copyWithStructuralSharing.test.ts
+++ b/packages/toolkit/src/query/tests/copyWithStructuralSharing.test.ts
@@ -86,3 +86,13 @@ test('equal object from JSON Array', () => {
   expect(newCopy[2]).not.toBe(objB[2])
   expect(newCopy[2]).toStrictEqual(objB[2])
 })
+
+test('sparse arrays with changed length return the new array', () => {
+  const objA = Array(3)
+  const objB = Array(2)
+
+  const newCopy = copyWithStructuralSharing(objA, objB)
+
+  expect(newCopy).not.toBe(objA)
+  expect(newCopy).toStrictEqual(objB)
+})

--- a/packages/toolkit/src/query/utils/copyWithStructuralSharing.ts
+++ b/packages/toolkit/src/query/utils/copyWithStructuralSharing.ts
@@ -18,7 +18,10 @@ export function copyWithStructuralSharing(oldObj: any, newObj: any): any {
   const oldKeys = Object.keys(oldObj)
 
   let isSameObject = newKeys.length === oldKeys.length
-  const mergeObj: any = Array.isArray(newObj) ? [] : {}
+  if (Array.isArray(newObj) && oldObj.length !== newObj.length) {
+    isSameObject = false
+  }
+  const mergeObj: any = Array.isArray(newObj) ? new Array(newObj.length) : {}
   for (const key of newKeys) {
     mergeObj[key] = copyWithStructuralSharing(oldObj[key], newObj[key])
     if (isSameObject) isSameObject = oldObj[key] === mergeObj[key]


### PR DESCRIPTION
Closes #5324\n\n## Problem\n`copyWithStructuralSharing` can incorrectly reuse the previous array when comparing sparse arrays whose lengths changed but whose enumerable indexes match. For example, `Array(3)` and `Array(2)` both have no enumerable index keys, so the old array was treated as structurally identical.\n\n## Fix\nInclude array length in the sameness check and create array merge results with the new array's length so sparse arrays preserve their shape.\n\n## Verification\n- RED: `yarn workspace @reduxjs/toolkit test src/query/tests/copyWithStructuralSharing.test.ts` (1 failed, 4 passed)\n- GREEN: `yarn workspace @reduxjs/toolkit test src/query/tests/copyWithStructuralSharing.test.ts` (5 passed)