### PR TITLE
docs: note redux-persist maintenance status in persistence guide

### DIFF
--- a/docs/rtk-query/usage/persistence-and-rehydration.mdx
+++ b/docs/rtk-query/usage/persistence-and-rehydration.mdx
@@ -31,6 +31,15 @@ persistence might still be a viable option.
 
 ## Redux Persist
 
+:::caution
+
+[Redux Persist](https://github.com/rt2zz/redux-persist) is no longer actively maintained
+(its last release was in 2019). The example below remains valid, and the same
+`extractRehydrationInfo` pattern applies to any other persistence library that dispatches
+a rehydration action.
+
+:::
+
 API state rehydration can be used in conjunction with [Redux Persist](https://github.com/rt2zz/redux-persist)
 by leveraging the `REHYDRATE` action type imported from `redux-persist`. This can be used out of the
 box with the `autoMergeLevel1` or `autoMergeLevel2` [state reconcilers](https://github.com/rt2zz/redux-persist#state-reconciler)


### PR DESCRIPTION
## Problem

The RTK Query [Persistence and Rehydration](https://redux-toolkit.js.org/rtk-query/usage/persistence-and-rehydration#redux-persist) page links to [redux-persist](https://github.com/rt2zz/redux-persist) with no indication of its maintenance status. As raised in #5180, readers can reasonably take the link as an unqualified recommendation.

## Root cause

The docs predate redux-persist going dormant: its last release (v6.0.0) was in September 2019 (see rt2zz/redux-persist#1463). (Note: the repository is not archived — verified via the GitHub API — so the wording sticks to "no longer actively maintained" rather than "archived".)

## Fix

Adds a short `:::caution` admonition under the "Redux Persist" heading stating that redux-persist is no longer actively maintained (last release 2019), that the example remains valid, and that the same `extractRehydrationInfo` pattern applies to any other persistence library that dispatches a rehydration action. The existing `REHYDRATE` reconciler example is left intact.

The admonition deliberately doesn't recommend a specific alternative (the issue floated `redux-remember`) — naming one felt like a maintainer call. Happy to add it if you'd like.

## Tests

Docs-only change; verified with Prettier (`prettier --check` using the repo config) and matched the admonition style used elsewhere in `docs/`.

Fixes #5180
