### PR TITLE
docs(codegen): fix malformed config options block

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -121,24 +121,23 @@ interface SimpleUsage {
     | string
     | RegExp
     | EndpointMatcherFunction
-    | Array<string | RegExp | EndpointMatcherFunction>
+    | Array<string | RegExp>
   endpointOverrides?: EndpointOverrides[]
   flattenArg?: boolean
-}
-
-export type EndpointOverrides = {
-  pattern: EndpointMatcher
-} & AtLeastOneOf<{
-  type: 'mutation' | 'query'
-  parameterFilter: ParameterMatcher
-  providesTags: string[]
-  invalidatesTags: string[]
-}>
   useEnumType?: boolean
   enumStyle?: 'union' | 'enum' | 'as-const'
   outputRegexConstants?: boolean
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions
 }
+
+export type EndpointOverrides = {
+  pattern: EndpointMatcher
+} & AtLeastOneKey<{
+  type: 'mutation' | 'query'
+  parameterFilter: ParameterMatcher
+  providesTags: string[]
+  invalidatesTags: string[]
+}>
 
 export type EndpointMatcherFunction = (
   operationName: string,
@@ -429,3 +428,4 @@ const config: ConfigFile = {
   outputFile: './src/store/petApi.ts',
   exportAllSchemas: true,
 }
+```


### PR DESCRIPTION
The **`SimpleUsage`** interface in the code generation docs is syntactically invalid on the [**published page**](https://redux-toolkit.js.org/rtk-query/usage/code-generation#simple-usage). **`EndpointOverrides`** sits in the middle of it, closing the interface early and stranding four options outside any type, followed by a stray brace.

- Close **`SimpleUsage`** and move **`EndpointOverrides`** out below it
- Return **`useEnumType`**, **`enumStyle`**, **`outputRegexConstants`** and **`httpResolverOptions`** to the interface
- Drop **`EndpointMatcherFunction`** from the **`filterEndpoints`** array member, since **`TextMatcher`** only accepts **`(string | RegExp)[]`**
- Rename **`AtLeastOneOf`** to **`AtLeastOneKey`** to match the helper in **`types.ts`**
- Close the final code block, whose fence was missing

Docs-only, no runtime change. The site builds.

Introduced in: [**#5135**](https://github.com/reduxjs/redux-toolkit/pull/5135), [**#5304**](https://github.com/reduxjs/redux-toolkit/pull/5304)

Closes #5369
Ref #5368
