### PR TITLE
docs: fix `selectFromResult` example data access

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -587,7 +587,7 @@ export type UseQueryStateOptions<
    *
    *   return (
    *     <ul>
-   *       {posts?.data?.map((post) => (
+   *       {posts?.map((post) => (
    *         <PostById key={post.id} id={post.id} />
    *       ))}
    *     </ul>
@@ -1171,7 +1171,7 @@ export type UseInfiniteQueryStateOptions<
    *
    *   return (
    *     <ul>
-   *       {posts?.data?.map((post) => (
+   *       {posts?.map((post) => (
    *         <PostById key={post.id} id={post.id} />
    *       ))}
    *     </ul>


### PR DESCRIPTION
The `selectFromResult` JSDoc example destructures the query data as `const { data: posts } = api.useGetPostsQuery()`, so `posts` is already the endpoint's data. It then maps over `posts?.data?.map(...)`, dereferencing a `data` property that does not exist on the unwrapped value; the same example accesses it directly as an array with `data?.find(...)`.

Fixed the example to map `posts?.map(...)`.
