### PR TITLE
fix(toolkit): prevent infinite refetch loop when query args contain `NaN`

### DIFF
--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -16,7 +16,10 @@ import {
   createListenerMiddleware,
   createSlice,
 } from '@reduxjs/toolkit'
-import type { SubscriptionOptions } from '@reduxjs/toolkit/query/react'
+import type {
+  BaseQueryFn,
+  SubscriptionOptions,
+} from '@reduxjs/toolkit/query/react'
 import {
   QueryStatus,
   createApi,
@@ -1269,6 +1272,79 @@ describe('hooks tests', () => {
 
       // The abort signal should now be aborted
       expect(abortSignalFromQueryFn!.aborted).toBe(true)
+    })
+
+    // NaN !== NaN, so structural sharing of query args must compare values
+    // with Object.is. Otherwise an arg object containing NaN gets a new
+    // identity on every render, and when the query also errors, each
+    // rejection triggers a rerender which dispatches a new request,
+    // producing an infinite refetch loop.
+    test('query args containing NaN do not cause an infinite refetch loop on error', async () => {
+      let baseQueryCalls = 0
+      const failingBaseQuery: BaseQueryFn = async () => {
+        baseQueryCalls += 1
+        await delay(5)
+        return { error: { status: 400, data: null } }
+      }
+      const nanApi = createApi({
+        baseQuery: failingBaseQuery,
+        endpoints: (build) => ({
+          getUser: build.query<unknown, { id: number }>({
+            query: (arg: { id: number }) => arg,
+          }),
+        }),
+      })
+      const storeRef = setupApiStore(nanApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      function User() {
+        nanApi.endpoints.getUser.useQuery({ id: NaN })
+        return null
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper })
+
+      await waitFor(() => expect(baseQueryCalls).toBeGreaterThan(0))
+      await act(async () => {
+        await delay(150)
+      })
+
+      expect(baseQueryCalls).toBe(1)
+    })
+
+    test('a bare NaN query arg does not cause an infinite refetch loop on error', async () => {
+      let baseQueryCalls = 0
+      const failingBaseQuery: BaseQueryFn = async () => {
+        baseQueryCalls += 1
+        await delay(5)
+        return { error: { status: 400, data: null } }
+      }
+      const nanApi = createApi({
+        baseQuery: failingBaseQuery,
+        endpoints: (build) => ({
+          getUser: build.query<unknown, number>({
+            query: (arg: number) => arg,
+          }),
+        }),
+      })
+      const storeRef = setupApiStore(nanApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      function User() {
+        nanApi.endpoints.getUser.useQuery(NaN)
+        return null
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper })
+
+      await waitFor(() => expect(baseQueryCalls).toBeGreaterThan(0))
+      await act(async () => {
+        await delay(150)
+      })
+
+      expect(baseQueryCalls).toBe(1)
     })
 
     describe('Hook middleware requirements', () => {

--- a/packages/toolkit/src/query/tests/copyWithStructuralSharing.test.ts
+++ b/packages/toolkit/src/query/tests/copyWithStructuralSharing.test.ts
@@ -86,3 +86,22 @@ test('equal object from JSON Array', () => {
   expect(newCopy[2]).not.toBe(objB[2])
   expect(newCopy[2]).toStrictEqual(objB[2])
 })
+
+test('equal objects containing NaN preserve identity', () => {
+  const objA = { a: NaN, b: { c: NaN, d: 1 } }
+  const objB = { a: NaN, b: { c: NaN, d: 1 } }
+
+  const newCopy = copyWithStructuralSharing(objA, objB)
+  expect(newCopy).toBe(objA)
+})
+
+test('unequal objects containing NaN still share unchanged branches', () => {
+  const objA = { a: { b: NaN }, c: 1 }
+  const objB = { a: { b: NaN }, c: 2 }
+
+  const newCopy = copyWithStructuralSharing(objA, objB)
+  expect(newCopy).not.toBe(objA)
+  expect(newCopy).not.toBe(objB)
+  expect(newCopy.c).toBe(2)
+  expect(newCopy.a).toBe(objA.a)
+})

--- a/packages/toolkit/src/query/utils/copyWithStructuralSharing.ts
+++ b/packages/toolkit/src/query/utils/copyWithStructuralSharing.ts
@@ -21,7 +21,7 @@ export function copyWithStructuralSharing(oldObj: any, newObj: any): any {
   const mergeObj: any = Array.isArray(newObj) ? [] : {}
   for (const key of newKeys) {
     mergeObj[key] = copyWithStructuralSharing(oldObj[key], newObj[key])
-    if (isSameObject) isSameObject = oldObj[key] === mergeObj[key]
+    if (isSameObject) isSameObject = Object.is(oldObj[key], mergeObj[key])
   }
   return isSameObject ? oldObj : mergeObj
 }


### PR DESCRIPTION
Fixes https://github.com/reduxjs/redux-toolkit/issues/5338

AI warning - I certainly fixed this with Claude, but I did go through a lot of manual testing and verification for this.

## The problem

If the argument passed to a `useQuery` hook contains `NaN` and the request returns an error, the hook dispatches the same query again in an endless loop. Each rejection causes a rerender and each rerender dispatches a new request, so the loop runs for as long as the hook is mounted, paced only by network latency.

This is easy to hit in practice. Our case was a URL where a route param placeholder was never substituted, so the page received the literal string `"worker_id"`, and `Number("worker_id")` produced `NaN` which then flowed into a query arg.

The regression was introduced in 2.9.0 when `useStableQueryArgs` switched from comparing serialized args to reference checks via `copyWithStructuralSharing`. On earlier versions the same code fails once and stops.

## The cause

`copyWithStructuralSharing` decides whether the new object is identical to the old one using strict equality:

```ts
if (isSameObject) isSameObject = oldObj[key] === mergeObj[key]
```

`NaN === NaN` is `false`, so an arg object containing `NaN` is never considered equal to the previous one and `useStableQueryArgs` returns a new object on every render. `useQuerySubscription` then sees `lastPromise.arg !== stableArg` on every render and dispatches `initiate` again. While the query is in an error state, the thunk `condition` lets the dispatch through because the cache entry has no `fulfilledTimeStamp`, so every one of these dispatches reaches the network:

```
rejected -> rerender -> new stableArg reference -> initiate -> request -> rejected -> ...
```

The serialized cache key is unaffected the whole time, since `JSON.stringify` turns `NaN` into `null`, so all of this happens on a single cache entry.

## The fix

Compare values with `Object.is`, which treats `NaN` as equal to itself. One line in `copyWithStructuralSharing`.

## Tests

- Two unit tests for `copyWithStructuralSharing`: objects containing `NaN` preserve identity when equal, and unchanged branches containing `NaN` are still shared when a sibling value changes.
- Two hook level regression tests: an arg object containing `NaN` and a bare `NaN` arg, each asserting the base query runs exactly once when the query errors. Before the fix the object case makes 27 requests in 150ms against a 5ms mock; after the fix it makes exactly one.

The bare `NaN` case already behaved correctly before this change because React compares effect dependencies with `Object.is`, so a primitive `NaN` dep never retriggers the subscription effect. The test is included to lock that behavior in.

No public types change, so the API report is untouched. `yarn test` for the toolkit package passes: 88 files, 1320 tests, no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
