### PR TITLE
fix(query): reflect cache updates in hook data

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1570,9 +1570,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         lastResult = undefined
     }
 
-    // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
-    let data = currentState.isSuccess ? currentState.data : lastResult?.data
-    if (data === undefined) data = currentState.data
+    // data is the latest available cache entry, or the last known good request result we have tracked
+    let data = currentState.data
+    if (data === undefined) data = lastResult?.data
 
     const hasData = data !== undefined
 
@@ -1630,9 +1630,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         lastResult = undefined
     }
 
-    // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args
-    let data = currentState.isSuccess ? currentState.data : lastResult?.data
-    if (data === undefined) data = currentState.data
+    // data is the latest available cache entry, or the last known good request result we have tracked
+    let data = currentState.data
+    if (data === undefined) data = lastResult?.data
 
     const hasData = data !== undefined
 

--- a/packages/toolkit/src/query/tests/optimisticUpdates.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpdates.test.tsx
@@ -192,6 +192,59 @@ describe('updateQueryData', () => {
     expect(result.current.data).toEqual(dataBefore)
   })
 
+  test('updates hook data while a refetch is in flight', async () => {
+    let resolveRefetch!: (value: Post) => void
+    const refetchPromise = new Promise<Post>((resolve) => {
+      resolveRefetch = resolve
+    })
+
+    baseQuery
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'TODO',
+      })
+      .mockReturnValueOnce(refetchPromise)
+
+    const { result } = renderHook(() => api.endpoints.post.useQuery('3'), {
+      wrapper: storeRef.wrapper,
+    })
+    await hookWaitFor(() => expect(result.current.isSuccess).toBeTruthy())
+
+    act(() => {
+      void result.current.refetch()
+    })
+    await hookWaitFor(() => expect(result.current.isFetching).toBe(true))
+
+    act(() => {
+      storeRef.store.dispatch(
+        api.util.updateQueryData('post', '3', (draft) => {
+          draft.contents = 'I love cheese!'
+        }),
+      )
+    })
+
+    expect(result.current.currentData).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'I love cheese!',
+    })
+    expect(result.current.data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'I love cheese!',
+    })
+
+    await act(async () => {
+      resolveRefetch({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'Refetched',
+      })
+      await refetchPromise
+    })
+  })
+
   test('updates (list) cache values including provided tags, undos that', async () => {
     baseQuery
       .mockResolvedValueOnce([


### PR DESCRIPTION
This PR updates RTK Query's hook state derivation so `data` reflects cache updates made while a refetch is in flight.

Previously, `queryStatePreSelector` preferred `lastResult.data` whenever `currentState.isSuccess` was false. During polling/refetching, that could hide updates from `api.util.updateQueryData`, even though `currentData` and the cache already contained the updated value.

The new behavior prefers `currentState.data` when present, and only falls back to `lastResult.data` when the current cache entry has no data. This preserves previous-data behavior for arg changes.

In discussion #2861, this behavior came up and @phryneas replied: "I guess it should reflect those changes immediately. PRs and investigation would be very welcome."

Related to #5140.
Refs https://github.com/reduxjs/redux-toolkit/discussions/2861.

Tests:
- `yarn workspace @reduxjs/toolkit test src/query/tests/optimisticUpdates.test.tsx`
- `yarn workspace @reduxjs/toolkit test src/query/tests/buildHooks.test.tsx`
- `yarn prettier --check packages/toolkit/src/query/react/buildHooks.ts packages/toolkit/src/query/tests/optimisticUpdates.test.tsx`
- `NODE_OPTIONS=--no-experimental-require-module yarn eslint packages/toolkit/src/query/react/buildHooks.ts packages/toolkit/src/query/tests/optimisticUpdates.test.tsx`