### PR TITLE
docs(codegen): document the remaining config options

### DIFF
--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -121,24 +121,23 @@ interface SimpleUsage {
     | string
     | RegExp
     | EndpointMatcherFunction
-    | Array<string | RegExp | EndpointMatcherFunction>
+    | Array<string | RegExp>
   endpointOverrides?: EndpointOverrides[]
   flattenArg?: boolean
-}
-
-export type EndpointOverrides = {
-  pattern: EndpointMatcher
-} & AtLeastOneOf<{
-  type: 'mutation' | 'query'
-  parameterFilter: ParameterMatcher
-  providesTags: string[]
-  invalidatesTags: string[]
-}>
   useEnumType?: boolean
   enumStyle?: 'union' | 'enum' | 'as-const'
   outputRegexConstants?: boolean
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions
 }
+
+export type EndpointOverrides = {
+  pattern: EndpointMatcher
+} & AtLeastOneKey<{
+  type: 'mutation' | 'query'
+  parameterFilter: ParameterMatcher
+  providesTags: string[]
+  invalidatesTags: string[]
+}>
 
 export type EndpointMatcherFunction = (
   operationName: string,
@@ -429,3 +428,4 @@ const config: ConfigFile = {
   outputFile: './src/store/petApi.ts',
   exportAllSchemas: true,
 }
+```

--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -62,10 +62,16 @@ and then call the code generator:
 npx @rtk-query/codegen-openapi openapi-config.ts
 ```
 
+:::note
+Relative paths in the config are resolved against the **config file's own directory**, not the directory you run the command from. The CLI changes into that directory before generating, so `openapi-config.ts` produces the same output no matter where it is invoked from.
+
+The config file may be `.js`, `.cjs`, `.mjs`, `.ts`, `.cts`, `.mts`, `.jsx`, `.tsx`, `.json` or `.jsonc`. A TypeScript config requires either `esbuild` + `esbuild-runner` or `typescript` + `ts-node` to be installed.
+:::
+
 #### Generating tags
 
 If your OpenAPI specification uses [tags](https://swagger.io/docs/specification/grouping-operations-with-tags/), you can specify the `tag` option to the codegen.
-That will result in all generated endpoints having `providesTags`/`invalidatesTags` declarations for the `tags` of their respective operation definition.
+That will result in all generated endpoints having `providesTags`/`invalidatesTags` declarations for the `tags` of their respective operation definition - `providesTags` on queries and `invalidatesTags` on mutations.
 
 Note that this will only result in string tags with no ids, so it might lead to scenarios where too much is invalidated and unnecessary requests are made on mutation.
 
@@ -110,25 +116,57 @@ interface SimpleUsage {
   exportName?: string
   argSuffix?: string
   operationNameSuffix?: string
-  operationIdTransformer?: 'camelCase' | 'none' | ((operationId: string) => string)
+  operationIdTransformer?: OperationIdTransformer
   responseSuffix?: string
   hooks?:
     | boolean
     | { queries: boolean; lazyQueries: boolean; mutations: boolean }
   tag?: boolean
   outputFile: string
-  filterEndpoints?:
-    | string
-    | RegExp
-    | EndpointMatcherFunction
-    | Array<string | RegExp>
+  filterEndpoints?: EndpointMatcher
   endpointOverrides?: EndpointOverrides[]
   flattenArg?: boolean
+  unionUndefined?: boolean
+  encodePathParams?: boolean
+  encodeQueryParams?: boolean
+  includeDefault?: boolean
+  mergeReadWriteOnly?: boolean
+  useUnknown?: boolean
+  esmExtensions?: boolean
+  exportAllSchemas?: boolean
+  prettierConfigFile?: string
   useEnumType?: boolean
-  enumStyle?: 'union' | 'enum' | 'as-const'
+  enumStyle?: EnumStyle
   outputRegexConstants?: boolean
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions
 }
+```
+
+The supporting types referenced above:
+
+```ts no-transpile
+export type OperationIdTransformer =
+  | 'camelCase'
+  | 'none'
+  | ((operationId: string) => string)
+
+export type EnumStyle = 'union' | 'enum' | 'as-const'
+
+export type TextMatcher = string | RegExp | (string | RegExp)[]
+
+export type EndpointMatcherFunction = (
+  operationName: string,
+  operationDefinition: OperationDefinition,
+) => boolean
+
+export type EndpointMatcher = TextMatcher | EndpointMatcherFunction
+
+export type ParameterMatcherFunction = (
+  parameterName: string,
+  parameterDefinition: ParameterDefinition,
+) => boolean
+
+export type ParameterMatcher = TextMatcher | ParameterMatcherFunction
 
 export type EndpointOverrides = {
   pattern: EndpointMatcher
@@ -138,12 +176,9 @@ export type EndpointOverrides = {
   providesTags: string[]
   invalidatesTags: string[]
 }>
-
-export type EndpointMatcherFunction = (
-  operationName: string,
-  operationDefinition: OperationDefinition,
-) => boolean
 ```
+
+To generate more than one file from a single schema, replace `outputFile` with [`outputFiles`](#multiple-output-files).
 
 #### Filtering endpoints
 
@@ -161,7 +196,7 @@ const filteredConfig: ConfigFile = {
 
 #### Customizing endpoint name generation
 
-By default, each operation's `operationId` is converted to camelCase using lodash `camelCase` (via `oazapfts`). This means consecutive uppercase letters are lowercased — for example, `fetchMyJWTPlease` becomes `fetchMyJwtPlease`.
+By default, each operation's `operationId` is converted to camelCase using lodash `camelCase` (via `oazapfts`). This means consecutive uppercase letters are lowercased - for example, `fetchMyJWTPlease` becomes `fetchMyJwtPlease`.
 
 Use the `operationIdTransformer` option to control this behavior:
 
@@ -402,19 +437,19 @@ By default, the only schemas that are exported are those that are referenced in 
 
 ```ts no-transpile title="user.controller.ts"
 class User {
-  id: string;
-  name: string;
+  id: string
+  name: string
 }
 
 class LogoutMessage {
-  reason: string;
+  reason: string
 }
 
 @ApiExtraModels(LogoutMessage)
 @Controller('user')
 class UserController {
   getUsers(): User[] {
-    return this.getUsers();
+    return this.getUsers()
   }
 }
 ```

--- a/docs/rtk-query/usage/code-generation.mdx
+++ b/docs/rtk-query/usage/code-generation.mdx
@@ -196,6 +196,10 @@ const filteredConfig: ConfigFile = {
 
 #### Customizing endpoint name generation
 
+:::info
+`operationIdTransformer` requires `@rtk-query/codegen-openapi` 2.3.0 or later.
+:::
+
 By default, each operation's `operationId` is converted to camelCase using lodash `camelCase` (via `oazapfts`). This means consecutive uppercase letters are lowercased - for example, `fetchMyJWTPlease` becomes `fetchMyJwtPlease`.
 
 Use the `operationIdTransformer` option to control this behavior:
@@ -333,6 +337,10 @@ Setting `hooks: true` will generate `useQuery` and `useMutation` hook exports. I
 
 #### Controlling enum generation
 
+:::info
+`enumStyle` requires `@rtk-query/codegen-openapi` 2.3.0 or later. `useEnumType` is available in earlier versions.
+:::
+
 By default, OpenAPI `enum` definitions are generated as unions of string literals. Use the `enumStyle` option to control this behavior:
 
 - **`"union"`** _(default)_ - a union of string literals: `type Status = 'available' | 'pending'`
@@ -432,6 +440,10 @@ const config: ConfigFile = {
 ```
 
 #### Additional Schemas
+
+:::info
+`exportAllSchemas` requires `@rtk-query/codegen-openapi` 2.3.0 or later.
+:::
 
 By default, the only schemas that are exported are those that are referenced in endpoint definitions. Take the following NestJS example:
 


### PR DESCRIPTION
Builds on [**#5366**](https://github.com/reduxjs/redux-toolkit/pull/5366) — that commit is included here and the diff will shrink once it merges. Review the second commit only.

Ten options accepted by **`CommonOptions`** were missing from the config options table, including **`exportAllSchemas`**, which already has a section of its own further down the page.

- Add **`unionUndefined`**, **`encodePathParams`**, **`encodeQueryParams`**, **`includeDefault`**, **`mergeReadWriteOnly`**, **`useUnknown`**, **`esmExtensions`**, **`exportAllSchemas`** and **`prettierConfigFile`**
- Spell out the supporting types, so **`filterEndpoints`** and **`endpointOverrides`** resolve to something the page defines
- Note that the CLI resolves relative config paths against the config file's own directory, and which config extensions it accepts
- Say which of **`providesTags`**/**`invalidatesTags`** the **`tag`** option emits for a query and for a mutation
- Point **`outputFile`** at **`outputFiles`** for the multi-file case
- Format the NestJS example to match the repo [**Prettier**](https://prettier.io) config

The option list now matches **`CommonOptions`** and **`OutputFileOptions`** exactly — checked by pulling the properties out of **`types.ts`** with the [**TypeScript**](https://www.typescriptlang.org) compiler and diffing them against the table, rather than by eye.

The path behaviour is the one covered by the **`paths are relative to config file, not to cwd`** test in **`cli.test.ts`**, which came from [**`process.chdir`**](https://nodejs.org/api/process.html#processchdirdirectory) in the CLI entry point and was not documented anywhere.

Docs-only, no runtime change. The site builds and the file is Prettier-clean.

One thing left out deliberately: **`operationIdTransformer`**, **`enumStyle`** and **`exportAllSchemas`** are documented but are not in any published release — the newest tag is [**`@rtk-query/codegen-openapi@2.2.0`**](https://www.npmjs.com/package/@rtk-query/codegen-openapi/v/2.2.0) and the source marks them [**`@since 2.3.0`**](https://jsdoc.app/tags-since.html). Happy to add "requires 2.3.0" callouts if you want them, but I did not want to guess the next version number.

Closes #5370
Ref #5368
