### PR TITLE
docs: fix `getOriginalState` example to use `Promise.resolve`

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -157,7 +157,7 @@ export interface ListenerEffectAPI<
    *
    *     setTimeout(getOriginalState, 0); // async: throws Error
    *
-   *     await Promise().resolve();
+   *     await Promise.resolve();
    *
    *     getOriginalState(); // async: throws Error
    *   },


### PR DESCRIPTION
The `getOriginalState` `@example` calls `Promise().resolve()`, which throws at runtime (`Promise` must be called with `new`) and doesn't type-check (TS2348: `PromiseConstructor` is not callable). The intended microtask boundary is `Promise.resolve()`.
