### PR TITLE
feat(codegen): add enumStyle option

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -135,6 +135,7 @@ export type EndpointOverrides = {
   invalidatesTags: string[]
 }>
   useEnumType?: boolean
+  enumStyle?: 'union' | 'enum' | 'as-const'
   outputRegexConstants?: boolean
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions
 }
@@ -295,6 +296,24 @@ When using tag overrides with `tag: false`, the overridden tags will be emitted 
 #### Generating hooks
 
 Setting `hooks: true` will generate `useQuery` and `useMutation` hook exports. If you also want `useLazyQuery` hooks generated or more granular control, you can also pass an object in the shape of: `{ queries: boolean; lazyQueries: boolean; mutations: boolean }`.
+
+#### Controlling enum generation
+
+By default, OpenAPI `enum` definitions are generated as unions of string literals. Use the `enumStyle` option to control this behavior:
+
+- **`"union"`** _(default)_ - a union of string literals: `type Status = 'available' | 'pending'`
+- **`"enum"`** - a TypeScript enum: `enum Status { Available = 'available' }`
+- **`"as-const"`** - a const object with a companion type, which provides runtime values like an enum while remaining tree-shakeable and compatible with `isolatedModules`:
+
+```ts no-transpile
+export const Status = {
+  Available: 'available',
+  Pending: 'pending',
+} as const
+export type Status = (typeof Status)[keyof typeof Status]
+```
+
+`useEnumType: true` is equivalent to `enumStyle: 'enum'`. If both options are specified, `enumStyle` takes precedence.
 
 #### Generating regex constants for schema patterns
 

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -242,6 +242,7 @@ export async function generateApi(
     flattenArg = false,
     includeDefault = false,
     useEnumType = false,
+    enumStyle,
     mergeReadWriteOnly = false,
     httpResolverOptions,
     useUnknown = false,
@@ -255,6 +256,7 @@ export async function generateApi(
   const ctx = createContext(v3Doc, {
     unionUndefined,
     useEnumType,
+    enumStyle,
     mergeReadWriteOnly,
     useUnknown,
   });

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -184,6 +184,19 @@ export type ParameterMatcherFunction = (parameterName: string, parameterDefiniti
 
 export type ParameterMatcher = TextMatcher | ParameterMatcherFunction;
 
+/**
+ * Controls how enums are generated in TypeScript.
+ *
+ * - **`"union"`** *(default)* - a union of string literals: `type Status = "available" | "pending"`
+ * - **`"enum"`** - a TypeScript enum: `enum Status { Available = "available" }`
+ * - **`"as-const"`** - a const object with a companion type:
+ *   `const Status = { Available: "available" } as const; type Status = (typeof Status)[keyof typeof Status];`
+ *
+ * @since 2.3.0
+ * @public
+ */
+export type EnumStyle = 'union' | 'enum' | 'as-const';
+
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;
   filterEndpoints?: EndpointMatcher;
@@ -193,6 +206,15 @@ export interface OutputFileOptions extends Partial<CommonOptions> {
    * @default false
    */
   useEnumType?: boolean;
+  /**
+   * Controls how enums are generated in TypeScript.
+   * Takes precedence over `useEnumType` if both are specified.
+   * @see {@linkcode EnumStyle} for details.
+   *
+   * @default "union"
+   * @since 2.3.0
+   */
+  enumStyle?: EnumStyle;
 }
 
 /**

--- a/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
+++ b/packages/rtk-query-codegen-openapi/test/generateEndpoints.test.ts
@@ -796,6 +796,64 @@ describe('useEnumType option', () => {
   });
 });
 
+describe('enumStyle option', () => {
+  it('generates union types when enumStyle is "union"', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      apiFile: './fixtures/emptyApi.ts',
+      enumStyle: 'union',
+      filterEndpoints: ['findPetsByStatus'],
+    });
+
+    expect(api).toContain('status?: "available" | "pending" | "sold"');
+    expect(api).not.toMatch(/enum\s+\w+/);
+    expect(api).not.toContain('as const');
+  });
+
+  it('generates TypeScript enums when enumStyle is "enum"', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      apiFile: './fixtures/emptyApi.ts',
+      enumStyle: 'enum',
+      filterEndpoints: ['findPetsByStatus'],
+    });
+
+    expect(api).toMatch(/enum\s+\w+/);
+    expect(api).toContain('Available = "available"');
+  });
+
+  it('generates const objects with companion types when enumStyle is "as-const"', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      apiFile: './fixtures/emptyApi.ts',
+      enumStyle: 'as-const',
+      filterEndpoints: ['findPetsByStatus'],
+    });
+
+    expect(api).toContain('Available: "available"');
+    expect(api).toContain('} as const;');
+    expect(api).toContain('export type Status = (typeof Status)[keyof typeof Status];');
+    expect(api).not.toMatch(/enum\s+\w+/);
+  });
+
+  it('takes precedence over useEnumType when both are specified', async () => {
+    const api = await generateEndpoints({
+      unionUndefined: true,
+      schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+      apiFile: './fixtures/emptyApi.ts',
+      useEnumType: true,
+      enumStyle: 'as-const',
+      filterEndpoints: ['findPetsByStatus'],
+    });
+
+    expect(api).toContain('} as const;');
+    expect(api).not.toMatch(/enum\s+\w+/);
+  });
+});
+
 describe('query parameters', () => {
   it('parameters overridden in swagger should also be overridden in the code', async () => {
     const api = await generateEndpoints({


### PR DESCRIPTION
## Summary

Expose oazapfts's `enumStyle` option (`'union' | 'enum' | 'as-const'`) in `@rtk-query/codegen-openapi`, allowing enums to be generated as `as const` objects with companion types.

Closes #5223.

## Approach

Since #5228 migrated codegen to oazapfts v7.5.0, enum generation is handled entirely by oazapfts — codegen only needs to pass the option through to `createContext`. The precedence between the two options (`enumStyle` wins when both are specified) is also resolved inside oazapfts, so no additional logic is needed on the codegen side.

`useEnumType` remains supported as-is: `useEnumType: true` is equivalent to `enumStyle: 'enum'`.

## Changes

- Add `enumStyle` to `OutputFileOptions` (and an exported `EnumStyle` type)
- Pass `enumStyle` through to oazapfts's `createContext`
- Add tests covering the three styles and the `useEnumType` + `enumStyle` precedence
- Document the option in the code generation docs

With `enumStyle: 'as-const'`, an OpenAPI enum generates:

```ts
export const Status = {
  Available: "available",
  Pending: "pending",
  Sold: "sold",
} as const;
export type Status = (typeof Status)[keyof typeof Status];
```

## Tests

All 96 tests pass (`vitest --run --typecheck`), with no changes to existing snapshots — output is unchanged unless `enumStyle` is specified.

## Related

- #5223 — feature request
- #5228 — oazapfts v7 migration (prerequisite, merged)
- oazapfts/oazapfts#823 — `enumStyle` implementation in oazapfts (released in v7.3.0)
