### PR TITLE
feat(toolkit): add infinite query refetch behavior modes

### DIFF
--- a/docs/rtk-query/api/createApi.mdx
+++ b/docs/rtk-query/api/createApi.mdx
@@ -330,10 +330,21 @@ export type InfiniteQueryDefinition<
        */
       maxPages?: number
       /**
-       * Defaults to `true`. When this is `true` and an infinite query endpoint is refetched
-       * (due to tag invalidation, polling, arg change configuration, or manual refetching),
-       * RTK Query will try to sequentially refetch all pages currently in the cache.
-       * When `false` only the first page will be refetched.
+       * Defaults to `'refetch-all-pages'`. Controls how an infinite query endpoint is refetched
+       * (due to tag invalidation, polling, arg change configuration, or manual refetching).
+       * `'refetch-all-pages'` sequentially refetches all pages currently in the cache.
+       * `'refetch-first-page-discard-rest'` refetches only the first cached page and shrinks the cache to one page.
+       * `'refetch-first-page-preserve-rest'` refetches only the first cached page and preserves the remaining cached pages.
+       */
+      refetchBehavior?:
+        | 'refetch-all-pages'
+        | 'refetch-first-page-discard-rest'
+        | 'refetch-first-page-preserve-rest'
+      /**
+       * Defaults to `true`. This is a backwards-compatible alias for `refetchBehavior`.
+       * `true` maps to `'refetch-all-pages'`.
+       * `false` maps to `'refetch-first-page-discard-rest'`.
+       * If both options are provided at the same level, `refetchBehavior` takes precedence.
        */
       refetchCachedPages?: boolean
     }

--- a/docs/rtk-query/api/created-api/hooks.mdx
+++ b/docs/rtk-query/api/created-api/hooks.mdx
@@ -463,6 +463,10 @@ type UseInfiniteQueryOptions = {
   refetchOnMountOrArgChange?: boolean | number
   selectFromResult?: (result: UseQueryStateDefaultResult) => any
   initialPageParam?: PageParam
+  refetchBehavior?:
+    | 'refetch-all-pages'
+    | 'refetch-first-page-discard-rest'
+    | 'refetch-first-page-preserve-rest'
   refetchCachedPages?: boolean
 }
 
@@ -516,6 +520,10 @@ type UseInfiniteQueryResult<Data, PageParam> = {
 
   // A function to force refetch the query - returns a Promise with additional methods
   refetch: (options?: {
+    refetchBehavior?:
+      | 'refetch-all-pages'
+      | 'refetch-first-page-discard-rest'
+      | 'refetch-first-page-preserve-rest'
     refetchCachedPages?: boolean
   }) => InfiniteQueryActionCreatorResult
 

--- a/docs/rtk-query/usage/infinite-queries.mdx
+++ b/docs/rtk-query/usage/infinite-queries.mdx
@@ -281,13 +281,21 @@ When an infinite query endpoint is refetched (due to tag invalidation, polling, 
 
 If the cache entry is ever removed and then re-added, it will start with only fetching the initial page.
 
-There may be cases when you want a refetch to _only_ refetch the first page, and not any of the other pages in cache (ie, the refetch shrinks the cache from N pages to 1 page). This can be done via the `refetchCachedPages` option, which can be passed in several different places:
+There may be cases when you want different behavior when refetching an infinite query. This can be done via the `refetchBehavior` option, which can be passed in several different places:
 
-- Defined on the endpoint as part of `infiniteQueryOptions`: applies to all attempted refetches
-- Passed as an option to a `useInfiniteQuery` hook: applies to all attempted refetches
+- Defined on the endpoint as part of `infiniteQueryOptions`: applies to automatic refetches and manual refetches unless overridden
+- Passed as an option to a `useInfiniteQuery` hook: applies to forced refetches started by that hook, and is used as the default for the hook result's `refetch()` method
 - Passed as an option to `endpoint.initiate()`, or the `refetch` method available on the `initiate` or hook result objects: applies only to the manually triggered refetch
 
-Overall, the refetch logic defaults to refetching all pages, but will override that with the option provided to the endpoint or a manual refetch.
+The supported refetch behaviors are:
+
+- `'refetch-all-pages'`: the default behavior. Sequentially refetches all pages currently in the cache.
+- `'refetch-first-page-discard-rest'`: refetches only the first cached page and shrinks the cache from N pages to 1 page.
+- `'refetch-first-page-preserve-rest'`: refetches only the first cached page and preserves cached pages 2..N and their page params. This can be useful for feed-like UIs that deduplicate items while accepting that the preserved pages may be stale.
+
+Because preserving the remaining pages can leave stale page boundaries or cursors, it may also produce duplicate or missing items. Use this mode only when the UI can tolerate or reconcile those inconsistencies.
+
+`refetchCachedPages` is still supported as a backwards-compatible alias. `refetchCachedPages: true` maps to `'refetch-all-pages'`, and `refetchCachedPages: false` maps to `'refetch-first-page-discard-rest'`. If both options are provided at the same level, `refetchBehavior` takes precedence.
 
 ### Limiting Cache Entry Size
 

--- a/packages/toolkit/src/query/core/apiState.ts
+++ b/packages/toolkit/src/query/core/apiState.ts
@@ -25,6 +25,11 @@ export type RefetchConfigOptions = {
   refetchOnFocus: boolean
 }
 
+export type InfiniteQueryRefetchBehavior =
+  | 'refetch-all-pages'
+  | 'refetch-first-page-discard-rest'
+  | 'refetch-first-page-preserve-rest'
+
 export type InfiniteQueryConfigOptions<DataType, PageParam, QueryArg> = {
   /**
    * The initial page parameter to use for the first page fetch.
@@ -59,10 +64,18 @@ export type InfiniteQueryConfigOptions<DataType, PageParam, QueryArg> = {
    */
   maxPages?: number
   /**
-   * Defaults to `true`. When this is `true` and an infinite query endpoint is refetched
-   * (due to tag invalidation, polling, arg change configuration, or manual refetching),
-   * RTK Query will try to sequentially refetch all pages currently in the cache.
-   * When `false` only the first page will be refetched.
+   * Defaults to `'refetch-all-pages'`. Controls how an infinite query endpoint is refetched
+   * (due to tag invalidation, polling, arg change configuration, or manual refetching).
+   * `'refetch-all-pages'` sequentially refetches all pages currently in the cache.
+   * `'refetch-first-page-discard-rest'` refetches only the first cached page and shrinks the cache to one page.
+   * `'refetch-first-page-preserve-rest'` refetches only the first cached page and preserves the remaining cached pages.
+   */
+  refetchBehavior?: InfiniteQueryRefetchBehavior
+  /**
+   * Defaults to `true`. This is a backwards-compatible alias for `refetchBehavior`.
+   * `true` maps to `'refetch-all-pages'`.
+   * `false` maps to `'refetch-first-page-discard-rest'`.
+   * If both options are provided at the same level, `refetchBehavior` takes precedence.
    */
   refetchCachedPages?: boolean
 }

--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -74,6 +74,7 @@ export type StartQueryActionCreatorOptions = {
 }
 
 type RefetchOptions = {
+  refetchBehavior?: InfiniteQueryConfigOptions<any, any, any>['refetchBehavior']
   refetchCachedPages?: boolean
 }
 
@@ -91,7 +92,7 @@ export type StartInfiniteQueryActionCreatorOptions<
           InfiniteQueryArgFrom<D>
         >
       >,
-      'initialPageParam' | 'refetchCachedPages'
+      'initialPageParam' | 'refetchBehavior' | 'refetchCachedPages'
     >
   >
 
@@ -148,7 +149,7 @@ export type InfiniteQueryActionCreatorResult<
     refetch(
       options?: Pick<
         StartInfiniteQueryActionCreatorOptions<D>,
-        'refetchCachedPages'
+        'refetchBehavior' | 'refetchCachedPages'
       >,
     ): InfiniteQueryActionCreatorResult<D>
   }
@@ -415,17 +416,25 @@ You must add the middleware for RTK-Query to function correctly!`,
         if (isQueryDefinition(endpointDefinition)) {
           thunk = queryThunk(commonThunkArgs)
         } else {
-          const { direction, initialPageParam, refetchCachedPages } =
-            rest as Pick<
-              InfiniteQueryThunkArg<any>,
-              'direction' | 'initialPageParam' | 'refetchCachedPages'
-            >
+          const {
+            direction,
+            initialPageParam,
+            refetchBehavior,
+            refetchCachedPages,
+          } = rest as Pick<
+            InfiniteQueryThunkArg<any>,
+            | 'direction'
+            | 'initialPageParam'
+            | 'refetchBehavior'
+            | 'refetchCachedPages'
+          >
           thunk = infiniteQueryThunk({
             ...(commonThunkArgs as InfiniteQueryThunkArg<any>),
             // Supply these even if undefined. This helps with a field existence
             // check over in `buildSlice.ts`
             direction,
             initialPageParam,
+            refetchBehavior,
             refetchCachedPages,
           })
         }

--- a/packages/toolkit/src/query/core/buildThunks.ts
+++ b/packages/toolkit/src/query/core/buildThunks.ts
@@ -50,6 +50,7 @@ import type {
   QueryCacheKey,
   InfiniteQueryDirection,
   InfiniteQueryKeys,
+  InfiniteQueryRefetchBehavior,
 } from './apiState'
 import { QueryStatus, STATUS_UNINITIALIZED } from './apiState'
 import type {
@@ -163,6 +164,7 @@ export type InfiniteQueryThunkArg<
     endpointName: string
     param: unknown
     direction?: InfiniteQueryDirection
+    refetchBehavior?: InfiniteQueryRefetchBehavior
     refetchCachedPages?: boolean
   }
 
@@ -198,6 +200,28 @@ export type MutationThunk = AsyncThunk<
   MutationThunkArg,
   ThunkApiMetaConfig
 >
+
+function getInfiniteQueryRefetchBehavior(
+  arg: InfiniteQueryThunkArg<any>,
+  infiniteQueryOptions: InfiniteQueryConfigOptions<any, any, any>,
+): InfiniteQueryRefetchBehavior {
+  const mapRefetchCachedPages = (
+    refetchCachedPages: boolean,
+  ): InfiniteQueryRefetchBehavior =>
+    refetchCachedPages ? 'refetch-all-pages' : 'refetch-first-page-discard-rest'
+
+  return (
+    arg.refetchBehavior ??
+    (arg.refetchCachedPages != null
+      ? mapRefetchCachedPages(arg.refetchCachedPages)
+      : undefined) ??
+    infiniteQueryOptions.refetchBehavior ??
+    (infiniteQueryOptions.refetchCachedPages != null
+      ? mapRefetchCachedPages(infiniteQueryOptions.refetchCachedPages)
+      : undefined) ??
+    'refetch-all-pages'
+  )
+}
 
 function defaultTransformResponse(baseQueryReturnValue: unknown) {
   return baseQueryReturnValue
@@ -684,11 +708,11 @@ export function buildThunks<
         // Runtime checks should guarantee this is a positive number if provided
         const { maxPages = Infinity } = infiniteQueryOptions
 
-        // Priority: per-call override > endpoint config > default (true)
-        const refetchCachedPages =
-          (arg as InfiniteQueryThunkArg<any>).refetchCachedPages ??
-          infiniteQueryOptions.refetchCachedPages ??
-          true
+        // Priority: per-call override > endpoint config > default
+        const refetchBehavior = getInfiniteQueryRefetchBehavior(
+          arg as InfiniteQueryThunkArg<any>,
+          infiniteQueryOptions,
+        )
 
         let result: QueryReturnValue
 
@@ -745,9 +769,33 @@ export function buildThunks<
             result = {
               data: (result.data as InfiniteData<unknown, unknown>).pages[0],
             } as QueryReturnValue
+          } else if (
+            isForcedQueryNeedingRefetch &&
+            refetchBehavior === 'refetch-first-page-preserve-rest' &&
+            cachedData?.pages.length
+          ) {
+            const firstPageData = result.data as InfiniteData<unknown, unknown>
+            const latestCachedData = selectors.selectQueryEntry(
+              getState(),
+              arg.queryCacheKey,
+            )?.data as InfiniteData<unknown, unknown> | undefined
+            const dataToPreserve = latestCachedData ?? cachedData
+            result = {
+              data: {
+                pages: [
+                  firstPageData.pages[0],
+                  ...dataToPreserve.pages.slice(1),
+                ],
+                pageParams: [
+                  firstPageData.pageParams[0],
+                  ...dataToPreserve.pageParams.slice(1),
+                ],
+              },
+              meta: result.meta,
+            }
           }
 
-          if (refetchCachedPages) {
+          if (refetchBehavior === 'refetch-all-pages') {
             // Fetch remaining pages
             for (let i = 1; i < totalPages; i++) {
               const param = getNextPageParam(

--- a/packages/toolkit/src/query/core/index.ts
+++ b/packages/toolkit/src/query/core/index.ts
@@ -8,6 +8,7 @@ export type {
   CombinedState,
   InfiniteData,
   InfiniteQueryConfigOptions,
+  InfiniteQueryRefetchBehavior,
   InfiniteQuerySubState,
   MutationKeys,
   QueryCacheKey,

--- a/packages/toolkit/src/query/index.ts
+++ b/packages/toolkit/src/query/index.ts
@@ -81,6 +81,7 @@ export type {
   InfiniteData,
   InfiniteQueryActionCreatorResult,
   InfiniteQueryConfigOptions,
+  InfiniteQueryRefetchBehavior,
   InfiniteQueryResultSelectorResult,
   InfiniteQuerySubState,
   TypedMutationOnQueryStarted,

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -38,7 +38,10 @@ import type {
   TSHelpersOverride,
 } from '@reduxjs/toolkit/query'
 import type { DependencyList } from 'react'
-import type { InfiniteQueryDirection } from '../core/apiState'
+import type {
+  InfiniteQueryDirection,
+  InfiniteQueryRefetchBehavior,
+} from '../core/apiState'
 import type { StartInfiniteQueryActionCreator } from '../core/buildInitiate'
 import type { SubscriptionSelectors } from '../core/buildMiddleware/index'
 import type { InfiniteData } from '../core/index'
@@ -883,13 +886,29 @@ export type UseInfiniteQuerySubscriptionOptions<
   refetchOnMountOrArgChange?: boolean | number
   initialPageParam?: PageParamFrom<D>
   /**
-   * Defaults to `true`. When this is `true` and an infinite query endpoint is refetched
-   * (due to tag invalidation, polling, arg change configuration, or manual refetching),
-   * RTK Query will try to sequentially refetch all pages currently in the cache.
-   * When `false` only the first page will be refetched.
+   * Controls forced refetches started by this hook. When omitted, uses the
+   * endpoint setting, which defaults to `'refetch-all-pages'`.
+   * `'refetch-all-pages'` sequentially refetches all pages currently in the cache.
+   * `'refetch-first-page-discard-rest'` refetches only the first cached page and shrinks the cache to one page.
+   * `'refetch-first-page-preserve-rest'` refetches only the first cached page and preserves the remaining cached pages.
    *
-   * This option applies to all automatic refetches for this subscription (polling, tag invalidation, etc.).
-   * It can be overridden on a per-call basis using the `refetch()` method.
+   * This option applies to forced refetches started by this hook, and is used as
+   * the default for the hook result's `refetch()` method. For shared automatic
+   * refetches such as polling or tag invalidation, define this on the
+   * endpoint.
+   */
+  refetchBehavior?: InfiniteQueryRefetchBehavior
+  /**
+   * This is a backwards-compatible alias for `refetchBehavior`. When omitted,
+   * uses the endpoint setting, whose legacy default is `true`.
+   * `true` maps to `'refetch-all-pages'`.
+   * `false` maps to `'refetch-first-page-discard-rest'`.
+   * If both options are provided at the same level, `refetchBehavior` takes precedence.
+   *
+   * This option applies to forced refetches started by this hook, and is used as
+   * the default for the hook result's `refetch()` method. For shared automatic
+   * refetches such as polling or tag invalidation, define this on the
+   * endpoint.
    */
   refetchCachedPages?: boolean
 }
@@ -916,7 +935,7 @@ export type UseInfiniteQuerySubscriptionResult<
   refetch: (
     options?: Pick<
       UseInfiniteQuerySubscriptionOptions<D>,
-      'refetchCachedPages'
+      'refetchBehavior' | 'refetchCachedPages'
     >,
   ) => InfiniteQueryActionCreatorResult<D>
   trigger: LazyInfiniteQueryTrigger<D>
@@ -1737,6 +1756,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       .initialPageParam
     const stableInitialPageParam = useShallowStableValue(initialPageParam)
 
+    const refetchBehavior = (rest as UseInfiniteQuerySubscriptionOptions<any>)
+      .refetchBehavior
+    const stableRefetchBehavior = useShallowStableValue(refetchBehavior)
+
     const refetchCachedPages = (
       rest as UseInfiniteQuerySubscriptionOptions<any>
     ).refetchCachedPages
@@ -1793,6 +1816,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
             ...(isInfiniteQueryDefinition(endpointDefinitions[endpointName])
               ? {
                   initialPageParam: stableInitialPageParam,
+                  refetchBehavior: stableRefetchBehavior,
                   refetchCachedPages: stableRefetchCachedPages,
                 }
               : {}),
@@ -1811,6 +1835,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       stableSubscriptionOptions,
       subscriptionRemoved,
       stableInitialPageParam,
+      stableRefetchBehavior,
       stableRefetchCachedPages,
       endpointName,
     ])
@@ -2098,7 +2123,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         subscriptionOptionsRef.current = stableSubscriptionOptions
       }, [stableSubscriptionOptions])
 
-      // Extract and stabilize the hook-level refetchCachedPages option
+      // Extract and stabilize the hook-level refetch behavior options
+      const hookRefetchBehavior = (
+        options as UseInfiniteQuerySubscriptionOptions<any>
+      ).refetchBehavior
+      const stableHookRefetchBehavior =
+        useShallowStableValue(hookRefetchBehavior)
       const hookRefetchCachedPages = (
         options as UseInfiniteQuerySubscriptionOptions<any>
       ).refetchCachedPages
@@ -2134,21 +2164,27 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         (
           options?: Pick<
             UseInfiniteQuerySubscriptionOptions<any>,
-            'refetchCachedPages'
+            'refetchBehavior' | 'refetchCachedPages'
           >,
         ) => {
           if (!promiseRef.current)
             throw new Error(
               'Cannot refetch a query that has not been started yet.',
             )
-          // Merge per-call options with hook-level default
-          const mergedOptions = {
-            refetchCachedPages:
-              options?.refetchCachedPages ?? stableHookRefetchCachedPages,
-          }
-          return promiseRef.current.refetch(mergedOptions)
+          const hasPerCallOverride =
+            options?.refetchBehavior !== undefined ||
+            options?.refetchCachedPages !== undefined
+
+          return promiseRef.current.refetch(
+            hasPerCallOverride
+              ? options
+              : {
+                  refetchBehavior: stableHookRefetchBehavior,
+                  refetchCachedPages: stableHookRefetchCachedPages,
+                },
+          )
         },
-        [promiseRef, stableHookRefetchCachedPages],
+        [promiseRef, stableHookRefetchBehavior, stableHookRefetchCachedPages],
       )
 
       return useMemo(() => {

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -2610,6 +2610,90 @@ describe('hooks tests', () => {
       expect(pages).toHaveLength(1)
     })
 
+    test('useInfiniteQuery hook option refetchBehavior preserves remaining cached pages', async () => {
+      let requestCount = 0
+      server.use(
+        http.get('https://example.com/listItems', ({ request }) => {
+          const url = new URL(request.url)
+          const pageNum = Number(url.searchParams.get('page'))
+          requestCount++
+
+          return HttpResponse.json({
+            id: `${pageNum}`,
+            name: `Pokemon ${pageNum} request ${requestCount}`,
+          })
+        }),
+      )
+
+      const storeRef = setupApiStore(pokemonApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      function PokemonList() {
+        const { data, fetchNextPage, refetch } =
+          pokemonApi.useGetInfinitePokemonInfiniteQuery('fire', {
+            refetchBehavior: 'refetch-first-page-preserve-rest',
+          })
+
+        return (
+          <div>
+            <div data-testid="data">
+              {data?.pages.map((page, i) => (
+                <div key={i} data-testid={`page-${i}`}>
+                  {page.name}
+                </div>
+              ))}
+            </div>
+            <button data-testid="nextPage" onClick={() => fetchNextPage()}>
+              Next Page
+            </button>
+            <button data-testid="refetch" onClick={() => refetch()}>
+              Refetch
+            </button>
+          </div>
+        )
+      }
+
+      render(<PokemonList />, { wrapper: storeRef.wrapper })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('page-0').textContent).toBe(
+          'Pokemon 0 request 1',
+        )
+      })
+
+      fireEvent.click(screen.getByTestId('nextPage'))
+      await waitFor(() => {
+        expect(screen.getByTestId('page-1').textContent).toBe(
+          'Pokemon 1 request 2',
+        )
+      })
+
+      fireEvent.click(screen.getByTestId('nextPage'))
+      await waitFor(() => {
+        expect(screen.getByTestId('page-2').textContent).toBe(
+          'Pokemon 2 request 3',
+        )
+      })
+
+      fireEvent.click(screen.getByTestId('refetch'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('page-0').textContent).toBe(
+          'Pokemon 0 request 4',
+        )
+        expect(screen.getByTestId('page-1').textContent).toBe(
+          'Pokemon 1 request 2',
+        )
+        expect(screen.getByTestId('page-2').textContent).toBe(
+          'Pokemon 2 request 3',
+        )
+      })
+
+      expect(screen.getAllByTestId(/^page-/)).toHaveLength(3)
+      expect(requestCount).toBe(4)
+    })
+
     test('useInfiniteQuery refetch() method option refetchCachedPages: false only refetches first page', async () => {
       const storeRef = setupApiStore(pokemonApi, undefined, {
         withoutTestLifecycles: true,
@@ -2673,6 +2757,66 @@ describe('hooks tests', () => {
       // Verify we only have 1 page (not refetched all)
       const pages = screen.getAllByTestId(/^page-/)
       expect(pages).toHaveLength(1)
+    })
+
+    test('useInfiniteQuery refetch() per-call legacy option overrides hook refetchBehavior', async () => {
+      const storeRef = setupApiStore(pokemonApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      function PokemonList() {
+        const { data, fetchNextPage, refetch } =
+          pokemonApi.useGetInfinitePokemonInfiniteQuery('fire', {
+            refetchBehavior: 'refetch-first-page-preserve-rest',
+          })
+
+        return (
+          <div>
+            <div data-testid="data">
+              {data?.pages.map((page, i) => (
+                <div key={i} data-testid={`page-${i}`}>
+                  {page.name}
+                </div>
+              ))}
+            </div>
+            <button data-testid="nextPage" onClick={() => fetchNextPage()}>
+              Next Page
+            </button>
+            <button
+              data-testid="refetch"
+              onClick={() => refetch({ refetchCachedPages: false })}
+            >
+              Refetch
+            </button>
+          </div>
+        )
+      }
+
+      render(<PokemonList />, { wrapper: storeRef.wrapper })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('page-0').textContent).toBe('Pokemon 0')
+      })
+
+      fireEvent.click(screen.getByTestId('nextPage'))
+      await waitFor(() => {
+        expect(screen.getByTestId('page-1').textContent).toBe('Pokemon 1')
+      })
+
+      fireEvent.click(screen.getByTestId('nextPage'))
+      await waitFor(() => {
+        expect(screen.getByTestId('page-2').textContent).toBe('Pokemon 2')
+      })
+
+      fireEvent.click(screen.getByTestId('refetch'))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('page-0')).toBeTruthy()
+        expect(screen.queryByTestId('page-1')).toBeNull()
+        expect(screen.queryByTestId('page-2')).toBeNull()
+      })
+
+      expect(screen.getAllByTestId(/^page-/)).toHaveLength(1)
     })
   })
 

--- a/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
@@ -1,5 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit'
-import type { InfiniteData, skipToken } from '@reduxjs/toolkit/query/react'
+import type {
+  InfiniteData,
+  InfiniteQueryRefetchBehavior,
+  skipToken,
+} from '@reduxjs/toolkit/query/react'
 import {
   createApi,
   fetchBaseQuery,
@@ -9,6 +13,12 @@ import { setupApiStore } from '../../tests/utils/helpers'
 
 describe('Infinite queries', () => {
   test('Basic infinite query behavior', async () => {
+    expectTypeOf<InfiniteQueryRefetchBehavior>().toEqualTypeOf<
+      | 'refetch-all-pages'
+      | 'refetch-first-page-discard-rest'
+      | 'refetch-first-page-preserve-rest'
+    >()
+
     type Pokemon = {
       id: string
       name: string
@@ -20,6 +30,7 @@ describe('Infinite queries', () => {
         getInfinitePokemon: build.infiniteQuery<Pokemon[], string, number>({
           infiniteQueryOptions: {
             initialPageParam: 0,
+            refetchBehavior: 'refetch-first-page-preserve-rest',
             getNextPageParam: (
               lastPage,
               allPages,
@@ -127,6 +138,21 @@ describe('Infinite queries', () => {
       }),
     )
 
+    storeRef.store.dispatch(
+      pokemonApi.endpoints.getInfinitePokemon.initiate('fire', {
+        forceRefetch: true,
+        refetchBehavior: 'refetch-first-page-discard-rest',
+      }),
+    )
+
+    storeRef.store.dispatch(
+      pokemonApi.endpoints.getInfinitePokemon.initiate('fire', {
+        forceRefetch: true,
+        // @ts-expect-error invalid infinite query refetch behavior
+        refetchBehavior: 'refetch-first-page',
+      }),
+    )
+
     const useGetInfinitePokemonQuery =
       pokemonApi.endpoints.getInfinitePokemon.useInfiniteQuery
 
@@ -142,7 +168,15 @@ describe('Infinite queries', () => {
         isUninitialized,
         isSuccess,
         fetchNextPage,
-      } = useGetInfinitePokemonQuery('a')
+        refetch,
+      } = useGetInfinitePokemonQuery('a', {
+        refetchBehavior: 'refetch-all-pages',
+      })
+
+      useGetInfinitePokemonQuery('a', {
+        // @ts-expect-error invalid infinite query refetch behavior
+        refetchBehavior: 'refetch-first-page',
+      })
 
       expectTypeOf(data).toEqualTypeOf<
         InfiniteData<Pokemon[], number> | undefined
@@ -164,6 +198,20 @@ describe('Infinite queries', () => {
         if (res.status === QueryStatus.fulfilled) {
           expectTypeOf(res.data.pages).toEqualTypeOf<Pokemon[][]>()
           expectTypeOf(res.data.pageParams).toEqualTypeOf<number[]>()
+        }
+
+        const refetchRes = await refetch({
+          refetchBehavior: 'refetch-first-page-preserve-rest',
+        })
+
+        refetch({
+          // @ts-expect-error invalid infinite query refetch behavior
+          refetchBehavior: 'refetch-first-page',
+        })
+
+        if (refetchRes.status === QueryStatus.fulfilled) {
+          expectTypeOf(refetchRes.data.pages).toEqualTypeOf<Pokemon[][]>()
+          expectTypeOf(refetchRes.data.pageParams).toEqualTypeOf<number[]>()
         }
       }
     }

--- a/packages/toolkit/src/query/tests/infiniteQueries.test.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test.ts
@@ -1193,7 +1193,7 @@ describe('Infinite queries', () => {
     ])
   })
 
-  describe('refetchCachedPages option', () => {
+  describe('infinite query refetch behavior options', () => {
     test('refetches all pages by default (refetchCachedPages: true)', async () => {
       let hitCounter = 0
 
@@ -1407,6 +1407,225 @@ describe('Infinite queries', () => {
       expect(refetchRes.data!.pageParams).toEqual([0])
     })
 
+    test('refetches first page and preserves remaining cached pages when refetchBehavior preserves rest', async () => {
+      let hitCounter = 0
+
+      const countersApi = createApi({
+        baseQuery: fakeBaseQuery(),
+        tagTypes: ['Counter'],
+        endpoints: (build) => ({
+          counters: build.infiniteQuery<HitCounter, string, number>({
+            queryFn({ pageParam }) {
+              hitCounter++
+              return { data: { page: pageParam, hitCounter } }
+            },
+            infiniteQueryOptions: {
+              initialPageParam: 0,
+              getNextPageParam: (
+                lastPage,
+                allPages,
+                lastPageParam,
+                allPageParams,
+              ) => lastPageParam + 1,
+              refetchBehavior: 'refetch-first-page-preserve-rest',
+            },
+            providesTags: ['Counter'],
+          }),
+        }),
+      })
+
+      const storeRef = setupApiStore(
+        countersApi,
+        { ...actionsReducer },
+        {
+          withoutTestLifecycles: true,
+        },
+      )
+
+      // Load 3 pages
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          initialPageParam: 0,
+        }),
+      )
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+
+      const thirdPromise = storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+
+      const thirdRes = await thirdPromise
+
+      expect(thirdRes.data!.pages).toEqual([
+        { page: 0, hitCounter: 1 },
+        { page: 1, hitCounter: 2 },
+        { page: 2, hitCounter: 3 },
+      ])
+      expect(thirdRes.data!.pageParams).toEqual([0, 1, 2])
+
+      const refetchRes = await thirdPromise.refetch()
+
+      expect(refetchRes.data!.pages).toEqual([
+        { page: 0, hitCounter: 4 },
+        { page: 1, hitCounter: 2 },
+        { page: 2, hitCounter: 3 },
+      ])
+      expect(refetchRes.data!.pageParams).toEqual([0, 1, 2])
+      expect(hitCounter).toBe(4)
+    })
+
+    test('preserves the latest cached tail while the first page refetch is in flight', async () => {
+      let hitCounter = 0
+      let signalRefetchStarted!: () => void
+      let releaseRefetch!: () => void
+      const refetchStarted = new Promise<void>((resolve) => {
+        signalRefetchStarted = resolve
+      })
+      const refetchGate = new Promise<void>((resolve) => {
+        releaseRefetch = resolve
+      })
+
+      const countersApi = createApi({
+        baseQuery: fakeBaseQuery(),
+        endpoints: (build) => ({
+          counters: build.infiniteQuery<HitCounter, string, number>({
+            async queryFn({ pageParam }) {
+              hitCounter++
+              const currentHit = hitCounter
+
+              if (currentHit === 4) {
+                signalRefetchStarted()
+                await refetchGate
+              }
+
+              return { data: { page: pageParam, hitCounter: currentHit } }
+            },
+            infiniteQueryOptions: {
+              initialPageParam: 0,
+              getNextPageParam: (
+                lastPage,
+                allPages,
+                lastPageParam,
+                allPageParams,
+              ) => lastPageParam + 1,
+              refetchBehavior: 'refetch-first-page-preserve-rest',
+            },
+          }),
+        }),
+      })
+
+      const storeRef = setupApiStore(countersApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item'),
+      )
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+
+      const refetchPromise = storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          forceRefetch: true,
+        }),
+      )
+
+      await refetchStarted
+      storeRef.store.dispatch(
+        countersApi.util.updateQueryData('counters', 'item', (draft) => {
+          draft.pages[0] = { page: 0, hitCounter: 100 }
+          draft.pages[1] = { page: 1, hitCounter: 200 }
+          draft.pages.pop()
+          draft.pageParams.pop()
+        }),
+      )
+      releaseRefetch()
+
+      const refetchResult = await refetchPromise
+      expect(refetchResult.data).toEqual({
+        pages: [
+          { page: 0, hitCounter: 4 },
+          { page: 1, hitCounter: 200 },
+        ],
+        pageParams: [0, 1],
+      })
+    })
+
+    test('keeps cached pages when a preserve-rest refetch is rejected', async () => {
+      let hitCounter = 0
+      let rejectNextRequest = false
+
+      const countersApi = createApi({
+        baseQuery: fakeBaseQuery<string>(),
+        endpoints: (build) => ({
+          counters: build.infiniteQuery<HitCounter, string, number>({
+            queryFn({ pageParam }) {
+              if (rejectNextRequest) {
+                return { error: 'rejected' }
+              }
+
+              hitCounter++
+              return { data: { page: pageParam, hitCounter } }
+            },
+            infiniteQueryOptions: {
+              initialPageParam: 0,
+              getNextPageParam: (
+                lastPage,
+                allPages,
+                lastPageParam,
+                allPageParams,
+              ) => lastPageParam + 1,
+              refetchBehavior: 'refetch-first-page-preserve-rest',
+            },
+          }),
+        }),
+      })
+
+      const storeRef = setupApiStore(countersApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item'),
+      )
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+      const beforeRefetch = countersApi.endpoints.counters.select('item')(
+        storeRef.store.getState(),
+      ).data
+
+      rejectNextRequest = true
+      const refetchResult = await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          forceRefetch: true,
+        }),
+      )
+
+      expect(refetchResult.status).toBe(QueryStatus.rejected)
+      expect(
+        countersApi.endpoints.counters.select('item')(storeRef.store.getState())
+          .data,
+      ).toEqual(beforeRefetch)
+    })
+
     test('refetches only first page on tag invalidation when refetchCachedPages is false', async () => {
       let hitCounter = 0
 
@@ -1484,6 +1703,79 @@ describe('Infinite queries', () => {
       expect((finalRes as any).data.pages).toEqual([{ page: 0, hitCounter: 4 }])
     })
 
+    test('refetches first page and preserves remaining cached pages on tag invalidation when refetchBehavior preserves rest', async () => {
+      let hitCounter = 0
+
+      const countersApi = createApi({
+        baseQuery: fakeBaseQuery(),
+        tagTypes: ['Counter'],
+        endpoints: (build) => ({
+          counters: build.infiniteQuery<HitCounter, string, number>({
+            queryFn({ pageParam }) {
+              hitCounter++
+              return { data: { page: pageParam, hitCounter } }
+            },
+            infiniteQueryOptions: {
+              initialPageParam: 0,
+              getNextPageParam: (
+                lastPage,
+                allPages,
+                lastPageParam,
+                allPageParams,
+              ) => lastPageParam + 1,
+              refetchBehavior: 'refetch-first-page-preserve-rest',
+            },
+            providesTags: ['Counter'],
+          }),
+          mutation: build.mutation<null, void>({
+            queryFn: async () => ({ data: null }),
+            invalidatesTags: ['Counter'],
+          }),
+        }),
+      })
+
+      const storeRef = setupApiStore(
+        countersApi,
+        { ...actionsReducer },
+        {
+          withoutTestLifecycles: true,
+        },
+      )
+
+      // Load 3 pages
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          initialPageParam: 0,
+        }),
+      )
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+
+      await storeRef.store.dispatch(countersApi.endpoints.mutation.initiate())
+
+      const promise = storeRef.store.dispatch(
+        countersApi.util.getRunningQueryThunk('counters', 'item'),
+      )
+      const finalRes = await promise
+
+      expect((finalRes as any).data.pages).toEqual([
+        { page: 0, hitCounter: 4 },
+        { page: 1, hitCounter: 2 },
+        { page: 2, hitCounter: 3 },
+      ])
+      expect((finalRes as any).data.pageParams).toEqual([0, 1, 2])
+    })
+
     test('refetches only first page during polling when refetchCachedPages is false', async () => {
       let hitCounter = 0
 
@@ -1552,6 +1844,75 @@ describe('Infinite queries', () => {
 
       // Should only have 1 page after poll
       expect(entry.data?.pages).toEqual([{ page: 0, hitCounter: 4 }])
+
+      thirdPromise.updateSubscriptionOptions({ pollingInterval: 0 })
+      thirdPromise.unsubscribe()
+      storeRef.store.dispatch(countersApi.util.resetApiState())
+    })
+
+    test('refetches the first page and preserves the cached tail during polling', async () => {
+      let hitCounter = 0
+
+      const countersApi = createApi({
+        baseQuery: fakeBaseQuery(),
+        endpoints: (build) => ({
+          counters: build.infiniteQuery<HitCounter, string, number>({
+            queryFn({ pageParam }) {
+              hitCounter++
+              return { data: { page: pageParam, hitCounter } }
+            },
+            infiniteQueryOptions: {
+              initialPageParam: 0,
+              getNextPageParam: (
+                lastPage,
+                allPages,
+                lastPageParam,
+                allPageParams,
+              ) => lastPageParam + 1,
+              refetchBehavior: 'refetch-first-page-preserve-rest',
+            },
+          }),
+        }),
+      })
+
+      const storeRef = setupApiStore(countersApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item'),
+      )
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+      const thirdPagePromise = storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+      await thirdPagePromise
+
+      thirdPagePromise.updateSubscriptionOptions({ pollingInterval: 50 })
+      await delay(75)
+      thirdPagePromise.updateSubscriptionOptions({ pollingInterval: 0 })
+
+      const entry = countersApi.endpoints.counters.select('item')(
+        storeRef.store.getState(),
+      )
+      expect(entry.data).toEqual({
+        pages: [
+          { page: 0, hitCounter: 4 },
+          { page: 1, hitCounter: 2 },
+          { page: 2, hitCounter: 3 },
+        ],
+        pageParams: [0, 1, 2],
+      })
+      expect(hitCounter).toBe(4)
+
+      thirdPagePromise.unsubscribe()
+      storeRef.store.dispatch(countersApi.util.resetApiState())
     })
 
     test('refetchCachedPages: false works with maxPages', async () => {
@@ -1632,6 +1993,85 @@ describe('Infinite queries', () => {
       expect(refetchRes.data!.pages[0].page).toBe(2)
     })
 
+    test('preserve-rest works with maxPages and subsequent page fetching', async () => {
+      let hitCounter = 0
+      const requestedPageParams: number[] = []
+
+      const countersApi = createApi({
+        baseQuery: fakeBaseQuery(),
+        endpoints: (build) => ({
+          counters: build.infiniteQuery<HitCounter, string, number>({
+            queryFn({ pageParam }) {
+              requestedPageParams.push(pageParam)
+              hitCounter++
+              return { data: { page: pageParam, hitCounter } }
+            },
+            infiniteQueryOptions: {
+              initialPageParam: 0,
+              maxPages: 3,
+              getNextPageParam: (
+                lastPage,
+                allPages,
+                lastPageParam,
+                allPageParams,
+              ) => lastPageParam + 1,
+              getPreviousPageParam: (
+                firstPage,
+                allPages,
+                firstPageParam,
+                allPageParams,
+              ) => firstPageParam - 1,
+              refetchBehavior: 'refetch-first-page-preserve-rest',
+            },
+          }),
+        }),
+      })
+
+      const storeRef = setupApiStore(countersApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item'),
+      )
+      for (let i = 0; i < 4; i++) {
+        await storeRef.store.dispatch(
+          countersApi.endpoints.counters.initiate('item', {
+            direction: 'forward',
+          }),
+        )
+      }
+
+      const refetchResult = await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          forceRefetch: true,
+        }),
+      )
+      expect(refetchResult.data).toEqual({
+        pages: [
+          { page: 2, hitCounter: 6 },
+          { page: 3, hitCounter: 4 },
+          { page: 4, hitCounter: 5 },
+        ],
+        pageParams: [2, 3, 4],
+      })
+      expect(requestedPageParams).toEqual([0, 1, 2, 3, 4, 2])
+
+      const nextPageResult = await storeRef.store.dispatch(
+        countersApi.endpoints.counters.initiate('item', {
+          direction: 'forward',
+        }),
+      )
+      expect(nextPageResult.data).toEqual({
+        pages: [
+          { page: 3, hitCounter: 4 },
+          { page: 4, hitCounter: 5 },
+          { page: 5, hitCounter: 7 },
+        ],
+        pageParams: [3, 4, 5],
+      })
+    })
+
     test('can fetch next page after refetch with refetchCachedPages: false', async () => {
       let hitCounter = 0
 
@@ -1708,7 +2148,7 @@ describe('Infinite queries', () => {
       ])
     })
 
-    describe('per-call refetchCachedPages override', () => {
+    describe('per-call refetch behavior override', () => {
       test('per-call false overrides endpoint true', async () => {
         let hitCounter = 0
 
@@ -1782,6 +2222,74 @@ describe('Infinite queries', () => {
         // Only first page should be refetched (hitCounter 4)
         expect(refetchRes.data!.pages).toEqual([{ page: 0, hitCounter: 4 }])
         expect(refetchRes.data!.pageParams).toEqual([0])
+      })
+
+      test('per-call refetchBehavior takes precedence over refetchCachedPages and endpoint config', async () => {
+        let hitCounter = 0
+
+        const countersApi = createApi({
+          baseQuery: fakeBaseQuery(),
+          endpoints: (build) => ({
+            counters: build.infiniteQuery<HitCounter, string, number>({
+              queryFn({ pageParam }) {
+                hitCounter++
+                return { data: { page: pageParam, hitCounter } }
+              },
+              infiniteQueryOptions: {
+                initialPageParam: 0,
+                getNextPageParam: (
+                  lastPage,
+                  allPages,
+                  lastPageParam,
+                  allPageParams,
+                ) => lastPageParam + 1,
+                refetchCachedPages: false, // Endpoint default: discard remaining pages
+              },
+            }),
+          }),
+        })
+
+        const storeRef = setupApiStore(
+          countersApi,
+          { ...actionsReducer },
+          {
+            withoutTestLifecycles: true,
+          },
+        )
+
+        // Load 3 pages
+        await storeRef.store.dispatch(
+          countersApi.endpoints.counters.initiate('item', {
+            initialPageParam: 0,
+          }),
+        )
+
+        await storeRef.store.dispatch(
+          countersApi.endpoints.counters.initiate('item', {
+            direction: 'forward',
+          }),
+        )
+
+        await storeRef.store.dispatch(
+          countersApi.endpoints.counters.initiate('item', {
+            direction: 'forward',
+          }),
+        )
+
+        const refetchRes = await storeRef.store.dispatch(
+          countersApi.endpoints.counters.initiate('item', {
+            forceRefetch: true,
+            refetchBehavior: 'refetch-first-page-preserve-rest',
+            refetchCachedPages: true,
+          }),
+        )
+
+        expect(refetchRes.data!.pages).toEqual([
+          { page: 0, hitCounter: 4 },
+          { page: 1, hitCounter: 2 },
+          { page: 2, hitCounter: 3 },
+        ])
+        expect(refetchRes.data!.pageParams).toEqual([0, 1, 2])
       })
 
       test('per-call true overrides endpoint false', async () => {


### PR DESCRIPTION
## Summary

Adds an explicit `refetchBehavior` option for infinite queries, including an opt-in mode that refetches the first cached page while preserving the current cached tail.

Closes #5329.

### Motivation

Infinite queries currently support two behaviors through `refetchCachedPages`:

- `true` or omitted: refetch every cached page sequentially;
- `false`: refetch the first cached page and shrink the cache to one page.

Feed-like UIs such as inboxes, timelines, notifications, and chat lists often need a third tradeoff: keep the already-rendered tail while refreshing only the newest page. This keeps the request cost O(1) and prevents the list from collapsing after polling or pull-to-refresh.

### API and backwards compatibility

```ts
type InfiniteQueryRefetchBehavior =
  | 'refetch-all-pages'
  | 'refetch-first-page-discard-rest'
  | 'refetch-first-page-preserve-rest'
```

`refetchCachedPages` remains supported as a backwards-compatible alias and is not marked deprecated in this PR:

- `true` maps to `refetch-all-pages`;
- `false` maps to `refetch-first-page-discard-rest`.

Explicit per-call configuration wins over hook/endpoint defaults. If both spellings are provided at the same level, `refetchBehavior` wins.

The option is available through endpoint infinite-query options, `initiate()`, React infinite-query hooks, and `refetch()`. Shared automatic refetches such as polling, tag invalidation, focus, and reconnect use endpoint-level configuration because the cache entry can have multiple subscribers with different hook options.

### Preserve-rest behavior

For cached data `[page1, page2, page3]`, `refetch-first-page-preserve-rest` fetches a fresh `page1` and combines it with the latest cached `page2` and `page3`, retaining their matching page params. If the cached tail changes while the request is in flight, the latest tail is retained while the HTTP result wins for `page1`.

This is intentionally opt-in. It may create stale page boundaries, duplicate or missing records, and stale cursors when backend ordering changes. It is intended for feed-like UIs that accept a stale tail and typically deduplicate flattened results by stable item ID; it does not replace the consistency-preserving all-page default.

## Changes

- add and export `InfiniteQueryRefetchBehavior`;
- normalize the new enum and legacy boolean with deterministic precedence;
- implement first-page refetch with current-tail preservation in RTK Query core;
- expose the behavior through core and React public APIs;
- document scope, compatibility, and pagination tradeoffs;
- add core, React hook, and public type coverage.

## Testing

- `yarn workspace @reduxjs/toolkit test src/query/tests/infiniteQueries.test.ts src/query/tests/buildHooks.test.tsx` (106 passed)
- `yarn workspace @reduxjs/toolkit type-tests`
- `yarn workspace @reduxjs/toolkit test` (1,325 passed, 2 todo)
- `yarn test`
- `yarn workspace @reduxjs/toolkit build`
- `yarn build`
- `yarn build:docs`
- `yarn pack`
- `yarn attw ./package.tgz --format table` (no problems found)

## Links

- Issue proposal: [#5329](https://github.com/reduxjs/redux-toolkit/issues/5329)
- Prior work: [#5011](https://github.com/reduxjs/redux-toolkit/discussions/5011), [#5016](https://github.com/reduxjs/redux-toolkit/pull/5016), [#4920](https://github.com/reduxjs/redux-toolkit/issues/4920), [#5143](https://github.com/reduxjs/redux-toolkit/discussions/5143), [#3174](https://github.com/reduxjs/redux-toolkit/discussions/3174), and [#4801](https://github.com/reduxjs/redux-toolkit/discussions/4801)
