### PR TITLE
fix(query): don't reset `keepUnusedDataFor` on condition-skipped queries

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -65,10 +65,21 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
   const { removeQueryResult, unsubscribeQueryResult, cacheEntriesUpserted } =
     api.internalActions
 
+  // A `condition`-based rejection means the query bailed out before it ever ran
+  // (e.g. `initiate(arg, { subscribe: false })` served fresh cached data). Nothing
+  // was fetched and no subscription changed, so we must not treat it as an
+  // unsubscribe trigger: rescheduling the removal timer here resets
+  // `keepUnusedDataFor` on every such call and prevents unused data from ever
+  // being collected. See https://github.com/reduxjs/redux-toolkit/issues/4480
+  const isQueryThunkRejectedByError = (
+    action: any,
+  ): action is ReturnType<typeof queryThunk.rejected> =>
+    queryThunk.rejected.match(action) && !action.meta.condition
+
   const canTriggerUnsubscribe = isAnyOf(
     unsubscribeQueryResult.match,
     queryThunk.fulfilled,
-    queryThunk.rejected,
+    isQueryThunkRejectedByError,
     cacheEntriesUpserted.match,
   )
 

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -90,6 +90,38 @@ test(`query: handles large keepUnusedDataFor values over 32-bit ms`, async () =>
   expect(onCleanup).toHaveBeenCalled()
 })
 
+test(`query: repeated \`initiate\` with \`subscribe: false\` does not reset the removal timer (#4480)`, async () => {
+  const { store, api } = storeForApi(
+    createApi({
+      baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
+      endpoints: (build) => ({
+        query: build.query<unknown, string>({
+          query: () => '/success',
+        }),
+      }),
+    }),
+  )
+
+  // First unsubscribed request fetches and schedules removal 60s from now.
+  await store.dispatch(api.endpoints.query.initiate('arg', { subscribe: false }))
+
+  vi.advanceTimersByTime(30000)
+  expect(onCleanup).not.toHaveBeenCalled()
+
+  // Second unsubscribed request hits the fresh cache and is rejected by the
+  // thunk `condition`. This must NOT restart the `keepUnusedDataFor` timer.
+  await store.dispatch(api.endpoints.query.initiate('arg', { subscribe: false }))
+
+  // Still not cleaned right before the original 60s deadline...
+  vi.advanceTimersByTime(29000)
+  expect(onCleanup).not.toHaveBeenCalled()
+
+  // ...but cleaned once the original deadline passes (would still be pending if
+  // the second call had reset the timer to fire at 90s).
+  vi.advanceTimersByTime(2000)
+  expect(onCleanup).toHaveBeenCalled()
+})
+
 describe(`query: await cleanup, keepUnusedDataFor set`, () => {
   const { store, api } = storeForApi(
     createApi({


### PR DESCRIPTION
Fixes #4480

If you keep dispatching `initiate` with `{ subscribe: false }` for an arg that's
already cached, the data never gets removed. Each call pushes the expiry back, so
`keepUnusedDataFor` effectively turns into "keep forever" as long as something
polls that endpoint without subscribing.

Repro from the issue:

```ts
// default keepUnusedDataFor is 60s

// fetches and caches the data
store.dispatch(api.endpoints.myEndpoint.initiate({}, { subscribe: false }))

// 30s later — served from cache, no request
setTimeout(() => store.dispatch(
  api.endpoints.myEndpoint.initiate({}, { subscribe: false })
), 30_000)

// 61s later — data should be gone, but it's still cached
setTimeout(() => store.dispatch(
  api.endpoints.myEndpoint.initiate({}, { subscribe: false })
), 61_000)
```

## Cause

The cache-collection middleware reschedules the removal timer whenever
`canTriggerUnsubscribe` matches, and it was matching `queryThunk.rejected` as a
whole.

When `initiate(..., { subscribe: false })` hits a fresh cache entry, the thunk's
`condition` returns `false` and bails out before running. But the thunk uses
`dispatchConditionRejection: true`, so it still dispatches a `rejected` action —
one tagged with `meta.condition === true`. That made a plain cache hit look like
a finished request: the pending removal timeout got cleared and a fresh one
started, even though nothing was fetched and no subscription changed.

## Fix

Ignore condition-based rejections when deciding whether to reschedule cleanup. A
query that bailed out via `condition` never ran and never touched a
subscription, so it shouldn't restart the removal timer. Real failures of
unsubscribed queries (`meta.condition === false`) still schedule removal as
before:

```ts
const isQueryThunkRejectedByError = (action: any) =>
  queryThunk.rejected.match(action) && !action.meta.condition
```

I also added a regression test that fires two `initiate({ subscribe: false })`
calls 30s apart and checks the entry is removed on the original deadline instead
of being pushed out.