### PR TITLE
chore(toolkit): remove redundant and unused type declarations

### DIFF
--- a/packages/toolkit/src/createReducer.ts
+++ b/packages/toolkit/src/createReducer.ts
@@ -191,7 +191,7 @@ export function createReducer<S extends NotFunction<any>>(
             if (previousState === null) {
               return previousState
             }
-            throw Error(
+            throw new Error(
               'A case reducer on a non-draftable value must not return undefined',
             )
           }

--- a/packages/toolkit/src/listenerMiddleware/types.ts
+++ b/packages/toolkit/src/listenerMiddleware/types.ts
@@ -37,7 +37,6 @@ export type ListenerPredicate<ActionType extends Action, State> = (
 /** @public */
 export interface ConditionFunction<State> {
   (predicate: AnyListenerPredicate<State>, timeout?: number): Promise<boolean>
-  (predicate: AnyListenerPredicate<State>, timeout?: number): Promise<boolean>
   (predicate: () => boolean, timeout?: number): Promise<boolean>
 }
 
@@ -833,7 +832,7 @@ export type TypedCreateListenerEntry<
       UnknownAction
     >,
     OverrideExtraArgument = unknown,
-  >() => TypedStopListening<
+  >() => TypedCreateListenerEntry<
     OverrideStateType,
     OverrideDispatchType,
     OverrideExtraArgument
@@ -870,7 +869,8 @@ export type FallbackAddListenerOptions = {
   type?: string
   matcher?: MatchFunction<any>
   predicate?: ListenerPredicate<any, any>
-} & { effect: ListenerEffect<any, any, any> }
+  effect: ListenerEffect<any, any, any>
+}
 
 /**
  * Utility Types

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -354,7 +354,7 @@ export type SubscriptionState = {
   [queryCacheKey: string]: Subscribers | undefined
 }
 
-export type ConfigState<ReducerPath> = RefetchConfigOptions & {
+export type ConfigState<ReducerPath> = {
   reducerPath: ReducerPath
   online: boolean
   focused: boolean

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -13,7 +13,6 @@ import type { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs'
 import {
   ENDPOINT_QUERY,
   isQueryDefinition,
-  type EndpointDefinition,
   type EndpointDefinitions,
   type InfiniteQueryArgFrom,
   type InfiniteQueryDefinition,
@@ -96,7 +95,7 @@ export type StartInfiniteQueryActionCreatorOptions<
     >
   >
 
-type AnyQueryActionCreator<D extends EndpointDefinition<any, any, any, any>> = (
+type AnyQueryActionCreator = (
   arg: any,
   options?: StartQueryActionCreatorOptions,
 ) => ThunkAction<AnyActionCreatorResult, any, any, UnknownAction>
@@ -381,7 +380,7 @@ You must add the middleware for RTK-Query to function correctly!`,
       | QueryDefinition<any, any, any, any>
       | InfiniteQueryDefinition<any, any, any, any, any>,
   ) {
-    const queryAction: AnyQueryActionCreator<any> =
+    const queryAction: AnyQueryActionCreator =
       (
         arg,
         {


### PR DESCRIPTION
## Summary

- remove a duplicate overload from **`ConditionFunction`**
- return **`TypedCreateListenerEntry`** instead of **`TypedStopListening`** from **`TypedCreateListenerEntry.withTypes()`**
- fold the trailing **`& { effect }`** intersection into **`FallbackAddListenerOptions`**
- remove the redundant leading **`RefetchConfigOptions &`** from **`ConfigState`**, which **`ModifiableConfigState`** already intersects
- remove the unused generic type parameter from **`AnyQueryActionCreator`**