### PR TITLE
fix(codegen): respect optional request bodies

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -444,7 +444,8 @@ export async function generateApi(
         name,
         originalName: schemaName,
         type: getTypeFromSchema(withMode(ctx, 'writeOnly'), schema),
-        required: true,
+        // A request body is optional unless the spec explicitly marks it required (OpenAPI defaults `required` to `false`).
+        required: body.required ?? false,
         body,
       };
     }

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/cli.test.ts.snap
@@ -147,7 +147,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -155,7 +155,7 @@ export type GetInventoryApiResponse = /** status 200 successful operation */ {
 export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse = /** status 200 successful operation */ Order;
 export type GetOrderByIdApiArg = {
@@ -170,11 +170,11 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse = /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse = /** status 200 successful operation */ string;
 export type LoginUserApiArg = {
@@ -195,7 +195,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -395,7 +395,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -403,7 +403,7 @@ export type GetInventoryApiResponse = /** status 200 successful operation */ {
 export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse = /** status 200 successful operation */ Order;
 export type GetOrderByIdApiArg = {
@@ -418,11 +418,11 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse = /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse = /** status 200 successful operation */ string;
 export type LoginUserApiArg = {
@@ -443,7 +443,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {

--- a/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
+++ b/packages/rtk-query-codegen-openapi/test/__snapshots__/generateEndpoints.test.ts.snap
@@ -147,7 +147,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -155,7 +155,7 @@ export type GetInventoryApiResponse = /** status 200 successful operation */ {
 export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse = /** status 200 successful operation */ Order;
 export type GetOrderByIdApiArg = {
@@ -170,11 +170,11 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse = /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse = /** status 200 successful operation */ string;
 export type LoginUserApiArg = {
@@ -195,7 +195,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -395,7 +395,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -403,7 +403,7 @@ export type GetInventoryApiResponse = /** status 200 successful operation */ {
 export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse = /** status 200 successful operation */ Order;
 export type GetOrderByIdApiArg = {
@@ -418,11 +418,11 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse = /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse = /** status 200 successful operation */ string;
 export type LoginUserApiArg = {
@@ -443,7 +443,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -694,7 +694,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -703,7 +703,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -719,12 +719,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -747,7 +747,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -879,7 +879,7 @@ export { injectedRtkApi as enhancedApi };
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -1105,7 +1105,7 @@ export type UploadFileApiResponse =
 export type UploadFileApiArg = {
   /** ID of pet to update */
   petId: number;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -1114,7 +1114,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -1130,12 +1130,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -1153,7 +1153,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -1384,7 +1384,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -1393,7 +1393,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -1409,12 +1409,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -1435,7 +1435,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -1682,7 +1682,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -1691,7 +1691,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -1707,12 +1707,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -1735,7 +1735,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -1966,7 +1966,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -1975,7 +1975,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -1991,12 +1991,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -2017,7 +2017,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -2242,7 +2242,7 @@ export type UploadFileApiResponse =
 export type UploadFileApiArg = {
   /** ID of pet to update */
   petId: number;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -2251,7 +2251,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -2267,12 +2267,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -2290,7 +2290,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -2367,11 +2367,11 @@ const injectedRtkApi = api.injectEndpoints({
 export { injectedRtkApi as enhancedApi };
 export type PostV1ExportApiResponse = unknown;
 export type PostV1ExportApiArg = {
-  exportedEntityIds: IdList;
+  exportedEntityIds?: IdList;
 };
 export type PostV1ImportApiResponse = unknown;
 export type PostV1ImportApiArg = {
-  rawData: string;
+  rawData?: string;
 };
 export type IdList = number[];
 "
@@ -2795,7 +2795,7 @@ export type UploadFileV2ApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryV2ApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -2804,7 +2804,7 @@ export type GetInventoryV2ApiArg = void;
 export type PlaceOrderV2ApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderV2ApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdV2ApiResponse =
   /** status 200 successful operation */ Order;
@@ -2820,12 +2820,12 @@ export type DeleteOrderV2ApiArg = {
 export type CreateUserV2ApiResponse = unknown;
 export type CreateUserV2ApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputV2ApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputV2ApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserV2ApiResponse =
   /** status 200 successful operation */ string;
@@ -2848,7 +2848,7 @@ export type UpdateUserV2ApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserV2ApiResponse = unknown;
 export type DeleteUserV2ApiArg = {
@@ -3474,7 +3474,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -3483,7 +3483,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -3499,12 +3499,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -3527,7 +3527,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {
@@ -3876,7 +3876,7 @@ export type UploadFileApiArg = {
   petId: number;
   /** Additional Metadata */
   additionalMetadata?: string;
-  body: Blob;
+  body?: Blob;
 };
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
@@ -3885,7 +3885,7 @@ export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse =
   /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
-  order: Order;
+  order?: Order;
 };
 export type GetOrderByIdApiResponse =
   /** status 200 successful operation */ Order;
@@ -3901,12 +3901,12 @@ export type DeleteOrderApiArg = {
 export type CreateUserApiResponse = unknown;
 export type CreateUserApiArg = {
   /** Created user object */
-  user: User;
+  user?: User;
 };
 export type CreateUsersWithListInputApiResponse =
   /** status 200 Successful operation */ User;
 export type CreateUsersWithListInputApiArg = {
-  body: User[];
+  body?: User[];
 };
 export type LoginUserApiResponse =
   /** status 200 successful operation */ string;
@@ -3929,7 +3929,7 @@ export type UpdateUserApiArg = {
   /** name that need to be deleted */
   username: string;
   /** Update an existent user in the store */
-  user: User;
+  user?: User;
 };
 export type DeleteUserApiResponse = unknown;
 export type DeleteUserApiArg = {

--- a/packages/rtk-query-codegen-openapi/test/fixtures/issue-4824.json
+++ b/packages/rtk-query-codegen-openapi/test/fixtures/issue-4824.json
@@ -1,0 +1,58 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Issue 4824 - optional request body",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/foo": {
+      "delete": {
+        "operationId": "deleteFoo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/bar": {
+      "post": {
+        "operationId": "createBar",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -743,6 +743,20 @@ describe('tests from issues', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('issue #4824: an optional request body should generate an optional arg', async () => {
+    const result = await generateEndpoints({
+      apiFile: './test/fixtures/emptyApi.ts',
+      schemaFile: resolve(__dirname, 'fixtures/issue-4824.json'),
+    });
+
+    // `deleteFoo` has a request body without `required: true`, so the generated arg must be optional.
+    expect(result).toMatch(/export type DeleteFooApiArg = \{\s*body\?:/);
+
+    // `createBar` explicitly sets `required: true`, so its body arg must stay required.
+    expect(result).toMatch(/export type CreateBarApiArg = \{\s*body:/);
+    expect(result).not.toMatch(/export type CreateBarApiArg = \{\s*body\?:/);
+  });
 });
 
 describe('openapi spec', () => {


### PR DESCRIPTION
Fixes #4824.

## Problem

`rtk-query-codegen-openapi` hardcodes `required: true` for the request-body arg:

```ts
queryArg[name] = {
  origin: 'body',
  // ...
  required: true, // <- always required
  body,
};
```

As a result, **every** operation with a request body generates a non-optional arg (`body: T`), even when the OpenAPI document does not mark the body as required. Per the [OpenAPI 3.x spec](https://spec.openapis.org/oas/v3.0.3#request-body-object), `requestBody.required` **defaults to `false`**, so an un-required body should produce an optional arg (`body?: T`). Query and path params already respect this correctly via `param.required`; only the body branch was wrong.

## Fix

One line — use the resolved request body's own `required` flag, defaulting to the spec default:

```ts
required: body.required ?? false,
```

The `required` value flows into `createQuestionToken(!def.required)` (and the flat-arg `| undefined` branch), so the generated property becomes optional when appropriate.

## Tests

Added `test/fixtures/issue-4824.json` (a `deleteFoo` op with a non-required body and a `createBar` op with `required: true`) plus a regression test in `generateEndpoints.test.ts`:

- non-required body → `DeleteFooApiArg = { body?: … }`
- `required: true` body → `CreateBarApiArg = { body: … }` (stays required)

The test **fails on the current code** (the non-required body is emitted as `body:`) and **passes with the fix**.

## Snapshot updates

The existing snapshots captured the buggy output, so 15 updated. Every changed line is a request-body arg becoming optional (`user: User` → `user?: User`, `order: Order` → `order?: Order`, `body: Blob` → `body?: Blob`, etc.). Notably, petstore's `pet` body — which **is** marked `required: true` — stays `pet: Pet`, confirming the change only affects bodies the spec leaves optional.

The full package test suite (`yarn test`, incl. typecheck) passes and Prettier is clean.
