### PR TITLE
docs: clarify `useLazyQuery` data is undefined until trigger

### DIFF
--- a/docs/rtk-query/api/created-api/hooks.mdx
+++ b/docs/rtk-query/api/created-api/hooks.mdx
@@ -630,7 +630,7 @@ type UseLazyQueryLastPromiseInfo = {
 
 - **Returns**: A tuple containing:
   - `trigger`: A function that fetches the corresponding data for the endpoint when called
-  - `result`: A query result object containing the current loading state, the actual data or error returned from the API call and metadata about the request. Can be customized with `selectFromResult`
+  - `result`: A query result object containing the current loading state, the actual data or error returned from the API call and metadata about the request. Can be customized with `selectFromResult`. Before the first `trigger` call, this stays `uninitialized` and `data` is `undefined` even if the cache already has matching data.
   - `lastPromiseInfo`: An object containing the last argument used to call the trigger function
 
 ### `usePrefetch`

--- a/docs/rtk-query/api/created-api/hooks.mdx
+++ b/docs/rtk-query/api/created-api/hooks.mdx
@@ -630,7 +630,7 @@ type UseLazyQueryLastPromiseInfo = {
 
 - **Returns**: A tuple containing:
   - `trigger`: A function that fetches the corresponding data for the endpoint when called
-  - `result`: A query result object containing the current loading state, the actual data or error returned from the API call and metadata about the request. Can be customized with `selectFromResult`. Before the first `trigger` call, this stays `uninitialized` and `data` is `undefined` even if the cache already has matching data.
+  - `result`: A query result object containing the current loading state, the actual data or error returned from the API call and metadata about the request. Can be customized with `selectFromResult`. Before the first `trigger` call, this stays `uninitialized` and `data` is `undefined`.
   - `lastPromiseInfo`: An object containing the last argument used to call the trigger function
 
 ### `usePrefetch`

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -271,11 +271,13 @@ export type UseLazyQueryLastPromiseInfo<
  *
  * - Manual control over firing a request to retrieve data
  * - 'Subscribes' the component to keep cached data in the store, and 'unsubscribes' when the component unmounts
- * - Returns the latest request status and cached data from the Redux store
+ * - After `trigger` is called, returns the latest request status and cached data from the Redux store for that request
  * - Re-renders as the request status changes and data becomes available
  * - Accepts polling/re-fetching options to trigger automatic re-fetches when the corresponding criteria is met and the fetch has been manually called at least once
  *
  * #### Note
+ *
+ * Until you call the trigger function, the result stays `uninitialized` and `data` is `undefined`, even if matching data already exists in the cache.
  *
  * When the trigger function returned from a LazyQuery is called, it always initiates a new request to the server even if there is cached data. Set `preferCacheValue`(the second argument to the function) as `true` if you want it to immediately return a cached value if one exists.
  */

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -277,7 +277,7 @@ export type UseLazyQueryLastPromiseInfo<
  *
  * #### Note
  *
- * Until you call the trigger function, the result stays `uninitialized` and `data` is `undefined`, even if matching data already exists in the cache.
+ * Until you call the trigger function, the result stays `uninitialized` and `data` is `undefined`.
  *
  * When the trigger function returned from a LazyQuery is called, it always initiates a new request to the server even if there is cached data. Set `preferCacheValue`(the second argument to the function) as `true` if you want it to immediately return a cached value if one exists.
  */


### PR DESCRIPTION
## Summary
- Clarify that `useLazyQuery` keeps `data` undefined and the result `uninitialized` until `trigger` is called, even when matching cache data already exists.
- Update the `UseLazyQuery` JSDoc and the hooks API page Returns section so they match that behavior.

Fixes #4094

## Test plan
- [ ] Review the `UseLazyQuery` summary rendered on the hooks API docs page
- [ ] Confirm the wording matches known lazy-query behavior (no store data until first trigger)