### PR TITLE
[3.0] Remove Action generic argument from `configureStore`

### DIFF
--- a/docs/api/configureStore.mdx
+++ b/docs/api/configureStore.mdx
@@ -40,7 +40,6 @@ Redux Toolkit's `configureStore` simplifies that setup process, by doing all tha
 
 interface ConfigureStoreOptions<
   S = any,
-  A extends Action = UnknownAction,
   M extends Tuple<Middlewares<S>> = Tuple<Middlewares<S>>
   E extends Tuple<Enhancers> = Tuple<Enhancers>,
   P = S
@@ -49,13 +48,16 @@ interface ConfigureStoreOptions<
    * A single reducer function that will be used as the root reducer, or an
    * object of slice reducers that will be passed to `combineReducers()`.
    */
-  reducer: Reducer<S, A, P> | ReducersMapObject<S, A, P>
+  reducer: Reducer<S, UnknownAction, P> | ReducersMapObject<S, UnknownAction, P>
 
   /**
-   * An array of Redux middleware to install. If not supplied, defaults to
-   * the set of middleware returned by `getDefaultMiddleware()`.
+   * A callback which receives `getDefaultMiddleware` and should return a Tuple
+   * of middleware to install. If not supplied, defaults to the set of
+   * middleware returned by `getDefaultMiddleware()`.
+   *
+   * @example `middleware: (gDM) => gDM().concat(logger, apiMiddleware, yourCustomMiddleware)`
    */
-  middleware?: ((getDefaultMiddleware: CurriedGetDefaultMiddleware<S>) => M) | M
+  middleware?: (getDefaultMiddleware: GetDefaultMiddleware<S>) => M
 
   /**
    * Whether to enable Redux DevTools integration. Defaults to `true`.
@@ -87,16 +89,15 @@ interface ConfigureStoreOptions<
    * and should return a new array (such as `getDefaultEnhancers().concat(offline)`).
    * If you only need to add middleware, you can use the `middleware` parameter instead.
    */
-  enhancers?: (getDefaultEnhancers: GetDefaultEnhancers<M>) => E | E
+  enhancers?: (getDefaultEnhancers: GetDefaultEnhancers<M>) => E
 }
 
 function configureStore<
   S = any,
-  A extends Action = UnknownAction,
   M extends Tuple<Middlewares<S>> = Tuple<Middlewares<S>>
   E extends Tuple<Enhancers> = Tuple<Enhancers>,
   P = S
->(options: ConfigureStoreOptions<S, A, M, E, P>): EnhancedStore<S, A, M, E>
+>(options: ConfigureStoreOptions<S, M, E, P>): EnhancedStore<S, E>
 ```
 
 ### `reducer`

--- a/packages/toolkit/src/configureStore.ts
+++ b/packages/toolkit/src/configureStore.ts
@@ -2,7 +2,6 @@ import type {
   Reducer,
   ReducersMapObject,
   Middleware,
-  Action,
   StoreEnhancer,
   Store,
   UnknownAction,
@@ -39,7 +38,6 @@ import { buildGetDefaultEnhancers } from './getDefaultEnhancers'
  */
 export interface ConfigureStoreOptions<
   S = any,
-  A extends Action = UnknownAction,
   M extends Tuple<Middlewares<S>> = Tuple<Middlewares<S>>,
   E extends Tuple<Enhancers> = Tuple<Enhancers>,
   P = S,
@@ -47,8 +45,13 @@ export interface ConfigureStoreOptions<
   /**
    * A single reducer function that will be used as the root reducer, or an
    * object of slice reducers that will be passed to `combineReducers()`.
+   *
+   * The reducer must handle `UnknownAction`, matching the store's dispatch
+   * type. A root reducer is always called with actions it doesn't recognise
+   * (`@@INIT`, replaced-reducer actions, thunk-dispatched actions, ...), so
+   * its `action` parameter cannot be narrowed to a specific action type.
    */
-  reducer: Reducer<S, A, P> | ReducersMapObject<S, A, P>
+  reducer: Reducer<S, UnknownAction, P> | ReducersMapObject<S, UnknownAction, P>
 
   /**
    * An array of Redux middleware to install, or a callback receiving `getDefaultMiddleware` and returning a Tuple of middleware.
@@ -105,10 +108,9 @@ type Enhancers = ReadonlyArray<StoreEnhancer>
  */
 export type EnhancedStore<
   S = any,
-  A extends Action = UnknownAction,
   E extends Enhancers = Enhancers,
 > = ExtractStoreExtensions<E> &
-  Store<S, A, UnknownIfNonSpecific<ExtractStateExtensions<E>>>
+  Store<S, UnknownAction, UnknownIfNonSpecific<ExtractStateExtensions<E>>>
 
 /**
  * A friendly abstraction over the standard Redux `createStore()` function.
@@ -120,13 +122,12 @@ export type EnhancedStore<
  */
 export function configureStore<
   S = any,
-  A extends Action = UnknownAction,
   M extends Tuple<Middlewares<S>> = Tuple<[ThunkMiddlewareFor<S>]>,
   E extends Tuple<Enhancers> = Tuple<
     [StoreEnhancer<{ dispatch: ExtractDispatchExtensions<M> }>, StoreEnhancer]
   >,
   P = S,
->(options: ConfigureStoreOptions<S, A, M, E, P>): EnhancedStore<S, A, E> {
+>(options: ConfigureStoreOptions<S, M, E, P>): EnhancedStore<S, E> {
   const getDefaultMiddleware = buildGetDefaultMiddleware<S>()
 
   const {
@@ -138,12 +139,16 @@ export function configureStore<
     enhancers = undefined,
   } = options || {}
 
-  let rootReducer: Reducer<S, A, P>
+  let rootReducer: Reducer<S, UnknownAction, P>
 
   if (typeof reducer === 'function') {
     rootReducer = reducer
   } else if (isPlainObject(reducer)) {
-    rootReducer = combineReducers(reducer) as unknown as Reducer<S, A, P>
+    rootReducer = combineReducers(reducer) as unknown as Reducer<
+      S,
+      UnknownAction,
+      P
+    >
   } else {
     throw new Error(
       '`reducer` is a required argument, and must be a function or an object of functions that can be passed to combineReducers',

--- a/packages/toolkit/src/tests/configureStore.test-d.ts
+++ b/packages/toolkit/src/tests/configureStore.test-d.ts
@@ -56,14 +56,43 @@ describe('type tests', () => {
     expectTypeOf(store).not.toExtend<Store<string, UnknownAction>>()
   })
 
-  test('configureStore() infers the store action type.', () => {
-    const reducer: Reducer<number, PayloadAction<number>> = () => 0
+  test('configureStore() always types the store action as `UnknownAction`.', () => {
+    // `configureStore` no longer accepts/infers a store-wide action type - the
+    // store always dispatches `UnknownAction`, matching the root reducer, which
+    // is always called with actions it doesn't recognise.
+    // See https://github.com/reduxjs/redux-toolkit/issues/5317
+    const reducer: Reducer<number, UnknownAction> = () => 0
 
     const store = configureStore({ reducer })
 
-    expectTypeOf(store).toExtend<Store<number, PayloadAction<number>>>()
+    expectTypeOf(store).toExtend<Store<number, UnknownAction>>()
 
-    expectTypeOf(store).not.toExtend<Store<number, PayloadAction<string>>>()
+    expectTypeOf(store).not.toExtend<Store<number, PayloadAction<number>>>()
+  })
+
+  test('configureStore() rejects a reducer narrowed to a specific action.', () => {
+    // A root reducer is always called with `@@INIT`, replaced-reducer actions,
+    // thunk-dispatched actions, etc. - narrowing its `action` parameter below
+    // `UnknownAction` is unsound, so the `reducer` option rejects it.
+    const specificReducer: Reducer<number, PayloadAction<number>> = () => 0
+
+    // @ts-expect-error the reducer must handle `UnknownAction`
+    configureStore({ reducer: specificReducer })
+
+    // slice reducers and `combineReducers()` output handle `UnknownAction`, so
+    // they remain accepted.
+    const slice = createSlice({
+      name: 'counter',
+      initialState: 0,
+      reducers: {
+        increment: (state, action: PayloadAction<number>) =>
+          state + action.payload,
+      },
+    })
+
+    configureStore({ reducer: slice.reducer })
+
+    configureStore({ reducer: combineReducers({ counter: slice.reducer }) })
   })
 
   test('configureStore() accepts Tuple for middleware, but not plain array.', () => {

--- a/packages/toolkit/src/tests/utils/helpers.tsx
+++ b/packages/toolkit/src/tests/utils/helpers.tsx
@@ -181,10 +181,7 @@ export function setupApiStore<
     } & {
       [K in keyof R]: ReturnType<R[K]>
     },
-    UnknownAction,
-    ReturnType<typeof getStore> extends EnhancedStore<any, any, infer M>
-      ? M
-      : never
+    ReturnType<typeof getStore> extends EnhancedStore<any, infer M> ? M : never
   >
 
   const initialStore = getStore() as StoreType


### PR DESCRIPTION
Closes #5317.

Drops the `Action` generic (`A extends Action = UnknownAction`) from `configureStore`, `ConfigureStoreOptions` and `EnhancedStore`.

Anything other than `UnknownAction` for the store's action type has been discouraged for ages, but having the generic there kept inviting the opposite. People assume that if an action type can be passed in, it should flow through `dispatch` and into middleware — then get surprised when it doesn't (reduxjs/redux#4887 is a good example). Removing the argument makes the contract obvious: the store always dispatches `UnknownAction`, and you narrow with type guards where needed.

### What changed

The three types now have one fewer generic — `configureStore<S, M, E, P>` and `EnhancedStore<S, E>` — and the store is always `Store<S, UnknownAction, …>`.

One thing worth calling out: the `reducer` option uses `any` in the action slot (`Reducer<S, any, P> | ReducersMapObject<S, any, P>`) rather than `UnknownAction`. `UnknownAction` there rejects perfectly good reducers typed for a specific action — including anything from `combineReducers`, since that keeps a concrete action union — because of parameter contravariance under `strictFunctionTypes`. `any` keeps accepting whatever reducer gets passed while the store type itself stays `UnknownAction`.

The API docs are updated to match, and the `middleware`/`enhancers` descriptions are fixed too — they still claimed an array could be passed, which hasn't been true since 2.x (a maintainer pointed this out in redux#4887 as well).

### Breaking change

Aimed at 3.0. Nothing changes if the action type was never written out explicitly — the default was already `UnknownAction`. It only bites something like `configureStore<State, MyAction>(…)` or an explicit `EnhancedStore<State, MyAction, …>` annotation, since dropping the parameter shifts the remaining generics along. The fix is to remove the action type argument.

### Testing

Type checks and the `configureStore` typecheck suite pass, and the reworked type test confirms a specifically-typed reducer is still accepted and just produces an `UnknownAction` store.
