### PR TITLE
Modern Tooling, Part 4: Vitest type assertions

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test-d.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test-d.ts
@@ -322,7 +322,7 @@ describe('type tests', () => {
     startListening({
       matcher,
       effect: (action, listenerApi) => {
-        expectTypeOf(action).toMatchTypeOf<ExtraAction>()
+        expectTypeOf(action).toExtend<ExtraAction>()
       },
     })
   })

--- a/packages/toolkit/src/query/tests/buildHooks.test-d.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test-d.tsx
@@ -114,6 +114,8 @@ describe('type tests', () => {
           }
 
           if (result.isError) {
+            // `toExtend`, not `toMatchObjectType`: `toMatchObjectType` rejects
+            // union-typed properties.
             expectTypeOf(result).toExtend<{
               error: { status: number; data: unknown } | SerializedError
             }>()

--- a/packages/toolkit/src/query/tests/cacheLifecycle.test-d.ts
+++ b/packages/toolkit/src/query/tests/cacheLifecycle.test-d.ts
@@ -19,6 +19,9 @@ describe('type tests', () => {
           ) {
             const firstValue = await cacheDataLoaded
 
+            // `toExtend`, not `toMatchObjectType`: `toMatchObjectType` cannot
+            // handle an optional property whose type is an object type alias
+            // (`FetchBaseQueryMeta`).
             expectTypeOf(firstValue).toExtend<{
               data: number
               meta?: FetchBaseQueryMeta

--- a/packages/toolkit/src/query/tests/queryLifecycle.test-d.tsx
+++ b/packages/toolkit/src/query/tests/queryLifecycle.test-d.tsx
@@ -26,6 +26,9 @@ describe('type tests', () => {
             // unfortunately we cannot test for that in jest.
             const result = await queryFulfilled
 
+            // `toExtend`, not `toMatchObjectType`: `toMatchObjectType` cannot
+            // handle an optional property whose type is an object type alias
+            // (`FetchBaseQueryMeta`).
             expectTypeOf(result).toExtend<{
               data: number
               meta?: FetchBaseQueryMeta
@@ -45,6 +48,9 @@ describe('type tests', () => {
           async onQueryStarted(arg, { queryFulfilled }) {
             queryFulfilled.then(
               (result) => {
+                // `toExtend`, not `toMatchObjectType`: `toMatchObjectType`
+                // cannot handle an optional property whose type is an object
+                // type alias (`FetchBaseQueryMeta`).
                 expectTypeOf(result).toExtend<{
                   data: number
                   meta?: FetchBaseQueryMeta
@@ -85,6 +91,9 @@ describe('type tests', () => {
 
             const result = await queryFulfilled
 
+            // `toExtend`, not `toMatchObjectType`: `toMatchObjectType` cannot
+            // handle an optional property whose type is an object type alias
+            // (`FetchBaseQueryMeta`).
             expectTypeOf(result).toExtend<{
               data: number
               meta?: FetchBaseQueryMeta
@@ -104,6 +113,9 @@ describe('type tests', () => {
           async onQueryStarted(arg, { queryFulfilled }) {
             queryFulfilled.then(
               (result) => {
+                // `toExtend`, not `toMatchObjectType`: `toMatchObjectType`
+                // cannot handle an optional property whose type is an object
+                // type alias (`FetchBaseQueryMeta`).
                 expectTypeOf(result).toExtend<{
                   data: number
                   meta?: FetchBaseQueryMeta
@@ -144,6 +156,9 @@ describe('type tests', () => {
 
             const result = await queryFulfilled
 
+            // `toExtend`, not `toMatchObjectType`: `toMatchObjectType` cannot
+            // handle an optional property whose type is an object type alias
+            // (`FetchBaseQueryMeta`).
             expectTypeOf(result).toExtend<{
               data: number
               meta?: FetchBaseQueryMeta

--- a/packages/toolkit/src/tests/configureStore.test-d.ts
+++ b/packages/toolkit/src/tests/configureStore.test-d.ts
@@ -468,8 +468,8 @@ describe('type tests', () => {
 
       const dispatchResult = store.dispatch(action)
 
-      expectTypeOf(dispatchResult).toExtend<{
-        type: string
+      expectTypeOf(dispatchResult).toMatchObjectType<{
+        type: 'counter/incrementByAmount'
         payload: number
       }>()
 
@@ -493,8 +493,8 @@ describe('type tests', () => {
 
       const dispatchResult2 = store2.dispatch(action)
 
-      expectTypeOf(dispatchResult2).toExtend<{
-        type: string
+      expectTypeOf(dispatchResult2).toMatchObjectType<{
+        type: 'counter/incrementByAmount'
         payload: number
       }>()
     })

--- a/packages/toolkit/src/tests/mapBuilders.test-d.ts
+++ b/packages/toolkit/src/tests/mapBuilders.test-d.ts
@@ -185,6 +185,10 @@ describe('type tests', () => {
           })
 
           builder.addCase(thunk.rejected, (_, action) => {
+            // `toExtend`, not `toMatchObjectType`: the rejected action's `meta`
+            // is a union (`rejectedWithValue` true/false), and
+            // `toMatchObjectType` cannot deep-pick through a union in the
+            // actual type.
             expectTypeOf(action).toExtend<{
               payload: unknown
               error: SerializedError
@@ -221,6 +225,10 @@ describe('type tests', () => {
               }>()
             },
             rejected(_, action) {
+              // `toExtend`, not `toMatchObjectType`: the rejected action's
+              // `meta` is a union (`rejectedWithValue` true/false), and
+              // `toMatchObjectType` cannot deep-pick through a union in the
+              // actual type.
               expectTypeOf(action).toExtend<{
                 payload: unknown
                 error: SerializedError
@@ -313,6 +321,10 @@ describe('type tests', () => {
           })
 
           builder.addCase(thunk.rejected, (_, action) => {
+            // `toExtend`, not `toMatchObjectType`: the rejected action's `meta`
+            // is a union (`rejectedWithValue` true/false), and
+            // `toMatchObjectType` cannot deep-pick through a union in the
+            // actual type.
             expectTypeOf(action).toExtend<{
               payload: unknown
               error: SerializedError
@@ -356,6 +368,10 @@ describe('type tests', () => {
               }>()
             },
             rejected(_, action) {
+              // `toExtend`, not `toMatchObjectType`: the rejected action's
+              // `meta` is a union (`rejectedWithValue` true/false), and
+              // `toMatchObjectType` cannot deep-pick through a union in the
+              // actual type.
               expectTypeOf(action).toExtend<{
                 payload: unknown
                 error: SerializedError


### PR DESCRIPTION
- listenerMiddleware.test-d.ts: last `toMatchTypeOf` in the repo becomes
  `toExtend`. `toMatchObjectType` cannot be used: `ExtraAction` is an
  `interface`, and the matcher's constraint requires
  `Expected extends Record<string, unknown>`, which interfaces do not satisfy.
- configureStore.test-d.ts: two `toExtend<{ type: string; ... }>` become
  `toMatchObjectType<{ type: 'counter/incrementByAmount'; ... }>`. The actual
  type is the string literal, so the old assertion was under-testing.
- Eleven further sites were tried as `toMatchObjectType`, failed, and stay
  `toExtend` with comments recording why: unions in the actual type
  (thunk.rejected `meta`), union-typed expected properties (RTK Query error),
  and optional properties typed by a type alias (`FetchBaseQueryMeta`).

Rule used: `toMatchObjectType` when asserting a property subset on a non-union
object type literal with no union or optional type-alias property along the
compared path; `toExtend` otherwise, and always for negative assertions.

Verified: tsc -p tsconfig.test.json (0 errors), vitest --typecheck
(88 files / 1316 tests, no type errors), oxlint, oxfmt --check.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>