### PR TITLE
fix(types): fix tsgo (TS 7.0) type errors and re-enable the native-preview CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -465,7 +465,6 @@ jobs:
           yarn workspace @examples-type-portability/${{ matrix.example.name }} run test --module ESNext --moduleResolution Node10 --preserveSymLinks --verbatimModuleSyntax false
 
   test-types-native-preview:
-    if: false # Disabled pending TS 7.0 compatibility fixes
     name: 'Test Types: TypeScript Native Preview'
     needs: [build]
     runs-on: ubuntu-latest

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1856,6 +1856,11 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
               (_: ApiRootState, lastResult: any) => lastResult,
               (_: ApiRootState) => stableArg,
             ],
+            // `preSelector` is a union of the standard/infinite query pre-selectors.
+            // `tsc` attributes the resulting overload error to the `createSelector` call
+            // (suppressed above), but `tsgo` attributes it to this argument line, so it
+            // needs its own directive.
+            // @ts-ignore
             preSelector,
             {
               memoizeOptions: {

--- a/packages/toolkit/src/tests/mapBuilders.test-d.ts
+++ b/packages/toolkit/src/tests/mapBuilders.test-d.ts
@@ -52,22 +52,20 @@ describe('type tests', () => {
         (state, action: ReturnType<typeof increment>) => state,
       )
 
-      // @ts-expect-error
-      builder.addCase(
-        increment,
-        (state, action: ReturnType<typeof decrement>) => state,
-      )
+      // @ts-expect-error `increment` and `decrement` action types are incompatible.
+      // The call is kept on a single line so `tsc` and `tsgo` attribute the error to the same line.
+      // prettier-ignore
+      builder.addCase(increment, (state, action: ReturnType<typeof decrement>) => state)
 
       builder.addCase(
         'increment',
         (state, action: ReturnType<typeof increment>) => state,
       )
 
-      // @ts-expect-error
-      builder.addCase(
-        'decrement',
-        (state, action: ReturnType<typeof increment>) => state,
-      )
+      // @ts-expect-error The reducer is typed for `increment`, but the case is `'decrement'`.
+      // The call is kept on a single line so `tsc` and `tsgo` attribute the error to the same line.
+      // prettier-ignore
+      builder.addCase('decrement', (state, action: ReturnType<typeof increment>) => state)
 
       // action type is inferred
       builder.addMatcher(increment.match, (state, action) => {


### PR DESCRIPTION
Fixes #5156.

## Problem

The `test-types-native-preview` (tsgo) job added in #5155 was disabled because it surfaced type errors under TypeScript 7.0 (`tsgo`), while `tsc` stayed green.

## Root cause

Not an actual type regression. `tsc` and `tsgo` attribute overload errors (TS2769) to different lines: `tsc` reports them on the call site, `tsgo` on the argument that failed to match. As a result, some of our `@ts-ignore` / `@ts-expect-error` directives sat on the line `tsgo` doesn't associate with the error, so they either failed to suppress it or were flagged as unused (TS2578).

## Changes

- **`buildHooks.ts`**: the `preSelector` argument to `createSelector` is a union of the standard and infinite-query pre-selectors; `tsgo` reports the overload mismatch on that argument line. Added an inline `@ts-ignore` on the argument, matching the existing one on `select(stableArg)`.
- **`mapBuilders.test-d.ts`**: the two `addCase` calls that are expected to error had their `@ts-expect-error` on the `builder.addCase(` line, but `tsgo` reports the error on the reducer argument. Collapsed each call onto a single line (with `// prettier-ignore`) so both compilers attribute the error to the line directly below the directive. Test intent is unchanged — the calls are still expected to error.
- **`tests.yml`**: removed `if: false` from the `test-types-native-preview` job so it runs. Kept `continue-on-error: true`, since it targets a moving `-dev` build and shouldn't block unrelated PRs if a future nightly changes behavior.

## Testing

Verified clean under both `tsc` 5.9.3 and `tsgo` 7.0.0-dev across:

- the source (`tsconfig.test.json`)
- the built dist (`TEST_DIST=true`, prod path aliases erased)
- the bundler type-portability example