### PR TITLE
docs: correct `autoBatchEnhancer` JSDoc default to `requestAnimationFrame`

### DIFF
--- a/packages/toolkit/src/autoBatchEnhancer.ts
+++ b/packages/toolkit/src/autoBatchEnhancer.ts
@@ -52,7 +52,7 @@ export type AutoBatchOptions =
  * This can be added to `action.meta` manually, or by using the
  * `prepareAutoBatched` helper.
  *
- * By default, it will queue a notification for the end of the event loop tick.
+ * By default, it will queue a notification using `requestAnimationFrame`.
  * However, you can pass several other options to configure the behavior:
  * - `{type: 'tick'}`: queues using `queueMicrotask`
  * - `{type: 'timer', timeout: number}`: queues using `setTimeout`


### PR DESCRIPTION
The `autoBatchEnhancer` JSDoc says the default queues a notification "for the end of the event loop tick", but that describes the non-default `{ type: 'tick' }` (`queueMicrotask`) option. The actual default is `{ type: 'raf' }`, which queues via `requestAnimationFrame` (as the option list two lines below already notes, and as the docs page states).

This corrects the sentence to match the real default.