### PR TITLE
fix(toolkit): preserve unsubscribed results during invalidation

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -122,11 +122,47 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
 
         if (querySubState) {
           if (subscriptionSubState.size === 0) {
-            mwApi.dispatch(
-              removeQueryResult({
-                queryCacheKey: queryCacheKey as QueryCacheKey,
-              }),
-            )
+            const runningQuery = internalState.runningQueries.get(queryCacheKey)
+
+            if (runningQuery) {
+              const requestId = querySubState.requestId
+
+              void runningQuery.then(() => {
+                const currentState = mwApi.getState()[reducerPath]
+                const currentQuerySubState = currentState.queries[queryCacheKey]
+
+                if (
+                  !currentQuerySubState ||
+                  currentQuerySubState.requestId !== requestId
+                ) {
+                  return
+                }
+
+                const currentSubscriptionSubState = getOrInsertComputed(
+                  internalState.currentSubscriptions,
+                  queryCacheKey,
+                  createNewMap,
+                )
+
+                if (currentSubscriptionSubState.size === 0) {
+                  mwApi.dispatch(
+                    removeQueryResult({
+                      queryCacheKey: queryCacheKey as QueryCacheKey,
+                    }),
+                  )
+                } else if (
+                  currentQuerySubState.status !== STATUS_UNINITIALIZED
+                ) {
+                  mwApi.dispatch(refetchQuery(currentQuerySubState))
+                }
+              })
+            } else {
+              mwApi.dispatch(
+                removeQueryResult({
+                  queryCacheKey: queryCacheKey as QueryCacheKey,
+                }),
+              )
+            }
           } else if (querySubState.status !== STATUS_UNINITIALIZED) {
             mwApi.dispatch(refetchQuery(querySubState))
           }

--- a/packages/toolkit/src/query/tests/raceConditions.test.ts
+++ b/packages/toolkit/src/query/tests/raceConditions.test.ts
@@ -107,3 +107,26 @@ it('invalidates a query whose corresponding mutation finished while the query wa
   expect(getQueryState()?.status).toBe(QueryStatus.fulfilled)
   expect(getQueryState()?.data).toBe(1)
 })
+
+it('returns an unsubscribed query result when a concurrent mutation invalidates it', async () => {
+  eatenBananas = 0
+
+  const query = storeRef.store.dispatch(
+    getEatenBananas.initiate(undefined, { subscribe: false }),
+  )
+  const mutation = storeRef.store.dispatch(eatBanana.initiate())
+
+  eatBananaPromises.resolveOldest()
+  await mutation
+
+  getEatenBananaPromises.resolveOldest()
+
+  await expect(query).resolves.toMatchObject({
+    data: 0,
+    status: QueryStatus.fulfilled,
+  })
+  await expect(query.unwrap()).resolves.toBe(0)
+  expect(
+    storeRef.store.getState().api.queries[query.queryCacheKey],
+  ).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- preserve the fulfilled result for an unsubscribed query when delayed invalidation runs during fulfillment
- defer cache removal until the running query settles
- add deterministic regression coverage for the invalidation race

Fixes #5346.

## Problem

A query initiated with `subscribe: false` can return an uninitialized result when a mutation triggers delayed invalidation while the query is still running.

During the fulfilled dispatch, invalidation sees the cache entry without an active subscription and removes it synchronously. `buildInitiate` then selects the public result after the cache entry has disappeared, so the initiating caller cannot observe the fulfilled data.

## Root cause

The invalidation middleware removes an unsubscribed query result before the running query promise and initiating result-selection flow have settled.

## Change

When the affected cache entry still has a running query, defer cleanup until that query settles.

Before cleanup, recheck:

- the current cache entry still belongs to the original `requestId`
- whether a newer request replaced it
- whether the entry gained an active subscription

An unchanged unsubscribed entry is removed. A newly subscribed entry is refetched, and a newer request is preserved.

## Validation

- focused issue regression — passed
- race-condition test file — 3/3 passed
- race-condition test file on Node 22.16 — 3/3 passed
- Redux Toolkit package suite — 88/88 files and 1,317 tests passed
- type tests and TypeScript validation — passed
- targeted ESLint and Prettier — passed
- production build — passed
- `git show --check` — passed

The broad package lint command references an absent `packages/toolkit/examples` directory. The optional size-limit command also remains blocked by Windows absolute-path resolution. The changed files pass targeted validation and the production build.

Rejected and aborted query results use RTK Query's non-rejecting result promise, so deferred cleanup does not introduce an unhandled rejection. No separate dedicated rejection or abort regression test is included in this change.

## Compatibility

No public API, dependency, lockfile, Node support, browser API, or TypeScript declaration change is included.
