### PR TITLE
fix(toolkit): prevent undefined endpoint reference

### DIFF
--- a/packages/toolkit/src/query/createApi.ts
+++ b/packages/toolkit/src/query/createApi.ts
@@ -365,7 +365,10 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
       extractRehydrationInfo,
       serializeQueryArgs(queryArgsApi) {
         let finalSerializeQueryArgs = defaultSerializeQueryArgs
-        if ('serializeQueryArgs' in queryArgsApi.endpointDefinition) {
+        if (
+          queryArgsApi.endpointDefinition &&
+          'serializeQueryArgs' in queryArgsApi.endpointDefinition
+        ) {
           const endpointSQA =
             queryArgsApi.endpointDefinition.serializeQueryArgs!
           finalSerializeQueryArgs = (queryArgsApi) => {


### PR DESCRIPTION
Fixes #5084.

The default `serializeQueryArgs` wrapper in `buildCreateApi` reads `queryArgsApi.endpointDefinition` with the `in` operator without verifying the `endpointDefinition` property is defined, which throws if an endpoint name does not map to a definition.

This PR adds a check to ensure the endpoint definition is defined before checking if it has a `serializeQueryArgs` to prevent the error and allow falling back to `defaultSerializeQueryArgs`.

<details>
<summary>Minimal reproductions:</summary>

```js
import { configureStore } from '@reduxjs/toolkit';
import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query';

const api = createApi({
  baseQuery: fakeBaseQuery(),
  keepUnusedDataFor: 0,
  extractRehydrationInfo: (action) => (action.type === 'REHYDRATE' ? action.payload : undefined),
  endpoints: () => ({}),
});

const store = configureStore({
  reducer: { [api.reducerPath]: api.reducer },
  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
});

// Example 1: `cacheEntriesUpserted.prepare` reads `definitions[endpointName]`
try {
  store.dispatch(
    api.util.upsertQueryEntries([
      {
        endpointName: 'missing',
        arg: 1,
        value: {},
      },
    ]),
  );
} catch (error) {
  console.log('upsertQueryEntries:', error);
}

// Example 2: The `keepUnusedDataFor` timer calls `getRunningQueryThunk` for a rehydrated entry with an endpoint not defined.
store.dispatch({
  type: 'REHYDRATE',
  payload: {
    queries: {
      missing: { status: 'fulfilled', endpointName: 'missing' },
    },
    mutations: {},
    provided: {},
  },
});
// (The error is thrown later)
```

Output:

```
$ node index.mjs
upsertQueryEntries: TypeError: Cannot use 'in' operator to search for 'serializeQueryArgs' in undefined
    at serializeQueryArgs (file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:1928:34)
    at file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:1392:30
    at Array.map (<anonymous>)
    at prepare (file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:1381:45)
    at Object.actionCreator [as upsertQueryEntries] (file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/redux-toolkit.modern.mjs:56:22)
    at file:///%reproduction-path%/index.mjs:19:14
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:643:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:1928
        if ("serializeQueryArgs" in queryArgsApi.endpointDefinition) {
                                 ^

TypeError: Cannot use 'in' operator to search for 'serializeQueryArgs' in undefined
    at serializeQueryArgs (file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:1928:34)
    at file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:541:29
    at file:///%reproduction-path%/node_modules/redux-thunk/dist/redux-thunk.mjs:5:14
    at file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/redux-toolkit.modern.mjs:290:34
    at file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/redux-toolkit.modern.mjs:110:12
    at Object.dispatch (file:///%reproduction-path%/node_modules/redux/dist/redux.mjs:371:38)
    at Timeout._onTimeout (file:///%reproduction-path%/node_modules/@reduxjs/toolkit/dist/query/rtk-query.modern.mjs:2272:39)
    at listOnTimeout (node:internal/timers:635:17)
    at process.processTimers (node:internal/timers:571:7)

Node.js v24.19.0
```

</details>