### PR TITLE
docs: fix `isJsonContentType` example to type-check

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -132,7 +132,7 @@ export type FetchBaseQueryArgs = {
    * in a predicate function for your given api to get the same automatic stringifying behavior
    * @example
    * ```ts
-   * const isJsonContentType = (headers: Headers) => ["application/vnd.api+json", "application/json", "application/vnd.hal+json"].includes(headers.get("content-type")?.trim());
+   * const isJsonContentType = (headers: Headers) => ["application/vnd.api+json", "application/json", "application/vnd.hal+json"].includes((headers.get("content-type") ?? "").trim());
    * ```
    */
   isJsonContentType?: (headers: Headers) => boolean


### PR DESCRIPTION
The `isJsonContentType` `@example` passes `headers.get("content-type")?.trim()` (type `string | undefined`) to `Array.prototype.includes`, which expects a `string`, so the snippet does not type-check under `strict`. Guarding the `null` with `(headers.get("content-type") ?? "").trim()` makes the example compile.
