### PR TITLE
Modern Tooling, Part 7: vendor `remark-typescript-tools` and update to TS7

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,6 +10,7 @@
     "**/temp/**",
     "**/__testfixtures__/**",
     "examples/publish-ci/**",
+    "website/plugins/**",
     ".yarn/**",
     "**/mockServiceWorker.js",
     "packages/rtk-query-codegen-openapi/test/fixtures/**"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,12 +641,49 @@ importers:
       netlify-plugin-cache:
         specifier: ^1.0.3
         version: 1.0.3
-      prettier:
-        specifier: ^3.2.5
-        version: 3.8.1
-      remark-typescript-tools:
-        specifier: 2.0.0-alpha.1
-        version: 2.0.0-alpha.1(supports-color@8.1.1)(typescript@6.0.3)
+
+  website/plugins/remark-typescript-tools:
+    dependencies:
+      '@microsoft/tsdoc':
+        specifier: ^0.15.0
+        version: 0.15.1
+      make-synchronized:
+        specifier: ^0.8.0
+        version: 0.8.0
+      mdast-util-mdx-jsx:
+        specifier: ^3.1.3
+        version: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm:
+        specifier: ^2.0.1
+        version: 2.0.1(supports-color@8.1.1)
+      oxc-transform:
+        specifier: ^0.144.0
+        version: 0.144.0
+      oxfmt:
+        specifier: ^0.63.0
+        version: 0.63.0
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-flatmap:
+        specifier: ^1.0.0
+        version: 1.0.0
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.1.0
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@types/estree':
+        specifier: ^1.0.5
+        version: 1.0.8
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
 
 packages:
 
@@ -2597,6 +2634,128 @@ packages:
   '@oxc-project/types@0.144.0':
     resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
+  '@oxc-transform/binding-android-arm-eabi@0.144.0':
+    resolution: {integrity: sha512-Sskiy+uGMIjOFI9D1OZdYgT2NzVuvkOU5HDWAdp36BNuBbOoBFpNTVAT2D9PGfRQJEKJ/K/Wb2L0gA2VC23UUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.144.0':
+    resolution: {integrity: sha512-osVA5RRHE63G9effQf2ME3HOscX0zDTTG1O9Xz6tIdxY11y+Pj51l6XD2lk4m3scUa8biI6qUhDInH7IKGUopw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.144.0':
+    resolution: {integrity: sha512-gRpF9QorjIHzvPQ+ix7Tu0gDViikaU8iGZN/FkZSW8AJCqJrlInJpnugZisgmBDmWlPD9XuEuWPR0kXDI70nww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.144.0':
+    resolution: {integrity: sha512-EyxYXw5qm/Z1wi2DJQr2IXTOvYNHKFzI6sITYvwRBdWt6mRNrskUNXq5Jqr47183kSb8w1f5ygVQLS2x2k2yVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.144.0':
+    resolution: {integrity: sha512-aKhXnBEvbUJBxTgh5ai9RGGjZOCL8Y9IZM0IfG7WQOdQc2aha4IukyBQ3/V1c5DQFZl8hblGzf95D3Es2uNV2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.144.0':
+    resolution: {integrity: sha512-wWGIK7+bG1gQRR0VEhaQrUOSQqwc6Mo3NuHlBIXt20YLxHSzeghFHU/KuIs2S7xcOZOaWqM4aRKB86fxV1QKeA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.144.0':
+    resolution: {integrity: sha512-R8XAHI6gxenWpzpNe7hll2KXAtfIaDL/6w/oFuuVZ3/bpKwEYH/U1fdSmq3ImbtJbIZXAhGGOTOeaWoKLLhF2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.144.0':
+    resolution: {integrity: sha512-PBGyvBcPeSHujvTNDNj5lVEZGI2CEszyBIKBnQsuhXE6PbkXsXN+ar1tAv9MDFByIppTa6eHCkBCx2wLRGRd5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.144.0':
+    resolution: {integrity: sha512-vbXqLri/fGsRzvFm9sUDjEadBq3OlGfmb5c33pyfKVM+AjP685LXb7smUNzjfbmKpGkXB18tHvqpt/QXNadZTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.144.0':
+    resolution: {integrity: sha512-0SYHjw+KLnjFI1rdZAf0TfgoIqDIDvjsedNZ0U0rxZiHVNJyDltaB8m75rvNToTMfcmV76k61HXOmW6Neylo/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.144.0':
+    resolution: {integrity: sha512-n7uZFeZimHxuasIpwnwybw9UXQ0AxLHkGeOmHGMtcqey2mYmdVdW/5M+tliPVgPwVGu4HlBqv/riWsqWmrVQEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.144.0':
+    resolution: {integrity: sha512-Dc/pGt10QuqCO4tG51hZ+zp/+BNnUVTcDFS7FHCR67X8IaoEE8J7Pr0DkAcn8uPTvvSFzzNkhPwSx/L4XCUb/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.144.0':
+    resolution: {integrity: sha512-BeZ9tDcUVwfHlUl76GBwuDxrqmRLqdugPrq+LXuFRJ2mCzn3oFe4vOGCDMLW9ObIRAISR7+NIPH3CUyxM8VgOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.144.0':
+    resolution: {integrity: sha512-6U5R564AZ/ormt8iXXFETByq9dtADi9j2zEs4IEu0/5nvx27I+M7WTwGYBmWvYr1CfHTkM3a5KgNU0Vn3VoQPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-musl@0.144.0':
+    resolution: {integrity: sha512-gpEHX25aa33npfw/GcjHT+Hrk3n7kNrKdsDcNB43u5XIyvCgyVR/S/YncSbYI1Woko30YfiE77jKsDx1WrkauQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-openharmony-arm64@0.144.0':
+    resolution: {integrity: sha512-1kEUpTvm8ADkrUCX5xMop3/8szkTANZ1rLSbuiLGQ6KtbWWQm7hJUDvj78Sig8rZ8TqZS+BwUI4dcw4lK+Yysw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.144.0':
+    resolution: {integrity: sha512-/02/Bsw7WPxPQhhEfU80oRtOakHWPzE3MuPVkU4aTACPhismESGl2iIWVsTBddTiViyj30VxyqiEN/022LQnNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.144.0':
+    resolution: {integrity: sha512-nNxuvrVG9xR06XyZqPqGxt2kNkcYyseki1CFpzHSw+8iZs22EyaGVocjirIsp5t5SBj8Zd+xOLHmT9ldn6ZOTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.144.0':
+    resolution: {integrity: sha512-2mqtOa1KR/v8F85Cf8l1jX411AM7dYDO1HUDzucPXvO9LX63AaHxwafv+Uds1NzxSqnZtlpd1/OKUXrb0KvUFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxfmt/binding-android-arm-eabi@0.63.0':
     resolution: {integrity: sha512-YmRth4ZPGgEXcgmkhvANbC9uD67dxmSobW7DQuyt5tOBOKvPnIpk5SVHBj88E+7wMNRI2FhqaDbOhQFBix+b8A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2926,11 +3085,6 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
-
-  '@prettier/sync@0.5.5':
-    resolution: {integrity: sha512-6BMtNr7aQhyNcGzmumkL0tgr1YQGfm9d7ZdmRpWqWuqpc9vZBind4xMe5NMiRECOhjuSiWHfBWLBnXkpeE90bw==}
-    peerDependencies:
-      prettier: '*'
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -3932,6 +4086,126 @@ packages:
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -7228,8 +7502,8 @@ packages:
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
-  make-synchronized@0.4.2:
-    resolution: {integrity: sha512-EwEJSg8gSGLicKXp/VzNi1tvzhdmNBxOzslkkJSoNUCQFZKH/NIUIp7xlfN+noaHrz4BJDN73gne8IHnjl/F/A==}
+  make-synchronized@0.8.0:
+    resolution: {integrity: sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -7968,6 +8242,10 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  oxc-transform@0.144.0:
+    resolution: {integrity: sha512-a6mYoz3PPIlwbU4xtHAmWJHD0SvXh9ayAHI1D0+LJEKvln+koaD2M9AAAm5bAN5kkT2AWxN37IVhL1EAzXUyfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxfmt@0.63.0:
     resolution: {integrity: sha512-kgdDwv35wvVf6554U2Ab8Jnd0zTM+TsEQWwaB70RAjK3gICFAFGO+2Hd3Be27GMoXj3XRL9IKSNRVl7KBQL6iw==}
@@ -9302,15 +9580,6 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  remark-typescript-tools@2.0.0-alpha.1:
-    resolution: {integrity: sha512-/adMTY7icJYzXBfe9rhOhG3LV11fQpHC89eoaiNVcxjSXcDip2rczUDu7wMAmeWs9MBN/spHHUCx8zKLWEyBLA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
 
@@ -10315,6 +10584,11 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   ua-parser-js@1.0.41:
@@ -13807,6 +14081,63 @@ snapshots:
 
   '@oxc-project/types@0.144.0': {}
 
+  '@oxc-transform/binding-android-arm-eabi@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-openharmony-arm64@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.144.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.144.0':
+    optional: true
+
   '@oxfmt/binding-android-arm-eabi@0.63.0':
     optional: true
 
@@ -14046,11 +14377,6 @@ snapshots:
       config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.29': {}
-
-  '@prettier/sync@0.5.5(prettier@3.8.1)':
-    dependencies:
-      make-synchronized: 0.4.2
-      prettier: 3.8.1
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -15060,6 +15386,66 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -18813,7 +19199,7 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-synchronized@0.4.2: {}
+  make-synchronized@0.8.0: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -20038,6 +20424,28 @@ snapshots:
       get-intrinsic: 1.3.1
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  oxc-transform@0.144.0:
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.144.0
+      '@oxc-transform/binding-android-arm64': 0.144.0
+      '@oxc-transform/binding-darwin-arm64': 0.144.0
+      '@oxc-transform/binding-darwin-x64': 0.144.0
+      '@oxc-transform/binding-freebsd-x64': 0.144.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.144.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.144.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.144.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.144.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.144.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-x64-musl': 0.144.0
+      '@oxc-transform/binding-openharmony-arm64': 0.144.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.144.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.144.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.144.0
 
   oxfmt@0.63.0:
     dependencies:
@@ -21629,24 +22037,6 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark-typescript-tools@2.0.0-alpha.1(supports-color@8.1.1)(typescript@6.0.3):
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@prettier/sync': 0.5.5(prettier@3.8.1)
-      '@types/estree': 1.0.8
-      '@types/unist': 3.0.3
-      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
-      prettier: 3.8.1
-      tsx: 4.21.0
-      unist-util-flatmap: 1.0.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   renderkid@3.0.0:
     dependencies:
       css-select: 4.3.0
@@ -22761,6 +23151,29 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ua-parser-js@1.0.41: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,10 @@ packages:
   - 'packages/*'
   - 'docs'
   - 'website'
+  # The vendored docs plugin is a workspace package purely to isolate its
+  # dependencies. It needs TypeScript 7, and the rest of the repo is on 6.x.
+  # `docusaurus.config.ts` imports it by relative path, not by name.
+  - 'website/plugins/remark-typescript-tools'
   - 'examples/query/react/infinite-queries'
   - 'examples/type-portability/*'
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,8 +6,11 @@ import { resolve } from 'node:path'
 import type {
   LinkDocblocksSettings,
   TranspileCodeblocksSettings,
-} from 'remark-typescript-tools'
-import { linkDocblocks, transpileCodeblocks } from 'remark-typescript-tools'
+} from './plugins/remark-typescript-tools/index.js'
+import {
+  linkDocblocks,
+  transpileCodeblocks,
+} from './plugins/remark-typescript-tools/index.js'
 
 const config: Config = {
   future: {

--- a/website/package.json
+++ b/website/package.json
@@ -42,8 +42,6 @@
     "@docusaurus/types": "^3.9.2",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
-    "netlify-plugin-cache": "^1.0.3",
-    "prettier": "^3.2.5",
-    "remark-typescript-tools": "2.0.0-alpha.1"
+    "netlify-plugin-cache": "^1.0.3"
   }
 }

--- a/website/plugins/remark-typescript-tools/LICENSE
+++ b/website/plugins/remark-typescript-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Lenz Weber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/website/plugins/remark-typescript-tools/README.md
+++ b/website/plugins/remark-typescript-tools/README.md
@@ -1,0 +1,43 @@
+# Vendored `remark-typescript-tools`
+
+This is a vendored copy of the `src/` tree from
+[`phryneas/remark-typescript-tools`](https://github.com/phryneas/remark-typescript-tools),
+ported to TypeScript 7 and oxfmt.
+
+## Why it is here
+
+TypeScript 7's main export is `{ version, versionMajorMinor }`. There is no
+`typescript.js` and no `typescript.d.ts`, so any tool driving the classic `ts.*`
+API stops working. `remark-typescript-tools` drives it heavily — a hand-written
+`LanguageServiceHost`, `getEmitOutput` for transpilation, and AST walking for
+docblock extraction.
+
+The port replaces all of that:
+
+- `transpileCodeblocks/compiler.ts` uses one `API` instance from
+  `typescript/unstable/sync` with an overlay filesystem. Emit moves to
+  `oxc-transform`, because the TS 7 API has no emit at all.
+- `linkDocblocks/extract.ts` and `linkDocblocks/utils.ts` use the same program
+  construction, with AST helpers from `typescript/unstable/ast`.
+- `transpileCodeblocks/postProcessing.ts` formats with `oxfmt` instead of
+  Prettier, wrapped in `make-synchronized` because oxfmt's `format` crosses a
+  napi boundary and is async while the remark walk is sync. A missing config
+  falls back to defaults rather than skipping formatting.
+
+## Why vendored rather than a published release
+
+The only unfinished part of the port is declaration output: `rollup-plugin-dts`
+drives the classic TypeScript API and crashes under TS 7, so the upstream
+package cannot ship a release yet. Vendored here, no declarations are needed —
+`website/docusaurus.config.ts` imports this source directly.
+
+## This is a bridge, not a fork
+
+Do not develop features here. An upstream PR carries the same port. When an
+upstream release lands, delete this directory and depend on the package again.
+
+Keep this copy formatter-clean against upstream so the two stay diffable:
+`website/plugins/**` is in `ignorePatterns` in `.oxfmtrc.json` for that reason.
+
+Upstream base: `main` @ `5c375b1`. Port: branch `feat/typescript-7-and-oxfmt`
+@ `b2ce7f2`.

--- a/website/plugins/remark-typescript-tools/index.ts
+++ b/website/plugins/remark-typescript-tools/index.ts
@@ -1,0 +1,14 @@
+export { linkDocblocks } from './linkDocblocks/plugin.js';
+export type { LinkDocblocksSettings } from './linkDocblocks/plugin.js';
+
+export {
+  defaultAssembleReplacementNodes,
+  transpileCodeblocks,
+} from './transpileCodeblocks/plugin.js';
+
+export type { TranspileCodeblocksSettings } from './transpileCodeblocks/plugin.js';
+
+export {
+  defaultPostProcessTranspiledJs,
+  defaultPostProcessTs,
+} from './transpileCodeblocks/postProcessing.js';

--- a/website/plugins/remark-typescript-tools/linkDocblocks/extract.ts
+++ b/website/plugins/remark-typescript-tools/linkDocblocks/extract.ts
@@ -1,0 +1,170 @@
+import {
+  API,
+  isIdentifier,
+  isVariableDeclaration,
+  isVariableStatement,
+} from '../ts7.cjs';
+import type { Node, Program } from 'typescript/unstable/ast';
+import * as path from 'node:path';
+import * as tsdoc from '@microsoft/tsdoc';
+
+import { getJSDocCommentRanges } from './utils.js';
+
+export interface ExtractorSettings {
+  tsconfig: string;
+  basedir: string;
+  rootFiles: string[];
+}
+
+const slash = (p: string) => path.normalize(p).replace(/\\/g, '/');
+
+/** Name of the generated tsconfig placed next to the user's real one. */
+const GENERATED_TSCONFIG = '__remark_typescript_tools.docblocks.tsconfig.json';
+
+export class Extractor {
+  program: Program;
+  basedir: string;
+  private api: API;
+
+  constructor({ tsconfig, rootFiles, basedir }: ExtractorSettings) {
+    this.basedir = basedir;
+
+    const tsconfigDir = slash(path.dirname(tsconfig));
+    const configPath = `${tsconfigDir}/${GENERATED_TSCONFIG}`;
+    const files = rootFiles.map((file) =>
+      slash(path.resolve(basedir, file))
+    );
+
+    // The user's tsconfig has no `files`/`include`, so a generated config that
+    // extends it is what pins the program to just these root files. It is
+    // served from an overlay rather than written to disk.
+    const generated = JSON.stringify({
+      extends: `./${path.basename(tsconfig)}`,
+      compilerOptions: { noEmit: true },
+      include: [],
+      files,
+    });
+
+    // Returning `undefined` falls back to the real filesystem.
+    this.api = new API({
+      cwd: tsconfigDir,
+      fs: {
+        readFile: (fileName: string) =>
+          slash(fileName) === configPath ? generated : undefined,
+        fileExists: (fileName: string) =>
+          slash(fileName) === configPath ? true : undefined,
+      },
+    });
+
+    this.program = this.api
+      .updateSnapshot({ openProjects: [configPath] })
+      .getProject(configPath).program;
+  }
+
+  findTokens(token: string, node: Node) {
+    const [lookFor, ...tail] = token.split('.');
+    const found: Node[] = [];
+    node.forEachChild((child: Node & { name?: Node }) => {
+      if (isVariableStatement(child)) {
+        found.push(...this.findTokens(token, child.declarationList));
+        if (child.declarationList.declarations.length === 1) {
+          const name = child.declarationList.declarations[0].name;
+          if (name && isIdentifier(name) && name.text === lookFor) {
+            // push the whole declarationList if it contains only one declaration, for "outside style"
+            found.push(child);
+          }
+        }
+        return;
+      }
+
+      const name = child.name;
+      if (name && isIdentifier(name) && name.text === lookFor) {
+        if (lookFor === token) {
+          if (isVariableDeclaration(child) && child.initializer) {
+            // push the initializer for "inside" style
+            found.push(child.initializer);
+          }
+          found.push(child);
+        } else {
+          found.push(...this.findTokens(tail.join('.'), child));
+        }
+      }
+    });
+    return found;
+  }
+
+  getComment(token: string, fileName = 'index.ts', overload = 0) {
+    const inputFileName = slash(path.resolve(this.basedir, fileName));
+    const sourceFile = this.program.getSourceFile(inputFileName);
+    if (!sourceFile) {
+      throw new Error(
+        `Error retrieving source file ${sourceFile} (looked for ${fileName} in ${this.basedir})`
+      );
+    }
+
+    const foundComments = [];
+
+    const buffer = sourceFile.text;
+
+    for (const node of this.findTokens(token, sourceFile)) {
+      const comments = getJSDocCommentRanges(node, buffer);
+
+      if (comments.length > 0) {
+        for (const comment of comments) {
+          foundComments.push({
+            compilerNode: node,
+            textRange: tsdoc.TextRange.fromStringRange(
+              buffer,
+              comment.pos,
+              comment.end
+            ),
+          });
+        }
+      }
+    }
+
+    const customConfiguration = new tsdoc.TSDocConfiguration();
+
+    customConfiguration.addTagDefinition(
+      new tsdoc.TSDocTagDefinition({
+        tagName: '@overloadSummary',
+        syntaxKind: tsdoc.TSDocTagSyntaxKind.BlockTag,
+      })
+    );
+
+    customConfiguration.addTagDefinition(
+      new tsdoc.TSDocTagDefinition({
+        tagName: '@overloadRemarks',
+        syntaxKind: tsdoc.TSDocTagSyntaxKind.BlockTag,
+      })
+    );
+
+    const tsdocParser = new tsdoc.TSDocParser(customConfiguration);
+
+    const selectedOverload = foundComments[overload];
+    if (!selectedOverload) {
+      console.warn(
+        `could not find overload ${overload} for ${token} in ${fileName}`
+      );
+      return null;
+    }
+
+    const parserContext = tsdocParser.parseRange(selectedOverload.textRange);
+    const docComment = parserContext.docComment;
+    return Object.assign(docComment, {
+      parserContext,
+      buffer: selectedOverload.textRange.buffer,
+      overloadSummary: docComment.customBlocks.find(
+        this.byTagName('@overloadSummary')
+      ),
+      overloadRemarks: docComment.customBlocks.find(
+        this.byTagName('@overloadRemarks')
+      ),
+      examples: docComment.customBlocks.filter(this.byTagName('@example')),
+    });
+  }
+
+  byTagName(name: string) {
+    return (block: tsdoc.DocBlock) => block.blockTag.tagName === name;
+  }
+}

--- a/website/plugins/remark-typescript-tools/linkDocblocks/plugin.ts
+++ b/website/plugins/remark-typescript-tools/linkDocblocks/plugin.ts
@@ -1,0 +1,135 @@
+// @ts-ignore
+import flatMap from 'unist-util-flatmap';
+import { Extractor } from './extract.js';
+import type { ExtractorSettings } from './extract.js';
+import { renderDocNode } from './utils.js';
+import { URL } from 'node:url';
+import type { Node, Parent } from 'unist';
+import { visit } from 'unist-util-visit';
+
+import type { Plugin } from 'unified';
+import type { DocNode } from '@microsoft/tsdoc';
+
+type Comment = NonNullable<ReturnType<Extractor['getComment']>>;
+type RenderFunction = (c: Comment) => import('unist').Node[];
+
+type RenderableKey = {
+  [K in keyof Comment]: NonNullable<Comment[K]> extends DocNode | DocNode[]
+    ? K
+    : never;
+}[keyof Comment];
+
+export interface LinkDocblocksSettings {
+  extractorSettings: ExtractorSettings;
+}
+
+const extractors = new WeakMap<ExtractorSettings, Extractor>();
+
+export const linkDocblocks: Plugin<[LinkDocblocksSettings]> = function ({
+  extractorSettings,
+}) {
+  if (!extractors.has(extractorSettings)) {
+    extractors.set(extractorSettings, new Extractor(extractorSettings));
+  }
+  const extractor = extractors.get(extractorSettings)!;
+
+  const parseNodes = (markdown: string): Node[] => {
+    return (this.parse(markdown) as Parent).children;
+  };
+
+  function renderAsMarkdown(
+    key: RenderableKey,
+    prepare = (str: string) => str
+  ): RenderFunction {
+    function render(comment: Comment) {
+      const docBlock = comment[key];
+      const rendered = renderDocNode(docBlock);
+      return parseNodes(prepare(rendered));
+    }
+    return render;
+  }
+
+  const sectionMapping = {
+    summary: renderAsMarkdown('summarySection', (s) =>
+      s.replace(/@summary/g, '')
+    ),
+    remarks: renderAsMarkdown('remarksBlock', (s) =>
+      s.replace(/@remarks/g, '')
+    ),
+    overloadSummary: renderAsMarkdown('overloadSummary', (s) =>
+      s.replace(/@overloadSummary/g, '')
+    ),
+    overloadRemarks: renderAsMarkdown('overloadRemarks', (s) =>
+      s.replace(/@overloadRemarks/g, '')
+    ),
+    examples: renderAsMarkdown('examples', (s) => s.replace(/@example/g, '')),
+    params: renderAsMarkdown('params', (s) =>
+      s.replace(/@param (.*) -/g, '* **$1**')
+    ),
+  };
+
+  return function transformer(tree) {
+    return flatMap(tree, function mapper(parent: Parent): Node[] {
+      if (!(parent.type === 'paragraph' && parent.children.length === 1)) {
+        return [parent];
+      }
+
+      const node = parent.children[0] as Node & {
+        url: string;
+        children: [import('unist').Node & { value: string }];
+      };
+
+      if (node.type !== 'link' || !node.url.startsWith('docblock://')) {
+        return [parent];
+      }
+
+      if (node.children.length !== 1 || node.children[0].type !== 'text') {
+        throw new Error('invalid meta content for docblock link');
+      }
+      const meta = node.children[0].value;
+      const sections = meta.split(',').map((s) => s.trim());
+
+      const url = new URL(node.url);
+      const fileName = url.host + url.pathname;
+      const args = url.searchParams;
+
+      const token = args.get('token');
+      const overload = Number.parseInt(args.get('overload') || '0');
+
+      if (!token) {
+        throw new Error(
+          'token name must be provided as query parameter `token`'
+        );
+      }
+
+      const comment = extractor.getComment(token, fileName, overload);
+      if (!comment) {
+        return [];
+      }
+
+      const retVal = sections.reduce<Node[]>((acc, section) => {
+        if (!(section in sectionMapping)) {
+          throw new Error(
+            `invalid comment section reference. valid references are ${Object.keys(
+              sectionMapping
+            ).concat(',')}`
+          );
+        }
+        acc.push(
+          ...sectionMapping[section as keyof typeof sectionMapping](comment)
+        );
+        return acc;
+      }, []);
+
+      visit(
+        { type: 'fakeRoot', children: retVal },
+        'code',
+        (node: Node & { value: string }) => {
+          node.value = node.value.trimEnd();
+        }
+      );
+
+      return retVal;
+    });
+  };
+};

--- a/website/plugins/remark-typescript-tools/linkDocblocks/utils.ts
+++ b/website/plugins/remark-typescript-tools/linkDocblocks/utils.ts
@@ -1,0 +1,75 @@
+import {
+  SyntaxKind,
+  getLeadingCommentRanges,
+  getTrailingCommentRanges,
+} from '../ts7.cjs';
+import type { CommentRange, Node } from 'typescript/unstable/ast';
+import * as tsdoc from '@microsoft/tsdoc';
+
+/**
+ * Retrieves the JSDoc-style comments associated with a specific AST node.
+ *
+ * Based on ts.getJSDocCommentRanges() from the compiler.
+ * https://github.com/Microsoft/TypeScript/blob/v3.0.3/src/compiler/utilities.ts#L924
+ */
+export function getJSDocCommentRanges(node: Node, text: string) {
+  const commentRanges: CommentRange[] = [];
+
+  switch (node.kind) {
+    case SyntaxKind.Parameter:
+    case SyntaxKind.TypeParameter:
+    case SyntaxKind.FunctionExpression:
+    case SyntaxKind.ArrowFunction:
+    case SyntaxKind.ParenthesizedExpression:
+    case SyntaxKind.VariableDeclaration:
+    case SyntaxKind.VariableStatement:
+      commentRanges.push(...(getTrailingCommentRanges(text, node.pos) || []));
+      break;
+  }
+  commentRanges.push(...(getLeadingCommentRanges(text, node.pos) || []));
+
+  // True if the comment starts with '/**' but not if it is '/**/'
+  return commentRanges.filter(
+    (comment) =>
+      text.charCodeAt(comment.pos + 1) ===
+        0x2a /* ts.CharacterCodes.asterisk */ &&
+      text.charCodeAt(comment.pos + 2) ===
+        0x2a /* ts.CharacterCodes.asterisk */ &&
+      text.charCodeAt(comment.pos + 3) !== 0x2f /* ts.CharacterCodes.slash */
+  );
+}
+
+export function renderDocNode(
+  docNode?: tsdoc.DocNode | tsdoc.DocNode[]
+): string {
+  if (!docNode) {
+    return '';
+  }
+  if (Array.isArray(docNode)) {
+    return docNode.map((node) => renderDocNode(node)).join('');
+  }
+
+  let result = '';
+  if (docNode) {
+    if (docNode instanceof tsdoc.DocFencedCode) {
+      let code: string = docNode.code.toString();
+      let meta: string = '';
+      code = code.replace(
+        /^\s*\/\/\s*codeblock-meta(\s.*?)$\n?/gm,
+        (_line, metaMatch) => {
+          meta += metaMatch;
+          return '';
+        }
+      );
+      return '```' + docNode.language + meta + '\n' + code + '\n```';
+    }
+    if (docNode instanceof tsdoc.DocExcerpt) {
+      result += docNode.content.toString();
+    }
+
+    for (const childNode of docNode.getChildNodes()) {
+      result += renderDocNode(childNode);
+    }
+  }
+  return result;
+}

--- a/website/plugins/remark-typescript-tools/package.json
+++ b/website/plugins/remark-typescript-tools/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@website/remark-typescript-tools",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Vendored TypeScript 7 + oxfmt port of remark-typescript-tools. See README.md.",
+  "license": "MIT",
+  "main": "index.ts",
+  "dependencies": {
+    "@microsoft/tsdoc": "^0.15.0",
+    "make-synchronized": "^0.8.0",
+    "mdast-util-mdx-jsx": "^3.1.3",
+    "mdast-util-mdxjs-esm": "^2.0.1",
+    "oxc-transform": "^0.144.0",
+    "oxfmt": "^0.63.0",
+    "typescript": "^7.0.2",
+    "unified": "^11.0.5",
+    "unist-util-flatmap": "^1.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/estree": "^1.0.5",
+    "@types/unist": "^3.0.3"
+  }
+}

--- a/website/plugins/remark-typescript-tools/transpileCodeblocks/compiler.ts
+++ b/website/plugins/remark-typescript-tools/transpileCodeblocks/compiler.ts
@@ -1,0 +1,230 @@
+import { API } from '../ts7.cjs';
+import type { SourceFile } from 'typescript/unstable/ast';
+import { transformSync } from 'oxc-transform';
+import { basename, dirname, normalize } from 'node:path';
+
+import type { VirtualFiles, VirtualFile } from './plugin.js';
+
+export type Diagnostic =
+  | { line: number; character: number; message: string }
+  | { line?: undefined; character?: undefined; message: string };
+
+export interface TranspiledFile extends VirtualFile {
+  diagnostics: Array<Diagnostic>;
+}
+
+export type TranspiledFiles = Record<string, TranspiledFile>;
+
+/**
+ * Under TypeScript 7 the checker runs in a Go process that cannot call back into
+ * a JavaScript module resolver, so `externalResolutions` is applied by injecting
+ * `paths` entries into the generated tsconfig instead of via `resolveModuleNames`.
+ * `packageId` has no equivalent and is ignored.
+ */
+export interface ExternalResolution {
+  resolvedPath: string;
+  packageId?: unknown;
+}
+
+export interface CompilerSettings {
+  tsconfig: string;
+  externalResolutions: Record<string, ExternalResolution>;
+  /**
+   * Allows transforming the virtual filepath for codeblocks.
+   * This allows the files to resolve node modules from a different location
+   * to their own directory.
+   */
+  transformVirtualFilepath?: (filepath: string) => string;
+}
+
+const slash = (p: string) => normalize(p).replace(/\\/g, '/');
+
+/** Name of the generated tsconfig placed next to the user's real one. */
+const GENERATED_TSCONFIG = '__remark_typescript_tools.tsconfig.json';
+
+export class Compiler {
+  private api: API;
+  private configPath: string;
+  private baseConfigName: string;
+  private externalPaths: Record<string, string[]>;
+
+  /** Virtual overlay: absolute forward-slash path -> file contents. */
+  private virtual = new Map<string, string>();
+  /** Directories that exist only in the overlay. */
+  private virtualDirs = new Set<string>();
+  /** Root files of the previous `compile()` call, for change notification. */
+  private previousFiles: string[] = [];
+  private firstSnapshot = true;
+
+  constructor(settings: CompilerSettings) {
+    const tsconfigDir = slash(dirname(settings.tsconfig));
+    this.baseConfigName = basename(settings.tsconfig);
+    this.configPath = `${tsconfigDir}/${GENERATED_TSCONFIG}`;
+
+    this.externalPaths = Object.fromEntries(
+      Object.entries(settings.externalResolutions).map(([name, resolution]) => [
+        name,
+        [resolution.resolvedPath],
+      ])
+    );
+
+    this.api = new API({ fs: this.createOverlay(), cwd: tsconfigDir });
+  }
+
+  /**
+   * A TS 7 `FileSystem` is an overlay: returning `undefined` from a callback
+   * falls back to the real filesystem, so virtual code blocks and the real
+   * `node_modules` tree coexist without a temp directory.
+   */
+  private createOverlay() {
+    return {
+      readFile: (fileName: string) => this.virtual.get(slash(fileName)),
+      fileExists: (fileName: string) =>
+        this.virtual.has(slash(fileName)) ? true : undefined,
+      directoryExists: (dirName: string) =>
+        this.virtualDirs.has(slash(dirName)) ? true : undefined,
+      getAccessibleEntries: (dirName: string) => {
+        const dir = slash(dirName);
+        if (!this.virtualDirs.has(dir)) return undefined;
+        const files: string[] = [];
+        const directories = new Set<string>();
+        for (const path of this.virtual.keys()) {
+          if (!path.startsWith(dir + '/')) continue;
+          const rest = path.slice(dir.length + 1);
+          if (rest.includes('/')) directories.add(rest.split('/')[0]);
+          else files.push(rest);
+        }
+        return { files, directories: [...directories] };
+      },
+    };
+  }
+
+  private addVirtualFile(fileName: string, contents: string) {
+    const path = slash(fileName);
+    this.virtual.set(path, contents);
+    // Register every ancestor directory. Code blocks live under a path like
+    // `docs/api/createAction.mdx/codeBlock_2/`, so `createAction.mdx` has to
+    // report as a directory even though a real file of that name exists.
+    let dir = slash(dirname(path));
+    while (dir && !this.virtualDirs.has(dir)) {
+      this.virtualDirs.add(dir);
+      const parent = slash(dirname(dir));
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+
+  public compile(files: VirtualFiles): TranspiledFiles {
+    const fileNames: string[] = [];
+
+    for (const [fileName, { code }] of Object.entries(files)) {
+      // Blank lines survive the round trip as comments; the marker is stripped
+      // again after emit.
+      this.addVirtualFile(fileName, code.replace(/^$/gm, '//__NEWLINE__'));
+      fileNames.push(slash(fileName));
+    }
+
+    this.writeGeneratedConfig(fileNames);
+
+    const previous = new Set(this.previousFiles);
+    const current = new Set(fileNames);
+    const fileChanges = this.firstSnapshot
+      ? undefined
+      : {
+          created: fileNames.filter((f) => !previous.has(f)),
+          deleted: this.previousFiles.filter((f) => !current.has(f)),
+          changed: [
+            this.configPath,
+            ...fileNames.filter((f) => previous.has(f)),
+          ],
+        };
+    this.previousFiles = fileNames;
+    this.firstSnapshot = false;
+
+    const snapshot = this.api.updateSnapshot({
+      openProjects: [this.configPath],
+      fileChanges,
+    });
+    const program = snapshot.getProject(this.configPath).program;
+
+    const configDiagnostics = program
+      .getConfigFileParsingDiagnostics()
+      .concat(program.getProgramDiagnostics());
+
+    const returnFiles: TranspiledFiles = {};
+
+    for (const [fileName, file] of Object.entries(files)) {
+      const path = slash(fileName);
+
+      const diagnostics = [
+        ...configDiagnostics,
+        ...program.getSyntacticDiagnostics(path),
+        ...program.getSemanticDiagnostics(path),
+      ].map((diagnostic) => {
+        const message = flattenMessage(diagnostic);
+        const sourceFile = diagnostic.fileName
+          ? program.getSourceFile(diagnostic.fileName)
+          : undefined;
+        if (sourceFile && typeof diagnostic.pos === 'number') {
+          const { line, character } = (
+            sourceFile as SourceFile
+          ).getLineAndCharacterOfPosition(diagnostic.pos);
+          return { line, character, message };
+        }
+        return { message };
+      });
+
+      returnFiles[fileName] = {
+        ...file,
+        code: this.emit(path, this.virtual.get(path)!),
+        diagnostics,
+      };
+    }
+
+    return returnFiles;
+  }
+
+  /**
+   * TypeScript 7 exposes no programmatic emit, so type stripping and the JSX
+   * transform are done by oxc. Checking already happened above, so this only
+   * needs to be a syntactic transform.
+   */
+  private emit(fileName: string, source: string): string {
+    const result = transformSync(fileName, source, { jsx: 'preserve' });
+    return result.code.replace(/\/\/__NEWLINE__/g, '');
+  }
+
+  private writeGeneratedConfig(fileNames: string[]) {
+    this.addVirtualFile(
+      this.configPath,
+      JSON.stringify({
+        extends: `./${this.baseConfigName}`,
+        compilerOptions: {
+          noEmit: true,
+          ...(Object.keys(this.externalPaths).length
+            ? { paths: this.externalPaths }
+            : {}),
+        },
+        // The user's tsconfig has no `files`/`include`, so it would otherwise
+        // pull in the whole docs tree for every code block.
+        include: [],
+        files: fileNames,
+      })
+    );
+  }
+
+  public dispose() {
+    this.api.close();
+  }
+}
+
+function flattenMessage(diagnostic: {
+  text?: string;
+  messageChain?: Array<{ text?: string }>;
+}): string {
+  const parts = [diagnostic.text ?? ''];
+  for (const child of diagnostic.messageChain ?? []) {
+    if (child.text) parts.push(child.text);
+  }
+  return parts.filter(Boolean).join('\n');
+}

--- a/website/plugins/remark-typescript-tools/transpileCodeblocks/plugin.ts
+++ b/website/plugins/remark-typescript-tools/transpileCodeblocks/plugin.ts
@@ -1,0 +1,407 @@
+import { visit } from 'unist-util-visit';
+// @ts-ignore
+import flatMap from 'unist-util-flatmap';
+import { Compiler } from './compiler.js';
+import type { CompilerSettings, TranspiledFile } from './compiler.js';
+import {
+  defaultPostProcessTranspiledJs,
+  defaultPostProcessTs,
+} from './postProcessing.js';
+import type { Plugin } from 'unified';
+import type { Node, Parent } from 'unist';
+import type { VFile } from 'vfile';
+import type { ImportDeclaration } from 'estree';
+import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
+
+export interface VirtualFile {
+  code: string;
+  skip?: boolean;
+}
+export type VirtualFiles = Record<string, VirtualFile>;
+
+interface CodeNode extends Node {
+  lang: string;
+  meta: string | null;
+  value: string;
+  indent: number[];
+}
+
+type PostProcessor = (
+  files: VirtualFiles,
+  parentFile?: string,
+  defaultProcessor?: PostProcessor
+) => VirtualFiles;
+
+export interface TranspileCodeblocksSettings {
+  compilerSettings: CompilerSettings;
+  postProcessTranspiledJs?: PostProcessor;
+  postProcessTs?: PostProcessor;
+  assembleReplacementNodes?: typeof defaultAssembleReplacementNodes;
+  fileExtensions?: string[];
+}
+
+const compilers = new WeakMap<CompilerSettings, Compiler>();
+
+export const transpileCodeblocks: Plugin<[TranspileCodeblocksSettings]> =
+  function ({
+    compilerSettings,
+    postProcessTranspiledJs = defaultPostProcessTranspiledJs,
+    postProcessTs = defaultPostProcessTs,
+    assembleReplacementNodes = defaultAssembleReplacementNodes,
+    fileExtensions = ['.mdx'],
+  }) {
+    if (!compilers.has(compilerSettings)) {
+      compilers.set(compilerSettings, new Compiler(compilerSettings));
+    }
+    const compiler = compilers.get(compilerSettings)!;
+
+    return function transformer(tree, file) {
+      if (!file.extname || !fileExtensions.includes(file.extname)) {
+        return tree;
+      }
+
+      const virtualFilepath =
+        compilerSettings.transformVirtualFilepath?.(file.path ?? '') ??
+        file.path;
+
+      let hasTabsImport = false;
+      let hasTabItemImport = false;
+
+      visit(tree, 'ImportDeclaration', (node: ImportDeclaration) => {
+        if (
+          node.source.value === '@theme/Tabs' &&
+          node.specifiers.some(
+            (sp) => sp.type === 'ImportSpecifier' && sp.local.name === 'Tabs'
+          )
+        ) {
+          hasTabsImport = true;
+        }
+        if (
+          node.source.value === '@theme/TabItem' &&
+          node.specifiers.some(
+            (sp) => sp.type === 'ImportSpecifier' && sp.local.name === 'TabItem'
+          )
+        ) {
+          hasTabItemImport = true;
+        }
+      });
+
+      visit(tree, 'root', (node: Parent) => {
+        if (!hasTabsImport) {
+          node.children.unshift({
+            type: 'mdxjsEsm',
+            value: "import Tabs from '@theme/Tabs'",
+            data: {
+              estree: {
+                type: 'Program',
+                body: [
+                  {
+                    type: 'ImportDeclaration',
+                    specifiers: [
+                      {
+                        type: 'ImportDefaultSpecifier',
+                        local: {
+                          type: 'Identifier',
+                          name: 'Tabs',
+                        },
+                      },
+                    ],
+                    source: {
+                      type: 'Literal',
+                      value: '@theme/Tabs',
+                    },
+                  },
+                ],
+                sourceType: 'module',
+              },
+            },
+          } satisfies MdxjsEsm as MdxjsEsm);
+        }
+        if (!hasTabItemImport) {
+          node.children.unshift({
+            type: 'mdxjsEsm',
+            value: "import TabItem from '@theme/TabItem'",
+            data: {
+              estree: {
+                type: 'Program',
+                body: [
+                  {
+                    type: 'ImportDeclaration',
+                    specifiers: [
+                      {
+                        type: 'ImportDefaultSpecifier',
+                        local: {
+                          type: 'Identifier',
+                          name: 'TabItem',
+                        },
+                      },
+                    ],
+                    source: {
+                      type: 'Literal',
+                      value: '@theme/TabItem',
+                    },
+                  },
+                ],
+                sourceType: 'module',
+              },
+            },
+          } satisfies MdxjsEsm as MdxjsEsm);
+        }
+      });
+
+      let codeBlock = 0;
+
+      return flatMap(tree, function mapper(node: CodeNode) {
+        if (node.type === 'code') {
+          codeBlock++;
+        }
+        if (!(node.type === 'code' && ['ts', 'tsx'].includes(node.lang))) {
+          return [node];
+        }
+        const tags = node.meta ? node.meta.split(' ') : [];
+        if (tags.includes('no-transpile')) {
+          return [node];
+        }
+
+        const virtualFolder = `${virtualFilepath}/codeBlock_${codeBlock}`;
+        const virtualFiles = splitFiles(node.value, virtualFolder);
+
+        //console.time(virtualFolder)
+        const transpilationResult = compiler.compile(virtualFiles);
+        //console.timeEnd(virtualFolder)
+
+        for (const [fileName, result] of Object.entries(transpilationResult)) {
+          for (const diagnostic of result.diagnostics) {
+            if (diagnostic.line && node.position) {
+              const lines = result.code
+                .split('\n')
+                .map(
+                  (line, lineNo) =>
+                    `${String(lineNo).padStart(3, ' ')}  ${line}`
+                );
+
+              file.fail(
+                `
+TypeScript error in code block in line ${diagnostic.line} of ${fileName}
+${diagnostic.message}
+
+${lines.slice(Math.max(0, diagnostic.line - 5), diagnostic.line + 6).join('\n')}
+            `,
+                {
+                  line: diagnostic.line + node.position.start.line,
+                  column: diagnostic.character,
+                }
+              );
+            } else {
+              file.fail(diagnostic.message, node);
+            }
+          }
+        }
+
+        return assembleReplacementNodes(
+          node,
+          file,
+          virtualFolder,
+          virtualFiles,
+          transpilationResult,
+          postProcessTs,
+          postProcessTranspiledJs
+        );
+      });
+    };
+  };
+
+export function defaultAssembleReplacementNodes(
+  node: CodeNode,
+  file: VFile,
+  virtualFolder: string,
+  virtualFiles: Record<string, VirtualFile>,
+  transpilationResult: Record<string, TranspiledFile>,
+  postProcessTs: PostProcessor,
+  postProcessTranspiledJs: PostProcessor
+): Node[] {
+  return [
+    {
+      type: 'mdxJsxFlowElement',
+      name: 'Tabs',
+      attributes: [
+        { type: 'mdxJsxAttribute', name: 'groupId', value: 'language' },
+        { type: 'mdxJsxAttribute', name: 'defaultValue', value: 'ts' },
+        {
+          type: 'mdxJsxAttribute',
+          name: 'values',
+          value: {
+            type: 'mdxJsxAttributeValueExpression',
+            value:
+              "[{ label: 'TypeScript', value: 'ts', }, { label: 'JavaScript', value: 'js', } ]",
+            data: {
+              estree: {
+                type: 'Program',
+                body: [
+                  {
+                    type: 'ExpressionStatement',
+                    expression: {
+                      type: 'ArrayExpression',
+                      elements: [
+                        {
+                          type: 'ObjectExpression',
+                          properties: [
+                            {
+                              type: 'Property',
+                              method: false,
+                              shorthand: false,
+                              computed: false,
+                              key: {
+                                type: 'Identifier',
+                                name: 'label',
+                              },
+                              value: {
+                                type: 'Literal',
+                                value: 'TypeScript',
+                              },
+                              kind: 'init',
+                            },
+                            {
+                              type: 'Property',
+                              method: false,
+                              shorthand: false,
+                              computed: false,
+                              key: {
+                                type: 'Identifier',
+                                name: 'value',
+                              },
+                              value: {
+                                type: 'Literal',
+                                value: 'ts',
+                              },
+                              kind: 'init',
+                            },
+                          ],
+                        },
+                        {
+                          type: 'ObjectExpression',
+                          properties: [
+                            {
+                              type: 'Property',
+                              method: false,
+                              shorthand: false,
+                              computed: false,
+                              key: {
+                                type: 'Identifier',
+                                name: 'label',
+                              },
+                              value: {
+                                type: 'Literal',
+                                value: 'JavaScript',
+                              },
+                              kind: 'init',
+                            },
+                            {
+                              type: 'Property',
+                              method: false,
+                              shorthand: false,
+                              computed: false,
+                              key: {
+                                type: 'Identifier',
+                                name: 'value',
+                              },
+                              value: {
+                                type: 'Literal',
+                                value: 'js',
+                              },
+                              kind: 'init',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                ],
+                sourceType: 'module',
+                comments: [],
+              },
+            },
+          },
+        },
+      ],
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'TabItem',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'value', value: 'ts' }],
+          children: [
+            {
+              ...node,
+              value: rearrangeFiles(
+                postProcessTs(virtualFiles, file.path, defaultPostProcessTs),
+                virtualFolder
+              ),
+            } satisfies CodeNode as any,
+          ],
+        },
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'TabItem',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'value', value: 'js' }],
+          children: [
+            {
+              ...node,
+              lang: 'js',
+              ...(typeof node.meta === 'string' && {
+                meta: node.meta.replace(
+                  /(title=['"].*)\.t(sx?)(.*")/,
+                  '$1.j$2$3'
+                ),
+              }),
+              value: rearrangeFiles(
+                postProcessTranspiledJs(
+                  transpilationResult,
+                  file.path,
+                  defaultPostProcessTranspiledJs
+                ),
+                virtualFolder
+              ),
+            } satisfies CodeNode as any,
+          ],
+        },
+      ],
+    } satisfies MdxJsxFlowElement as MdxJsxFlowElement,
+  ];
+}
+
+function splitFiles(fullCode: string, folder: string) {
+  const regex = /^\/\/ file: ([\w\-./\[\]]+)(?: (.*))?\s*$/gm;
+  let match = regex.exec(fullCode);
+
+  const files: VirtualFiles = {};
+
+  do {
+    const start = match ? match.index + match[0].length + 1 : 0;
+    const fileName = match ? match[1] : 'index.ts';
+    const flags = (match ? match[2] || '' : '').split(' ');
+    const skip = flags.includes('noEmit');
+    match = regex.exec(fullCode);
+    const end = match ? match.index : fullCode.length;
+    const code = fullCode.substring(start, end);
+    files[`${folder}/${fileName}`] = { code, skip };
+  } while (match);
+
+  return files;
+}
+
+function rearrangeFiles(files: VirtualFiles, folder: string) {
+  const filteredFiles = Object.entries(files).filter(([, { skip }]) => !skip);
+
+  if (filteredFiles.length === 1) {
+    const [[, { code }]] = filteredFiles;
+    return code;
+  }
+
+  return filteredFiles
+    .map(
+      ([fileName, { code }]) => `// file: ${fileName.replace(folder + '/', '')}
+${code.trim()}`
+    )
+    .join('\n\n\n');
+}

--- a/website/plugins/remark-typescript-tools/transpileCodeblocks/postProcessing.ts
+++ b/website/plugins/remark-typescript-tools/transpileCodeblocks/postProcessing.ts
@@ -1,0 +1,141 @@
+import type { VirtualFiles } from './plugin.js';
+import type { FormatConfig } from 'oxfmt';
+import { makeModuleSynchronized } from 'make-synchronized';
+import { dirname, join, parse } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+/**
+ * `oxfmt`'s `format` is async because it crosses a napi boundary, but the
+ * remark pipeline that drives post-processing is synchronous. `make-synchronized`
+ * runs it in a worker and blocks with `Atomics.wait` — the same technique
+ * `@prettier/sync` used to use for Prettier.
+ */
+const oxfmt: typeof import('oxfmt') = makeModuleSynchronized('oxfmt');
+
+const CONFIG_FILENAMES = ['.oxfmtrc.json', '.oxfmtrc', 'oxfmt.json'];
+
+export function defaultPostProcessTs(
+  files: VirtualFiles,
+  parentFile?: string
+): VirtualFiles {
+  return fromEntries(
+    Object.entries(files).map(([name, file]) => {
+      const prettyCode = formatCode(file.code, name, parentFile || name);
+
+      return [
+        name,
+        {
+          ...file,
+          code: prettyCode.trim(),
+        },
+      ];
+    })
+  );
+}
+
+export function defaultPostProcessTranspiledJs(
+  files: VirtualFiles,
+  parentFile?: string
+): VirtualFiles {
+  return fromEntries(
+    Object.entries(files).map(([name, file]) => {
+      const mangledCode = file.code.replace(
+        /(\n\s*|)\/\/ (@ts-ignore|@ts-expect-error).*$/gm,
+        ''
+      );
+      const prettyCode = formatCode(mangledCode, name, parentFile || name);
+
+      return [
+        name.replace(/.t(sx?)$/, '.j$1'),
+        {
+          ...file,
+          code: prettyCode.trim(),
+        },
+      ];
+    })
+  );
+}
+
+const configCache = new Map<string, FormatConfig>();
+
+/**
+ * Walk up from `parentFile` looking for an oxfmt config, so code blocks are
+ * formatted in the same style as the repository they are documented in.
+ *
+ * Unlike the previous Prettier-based implementation, a missing config is not a
+ * reason to skip formatting — `oxfmt`'s defaults are applied instead. Emitting
+ * unformatted compiler output into the docs is worse than formatting it with
+ * defaults, and the old behaviour failed silently apart from a log line.
+ */
+function resolveFormatConfig(parentFile: string): FormatConfig {
+  let dir = dirname(parentFile);
+  const cached = configCache.get(dir);
+  if (cached) return cached;
+
+  const visited: Array<string> = [];
+  const { root } = parse(dir);
+
+  for (;;) {
+    visited.push(dir);
+    const hit = configCache.get(dir);
+    if (hit) {
+      for (const seen of visited) configCache.set(seen, hit);
+      return hit;
+    }
+
+    for (const fileName of CONFIG_FILENAMES) {
+      let contents: string;
+      try {
+        contents = readFileSync(join(dir, fileName), 'utf8');
+      } catch {
+        continue;
+      }
+      const { $schema, ignorePatterns, ...config } = JSON.parse(
+        contents
+      ) as FormatConfig & { $schema?: string; ignorePatterns?: Array<string> };
+      for (const seen of visited) configCache.set(seen, config);
+      return config;
+    }
+
+    if (dir === root) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  const empty: FormatConfig = {};
+  for (const seen of visited) configCache.set(seen, empty);
+  return empty;
+}
+
+function formatCode(
+  sourceCode: string,
+  fileName: string,
+  parentFile: string
+): string {
+  if (!sourceCode.trim()) return sourceCode;
+
+  const { code, errors } = oxfmt.format(
+    fileName,
+    sourceCode,
+    resolveFormatConfig(parentFile)
+  ) as unknown as { code: string; errors: Array<unknown> };
+
+  if (errors.length) {
+    console.error(
+      `oxfmt could not format ${fileName} (from ${parentFile}), leaving it unformatted:\n` +
+        errors.map((error) => `  ${String(error)}`).join('\n')
+    );
+    return sourceCode;
+  }
+
+  return code;
+}
+
+function fromEntries<T>(entries: Array<[string, T]>): Record<string, T> {
+  const ret: Record<string, T> = {};
+  for (const [key, value] of entries) {
+    ret[key] = value;
+  }
+  return ret;
+}

--- a/website/plugins/remark-typescript-tools/ts7.cjs
+++ b/website/plugins/remark-typescript-tools/ts7.cjs
@@ -1,0 +1,33 @@
+// TypeScript 7 is ESM-only. Docusaurus loads `docusaurus.config.ts` through
+// jiti, and jiti transpiles everything it reaches - including this package's
+// dependencies - down to CommonJS. That transpile leaves TypeScript's
+// `import.meta` in place, and loading the result throws
+// "Cannot use 'import.meta' outside a module".
+//
+// Node's own require(esm) loads TypeScript 7 without complaint. This file is
+// plain CommonJS with no ESM syntax, so jiti has nothing to transform and
+// hands it to Node, whose native `require` then does the right thing.
+//
+// Only value imports need to come through here. `import type` is erased
+// before runtime, so the rest of the port still imports its types straight
+// from `typescript/unstable/ast`.
+
+const { API } = require('typescript/unstable/sync')
+const {
+  SyntaxKind,
+  getLeadingCommentRanges,
+  getTrailingCommentRanges,
+  isIdentifier,
+  isVariableDeclaration,
+  isVariableStatement,
+} = require('typescript/unstable/ast')
+
+module.exports = {
+  API,
+  SyntaxKind,
+  getLeadingCommentRanges,
+  getTrailingCommentRanges,
+  isIdentifier,
+  isVariableDeclaration,
+  isVariableStatement,
+}


### PR DESCRIPTION
Removing Prettier in RTK-2 left `transpileCodeblocks` with no config to
find. It logs a warning per code block and emits unformatted code tabs -
940 warnings a build. Netlify sets `CI=true`, so that ships the moment
the oxfmt PR merges. This repairs it.

The published `remark-typescript-tools` cannot be upgraded in place.
TypeScript 7's main export is `{ version, versionMajorMinor }`; there is
no `typescript.js` and no `typescript.d.ts`, so every tool driving the
classic `ts.*` API stops working, and this plugin drives it heavily.
The port replaces the hand-written `LanguageServiceHost` with one `API`
instance from `typescript/unstable/sync` over an overlay filesystem,
moves emit to `oxc-transform` because the TS 7 API has no emit, and
formats with oxfmt instead of Prettier.

It is vendored rather than depended on because the port cannot ship a
release yet: `rollup-plugin-dts` drives the classic API and crashes
under TS 7, so the package has no declaration output. Nothing here needs
declarations - `docusaurus.config.ts` imports the source directly. An
upstream PR carries the same port. When a release lands, delete
`website/plugins/remark-typescript-tools` and depend on the package
again. This is a bridge, not a fork.

Details:

- The plugin is its own workspace package purely to pin TypeScript 7 to
  its own directory. The rest of the repo stays on 6.0.3. Nothing
  imports it by name; the config uses a relative path.
- `ts7.cjs` is the one edit to upstream's source. Docusaurus loads the
  config through jiti, jiti transpiles TypeScript 7's ESM to CommonJS
  and leaves `import.meta` in it, and the result throws. Node's own
  require(esm) loads it fine. A plain CommonJS file gives jiti nothing
  to transform, so Node's native require handles the inner call. Only
  the three value imports route through it; type imports are erased
  before runtime and still point at `typescript/unstable/ast`.
- `website/plugins/**` is in `ignorePatterns` in `.oxfmtrc.json` so the
  vendored copy stays diffable against upstream.
- `prettier` leaves `website/package.json`. The plugin was its only
  remaining user.

Measured on the 156 code blocks in these docs: no transpilation 75s,
TypeScript 6.0.3 with the published plugin 177s, TypeScript 7.0.2 with
this port 100s, and 80s with oxfmt formatting.

Verified with `CI=true pnpm build:docs`: build succeeds, zero formatting
warnings. The 24 remaining "could not find overload" messages come from
`linkDocblocks` and are upstream's own code, unchanged by the port.

Upstream base: phryneas/remark-typescript-tools main @ 5c375b1.
Port: feat/typescript-7-and-oxfmt @ b2ce7f2.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>