### PR TITLE
docs(codegen): JSDoc pass over the rest of `src/`

### DIFF
--- a/packages/rtk-query-codegen-openapi/src/bin/cli.ts
+++ b/packages/rtk-query-codegen-openapi/src/bin/cli.ts
@@ -5,8 +5,20 @@ import program from 'commander';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 
+/**
+ * A CommonJS `require` bound to this file, used to resolve optional
+ * TypeScript runtimes and the config file itself.
+ *
+ * @internal
+ */
 const require = createRequire(__filename);
 
+/**
+ * Whether a runtime capable of loading a TypeScript config file was
+ * successfully registered.
+ *
+ * @internal
+ */
 let ts = false;
 try {
   if (require.resolve('esbuild') && require.resolve('esbuild-runner')) {
@@ -32,10 +44,21 @@ try {
 } catch {}
 
 // tslint:disable-next-line
+/**
+ * This package's `package.json`, read for the version reported by
+ * `--version`.
+ *
+ * @internal
+ */
 const meta = require('../../package.json');
 
 program.version(meta.version).usage('</path/to/config.js>').parse(process.argv);
 
+/**
+ * The config file path given on the command line.
+ *
+ * @internal
+ */
 const configFile = program.args[0];
 
 if (program.args.length === 0 || !/\.([mc]?(jsx?|tsx?)|jsonc?)?$/.test(configFile)) {
@@ -48,6 +71,18 @@ if (program.args.length === 0 || !/\.([mc]?(jsx?|tsx?)|jsonc?)?$/.test(configFil
   run(resolve(process.cwd(), configFile));
 }
 
+/**
+ * Loads a config file and generates every output file it declares.
+ *
+ * Changes the working directory to the config file's own directory first,
+ * so relative paths in the config resolve against it rather than against
+ * the directory the command was run from.
+ *
+ * @param configFile - The absolute path of the config file to run.
+ * @returns A {@linkcode Promise | promise} resolving once every output file has been generated.
+ *
+ * @internal
+ */
 async function run(configFile: string) {
   process.chdir(dirname(configFile));
 

--- a/packages/rtk-query-codegen-openapi/src/codegen.ts
+++ b/packages/rtk-query-codegen-openapi/src/codegen.ts
@@ -1,15 +1,62 @@
 import { factory } from './utils/factory';
 import ts from 'typescript';
 
+/**
+ * The identifier used for the endpoint builder argument when no other one
+ * is supplied, i.e. the `build` in `endpoints: (build) => ({ ... })`.
+ *
+ * @internal
+ */
 const defaultEndpointBuilder = factory.createIdentifier('build');
 
+/**
+ * A set of object properties to generate, keyed by property name.
+ * Properties whose value is `undefined` are skipped, which lets callers
+ * pass optional properties without filtering them first.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type ObjectPropertyDefinitions = Record<string, ts.Expression | undefined>;
+
+/**
+ * Turns a set of property definitions into property assignment nodes,
+ * dropping every entry with an `undefined` value.
+ *
+ * @param obj - The properties to generate.
+ * @returns The property assignment nodes for the defined entries.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function generateObjectProperties(obj: ObjectPropertyDefinitions) {
   return Object.entries(obj)
     .filter(([_, v]) => v)
     .map(([k, v]) => factory.createPropertyAssignment(factory.createIdentifier(k), v as ts.Expression));
 }
 
+/**
+ * Generates an import declaration for `pkg`.
+ *
+ * Each entry of {@linkcode namedImports} maps the exported name to the
+ * local name it is bound to; an alias is only emitted when the two differ.
+ *
+ * @example
+ * <caption>Aliasing an export while importing it</caption>
+ *
+ * ```ts
+ * generateImportNode('./api', { myApi: 'api' });
+ * // import { myApi as api } from './api';
+ * ```
+ *
+ * @param pkg - The module specifier to import from.
+ * @param namedImports - A mapping of exported name to local name.
+ * @param [defaultImportName] - The local name to bind the default export to, if any.
+ * @returns The import declaration node.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function generateImportNode(pkg: string, namedImports: Record<string, string>, defaultImportName?: string) {
   return factory.createImportDeclaration(
     undefined,
@@ -29,13 +76,41 @@ export function generateImportNode(pkg: string, namedImports: Record<string, str
   );
 }
 
+/**
+ * Generates the `const injectedRtkApi = ...` statement that injects the
+ * generated endpoints into the imported base api.
+ *
+ * When {@linkcode tag} is `true` the injection is chained onto an
+ * `enhanceEndpoints({ addTagTypes })` call so the generated tag types are
+ * registered first.
+ *
+ * @param params - The endpoint definitions to inject, plus the builder identifier and tag flag.
+ * @returns The variable statement declaring the injected api.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function generateCreateApiCall({
   endpointBuilder = defaultEndpointBuilder,
   endpointDefinitions,
   tag,
 }: {
+  /**
+   * The identifier bound as the endpoint builder argument.
+   *
+   * @default build
+   */
   endpointBuilder?: ts.Identifier;
+
+  /**
+   * The object literal of endpoint definitions to inject.
+   */
   endpointDefinitions: ts.ObjectLiteralExpression;
+
+  /**
+   * Whether to chain the injection onto an `enhanceEndpoints` call that
+   * registers the generated tag types.
+   */
   tag: boolean;
 }) {
   const injectEndpointsObjectLiteralExpression = factory.createObjectLiteralExpression(
@@ -110,6 +185,23 @@ export function generateCreateApiCall({
   );
 }
 
+/**
+ * Generates a single endpoint definition, i.e. one
+ * `name: build.query<Response, QueryArg>({ ... })` property.
+ *
+ * {@linkcode tags} are only emitted for the side that matches
+ * {@linkcode type} - `providesTags` for a query, `invalidatesTags` for a
+ * mutation - unless {@linkcode tagOverrides} supplies that key, in which
+ * case the override wins for both kinds of endpoint. An override present
+ * but set to an empty array therefore emits an empty array rather than
+ * falling back to {@linkcode tags}.
+ *
+ * @param params - The endpoint name, kind, types, query function, and tag configuration.
+ * @returns The property assignment defining the endpoint.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function generateEndpointDefinition({
   operationName,
   type,
@@ -121,14 +213,53 @@ export function generateEndpointDefinition({
   tags,
   tagOverrides,
 }: {
+  /**
+   * The name of the generated endpoint.
+   */
   operationName: string;
+
+  /**
+   * Whether the endpoint is a query or a mutation.
+   */
   type: 'query' | 'mutation';
+
+  /**
+   * A reference to the generated response type.
+   */
   Response: ts.TypeReferenceNode;
+
+  /**
+   * A reference to the generated query argument type.
+   */
   QueryArg: ts.TypeReferenceNode;
+
+  /**
+   * The arrow function building the request for this endpoint.
+   */
   queryFn: ts.Expression;
+
+  /**
+   * The identifier bound as the endpoint builder argument.
+   *
+   * @default build
+   */
   endpointBuilder?: ts.Identifier;
+
+  /**
+   * Extra properties to add to the endpoint definition object.
+   */
   extraEndpointsProps: ObjectPropertyDefinitions;
+
+  /**
+   * The tags read off the operation, applied according to
+   * {@linkcode type}.
+   */
   tags?: string[];
+
+  /**
+   * Explicit tag declarations that take precedence over
+   * {@linkcode tags}.
+   */
   tagOverrides?: { providesTags?: string[]; invalidatesTags?: string[] };
 }) {
   const objectProperties = generateObjectProperties({ query: queryFn, ...extraEndpointsProps });
@@ -173,7 +304,31 @@ export function generateEndpointDefinition({
   );
 }
 
-export function generateTagTypes({ addTagTypes }: { addTagTypes: string[] }) {
+/**
+ * Generates the exported `addTagTypes` constant holding every tag type
+ * found across the operations.
+ *
+ * @example
+ * <caption>The generated statement</caption>
+ *
+ * ```ts
+ * export const addTagTypes = ['Pet', 'Store'] as const;
+ * ```
+ *
+ * @param params - The tag types to declare.
+ * @returns The variable statement declaring the tag types.
+ *
+ * @since 1.0.0
+ * @public
+ */
+export function generateTagTypes({
+  addTagTypes,
+}: {
+  /**
+   * Every tag type to declare.
+   */
+  addTagTypes: string[];
+}) {
   return factory.createVariableStatement(
     [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     factory.createVariableDeclarationList(

--- a/packages/rtk-query-codegen-openapi/src/generate.ts
+++ b/packages/rtk-query-codegen-openapi/src/generate.ts
@@ -32,9 +32,34 @@ import { capitalize, getOperationDefinitions, getV3Doc, removeUndefined, isQuery
 
 const { createPropertyAssignment, createQuestionToken, keywordType, isValidIdentifier } = cg;
 
+/**
+ * The identifier of the internal const the endpoints are injected into.
+ * It is re-exported under the user-facing `exportName`.
+ *
+ * @internal
+ */
 const generatedApiName = 'injectedRtkApi';
+
+/**
+ * Resolved OpenAPI documents, keyed by the spec path or URL they were
+ * loaded from, so generating several output files from one spec only
+ * fetches and dereferences it once.
+ *
+ * @internal
+ */
 const v3DocCache: Record<string, OpenAPIV3.Document> = {};
 
+/**
+ * Merges bracketed parameters such as `filter[name]` and `filter[age]`
+ * into a single `deepObject` parameter whose schema carries one property
+ * per bracketed key. Parameters without brackets are passed through
+ * untouched.
+ *
+ * @param params - The parameters to merge.
+ * @returns The parameters, with bracketed ones merged into `deepObject` parameters.
+ *
+ * @internal
+ */
 function supportDeepObjects(params: OpenAPIV3.ParameterObject[]): OpenAPIV3.ParameterObject[] {
   const res: OpenAPIV3.ParameterObject[] = [];
   const merged: Record<string, any> = {};
@@ -63,6 +88,18 @@ function supportDeepObjects(params: OpenAPIV3.ParameterObject[]): OpenAPIV3.Para
   return res;
 }
 
+/**
+ * The default {@linkcode GenerationOptions.isDataResponse | isDataResponse}
+ * check: a response counts as data when its status code is in the `2xx`
+ * range, or when it is the `default` response and
+ * {@linkcode includeDefault} is `true`.
+ *
+ * @param code - The HTTP status code as a string.
+ * @param includeDefault - Whether the `default` response counts as a data response.
+ * @returns `true` if the response is a data response, `false` otherwise.
+ *
+ * @internal
+ */
 function defaultIsDataResponse(code: string, includeDefault: boolean) {
   if (includeDefault && code === 'default') {
     return true;
@@ -75,22 +112,17 @@ function defaultIsDataResponse(code: string, includeDefault: boolean) {
  * Resolves the generated endpoint name for an operation by applying the
  * configured {@linkcode OperationIdTransformer}.
  *
- * - `"camelCase"` *(default)* - delegates to `oazapfts`
- *   {@linkcode getOperationName | getOperationName()}, which applies lodash
- *   {@linkcode camelCase | camelCase()} and falls back to a verb+path derived
- *   name when {@linkcode operation.operationId} is absent.
- * - `"none"` - returns {@linkcode operation.operationId} verbatim.
- * - `(operationId: string) => string` - calls the provided function with
- *   {@linkcode operation.operationId}.
+ * - `"camelCase"` *(default)* - delegates to `oazapfts` {@linkcode getOperationName()}, which applies lodash {@linkcode camelCase()} and falls back to a verb+path derived name when `operationId` is absent.
+ * - `"none"` - returns `operationId` verbatim.
+ * - `(operationId: string) => string` - calls the provided function with `operationId`.
  *
- * For `"none"` and function transformers, a missing
- * {@linkcode operation.operationId} throws an {@linkcode Error} with the
- * offending HTTP method and path in the message.
+ * For `"none"` and function transformers, a missing `operationId` throws an
+ * {@linkcode Error} with the offending HTTP method and path in the message.
  *
  * @param operationDefinition - The operation to resolve a name for.
- * @param [operationIdTransformer] - How to transform the {@linkcode operation.operationId | operationId}.
+ * @param [operationIdTransformer="camelCase"] - How to transform the `operationId`.
  * @returns The resolved endpoint name string.
- * @throws An {@linkcode Error} when {@linkcode operation.operationId | operationId} is `undefined` and transformer is not `"camelCase"`.
+ * @throws An {@linkcode Error} when `operationId` is `undefined` and the transformer is not `"camelCase"`.
  *
  * @since 2.3.0
  * @public
@@ -118,10 +150,32 @@ export function resolveOperationName(
   return operationIdTransformer(operation.operationId);
 }
 
+/**
+ * Reads the OpenAPI `tags` declared on one operation of a path item.
+ *
+ * @param operationDefinition - The verb and path item to read tags from.
+ * @returns The tags declared on the operation, or an empty array if it declares none.
+ *
+ * @internal
+ */
 function getTags({ verb, pathItem }: Pick<OperationDefinition, 'verb' | 'pathItem'>): string[] {
   return verb ? pathItem[verb]?.tags || [] : [];
 }
 
+/**
+ * Builds a predicate that tests a name against a
+ * {@linkcode TextMatcher}. A `string` entry must match exactly, a
+ * {@linkcode RegExp} entry must test true, and an array matches if any of
+ * its entries does.
+ *
+ * An `undefined` pattern matches everything, so an absent filter is a
+ * no-op rather than a reject-all.
+ *
+ * @param [pattern] - The pattern to match against, or `undefined` to match everything.
+ * @returns A predicate taking the name to test.
+ *
+ * @internal
+ */
 function patternMatches(pattern?: TextMatcher) {
   const filters = Array.isArray(pattern) ? pattern : [pattern];
   return function matcher(operationName: string) {
@@ -132,6 +186,20 @@ function patternMatches(pattern?: TextMatcher) {
   };
 }
 
+/**
+ * Builds a predicate that tests an operation against an
+ * {@linkcode EndpointMatcher}, resolving the operation's generated name
+ * first so the pattern is matched against the same name the endpoint will
+ * be given.
+ *
+ * An `undefined` pattern matches every operation.
+ *
+ * @param [pattern] - The matcher to test against, or `undefined` to match everything.
+ * @param [operationIdTransformer="camelCase"] - How to resolve each operation's name before matching.
+ * @returns A predicate taking the {@linkcode OperationDefinition} to test.
+ *
+ * @internal
+ */
 function operationMatches(pattern?: EndpointMatcher, operationIdTransformer: OperationIdTransformer = 'camelCase') {
   const checkMatch = typeof pattern === 'function' ? pattern : patternMatches(pattern);
   return function matcher(operationDefinition: OperationDefinition) {
@@ -141,6 +209,18 @@ function operationMatches(pattern?: EndpointMatcher, operationIdTransformer: Ope
   };
 }
 
+/**
+ * Builds a predicate that tests a parameter against a
+ * {@linkcode ParameterMatcher}.
+ *
+ * Path parameters always match regardless of the pattern, since removing
+ * one would leave a hole in the generated url.
+ *
+ * @param [pattern] - The matcher to test against, or `undefined` to match everything.
+ * @returns A predicate taking the {@linkcode ParameterDefinition} to test.
+ *
+ * @internal
+ */
 function argumentMatches(pattern?: ParameterMatcher) {
   const checkMatch = typeof pattern === 'function' ? pattern : patternMatches(pattern);
   return function matcher(argumentDefinition: ParameterDefinition) {
@@ -150,6 +230,19 @@ function argumentMatches(pattern?: ParameterMatcher) {
   };
 }
 
+/**
+ * Attaches the OpenAPI description of a query argument to a node as a
+ * leading JSDoc comment, so the generated types carry the spec's own
+ * documentation. Returns the node unchanged when there is no description.
+ *
+ * @template T - The type of node being annotated.
+ * @param node - The node to attach the comment to.
+ * @param def - The query argument whose description is used.
+ * @param hasTrailingNewLine - Whether to emit a newline after the comment.
+ * @returns The node, with the comment attached when one was available.
+ *
+ * @internal
+ */
 function withQueryComment<T extends ts.Node>(node: T, def: QueryArgDefinition, hasTrailingNewLine: boolean): T {
   const comment = def.origin === 'param' ? def.param.description : def.body.description;
   if (comment) {
@@ -163,6 +256,16 @@ function withQueryComment<T extends ts.Node>(node: T, def: QueryArgDefinition, h
   return node;
 }
 
+/**
+ * Reads the non-empty `pattern` keyword off a string schema property,
+ * resolving the property first if it is a reference.
+ *
+ * @param property - The schema property to read the pattern from.
+ * @param ctx - The `oazapfts` context used to resolve references.
+ * @returns The pattern, or `null` if the property is not a string schema or declares no non-empty pattern.
+ *
+ * @internal
+ */
 function getPatternFromProperty(
   property: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
   ctx: OazapftsContext
@@ -174,6 +277,26 @@ function getPatternFromProperty(
   return typeof pattern === 'string' && pattern.length > 0 ? pattern : null;
 }
 
+/**
+ * Generates one exported regex constant per string property of a schema
+ * that declares a `pattern`, named `<typeName><PropertyName>Pattern` in
+ * camelCase. Forward slashes in the pattern are escaped so the emitted
+ * regex literal stays valid.
+ *
+ * @example
+ * <caption>The generated constant</caption>
+ *
+ * ```ts
+ * export const petNamePattern = /^[a-z]+$/;
+ * ```
+ *
+ * @param typeName - The name of the type the schema describes.
+ * @param schema - The schema whose properties are scanned for patterns.
+ * @param ctx - The `oazapfts` context used to resolve references.
+ * @returns One variable statement per property declaring a pattern, or an empty array if there are none.
+ *
+ * @internal
+ */
 function generateRegexConstantsForType(
   typeName: string,
   schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
@@ -213,6 +336,19 @@ function generateRegexConstantsForType(
   return constants;
 }
 
+/**
+ * Finds the first {@linkcode EndpointOverrides} whose
+ * {@linkcode EndpointOverrides.pattern | pattern} matches an operation.
+ * Only the first match applies, so earlier entries win over later ones.
+ *
+ * @param operation - The operation to find an override for.
+ * @param [endpointOverrides] - The overrides to search.
+ * @param [operationIdTransformer="camelCase"] - How to resolve the operation's name before matching.
+ * @returns The matching override, or `undefined` if none matches.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function getOverrides(
   operation: OperationDefinition,
   endpointOverrides?: EndpointOverrides[],
@@ -221,6 +357,20 @@ export function getOverrides(
   return endpointOverrides?.find((override) => operationMatches(override.pattern, operationIdTransformer)(operation));
 }
 
+/**
+ * Generates the source code of an RTK Query api from an OpenAPI schema.
+ *
+ * The returned code is printed but not formatted - callers are expected to
+ * run it through Prettier.
+ *
+ * @param spec - The path or URL of the OpenAPI schema to generate from.
+ * @param options - The generation options.
+ * @returns A {@linkcode Promise | promise} resolving to the generated source code.
+ * @throws An {@linkcode Error} if the schema cannot be loaded, if two generated types collide on a name, or if a path references a parameter it does not declare.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export async function generateApi(
   spec: string,
   {
@@ -276,7 +426,23 @@ export async function generateApi(
   );
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
+  /**
+   * The response and argument types generated so far, keyed by name.
+   *
+   * @internal
+   */
   const interfaces: Record<string, ts.InterfaceDeclaration | ts.TypeAliasDeclaration> = {};
+
+  /**
+   * Records a generated type so it can be emitted with the rest, rejecting
+   * duplicate names rather than silently overwriting the first one.
+   *
+   * @param declaration - The type to register.
+   * @returns The declaration that was passed in, so the call can be inlined.
+   * @throws An {@linkcode Error} if a type of the same name is already registered.
+   *
+   * @internal
+   */
   function registerInterface(declaration: ts.InterfaceDeclaration | ts.TypeAliasDeclaration) {
     const name = declaration.name.escapedText.toString();
     if (name in interfaces) {
@@ -369,6 +535,15 @@ export async function generateApi(
     resultFile
   );
 
+  /**
+   * Collects the distinct tags declared across every operation, preserving
+   * the order in which they are first seen.
+   *
+   * @param params - The operations to collect tags from.
+   * @returns Every distinct tag declared across the operations.
+   *
+   * @internal
+   */
   function extractAllTagTypes({ operationDefinitions }: { operationDefinitions: OperationDefinition[] }) {
     const allTagTypes = new Set<string>();
 
@@ -381,11 +556,27 @@ export async function generateApi(
     return [...allTagTypes];
   }
 
+  /**
+   * Generates one endpoint definition, registering its response and
+   * argument types along the way.
+   *
+   * @param params - The operation to generate, plus the override matching it.
+   * @returns The property assignment defining the endpoint.
+   *
+   * @internal
+   */
   function generateEndpoint({
     operationDefinition,
     overrides,
   }: {
+    /**
+     * The operation to generate an endpoint for.
+     */
     operationDefinition: OperationDefinition;
+
+    /**
+     * The override matching the operation, if any.
+     */
     overrides?: EndpointOverrides;
   }) {
     const {
@@ -449,6 +640,21 @@ export async function generateApi(
 
     const allNames = parameters.map((p) => p.name);
     const queryArg: QueryArgDefinitions = {};
+
+    /**
+     * Derives a collision-free property name for a query argument.
+     *
+     * Names are disambiguated in three steps: a name shared by several
+     * parameters is prefixed with where it came from, a pure snake_case
+     * name is camelCased unless that would collide, and anything still
+     * taken is prefixed with underscores until it is free.
+     *
+     * @param name - The parameter's name as written in the schema.
+     * @param potentialPrefix - Where the parameter came from, used as the prefix on a conflict.
+     * @returns A name not yet used by another query argument.
+     *
+     * @internal
+     */
     function generateName(name: string, potentialPrefix: string) {
       const isPureSnakeCase = /^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
       // prefix with `query`, `path` or `body` if there are multiple parameters with the same name
@@ -503,6 +709,15 @@ export async function generateApi(
       };
     }
 
+    /**
+     * Renders a query argument name as a property name, quoting it when it
+     * is not a valid identifier.
+     *
+     * @param name - The name to render.
+     * @returns The property name node.
+     *
+     * @internal
+     */
     const propertyName = (name: string | ts.PropertyName): ts.PropertyName => {
       if (typeof name === 'string') {
         return isValidIdentifier(name) ? factory.createIdentifier(name) : factory.createStringLiteral(name);
@@ -579,6 +794,19 @@ export async function generateApi(
     });
   }
 
+  /**
+   * Generates the arrow function that builds the request for an endpoint,
+   * i.e. the `query` property of an endpoint definition.
+   *
+   * The `method` property is omitted for `GET` queries, since that is RTK
+   * Query's default, and the whole argument is omitted when the operation
+   * takes no arguments at all.
+   *
+   * @param params - The operation, its query arguments, and the encoding flags.
+   * @returns The arrow function building the request.
+   *
+   * @internal
+   */
   function generateQueryFn({
     operationDefinition,
     queryArg,
@@ -587,11 +815,35 @@ export async function generateApi(
     encodePathParams,
     encodeQueryParams,
   }: {
+    /**
+     * The operation to build the request for.
+     */
     operationDefinition: OperationDefinition;
+
+    /**
+     * The resolved query arguments, keyed by their generated name.
+     */
     queryArg: QueryArgDefinitions;
+
+    /**
+     * Whether the single query argument is passed directly rather than
+     * wrapped in an object.
+     */
     isFlatArg: boolean;
+
+    /**
+     * Whether the endpoint is a query rather than a mutation.
+     */
     isQuery: boolean;
+
+    /**
+     * Whether to wrap path parameters in `encodeURIComponent`.
+     */
     encodePathParams: boolean;
+
+    /**
+     * Whether to wrap query parameters in `encodeURIComponent`.
+     */
     encodeQueryParams: boolean;
   }) {
     const { path, verb } = operationDefinition;
@@ -600,10 +852,30 @@ export async function generateApi(
 
     const rootObject = factory.createIdentifier('queryArg');
 
+    /**
+     * Selects the query arguments that came from parameters in a given
+     * location.
+     *
+     * @param paramIn - The OpenAPI parameter location to select, e.g. `query` or `header`.
+     * @returns The query arguments declared in that location.
+     *
+     * @internal
+     */
     function pickParams(paramIn: string) {
       return Object.values(queryArg).filter((def) => def.origin === 'param' && def.param.in === paramIn);
     }
 
+    /**
+     * Builds one property of the request object - `params`, `headers` or
+     * `cookies` - from a group of parameters, keyed by each parameter's
+     * original schema name rather than its generated one.
+     *
+     * @param parameters - The parameters to include.
+     * @param propertyName - The name of the request property to build.
+     * @returns The property assignment, or `undefined` if there are no parameters to include.
+     *
+     * @internal
+     */
     function createObjectLiteralProperty(parameters: QueryArgDefinition[], propertyName: string) {
       if (parameters.length === 0) return undefined;
 
@@ -671,6 +943,17 @@ export async function generateApi(
     );
   }
 
+  /**
+   * Generates a type for every schema in the document that was not
+   * already emitted while generating the endpoints, so schemas no endpoint
+   * references are still exported.
+   *
+   * @param schemas - Every schema declared in the document.
+   * @param ctx - The `oazapfts` context holding the types generated so far.
+   * @returns One type alias per schema not already generated.
+   *
+   * @internal
+   */
   function generateAllSchemaTypes(
     schemas: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject>,
     ctx: OazapftsContext
@@ -696,23 +979,68 @@ export async function generateApi(
     return types;
   }
 
+  /**
+   * Generates the extra endpoint definition properties specific to
+   * queries. Currently a placeholder that adds nothing.
+   *
+   * @param params - The operation the properties would be generated for.
+   * @returns The extra properties to add to the endpoint definition.
+   *
+   * @internal
+   */
   // eslint-disable-next-line no-empty-pattern
   function generateQueryEndpointProps({}: { operationDefinition: OperationDefinition }): ObjectPropertyDefinitions {
     return {}; /* TODO needs implementation - skip for now */
   }
 
+  /**
+   * Generates the extra endpoint definition properties specific to
+   * mutations. Currently a placeholder that adds nothing.
+   *
+   * @param params - The operation the properties would be generated for.
+   * @returns The extra properties to add to the endpoint definition.
+   *
+   * @internal
+   */
   // eslint-disable-next-line no-empty-pattern
   function generateMutationEndpointProps({}: { operationDefinition: OperationDefinition }): ObjectPropertyDefinitions {
     return {}; /* TODO needs implementation - skip for now */
   }
 }
 
+/**
+ * Accesses a property of an object, falling back to bracket notation when
+ * the name is not a valid identifier.
+ *
+ * @param rootObject - The object to read the property from.
+ * @param propertyName - The name of the property to access.
+ * @returns The property access expression.
+ *
+ * @internal
+ */
 function accessProperty(rootObject: ts.Identifier, propertyName: string) {
   return isValidIdentifier(propertyName)
     ? factory.createPropertyAccessExpression(rootObject, factory.createIdentifier(propertyName))
     : factory.createElementAccessExpression(rootObject, factory.createStringLiteral(propertyName));
 }
 
+/**
+ * Turns an OpenAPI path into the expression that builds the request url,
+ * substituting each `{placeholder}` for the query argument it names.
+ *
+ * A path with no placeholders yields a plain template literal rather than
+ * one with substitutions.
+ *
+ * @param path - The OpenAPI path, e.g. `/pet/{petId}`.
+ * @param pathParameters - The query arguments the placeholders may refer to.
+ * @param rootObject - The identifier the arguments are read from.
+ * @param isFlatArg - Whether the single query argument is passed directly rather than wrapped in an object.
+ * @param encodePathParams - Whether to wrap each substitution in `encodeURIComponent`.
+ * @returns The template expression building the url.
+ * @throws An {@linkcode Error} if the path references a placeholder that is not among {@linkcode pathParameters}.
+ *
+ * @internal
+ */
 function generatePathExpression(
   path: string,
   pathParameters: QueryArgDefinition[],
@@ -752,20 +1080,69 @@ function generatePathExpression(
     : factory.createNoSubstitutionTemplateLiteral(head);
 }
 
+/**
+ * One argument of a generated endpoint, resolved from either an operation
+ * parameter or the request body. The union on
+ * {@linkcode QueryArgDefinition.origin | origin} discriminates the two,
+ * so the source object is only reachable once the origin is known.
+ *
+ * @internal
+ */
 type QueryArgDefinition = {
+  /**
+   * The collision-free name of the generated property.
+   */
   name: string;
+
+  /**
+   * The name as written in the schema, used as the key when the argument
+   * is sent on the request.
+   */
   originalName: string;
+
+  /**
+   * The generated type of the argument.
+   */
   type: ts.TypeNode;
+
+  /**
+   * Whether the argument must be supplied.
+   */
   required?: boolean;
+
+  /**
+   * The parameter the argument came from, present only when
+   * {@linkcode QueryArgDefinition.origin | origin} is `param`.
+   */
   param?: OpenAPIV3.ParameterObject;
 } & (
   | {
+      /**
+       * Marks the argument as coming from an operation parameter.
+       */
       origin: 'param';
+
+      /**
+       * The parameter the argument came from.
+       */
       param: OpenAPIV3.ParameterObject;
     }
   | {
+      /**
+       * Marks the argument as coming from the request body.
+       */
       origin: 'body';
+
+      /**
+       * The request body the argument came from.
+       */
       body: OpenAPIV3.RequestBodyObject;
     }
 );
+
+/**
+ * The arguments of one generated endpoint, keyed by their generated name.
+ *
+ * @internal
+ */
 type QueryArgDefinitions = Record<string, QueryArgDefinition>;

--- a/packages/rtk-query-codegen-openapi/src/generators/react-hooks.ts
+++ b/packages/rtk-query-codegen-openapi/src/generators/react-hooks.ts
@@ -1,27 +1,79 @@
 import ts from 'typescript';
 import { getOverrides, resolveOperationName } from '../generate';
-import type { ConfigFile, EndpointOverrides, OperationDefinition, OperationIdTransformer } from '../types';
+import type { CommonOptions, EndpointOverrides, OperationDefinition, OutputFileOptions } from '../types';
 import { capitalize, isQuery } from '../utils';
 import { factory } from '../utils/factory';
 
-type HooksConfigOptions = NonNullable<ConfigFile['hooks']>;
+/**
+ * The resolved value of the {@linkcode CommonOptions.hooks | hooks} option,
+ * with `undefined` excluded. Either a `boolean` shorthand or an object
+ * selecting which kinds of hooks to generate.
+ *
+ * @internal
+ */
+type HooksConfigOptions = NonNullable<CommonOptions['hooks']>;
 
-type GetReactHookNameParams = {
+/**
+ * The inputs every hook-name builder in this file needs: the operation
+ * being named, plus the naming options taken straight from
+ * {@linkcode CommonOptions} so they are documented in exactly one place.
+ *
+ * @internal
+ */
+type HookNameBaseParams = Pick<CommonOptions, 'operationNameSuffix' | 'operationIdTransformer'> & {
+  /**
+   * The operation to generate hook bindings for.
+   */
   operationDefinition: OperationDefinition;
-  endpointOverrides: EndpointOverrides[] | undefined;
-  config: HooksConfigOptions;
-  operationNameSuffix?: string;
-  operationIdTransformer?: OperationIdTransformer;
 };
 
-type CreateBindingParams = {
-  operationDefinition: OperationDefinition;
+/**
+ * The parameters of {@linkcode createBinding()}.
+ *
+ * @internal
+ */
+type CreateBindingParams = HookNameBaseParams & {
+  /**
+   * The endpoint override matching the operation, if any. Its
+   * {@linkcode EndpointOverrides.type | type} decides whether the hook is
+   * named `...Query` or `...Mutation`.
+   */
   overrides?: EndpointOverrides;
+
+  /**
+   * Whether to generate the lazy variant of a query hook, which is named
+   * `useLazy...Query`.
+   *
+   * @default false
+   */
   isLazy?: boolean;
-  operationNameSuffix?: string;
-  operationIdTransformer?: OperationIdTransformer;
 };
 
+/**
+ * The parameters of {@linkcode getReactHookName()}. Unlike
+ * {@linkcode CreateBindingParams} this takes the full override list, since
+ * resolving the matching override is part of the job.
+ *
+ * @internal
+ */
+type GetReactHookNameParams = HookNameBaseParams &
+  Pick<OutputFileOptions, 'endpointOverrides'> & {
+    /**
+     * Which kinds of hooks to generate.
+     */
+    config: HooksConfigOptions;
+  };
+
+/**
+ * Creates a single binding element naming the generated hook for one
+ * operation, e.g. `useGetPetByIdQuery`.
+ *
+ * @param params - The operation to bind, plus the naming options.
+ * @returns A {@linkcode ts.BindingElement | BindingElement} holding the hook name.
+ * @throws An {@linkcode Error} if the operation has no `operationId` and {@linkcode CreateBindingParams.operationIdTransformer | operationIdTransformer} is not `"camelCase"`.
+ *
+ * @internal
+ */
 const createBinding = ({
   operationDefinition: { verb, path, operation },
   overrides,
@@ -40,6 +92,19 @@ const createBinding = ({
     undefined
   );
 
+/**
+ * Creates the binding elements for a single operation, honoring the
+ * {@linkcode CommonOptions.hooks | hooks} configuration.
+ *
+ * A query yields up to two bindings - the regular hook and its lazy
+ * variant - so the result is an array in that case and a single binding
+ * otherwise.
+ *
+ * @param params - The operation to bind, the hook configuration, and the naming options.
+ * @returns The binding element(s) for the operation, or an empty array if the configuration disables them.
+ *
+ * @internal
+ */
 const getReactHookName = ({
   operationDefinition,
   endpointOverrides,
@@ -74,14 +139,44 @@ const getReactHookName = ({
   return config.mutations ? createBinding(baseParams) : [];
 };
 
-type GenerateReactHooksParams = {
+/**
+ * The parameters of {@linkcode generateReactHooks()}.
+ *
+ * @internal
+ */
+type GenerateReactHooksParams = Omit<GetReactHookNameParams, 'operationDefinition'> & {
+  /**
+   * The identifier the hooks are destructured from. Note this is the
+   * internal injected api const, not the
+   * {@linkcode CommonOptions.exportName | exportName} option - the two are
+   * bridged by a separate `export { <internal> as <exportName> }`
+   * declaration.
+   */
   exportName: string;
+
+  /**
+   * Every operation to generate hooks for.
+   */
   operationDefinitions: OperationDefinition[];
-  endpointOverrides: EndpointOverrides[] | undefined;
-  config: HooksConfigOptions;
-  operationNameSuffix?: string;
-  operationIdTransformer?: OperationIdTransformer;
 };
+
+/**
+ * Builds the exported statement that destructures the generated hooks off
+ * the injected api.
+ *
+ * @example
+ * <caption>The generated statement</caption>
+ *
+ * ```ts
+ * export const { useAddPetMutation, useGetPetByIdQuery } = injectedRtkApi;
+ * ```
+ *
+ * @param params - The identifier to destructure from, the operations to bind, and the hook configuration.
+ * @returns A {@linkcode ts.VariableStatement | VariableStatement} destructuring the hooks from the injected api.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export const generateReactHooks = ({
   exportName,
   operationDefinitions,

--- a/packages/rtk-query-codegen-openapi/src/index.ts
+++ b/packages/rtk-query-codegen-openapi/src/index.ts
@@ -6,12 +6,39 @@ import type { CommonOptions, ConfigFile, GenerationOptions, OutputFileOptions } 
 import { isValidUrl, prettify } from './utils';
 export type { ConfigFile } from './types';
 
+/**
+ * A CommonJS `require` bound to this file, used to resolve the
+ * TypeScript copies that `oazapfts` and this package each load.
+ *
+ * @internal
+ */
 const require = createRequire(__filename);
 
+/**
+ * Generates RTK Query endpoints from an OpenAPI schema and returns the
+ * formatted source code.
+ *
+ * @param options - The generation options, without {@linkcode OutputFileOptions.outputFile | outputFile}.
+ * @returns A {@linkcode Promise | promise} resolving to the generated source code.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export async function generateEndpoints(
   options: Omit<GenerationOptions, 'outputFile'> & { outputFile?: never }
 ): Promise<string>;
 
+/**
+ * Generates RTK Query endpoints from an OpenAPI schema and writes the
+ * formatted source code to
+ * {@linkcode OutputFileOptions.outputFile | outputFile}.
+ *
+ * @param options - The generation options, including {@linkcode OutputFileOptions.outputFile | outputFile}.
+ * @returns A {@linkcode Promise | promise} resolving once the file has been written.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export async function generateEndpoints(
   options: Omit<GenerationOptions, 'outputFile'> & Required<Pick<GenerationOptions, 'outputFile'>>
 ): Promise<void>;
@@ -37,6 +64,20 @@ export async function generateEndpoints(options: GenerationOptions): Promise<str
   }
 }
 
+/**
+ * Flattens a config file into one entry per output file, merging the
+ * common options into each entry.
+ *
+ * A config using `outputFiles` yields one entry per key, with the key used
+ * as that entry's {@linkcode OutputFileOptions.outputFile | outputFile}; a
+ * single-output config yields exactly one entry.
+ *
+ * @param fullConfig - The parsed config file.
+ * @returns One fully merged options object per output file.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function parseConfig(fullConfig: ConfigFile) {
   const outFiles: (CommonOptions & OutputFileOptions)[] = [];
 
@@ -56,8 +97,19 @@ export function parseConfig(fullConfig: ConfigFile) {
 }
 
 /**
- * Enforces `oazapfts` to use the same TypeScript version as this module itself uses.
- * That should prevent enums from running out of sync if both libraries use different TS versions.
+ * Enforces `oazapfts` to use the same TypeScript version as this module
+ * itself uses. That should prevent enums from running out of sync if both
+ * libraries use different TS versions.
+ *
+ * The swap is done by pointing `oazapfts`' `typescript` entry in the
+ * require cache at this module's copy for the duration of the callback,
+ * then restoring the original entry.
+ *
+ * @template T - The return type of {@linkcode cb}.
+ * @param cb - The callback to run while the TypeScript versions are aligned.
+ * @returns Whatever {@linkcode cb} returns.
+ *
+ * @internal
  */
 function enforceOazapftsTsVersion<T>(cb: () => T): T {
   const ozTsPath = require.resolve('typescript', { paths: [require.resolve('oazapfts')] });

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -1,40 +1,105 @@
 import type SwaggerParser from '@apidevtools/swagger-parser';
 import type { OpenAPIV3 } from 'openapi-types';
 
+/**
+ * A single OpenAPI operation, paired with the path and HTTP verb it was
+ * found under.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type OperationDefinition = {
   /**
-   * The path of the API endpoint (e.g., "/users/{id}").
+   * The path of the API endpoint (e.g. `/users/{id}`).
    */
   path: string;
 
   /**
-   * The HTTP verb/method used for the operation
-   * (e.g., "get", "post").
+   * The HTTP verb/method used for the operation (e.g. `get`, `post`).
    */
   verb: (typeof operationKeys)[number];
 
   /**
-   * The OpenAPI `PathItemObject` associated with the operation.
+   * The OpenAPI {@linkcode OpenAPIV3.PathItemObject | PathItemObject}
+   * associated with the operation.
    */
   pathItem: OpenAPIV3.PathItemObject;
 
   /**
-   * The OpenAPI `OperationObject` defining the operation.
+   * The OpenAPI {@linkcode OpenAPIV3.OperationObject | OperationObject}
+   * defining the operation.
    */
   operation: OpenAPIV3.OperationObject;
 };
 
+/**
+ * A single parameter of an OpenAPI operation.
+ *
+ * @since 2.0.0
+ * @public
+ */
 export type ParameterDefinition = OpenAPIV3.ParameterObject;
 
+/**
+ * Makes the keys `K` of `T` required and non-nullable, leaving the rest
+ * of `T` untouched.
+ *
+ * @template T - The object type to modify.
+ * @template K - The keys of `T` to make required.
+ *
+ * @internal
+ */
 type Require<T, K extends keyof T> = { [k in K]-?: NonNullable<T[k]> } & Omit<T, K>;
+
+/**
+ * Makes the keys `K` of `T` optional and non-nullable, leaving the rest
+ * of `T` untouched.
+ *
+ * @template T - The object type to modify.
+ * @template K - The keys of `T` to make optional.
+ *
+ * @internal
+ */
 type Optional<T, K extends keyof T> = { [k in K]?: NonNullable<T[k]> } & Omit<T, K>;
+
+/**
+ * Flattens an intersection into a single object type so editors display it
+ * as one set of properties rather than as `A & B`.
+ *
+ * @template T - The type to flatten.
+ *
+ * @internal
+ */
 type Id<T> = { [K in keyof T]: T[K] } & {};
+
+/**
+ * Produces a union in which at least one key of `T` is required, while all
+ * remaining keys stay optional.
+ *
+ * @template T - The object type at least one key of which must be provided.
+ *
+ * @internal
+ */
 type AtLeastOneKey<T> = {
   [K in keyof T]-?: Pick<T, K> & Partial<T>;
 }[keyof T];
 
+/**
+ * The HTTP verbs that are read off an OpenAPI
+ * {@linkcode OpenAPIV3.PathItemObject | PathItemObject} when collecting
+ * operations.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export const operationKeys = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
+/**
+ * The fully resolved options for generating a single output file.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type GenerationOptions = Id<
   CommonOptions &
     Optional<OutputFileOptions, 'outputFile'> & {
@@ -56,9 +121,16 @@ export type GenerationOptions = Id<
     }
 >;
 
+/**
+ * The options that can be set once and shared by every generated output
+ * file.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export interface CommonOptions {
   /**
-   * filename of the api file to import base api from.
+   * The filename of the api file to import the base api from.
    */
   apiFile: string;
 
@@ -105,6 +177,7 @@ export interface CommonOptions {
   /**
    * Controls how OpenAPI **`operationId`** values are transformed into
    * endpoint names.
+   *
    * @see {@linkcode OperationIdTransformer} for details.
    *
    * @default "camelCase"
@@ -141,6 +214,7 @@ export interface CommonOptions {
    * `{ id?: string | undefined }` instead of `{ id?: string }`
    *
    * @example
+   * <caption>The effect on a generated property</caption>
    *
    * ```diff
    * {
@@ -165,7 +239,7 @@ export interface CommonOptions {
   tag?: boolean;
 
   /**
-   * `true` will add {@linkcode encodeURIComponent} to the generated
+   * `true` will add {@linkcode encodeURIComponent()} to the generated
    * {@linkcode OpenAPIV3.PathItemObject.parameters | Path parameters}.
    *
    * @default false
@@ -173,7 +247,7 @@ export interface CommonOptions {
   encodePathParams?: boolean;
 
   /**
-   * `true` will add {@linkcode encodeURIComponent} to the generated
+   * `true` will add {@linkcode encodeURIComponent()} to the generated
    * {@linkcode OpenAPIV3.OperationObject.parameters | query parameters}.
    *
    * @default false
@@ -185,6 +259,7 @@ export interface CommonOptions {
    * `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`.
    *
    * @example
+   * <caption>The effect on a generated hook call</caption>
    *
    * ```diff
    * - useGetEntityById({ entityId: 1 })
@@ -214,15 +289,14 @@ export interface CommonOptions {
 
   /**
    * {@linkcode SwaggerParser.HTTPResolverOptions | HTTPResolverOptions}
-   * object that is passed to the
-   * {@linkcode SwaggerParser.bundle | SwaggerParser bundle} function.
+   * object that is passed to the {@linkcode SwaggerParser.bundle()} function.
    */
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions;
 
   /**
-   * If present the given file will be used as prettier config when formatting
-   * the generated code. If `undefined` the default prettier config resolution
-   * mechanism will be used.
+   * If present the given file will be used as the Prettier config when
+   * formatting the generated code. If `undefined` the default Prettier
+   * config resolution mechanism will be used.
    *
    * @default undefined
    */
@@ -241,7 +315,7 @@ export interface CommonOptions {
 
   /**
    * Will generate imports with file extension matching the expected compiled
-   * output of the {@linkcode  CommonOptions.apiFile | api file}.
+   * output of the {@linkcode CommonOptions.apiFile | apiFile}.
    *
    * @default false
    */
@@ -296,14 +370,57 @@ export interface CommonOptions {
  */
 export type OperationIdTransformer = 'camelCase' | 'none' | ((operationId: string) => string);
 
+/**
+ * A name to match against, given either as an exact `string`, as a
+ * {@linkcode RegExp}, or as an array of either.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type TextMatcher = string | RegExp | (string | RegExp)[];
 
+/**
+ * Decides whether an endpoint should be matched, based on its generated
+ * name and the operation it came from.
+ *
+ * @param operationName - The generated name of the endpoint.
+ * @param operationDefinition - The {@linkcode OperationDefinition} the endpoint was generated from.
+ * @returns `true` if the endpoint matches, `false` otherwise.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type EndpointMatcherFunction = (operationName: string, operationDefinition: OperationDefinition) => boolean;
 
+/**
+ * Selects endpoints either by name via a {@linkcode TextMatcher}, or by
+ * arbitrary logic via an {@linkcode EndpointMatcherFunction}.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type EndpointMatcher = TextMatcher | EndpointMatcherFunction;
 
+/**
+ * Decides whether a parameter should be matched, based on its name and
+ * its definition.
+ *
+ * @param parameterName - The name of the parameter.
+ * @param parameterDefinition - The {@linkcode ParameterDefinition} of the parameter.
+ * @returns `true` if the parameter matches, `false` otherwise.
+ *
+ * @since 2.0.0
+ * @public
+ */
 export type ParameterMatcherFunction = (parameterName: string, parameterDefinition: ParameterDefinition) => boolean;
 
+/**
+ * Selects parameters either by name via a {@linkcode TextMatcher}, or by
+ * arbitrary logic via a {@linkcode ParameterMatcherFunction}.
+ *
+ * @since 2.0.0
+ * @public
+ */
 export type ParameterMatcher = TextMatcher | ParameterMatcherFunction;
 
 /**
@@ -311,14 +428,20 @@ export type ParameterMatcher = TextMatcher | ParameterMatcherFunction;
  *
  * - **`"union"`** *(default)* - a union of string literals: `type Status = "available" | "pending"`
  * - **`"enum"`** - a TypeScript enum: `enum Status { Available = "available" }`
- * - **`"as-const"`** - a const object with a companion type:
- *   `const Status = { Available: "available" } as const; type Status = (typeof Status)[keyof typeof Status];`
+ * - **`"as-const"`** - a const object with a companion type: `const Status = { Available: "available" } as const; type Status = (typeof Status)[keyof typeof Status];`
  *
  * @since 2.3.0
  * @public
  */
 export type EnumStyle = 'union' | 'enum' | 'as-const';
 
+/**
+ * The options that apply to one generated output file, on top of the
+ * {@linkcode CommonOptions} shared by every output file.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export interface OutputFileOptions extends Partial<CommonOptions> {
   /**
    * The output file path for the generated code.
@@ -349,7 +472,10 @@ export interface OutputFileOptions extends Partial<CommonOptions> {
 
   /**
    * Controls how enums are generated in TypeScript.
-   * Takes precedence over `useEnumType` if both are specified.
+   * Takes precedence over
+   * {@linkcode OutputFileOptions.useEnumType | useEnumType} if both are
+   * specified.
+   *
    * @see {@linkcode EnumStyle} for details.
    *
    * @default "union"
@@ -362,6 +488,9 @@ export interface OutputFileOptions extends Partial<CommonOptions> {
  * Configuration for overriding specific endpoint behaviors during
  * code generation. At least one override option
  * (besides {@linkcode EndpointOverrides.pattern | pattern}) must be specified.
+ *
+ * @since 1.0.0
+ * @public
  */
 export type EndpointOverrides = {
   /**
@@ -388,12 +517,14 @@ export type EndpointOverrides = {
    * Override `providesTags` for this endpoint.
    * Takes precedence over auto-generated tags from OpenAPI spec.
    * Use an empty array to explicitly omit `providesTags`.
-   * Works regardless of the global `tag` setting and endpoint `type`.
+   * Works regardless of the global {@linkcode CommonOptions.tag | tag}
+   * setting and endpoint {@linkcode EndpointOverrides.type | type}.
    *
    * @example
+   * <caption>Tagging an endpoint that returns a single pet</caption>
    *
    * ```ts
-   * ['Pet', 'SinglePet']
+   * ['Pet', 'SinglePet'];
    * ```
    */
   providesTags: string[];
@@ -402,17 +533,27 @@ export type EndpointOverrides = {
    * Override `invalidatesTags` for this endpoint.
    * Takes precedence over auto-generated tags from OpenAPI spec.
    * Use an empty array to explicitly omit `invalidatesTags`.
-   * Works regardless of the global `tag` setting and endpoint `type`.
+   * Works regardless of the global {@linkcode CommonOptions.tag | tag}
+   * setting and endpoint {@linkcode EndpointOverrides.type | type}.
    *
    * @example
+   * <caption>Invalidating both a pet and the pet list</caption>
    *
    * ```ts
-   * ['Pet', 'PetList']
+   * ['Pet', 'PetList'];
    * ```
    */
   invalidatesTags: string[];
 }>;
 
+/**
+ * The shape of the config file passed to the CLI. Either a single output
+ * file described inline, or a set of output files keyed by path under
+ * `outputFiles`.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export type ConfigFile =
   | Id<Require<CommonOptions & OutputFileOptions, 'outputFile'>>
   | Id<

--- a/packages/rtk-query-codegen-openapi/src/types.ts
+++ b/packages/rtk-query-codegen-openapi/src/types.ts
@@ -2,9 +2,25 @@ import type SwaggerParser from '@apidevtools/swagger-parser';
 import type { OpenAPIV3 } from 'openapi-types';
 
 export type OperationDefinition = {
+  /**
+   * The path of the API endpoint (e.g., "/users/{id}").
+   */
   path: string;
+
+  /**
+   * The HTTP verb/method used for the operation
+   * (e.g., "get", "post").
+   */
   verb: (typeof operationKeys)[number];
+
+  /**
+   * The OpenAPI `PathItemObject` associated with the operation.
+   */
   pathItem: OpenAPIV3.PathItemObject;
+
+  /**
+   * The OpenAPI `OperationObject` defining the operation.
+   */
   operation: OpenAPIV3.OperationObject;
 };
 
@@ -22,6 +38,15 @@ export const operationKeys = ['get', 'put', 'post', 'delete', 'options', 'head',
 export type GenerationOptions = Id<
   CommonOptions &
     Optional<OutputFileOptions, 'outputFile'> & {
+      /**
+       * Function to determine if a response is considered a "data" response.
+       *
+       * @param code - The HTTP status code as a string.
+       * @param includeDefault - Whether the default response is included.
+       * @param response - The OpenAPI response object for the given status code.
+       * @param allResponses - All responses defined for the operation.
+       * @returns `true` if the response is a data response, `false` otherwise.
+       */
       isDataResponse?(
         code: string,
         includeDefault: boolean,
@@ -32,28 +57,47 @@ export type GenerationOptions = Id<
 >;
 
 export interface CommonOptions {
-  apiFile: string;
   /**
-   * filename or url
+   * filename of the api file to import base api from.
+   */
+  apiFile: string;
+
+  /**
+   * The OpenAPI schema filename or URL to generate the API from.
    */
   schemaFile: string;
+
   /**
+   * The name to use for the imported API instance.
+   *
    * @default "api"
    */
   apiImport?: string;
+
   /**
+   * The name to use for the generated API instance.
+   *
    * @default "enhancedApi"
    */
   exportName?: string;
+
   /**
+   * A suffix to append to generated argument type names.
+   *
    * @default "ApiArg"
    */
   argSuffix?: string;
+
   /**
+   * A suffix to append to generated response type names.
+   *
    * @default "ApiResponse"
    */
   responseSuffix?: string;
+
   /**
+   * A suffix to append to generated operation names.
+   *
    * @default ""
    */
   operationNameSuffix?: string;
@@ -67,56 +111,119 @@ export interface CommonOptions {
    * @since 2.3.0
    */
   operationIdTransformer?: OperationIdTransformer;
+
   /**
-   * `true` will generate hooks for queries and mutations, but no lazyQueries
+   * An object can be provided to configure which hooks to generate.
+   * - **`true`:** will generate hooks for `queries` and `mutations`, but no
+   *   `lazyQueries`. Equivalent to:
+   *   ```ts
+   *   {
+   *     lazyQueries: false,
+   *     mutations: true,
+   *     queries: true,
+   *   };
+   *   ```
+   * - **`false` (Default):** will not generate any hooks. Equivalent to:
+   *   ```ts
+   *   {
+   *     lazyQueries: false,
+   *     mutations: false,
+   *     queries: false,
+   *   };
+   *   ```
+   *
    * @default false
    */
   hooks?: boolean | { queries: boolean; lazyQueries: boolean; mutations: boolean };
+
   /**
-   * `true` will generate a union type for `undefined` properties like: `{ id?: string | undefined }` instead of `{ id?: string }`
+   * `true` will generate a union type for `undefined` properties like:
+   * `{ id?: string | undefined }` instead of `{ id?: string }`
+   *
+   * @example
+   *
+   * ```diff
+   * {
+   * -  id?: string
+   * +  id?: string | undefined
+   * }
+   * ```
+   *
    * @default false
    */
   unionUndefined?: boolean;
+
   /**
-   * `true` will result in all generated endpoints having `providesTags`/`invalidatesTags` declarations for the `tags` of their respective operation definition
+   * `true` will result in all generated endpoints having
+   * {@linkcode EndpointOverrides.providesTags | providesTags}
+   * and {@linkcode EndpointOverrides.invalidatesTags | invalidatesTags}
+   * declarations for the `tags` of their respective operation definition.
+   *
    * @default false
-   * @see https://redux-toolkit.js.org/rtk-query/usage/code-generation for more information
+   * @see {@link https://redux-toolkit.js.org/rtk-query/usage/code-generation | code-generation docs} for more information
    */
   tag?: boolean;
+
   /**
-   * `true` will add `encodeURIComponent` to the generated path parameters
+   * `true` will add {@linkcode encodeURIComponent} to the generated
+   * {@linkcode OpenAPIV3.PathItemObject.parameters | Path parameters}.
+   *
    * @default false
    */
   encodePathParams?: boolean;
+
   /**
-   * `true` will add `encodeURIComponent` to the generated query parameters
+   * `true` will add {@linkcode encodeURIComponent} to the generated
+   * {@linkcode OpenAPIV3.OperationObject.parameters | query parameters}.
+   *
    * @default false
    */
   encodeQueryParams?: boolean;
+
   /**
-   * `true` will "flatten" the arg so that you can do things like `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`
+   * `true` will "flatten" the arg so that you can do things like
+   * `useGetEntityById(1)` instead of `useGetEntityById({ entityId: 1 })`.
+   *
+   * @example
+   *
+   * ```diff
+   * - useGetEntityById({ entityId: 1 })
+   * + useGetEntityById(1)
+   * ```
+   *
    * @default false
    */
   flattenArg?: boolean;
+
   /**
-   * If set to `true`, the default response type will be included in the generated code for all endpoints.
+   * If set to `true`, the default response type will be included in
+   * the generated code for all endpoints.
+   *
    * @default false
-   * @see https://swagger.io/docs/specification/describing-responses/#default
+   * @see {@link https://swagger.io/docs/specification/describing-responses/#default | docs}
    */
   includeDefault?: boolean;
+
   /**
-   * `true` will not generate separate types for read-only and write-only properties.
+   * `true` will not generate separate types for
+   * {@link https://swagger.io/docs/specification/v3_0/data-models/data-types/#read-only-and-write-only-properties | read-only and write-only properties}.
+   *
    * @default false
    */
   mergeReadWriteOnly?: boolean;
+
   /**
-   * HTTPResolverOptions object that is passed to the SwaggerParser bundle function.
+   * {@linkcode SwaggerParser.HTTPResolverOptions | HTTPResolverOptions}
+   * object that is passed to the
+   * {@linkcode SwaggerParser.bundle | SwaggerParser bundle} function.
    */
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions;
 
   /**
-   * If present the given file will be used as prettier config when formatting the generated code. If undefined the default prettier config
-   * resolution mechanism will be used.
+   * If present the given file will be used as prettier config when formatting
+   * the generated code. If `undefined` the default prettier config resolution
+   * mechanism will be used.
+   *
    * @default undefined
    */
   prettierConfigFile?: string;
@@ -131,20 +238,29 @@ export interface CommonOptions {
    * @since 2.1.0
    */
   useUnknown?: boolean;
+
   /**
+   * Will generate imports with file extension matching the expected compiled
+   * output of the {@linkcode  CommonOptions.apiFile | api file}.
+   *
    * @default false
-   * Will generate imports with file extension matching the expected compiled output of the api file
    */
   esmExtensions?: boolean;
+
   /**
+   * Will generate regex constants for
+   * {@linkcode OpenAPIV3.BaseSchemaObject.pattern | pattern}
+   * keywords in the schema.
+   *
    * @default false
-   * Will generate regex constants for pattern keywords in the schema
    */
   outputRegexConstants?: boolean;
+
   /**
+   * If set to `true`, all schemas from the OpenAPI document will be exported,
+   * regardless of whether they are referenced by any endpoint definitions.
+   *
    * @default false
-   * If set to `true`, all schemas from the OpenAPI document will be exported, regardless of whether they are referenced by any
-   * endpoint definitions.
    */
   exportAllSchemas?: boolean;
 }
@@ -204,14 +320,33 @@ export type ParameterMatcher = TextMatcher | ParameterMatcherFunction;
 export type EnumStyle = 'union' | 'enum' | 'as-const';
 
 export interface OutputFileOptions extends Partial<CommonOptions> {
-  outputFile: string;
-  filterEndpoints?: EndpointMatcher;
-  endpointOverrides?: EndpointOverrides[];
   /**
-   * If passed as true it will generate TS enums instead of union of strings
+   * The output file path for the generated code.
+   */
+  outputFile: string;
+
+  /**
+   * Filters which endpoints will be generated in this output file.
+   */
+  filterEndpoints?: EndpointMatcher;
+
+  /**
+   * Configuration for overriding specific endpoint behaviors during
+   * code generation.
+   */
+  endpointOverrides?: EndpointOverrides[];
+
+  /**
+   * If passed as true it will generate
+   * {@link https://www.typescriptlang.org/docs/handbook/enums.html | TypeScript Enums}
+   * instead of
+   * {@link https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#unions | union}
+   * of strings.
+   *
    * @default false
    */
   useEnumType?: boolean;
+
   /**
    * Controls how enums are generated in TypeScript.
    * Takes precedence over `useEnumType` if both are specified.
@@ -224,31 +359,56 @@ export interface OutputFileOptions extends Partial<CommonOptions> {
 }
 
 /**
- * Configuration for overriding specific endpoint behaviors during code generation.
- * At least one override option (besides `pattern`) must be specified.
+ * Configuration for overriding specific endpoint behaviors during
+ * code generation. At least one override option
+ * (besides {@linkcode EndpointOverrides.pattern | pattern}) must be specified.
  */
 export type EndpointOverrides = {
-  /** Pattern to match endpoint names. Can be a string, RegExp, or matcher function. */
+  /**
+   * Pattern to match endpoint names.
+   * Can be a `string`, {@linkcode RegExp}, or
+   * {@linkcode EndpointMatcherFunction | matcher function}.
+   */
   pattern: EndpointMatcher;
 } & AtLeastOneKey<{
-  /** Override the endpoint type (query vs mutation) when the inferred type is incorrect. */
-  type: 'mutation' | 'query';
-  /** Filter which parameters are included in the generated endpoint. Path parameters cannot be filtered. */
-  parameterFilter: ParameterMatcher;
   /**
-   * Override providesTags for this endpoint.
+   * Override the endpoint type (`query` vs `mutation`) when the
+   * inferred type is incorrect.
+   */
+  type: 'mutation' | 'query';
+
+  /**
+   * Filter which parameters are included in the generated endpoint.
+   * {@linkcode OpenAPIV3.PathItemObject.parameters | Path parameters}
+   * cannot be filtered.
+   */
+  parameterFilter: ParameterMatcher;
+
+  /**
+   * Override `providesTags` for this endpoint.
    * Takes precedence over auto-generated tags from OpenAPI spec.
-   * Use an empty array to explicitly omit providesTags.
-   * Works regardless of the global `tag` setting and endpoint type.
-   * @example ['Pet', 'SinglePet']
+   * Use an empty array to explicitly omit `providesTags`.
+   * Works regardless of the global `tag` setting and endpoint `type`.
+   *
+   * @example
+   *
+   * ```ts
+   * ['Pet', 'SinglePet']
+   * ```
    */
   providesTags: string[];
+
   /**
-   * Override invalidatesTags for this endpoint.
+   * Override `invalidatesTags` for this endpoint.
    * Takes precedence over auto-generated tags from OpenAPI spec.
-   * Use an empty array to explicitly omit invalidatesTags.
-   * Works regardless of the global `tag` setting and endpoint type.
-   * @example ['Pet', 'PetList']
+   * Use an empty array to explicitly omit `invalidatesTags`.
+   * Works regardless of the global `tag` setting and endpoint `type`.
+   *
+   * @example
+   *
+   * ```ts
+   * ['Pet', 'PetList']
+   * ```
    */
   invalidatesTags: string[];
 }>;
@@ -257,6 +417,9 @@ export type ConfigFile =
   | Id<Require<CommonOptions & OutputFileOptions, 'outputFile'>>
   | Id<
       Omit<CommonOptions, 'outputFile'> & {
+        /**
+         * Mapping of output file paths to their respective output file options.
+         */
         outputFiles: { [outputFile: string]: Omit<OutputFileOptions, 'outputFile'> };
       }
     >;

--- a/packages/rtk-query-codegen-openapi/src/utils/capitalize.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/capitalize.ts
@@ -1,3 +1,13 @@
+/**
+ * Upper-cases the first character of a string, leaving the rest as-is.
+ *
+ * @param str - The string to capitalize.
+ * @returns The string with its first character upper-cased.
+ * @throws A {@linkcode TypeError} if {@linkcode str} is empty, since there is no first character to upper-case.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function capitalize(str: string) {
   return str.replace(str[0], str[0].toUpperCase());
 }

--- a/packages/rtk-query-codegen-openapi/src/utils/factory.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/factory.ts
@@ -1,8 +1,28 @@
 import ts from 'typescript';
 import semver from 'semver';
 
+/**
+ * The unwrapped TypeScript node factory the overrides below delegate to.
+ *
+ * @internal
+ */
 const originalFactory = ts.factory;
 
+/**
+ * Creates an import specifier, i.e. one `name` or `propertyName as name`
+ * entry of an import clause.
+ *
+ * TypeScript 4.5 added a leading `isTypeOnly` argument to this factory
+ * method, so the call is dispatched on the TypeScript version actually
+ * loaded at runtime rather than the one this package was compiled
+ * against.
+ *
+ * @param propertyName - The name being imported, or `undefined` when no alias is used.
+ * @param name - The local name the import is bound to.
+ * @returns The import specifier node.
+ *
+ * @internal
+ */
 function createImportSpecifier(propertyName: ts.Identifier | undefined, name: ts.Identifier): ts.ImportSpecifier {
   if (semver.satisfies(ts.version, '>= 4.5'))
     // @ts-ignore
@@ -11,6 +31,19 @@ function createImportSpecifier(propertyName: ts.Identifier | undefined, name: ts
   return originalFactory.createImportSpecifier(propertyName, name);
 }
 
+/**
+ * Creates an export specifier, i.e. one `name` or `propertyName as name`
+ * entry of an export clause.
+ *
+ * Dispatches on the loaded TypeScript version for the same reason as
+ * {@linkcode createImportSpecifier()}.
+ *
+ * @param propertyName - The name being exported, or `undefined` when no alias is used.
+ * @param name - The name the export is exposed under.
+ * @returns The export specifier node.
+ *
+ * @internal
+ */
 function createExportSpecifier(
   propertyName: string | ts.Identifier | undefined,
   name: string | ts.Identifier
@@ -22,6 +55,14 @@ function createExportSpecifier(
   return originalFactory.createExportSpecifier(propertyName, name);
 }
 
+/**
+ * The TypeScript node factory used throughout code generation - the
+ * built-in one, with the two specifier methods replaced by
+ * version-tolerant wrappers.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export const factory = {
   ...originalFactory,
   createImportSpecifier,

--- a/packages/rtk-query-codegen-openapi/src/utils/getOperationDefinitions.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/getOperationDefinitions.ts
@@ -2,6 +2,20 @@ import type { OpenAPIV3 } from 'openapi-types';
 import type { OperationDefinition } from '../types';
 import { operationKeys } from '../types';
 
+/**
+ * Flattens an OpenAPI document into one
+ * {@linkcode OperationDefinition} per path and HTTP verb.
+ *
+ * Keys of a path item that are not among
+ * {@linkcode operationKeys} - such as `parameters` or `summary` - are
+ * skipped, as are paths with no path item.
+ *
+ * @param v3Doc - The OpenAPI v3 document to read operations from.
+ * @returns Every operation in the document, in the order the paths and verbs are declared.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function getOperationDefinitions(v3Doc: OpenAPIV3.Document): OperationDefinition[] {
   return Object.entries(v3Doc.paths).flatMap(([path, pathItem]) =>
     !pathItem

--- a/packages/rtk-query-codegen-openapi/src/utils/getV3Doc.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/getV3Doc.ts
@@ -3,6 +3,22 @@ import type { OpenAPIV3 } from 'openapi-types';
 // @ts-ignore
 import converter from 'swagger2openapi';
 
+/**
+ * Loads an API schema and returns it as an OpenAPI v3 document.
+ *
+ * The schema is bundled with {@linkcode SwaggerParser.bundle()}, which
+ * follows and inlines external references. A Swagger 2.0 document is then
+ * converted up to OpenAPI 3 with `swagger2openapi`, so callers always get
+ * a v3 document back.
+ *
+ * @param spec - The path or URL of the schema to load.
+ * @param [httpResolverOptions] - Options for resolving references fetched over HTTP.
+ * @returns A {@linkcode Promise | promise} resolving to the OpenAPI v3 document.
+ * @throws An {@linkcode Error} if the schema cannot be read, parsed, or converted.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export async function getV3Doc(
   spec: string,
   httpResolverOptions?: SwaggerParser.HTTPResolverOptions

--- a/packages/rtk-query-codegen-openapi/src/utils/isQuery.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/isQuery.ts
@@ -1,5 +1,19 @@
 import type { EndpointOverrides, operationKeys } from '../types';
 
+/**
+ * Decides whether an operation should be generated as a query rather than
+ * a mutation.
+ *
+ * An explicit {@linkcode EndpointOverrides.type | type} override always
+ * wins; otherwise only `get` operations are treated as queries.
+ *
+ * @param verb - The HTTP verb of the operation.
+ * @param overrides - The override matching the operation, if any.
+ * @returns `true` if the operation should be a query, `false` if it should be a mutation.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function isQuery(verb: (typeof operationKeys)[number], overrides: EndpointOverrides | undefined) {
   if (overrides?.type) {
     return overrides.type === 'query';

--- a/packages/rtk-query-codegen-openapi/src/utils/isValidUrl.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/isValidUrl.ts
@@ -1,3 +1,16 @@
+/**
+ * Checks whether a string parses as an absolute URL, used to tell a remote
+ * schema location apart from a local file path.
+ *
+ * Parsing is done with the {@linkcode URL} constructor, so a relative path
+ * such as `./schema.json` is not considered valid.
+ *
+ * @param string - The string to test.
+ * @returns `true` if the string parses as a URL, `false` otherwise.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function isValidUrl(string: string) {
   try {
     new URL(string);

--- a/packages/rtk-query-codegen-openapi/src/utils/messages.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/messages.ts
@@ -1,7 +1,38 @@
+/**
+ * Message strings describing failures to resolve a `--baseQuery` file.
+ *
+ * **Currently unused.** Nothing in this package reads
+ * {@linkcode MESSAGES}, and the CLI accepts no flags at all - it takes a
+ * single config file path - so none of the `--baseQuery`, `--baseUrl` or
+ * `-c, --config` options these messages mention exist. The messages are
+ * kept only so the wording is not lost if those options are reinstated.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export const MESSAGES = {
+  /**
+   * For a named export that is absent or empty in the resolved file.
+   */
   NAMED_EXPORT_MISSING: `You specified a named export that does not exist or was empty.`,
+
+  /**
+   * For a file that exists but has no default export to use.
+   */
   DEFAULT_EXPORT_MISSING: `Specified file exists, but no default export was found for the --baseQuery`,
+
+  /**
+   * For a file that cannot be found.
+   */
   FILE_NOT_FOUND: `Unable to locate the specified file provided to --baseQuery`,
+
+  /**
+   * For a config file that cannot be found.
+   */
   TSCONFIG_FILE_NOT_FOUND: `Unable to locate the specified file provided to -c, --config`,
+
+  /**
+   * For a base url that is ignored because a base query supplies its own.
+   */
   BASE_URL_IGNORED: `The url provided to --baseUrl is ignored when using --baseQuery`,
 };

--- a/packages/rtk-query-codegen-openapi/src/utils/prettier.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/prettier.ts
@@ -2,6 +2,12 @@ import path from 'node:path';
 import prettier from 'prettier';
 import type { BuiltInParserName } from 'prettier';
 
+/**
+ * The Prettier parser to use for a given file extension, keyed by the
+ * extension without its leading dot.
+ *
+ * @internal
+ */
 const EXTENSION_TO_PARSER: Record<string, BuiltInParserName> = {
   ts: 'typescript',
   tsx: 'typescript',
@@ -20,6 +26,25 @@ const EXTENSION_TO_PARSER: Record<string, BuiltInParserName> = {
   json: 'json',
 };
 
+/**
+ * Formats generated code with Prettier.
+ *
+ * The parser is chosen from {@linkcode filePath}'s extension; when no path
+ * is given the content is parsed as TypeScript and no config is resolved
+ * unless {@linkcode prettierConfigFile} names one. Config resolution is
+ * anchored at the current working directory rather than at
+ * {@linkcode filePath}, and `.editorconfig` is only consulted when no
+ * explicit config file was supplied.
+ *
+ * @param filePath - The path the content will be written to, or `null` to format it as TypeScript without resolving a config from a path.
+ * @param content - The source code to format.
+ * @param [prettierConfigFile] - An explicit Prettier config file to use instead of the default resolution.
+ * @returns A {@linkcode Promise | promise} resolving to the formatted source code.
+ * @throws An {@linkcode Error} if the content cannot be parsed, or if {@linkcode filePath} has an extension with no matching parser.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export async function prettify(filePath: string | null, content: string, prettierConfigFile?: string): Promise<string> {
   let config = null;
   let parser = 'typescript';

--- a/packages/rtk-query-codegen-openapi/src/utils/removeUndefined.ts
+++ b/packages/rtk-query-codegen-openapi/src/utils/removeUndefined.ts
@@ -1,3 +1,21 @@
+/**
+ * A type guard that narrows `undefined` out of a value, intended as a
+ * filter callback so the resulting array loses `undefined` from its type.
+ *
+ * @example
+ * <caption>Dropping optional entries from an array</caption>
+ *
+ * ```ts
+ * const defined = [a, undefined, b].filter(removeUndefined);
+ * ```
+ *
+ * @template T - The type of the value once `undefined` is excluded.
+ * @param t - The value to test.
+ * @returns `true` if the value is not `undefined`, `false` otherwise.
+ *
+ * @since 1.0.0
+ * @public
+ */
 export function removeUndefined<T>(t: T | undefined): t is T {
   return typeof t !== 'undefined';
 }


### PR DESCRIPTION
Builds on [**#5373**](https://github.com/reduxjs/redux-toolkit/pull/5373) — those commits are included here and the diff will shrink once it merges. Review the last commit only.

Part of [**#5368**](https://github.com/reduxjs/redux-toolkit/issues/5368) — the second half of the JSDoc work, covering everything outside **`src/types.ts`**.

- Document **`generate.ts`**, including the **`@throws`** cases on **`generateApi`** and **`resolveOperationName`**
- Document **`generators/react-hooks.ts`**, **`codegen.ts`**, **`index.ts`** and **`bin/cli.ts`**
- Document the **`utils/`** helpers — **`capitalize`**, **`factory`**, **`getOperationDefinitions`**, **`getV3Doc`**, **`isQuery`**, **`isValidUrl`**, **`messages`**, **`prettier`** and **`removeUndefined`**
- Fix **`resolveOperationName`**, whose [**`{@linkcode operation.operationId}`**](https://jsdoc.app/tags-inline-link.html) did not resolve because **`operation`** is destructured inside the function body rather than being a parameter in scope for the doc comment
- Tag exported symbols [**`@public`**](https://tsdoc.org/pages/tags/public/) + [**`@since`**](https://jsdoc.app/tags-since.html) and non-exported helpers [**`@internal`**](https://tsdoc.org/pages/tags/internal/), matching [**#5373**](https://github.com/reduxjs/redux-toolkit/pull/5373)

Documentation only, no runtime change. **`tsc --noEmit`** is clean and **`vitest --run --typecheck`** passes — 100 tests, no type errors.

One incidental non-comment change: the **`generateTagTypes`** parameter list in **`codegen.ts`** is expanded across lines, because documenting **`addTagTypes`** requires the inline object type to break. No behaviour change.

The two caveats from [**#5373**](https://github.com/reduxjs/redux-toolkit/pull/5373) apply here as well — the tagging convention is still an open question on [**#5368**](https://github.com/reduxjs/redux-toolkit/issues/5368), and the **`@since`** values are unverified against the releases the symbols actually shipped in.

Closes #5372
Ref #5368
