### PR TITLE
docs: document sending FormData / multipart requests with fetchBaseQuery

### DIFF
--- a/docs/rtk-query/api/fetchBaseQuery.mdx
+++ b/docs/rtk-query/api/fetchBaseQuery.mdx
@@ -287,6 +287,27 @@ By default, `fetchBaseQuery` assumes that every request you make will be `json`,
     }),
 ```
 
+#### FormData
+
+To send `multipart/form-data` requests, such as file uploads, pass a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) instance directly as the `body`. No dedicated option is needed (there is no `formData` flag) &mdash; `fetchBaseQuery` passes the `FormData` through to `fetch` as-is and ensures no `Content-Type` header is set, so that `fetch` can generate the `multipart/form-data` content type with the correct boundary automatically. There is no need to set the `Content-Type` header manually for these requests &mdash; a manually set value would be missing the boundary, so `fetchBaseQuery` removes it for `FormData` bodies.
+
+```ts no-transpile
+ // omitted
+  endpoints: (build) => ({
+    uploadFile: build.mutation({
+      query: (file: File) => {
+        const formData = new FormData()
+        formData.append('file', file)
+        return {
+          url: `files`,
+          method: 'POST',
+          // Sent as multipart/form-data; fetch sets the Content-Type (including the boundary)
+          body: formData,
+        }
+      },
+    }),
+```
+
 ### Setting the query string
 
 `fetchBaseQuery` provides a simple mechanism that converts an `object` to a serialized query string by passing the object to `new URLSearchParams()`. If this doesn't suit your needs, you have two options:


### PR DESCRIPTION
## Problem

`multipart/form-data` requests with `fetchBaseQuery` are completely undocumented — `FormData` and `multipart` return zero results across `docs/`. As a result, users copy a nonexistent `formData: true` request option from stray issue comments and blog posts (see #5213, where @phryneas confirmed the flag "doesn't seem to exist" — it appears nowhere in the source).

## Fix

Adds a `#### FormData` subsection to the `fetchBaseQuery` API page, under **Individual query options → Setting the body**, next to the existing `json` and `text` subsections. It shows the positive pattern:

- pass a `FormData` instance directly as `body` (no dedicated option needed — with a one-line note that there is no `formData` flag),
- `fetchBaseQuery` passes it through to `fetch` as-is and ensures no `Content-Type` header is set, so `fetch` generates the `multipart/form-data` content type with the correct boundary automatically,
- notes there is no need to set `Content-Type` manually — a manual value would be missing the boundary, so `fetchBaseQuery` removes it for `FormData` bodies.

This matches the actual implementation: `isJsonifiable` excludes `FormData`, and since #5112 `fetchBaseQuery` removes any `content-type` header for non-jsonifiable, non-string bodies (covered by the existing `FormData` tests in `packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx`).

## Tests

Docs-only change. `yarn prettier --check docs/rtk-query/api/fetchBaseQuery.mdx` passes.

Fixes #5213
