### PR TITLE
feat(toolkit): add `createAsyncThunkWithProgress`

### DIFF
--- a/docs/api/createAsyncThunkWithProgress.mdx
+++ b/docs/api/createAsyncThunkWithProgress.mdx
@@ -1,0 +1,116 @@
+---
+id: createAsyncThunkWithProgress
+title: createAsyncThunkWithProgress
+sidebar_label: createAsyncThunkWithProgress
+hide_title: true
+---
+
+&nbsp;
+
+# `createAsyncThunkWithProgress`
+
+## Overview
+
+A thin wrapper around [`createAsyncThunk`](./createAsyncThunk.mdx) for async operations that can report incremental progress while they run - such as file uploads or downloads.
+
+It accepts the exact same arguments as `createAsyncThunk`, except that the `payloadCreator` callback receives a third argument, `onProgress`, which can be called (repeatedly) with a progress value of your choosing. Every call to `onProgress` dispatches a `progress` action, which is attached to the returned thunk action creator alongside the usual `pending`, `fulfilled`, and `rejected` actions.
+
+The shape of the progress value is not prescribed by Redux Toolkit - pass whatever type fits your use case (such as `AxiosProgressEvent` from `axios`, or a custom `{ loaded: number; total: number }` shape) as the fourth type parameter.
+
+Sample usage with `axios`:
+
+```ts no-transpile {8-17,29-31}
+import { createAsyncThunkWithProgress, createSlice } from '@reduxjs/toolkit'
+import type { AxiosProgressEvent } from 'axios'
+import axios from 'axios'
+
+// First, create the thunk
+const uploadFile = createAsyncThunkWithProgress<
+  string,
+  FormData,
+  {},
+  AxiosProgressEvent
+>('files/upload', async (formData, thunkAPI, onProgress) => {
+  const response = await axios.post('/upload', formData, {
+    onUploadProgress: onProgress,
+    signal: thunkAPI.signal,
+  })
+  return response.data.fileUrl
+})
+
+interface FilesState {
+  uploadProgress: number
+  status: 'idle' | 'pending' | 'succeeded' | 'failed'
+}
+
+const initialState = {
+  uploadProgress: 0,
+  status: 'idle',
+} satisfies FilesState as FilesState
+
+// Then, handle actions in your reducers:
+const filesSlice = createSlice({
+  name: 'files',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(uploadFile.pending, (state) => {
+        state.status = 'pending'
+        state.uploadProgress = 0
+      })
+      .addCase(uploadFile.progress, (state, action) => {
+        state.uploadProgress = action.payload.progress ?? 0
+      })
+      .addCase(uploadFile.fulfilled, (state) => {
+        state.status = 'succeeded'
+        state.uploadProgress = 1
+      })
+  },
+})
+
+// Later, dispatch the thunk as needed in the app
+dispatch(uploadFile(formData))
+```
+
+## Parameters
+
+`createAsyncThunkWithProgress` accepts the same three parameters as [`createAsyncThunk`](./createAsyncThunk.mdx#parameters): a string action `type` value, a `payloadCreator` callback, and an `options` object.
+
+### `payloadCreator`
+
+Identical to the `payloadCreator` passed to `createAsyncThunk`, but called with a third argument:
+
+- `onProgress(progressEvent)`: a callback that, when called, dispatches the `progress` action described below with `progressEvent` as its `action.payload`. It can be called any number of times while the thunk is running.
+
+## Return Value
+
+`createAsyncThunkWithProgress` returns the same thunk action creator as `createAsyncThunk`, with one additional nested action creator attached:
+
+- `uploadFile.progress`, an action creator that dispatches a `'files/upload/progress'` action whenever `onProgress` is called
+
+Like the `pending` action, each dispatched `progress` action carries the current `requestId` and `arg` under `action.meta`, together with `requestStatus: 'pending'`:
+
+```ts no-transpile
+interface ProgressAction<ThunkArg, ProgressEvent> {
+  type: string
+  payload: ProgressEvent
+  meta: {
+    requestId: string
+    arg: ThunkArg
+    requestStatus: 'pending'
+  }
+}
+```
+
+To handle it in your reducers, reference `uploadFile.progress` in `createReducer` or `createSlice` using the "builder callback" notation, just like any other action creator:
+
+```ts no-transpile
+const reducer = createReducer(initialState, (builder) => {
+  builder.addCase(uploadFile.progress, (state, action) => {
+    state.uploadProgress = action.payload
+  })
+})
+```
+
+Everything else - cancellation, error handling, `unwrapResult`, the `condition` option, and so on - behaves exactly as documented for [`createAsyncThunk`](./createAsyncThunk.mdx), since `createAsyncThunkWithProgress` calls it internally without changing that behavior.

--- a/packages/toolkit/src/createAsyncThunkWithProgress.ts
+++ b/packages/toolkit/src/createAsyncThunkWithProgress.ts
@@ -1,0 +1,165 @@
+import type { ActionCreatorWithPreparedPayload } from './createAction'
+import { createAction } from './createAction'
+import type {
+  AsyncThunk,
+  AsyncThunkConfig,
+  AsyncThunkOptions,
+  AsyncThunkPayloadCreator,
+  AsyncThunkPayloadCreatorReturnValue,
+  GetThunkAPI,
+} from './createAsyncThunk'
+import { createAsyncThunk } from './createAsyncThunk'
+
+/**
+ * A type describing the `payloadCreator` argument to `createAsyncThunkWithProgress`.
+ * Identical to `AsyncThunkPayloadCreator`, but the payload creator additionally
+ * receives an `onProgress` callback that can be called (repeatedly) to report
+ * progress on the running request.
+ *
+ * @public
+ */
+export type AsyncThunkPayloadCreatorWithProgress<
+  Returned,
+  ThunkArg = void,
+  ThunkApiConfig extends AsyncThunkConfig = {},
+  ProgressEvent = unknown,
+> = (
+  arg: ThunkArg,
+  thunkAPI: GetThunkAPI<ThunkApiConfig>,
+  onProgress: (progressEvent: ProgressEvent) => void,
+) => AsyncThunkPayloadCreatorReturnValue<Returned, ThunkApiConfig>
+
+/**
+ * The action creator that is dispatched every time `onProgress` is called by
+ * the payload creator of a thunk created with `createAsyncThunkWithProgress`.
+ *
+ * @public
+ */
+export type AsyncThunkProgressActionCreator<ThunkArg, ProgressEvent> =
+  ActionCreatorWithPreparedPayload<
+    [payload: ProgressEvent, requestId: string, arg: ThunkArg, meta?: object],
+    ProgressEvent,
+    string,
+    never,
+    {
+      arg: ThunkArg
+      requestId: string
+      requestStatus: 'pending'
+    }
+  >
+
+/**
+ * A type describing the return value of `createAsyncThunkWithProgress`.
+ *
+ * @public
+ */
+export type AsyncThunkWithProgress<
+  Returned,
+  ThunkArg,
+  ThunkApiConfig extends AsyncThunkConfig,
+  ProgressEvent,
+> = AsyncThunk<Returned, ThunkArg, ThunkApiConfig> & {
+  progress: AsyncThunkProgressActionCreator<ThunkArg, ProgressEvent>
+}
+
+/**
+ * A wrapper around `createAsyncThunk` that additionally exposes a `progress`
+ * action, and passes the payload creator an `onProgress` callback which,
+ * when called, dispatches that `progress` action.
+ *
+ * This is useful for long-running async operations that can report
+ * incremental progress, such as file uploads or downloads - for example
+ * when driven by `axios`'s `onUploadProgress`/`onDownloadProgress` options,
+ * or the Fetch API's `ReadableStream`.
+ *
+ * The shape of the progress payload is not prescribed - pass whatever type
+ * fits your use case as the `ProgressEvent` type parameter.
+ *
+ * ```ts
+ * const uploadFile = createAsyncThunkWithProgress<Result, FormData, {}, AxiosProgressEvent>(
+ *   'file/upload',
+ *   async (formData, thunkAPI, onProgress) => {
+ *     const response = await axios.post('/upload', formData, {
+ *       onUploadProgress: onProgress,
+ *       signal: thunkAPI.signal,
+ *     })
+ *     return response.data
+ *   },
+ * )
+ *
+ * // in a reducer:
+ * builder.addCase(uploadFile.progress, (state, action) => {
+ *   state.progress = action.payload
+ * })
+ * ```
+ *
+ * @public
+ */
+export function createAsyncThunkWithProgress<
+  Returned,
+  ThunkArg = void,
+  ThunkApiConfig extends AsyncThunkConfig = {},
+  ProgressEvent = unknown,
+>(
+  typePrefix: string,
+  payloadCreator: AsyncThunkPayloadCreatorWithProgress<
+    Returned,
+    ThunkArg,
+    ThunkApiConfig,
+    ProgressEvent
+  >,
+  options?: AsyncThunkOptions<ThunkArg, ThunkApiConfig>,
+): AsyncThunkWithProgress<Returned, ThunkArg, ThunkApiConfig, ProgressEvent> {
+  const progress: AsyncThunkProgressActionCreator<ThunkArg, ProgressEvent> =
+    createAction(
+      typePrefix + '/progress',
+      (
+        payload: ProgressEvent,
+        requestId: string,
+        arg: ThunkArg,
+        meta?: object,
+      ) => ({
+        payload,
+        meta: {
+          ...((meta as object) || {}),
+          arg,
+          requestId,
+          requestStatus: 'pending' as const,
+        },
+      }),
+    )
+
+  // `thunkAPI` is deliberately typed against the unresolved `AsyncThunkConfig`
+  // base (rather than the generic `ThunkApiConfig` type parameter) so that
+  // TypeScript can eagerly resolve `dispatch` here - it can't do so for a
+  // still-generic `ThunkApiConfig`. The whole function is cast back to the
+  // properly-typed `AsyncThunkPayloadCreator` below.
+  const wrappedPayloadCreator = (
+    arg: ThunkArg,
+    thunkAPI: GetThunkAPI<AsyncThunkConfig>,
+  ): AsyncThunkPayloadCreatorReturnValue<Returned, ThunkApiConfig> => {
+    const onProgress = (progressEvent: ProgressEvent): void => {
+      thunkAPI.dispatch(progress(progressEvent, thunkAPI.requestId, arg))
+    }
+
+    return payloadCreator(
+      arg,
+      thunkAPI as GetThunkAPI<ThunkApiConfig>,
+      onProgress,
+    )
+  }
+
+  const asyncThunk = createAsyncThunk<Returned, ThunkArg, ThunkApiConfig>(
+    typePrefix,
+    wrappedPayloadCreator as AsyncThunkPayloadCreator<
+      Returned,
+      ThunkArg,
+      ThunkApiConfig
+    >,
+    options,
+  ) as AsyncThunkWithProgress<Returned, ThunkArg, ThunkApiConfig, ProgressEvent>
+
+  asyncThunk.progress = progress
+
+  return asyncThunk
+}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -132,6 +132,17 @@ export type {
 
 export {
   // js
+  createAsyncThunkWithProgress,
+} from './createAsyncThunkWithProgress'
+export type {
+  // types
+  AsyncThunkWithProgress,
+  AsyncThunkPayloadCreatorWithProgress,
+  AsyncThunkProgressActionCreator,
+} from './createAsyncThunkWithProgress'
+
+export {
+  // js
   isAllOf,
   isAnyOf,
   isPending,

--- a/packages/toolkit/src/tests/createAsyncThunkWithProgress.test-d.ts
+++ b/packages/toolkit/src/tests/createAsyncThunkWithProgress.test-d.ts
@@ -1,0 +1,128 @@
+import type {
+  AsyncThunkProgressActionCreator,
+  AsyncThunkWithProgress,
+  ThunkDispatch,
+  UnknownAction,
+} from '@reduxjs/toolkit'
+import {
+  createAsyncThunkWithProgress,
+  createReducer,
+  createSlice,
+} from '@reduxjs/toolkit'
+
+const defaultDispatch = (() => {}) as ThunkDispatch<{}, any, UnknownAction>
+
+describe('type tests', () => {
+  test('basic usage: `progress` action creator is attached and typed', async () => {
+    interface ProgressEvent {
+      loaded: number
+      total: number
+    }
+
+    const uploadFile = createAsyncThunkWithProgress<
+      string,
+      FormData,
+      {},
+      ProgressEvent
+    >('files/upload', async (formData, thunkAPI, onProgress) => {
+      expectTypeOf(onProgress).toEqualTypeOf<
+        (progressEvent: ProgressEvent) => void
+      >()
+
+      onProgress({ loaded: 0, total: 100 })
+
+      return 'https://example.com/file.png'
+    })
+
+    expectTypeOf(uploadFile).toEqualTypeOf<
+      AsyncThunkWithProgress<string, FormData, {}, ProgressEvent>
+    >()
+
+    expectTypeOf(uploadFile.progress).toEqualTypeOf<
+      AsyncThunkProgressActionCreator<FormData, ProgressEvent>
+    >()
+
+    const reducer = createReducer({}, (builder) =>
+      builder
+        .addCase(uploadFile.pending, (_, action) => {
+          expectTypeOf(action).toEqualTypeOf<
+            ReturnType<(typeof uploadFile)['pending']>
+          >()
+        })
+        .addCase(uploadFile.progress, (_, action) => {
+          expectTypeOf(action).toEqualTypeOf<
+            ReturnType<(typeof uploadFile)['progress']>
+          >()
+
+          expectTypeOf(action.payload).toEqualTypeOf<ProgressEvent>()
+
+          expectTypeOf(action.meta).toEqualTypeOf<{
+            arg: FormData
+            requestId: string
+            requestStatus: 'pending'
+          }>()
+        })
+        .addCase(uploadFile.fulfilled, (_, action) => {
+          expectTypeOf(action.payload).toBeString()
+        }),
+    )
+
+    const promise = defaultDispatch(uploadFile(new FormData()))
+
+    expectTypeOf(promise.requestId).toBeString()
+
+    const result = await promise
+
+    if (uploadFile.fulfilled.match(result)) {
+      expectTypeOf(result.payload).toBeString()
+    }
+  })
+
+  test('without a `ProgressEvent` type parameter, `onProgress` accepts `unknown`', () => {
+    const thunk = createAsyncThunkWithProgress(
+      'test',
+      async (_arg: void, _thunkAPI, onProgress) => {
+        expectTypeOf(onProgress).toEqualTypeOf<
+          (progressEvent: unknown) => void
+        >()
+
+        onProgress({ anything: 'goes' })
+
+        return 42
+      },
+    )
+
+    expectTypeOf(thunk.progress).toEqualTypeOf<
+      AsyncThunkProgressActionCreator<void, unknown>
+    >()
+  })
+
+  test("works within `createSlice`'s `extraReducers` builder callback", () => {
+    const uploadFile = createAsyncThunkWithProgress<
+      string,
+      void,
+      {},
+      { progress: number }
+    >('files/upload', async (_arg, _thunkAPI, onProgress) => {
+      onProgress({ progress: 1 })
+      return 'done'
+    })
+
+    const slice = createSlice({
+      name: 'files',
+      initialState: { progress: 0, url: null as string | null },
+      reducers: {},
+      extraReducers: (builder) => {
+        builder
+          .addCase(uploadFile.progress, (state, action) => {
+            state.progress = action.payload.progress
+          })
+          .addCase(uploadFile.fulfilled, (state, action) => {
+            state.url = action.payload
+          })
+      },
+    })
+
+    expectTypeOf(slice.reducer).toBeFunction()
+  })
+})

--- a/packages/toolkit/src/tests/createAsyncThunkWithProgress.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunkWithProgress.test.ts
@@ -1,0 +1,98 @@
+import type { UnknownAction } from '@reduxjs/toolkit'
+import { configureStore, createAsyncThunkWithProgress } from '@reduxjs/toolkit'
+
+describe('createAsyncThunkWithProgress', () => {
+  it('creates the action types, including `progress`', () => {
+    const thunkActionCreator = createAsyncThunkWithProgress(
+      'testType',
+      async () => 42,
+    )
+
+    expect(thunkActionCreator.fulfilled.type).toBe('testType/fulfilled')
+    expect(thunkActionCreator.pending.type).toBe('testType/pending')
+    expect(thunkActionCreator.rejected.type).toBe('testType/rejected')
+    expect(thunkActionCreator.progress.type).toBe('testType/progress')
+  })
+
+  it('calls onProgress with whatever the payload creator passes it', async () => {
+    type ProgressEvent = { loaded: number; total: number }
+
+    const thunkActionCreator = createAsyncThunkWithProgress<
+      number,
+      void,
+      {},
+      ProgressEvent
+    >('testType', async (_arg, _thunkAPI, onProgress) => {
+      onProgress({ loaded: 50, total: 100 })
+      onProgress({ loaded: 100, total: 100 })
+      return 42
+    })
+
+    const store = configureStore({
+      reducer: (state: UnknownAction[] = [], action) => [...state, action],
+    })
+
+    await store.dispatch(thunkActionCreator())
+
+    const progressActions = store
+      .getState()
+      .filter(thunkActionCreator.progress.match)
+
+    expect(progressActions).toHaveLength(2)
+    expect(progressActions[0].payload).toEqual({ loaded: 50, total: 100 })
+    expect(progressActions[1].payload).toEqual({ loaded: 100, total: 100 })
+  })
+
+  it('dispatches progress actions with the request metadata attached', async () => {
+    const thunkActionCreator = createAsyncThunkWithProgress<
+      number,
+      string,
+      {},
+      number
+    >('testType', async (arg, thunkAPI, onProgress) => {
+      onProgress(1)
+      return arg.length
+    })
+
+    const store = configureStore({
+      reducer: (state: UnknownAction[] = [], action) => [...state, action],
+    })
+
+    const result = await store.dispatch(thunkActionCreator('hello'))
+
+    const [progressAction] = store
+      .getState()
+      .filter(thunkActionCreator.progress.match)
+
+    expect(progressAction.payload).toBe(1)
+    expect(progressAction.meta).toMatchObject({
+      arg: 'hello',
+      requestId: result.meta.requestId,
+      requestStatus: 'pending',
+    })
+  })
+
+  it('still dispatches pending/fulfilled/rejected as usual', async () => {
+    const thunkActionCreator = createAsyncThunkWithProgress<number>(
+      'testType',
+      async (_arg, _thunkAPI, onProgress) => {
+        onProgress(undefined)
+        return 42
+      },
+    )
+
+    const store = configureStore({
+      reducer: (state: UnknownAction[] = [], action) => [...state, action],
+    })
+
+    await store.dispatch(thunkActionCreator())
+
+    const types = store.getState().map((action) => action.type)
+
+    expect(types.slice(1)).toEqual([
+      'testType/pending',
+      'testType/progress',
+      'testType/fulfilled',
+    ])
+  })
+})

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -69,6 +69,7 @@ const sidebars: SidebarsConfig = {
             'api/createAction',
             'api/createSlice',
             'api/createAsyncThunk',
+            'api/createAsyncThunkWithProgress',
             'api/createEntityAdapter',
             'api/combineSlices',
           ],


### PR DESCRIPTION
Closes #5355

## Summary

- Adds `createAsyncThunkWithProgress`, a thin wrapper around `createAsyncThunk` for async operations that can report incremental progress (e.g. file uploads/downloads).
- The payload creator receives a third `onProgress` argument; calling it dispatches a `progress` action attached to the returned thunk (alongside `pending`/`fulfilled`/`rejected`), carrying the usual `requestId`/`arg` metadata.
- The progress event shape is generic (`ProgressEvent` type param, defaults to `unknown`) rather than tied to `axios`, so it works with any progress-reporting API (axios, fetch `ReadableStream`, etc).

## Test plan

- [x] `tsc --noEmit -p tsconfig.build.json` passes
- [x] `vitest run` — new runtime tests in `createAsyncThunkWithProgress.test.ts` pass
- [x] `vitest --typecheck --run` — new type tests in `createAsyncThunkWithProgress.test-d.ts` pass
- [x] Added docs page `docs/api/createAsyncThunkWithProgress.mdx` and sidebar entry
