### PR TITLE
test(query): add regression test for mutation isSuccess with pessimistic updates

### DIFF
--- a/packages/toolkit/src/query/tests/optimisticUpdates.test.tsx
+++ b/packages/toolkit/src/query/tests/optimisticUpdates.test.tsx
@@ -397,6 +397,95 @@ describe('updateQueryData', () => {
   })
 })
 
+describe('pessimistic updates', () => {
+  // regression test for https://github.com/reduxjs/redux-toolkit/issues/5093
+  test('mutation hook reports isSuccess with pessimistic update and tag invalidation', async () => {
+    const extendedApi = api.injectEndpoints({
+      endpoints: (build) => ({
+        updatePostPessimistic: build.mutation<
+          Post,
+          Pick<Post, 'id'> & Partial<Post>
+        >({
+          query: ({ id, ...patch }) => ({
+            url: `post/${id}`,
+            method: 'PUT',
+            body: patch,
+          }),
+          async onQueryStarted({ id }, { dispatch, queryFulfilled }) {
+            const { data } = await queryFulfilled
+            dispatch(
+              api.util.updateQueryData('post', id, (draft) => {
+                Object.assign(draft, data)
+              }),
+            )
+          },
+          invalidatesTags: ['Post'],
+        }),
+      }),
+      overrideExisting: true,
+    })
+
+    baseQuery
+      // initial query
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'TODO',
+      })
+      // mutation response
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'Delicious cheese!',
+      })
+      // refetch triggered by invalidatesTags
+      .mockResolvedValueOnce({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'Delicious cheese!',
+      })
+      .mockResolvedValueOnce(42)
+
+    const { result } = renderHook(
+      () => ({
+        query: api.endpoints.post.useQuery('3'),
+        mutation: extendedApi.endpoints.updatePostPessimistic.useMutation(),
+      }),
+      { wrapper: storeRef.wrapper },
+    )
+    await hookWaitFor(() => expect(result.current.query.isSuccess).toBeTruthy())
+
+    act(() => {
+      void result.current.mutation[0]({
+        id: '3',
+        contents: 'Delicious cheese!',
+      })
+    })
+
+    await hookWaitFor(() =>
+      expect(result.current.mutation[1].isSuccess).toBe(true),
+    )
+    expect(result.current.mutation[1].data).toEqual({
+      id: '3',
+      title: 'All about cheese.',
+      contents: 'Delicious cheese!',
+    })
+
+    // the pessimistic update was applied to the cache
+    await hookWaitFor(() =>
+      expect(result.current.query.data).toEqual({
+        id: '3',
+        title: 'All about cheese.',
+        contents: 'Delicious cheese!',
+      }),
+    )
+
+    // isSuccess stays true after the invalidation refetch settles
+    await hookWaitFor(() => expect(result.current.query.isFetching).toBe(false))
+    expect(result.current.mutation[1].isSuccess).toBe(true)
+  })
+})
+
 describe('full integration', () => {
   test('success case', async () => {
     baseQuery


### PR DESCRIPTION
## Summary

Investigation of #5093 ("Pessimistic Updates: `isSuccess` is always `false`"). **The reported behavior does not reproduce at the library level** — this PR adds a regression test that pins the correct behavior of the documented pessimistic-update pattern, and documents the investigation for triage.

## Investigation

1. **Hook-level repro (this PR's test):** a mutation whose `onQueryStarted` awaits `queryFulfilled` and then dispatches `api.util.updateQueryData(...)`, combined with `invalidatesTags` — exactly the [documented pessimistic-update pattern](https://redux-toolkit.js.org/rtk-query/usage/manual-cache-updates#pessimistic-updates). The `useMutation` hook's `isSuccess` becomes `true`, the cache patch is applied, and `isSuccess` stays `true` after the invalidation refetch settles. Passes on current master.
2. **Reporter's exact environment:** the same repro run against published `@reduxjs/toolkit@2.9.0` + `react@18.3.1` also passes, so this is not something that was fixed since 2.9.0.
3. **Store level:** the mutation substate provably reaches `status: 'fulfilled'`. Auditing `buildSlice.ts`, nothing in the pessimistic flow (`queryResultPatched`, `invalidateTags`, invalidation refetches) touches mutation substate — the only ways it is cleared are hook unmount (`promise.reset()`) and manual `reset()`.
4. **The in-thread `invalidateTags`-ordering "workaround":** instrumented action/render traces show the before/after-`updateQueryData` asymmetry appears or disappears purely with React flush timing (whether the `isSuccess: true` render commits before an invalidation-refetch-driven re-render/unmount). It has no mechanism inside RTK Query.

## Conclusion

"`isSuccess` always `false`" in an app means the `useMutation` hook instance was reset — i.e. the component holding it unmounted/remounted (for example, a parent that hides the form while the invalidated list query is refetching). Mutation hook state is per-instance by design and removed on unmount; sharing results across mounts is what [`fixedCacheKey`](https://redux-toolkit.js.org/rtk-query/usage/mutations#shared-mutation-results) is for. The new test guards the library-level behavior so future regressions of the documented pattern are caught.

Note: the test intentionally passes on unmodified master — there is no code fix because there is no library bug.

## Tests

- `yarn workspace @reduxjs/toolkit test src/query/tests/optimisticUpdates.test.tsx` — 10/10 pass, no type errors
- `yarn eslint packages/toolkit/src/query/tests/optimisticUpdates.test.tsx` / prettier — clean

Refs #5093
