### PR TITLE
fix(toolkit): flag `rejectedWithValue` for falsy `rejectWithValue` payloads

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -590,7 +590,7 @@ export const createAsyncThunk = /* @__PURE__ */ (() => {
             ...((meta as any) || {}),
             arg,
             requestId,
-            rejectedWithValue: !!payload,
+            rejectedWithValue: payload !== undefined,
             requestStatus: 'rejected' as const,
             aborted: error?.name === 'AbortError',
             condition: error?.name === 'ConditionError',

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -307,6 +307,31 @@ describe('createAsyncThunk', () => {
     expect(errorAction.meta.arg).toBe(args)
   })
 
+  it.each([0, '', false, null])(
+    'flags the rejected action as rejectedWithValue when a user returns rejectWithValue(%p)',
+    async (errorPayload) => {
+      const dispatch = vi.fn()
+
+      const args = 123
+
+      const thunkActionCreator = createAsyncThunk(
+        'testType',
+        async (args: number, { rejectWithValue }) => {
+          return rejectWithValue(errorPayload)
+        },
+      )
+
+      await thunkActionCreator(args)(dispatch, () => {}, undefined)
+
+      expect(dispatch).toHaveBeenCalledTimes(2)
+
+      const errorAction = dispatch.mock.calls[1][0]
+
+      expect(errorAction.payload).toBe(errorPayload)
+      expect(errorAction.meta.rejectedWithValue).toBe(true)
+    },
+  )
+
   it('dispatches a rejected action with a miniSerializeError when rejectWithValue conditions are not satisfied', async () => {
     const dispatch = vi.fn()
 
@@ -777,6 +802,20 @@ describe('unwrapResult', () => {
 
     const unwrapPromise2 = asyncThunk()(dispatch, getState, extra)
     await expect(unwrapPromise2.unwrap()).rejects.toBe('rejectWithValue!')
+  })
+  test('rejectWithValue case with a falsy value', async () => {
+    const asyncThunk = createAsyncThunk('test', (_, { rejectWithValue }) => {
+      return rejectWithValue(0)
+    })
+
+    const unwrapPromise = asyncThunk()(dispatch, getState, extra).then(
+      unwrapResult,
+    )
+
+    await expect(unwrapPromise).rejects.toBe(0)
+
+    const unwrapPromise2 = asyncThunk()(dispatch, getState, extra)
+    await expect(unwrapPromise2.unwrap()).rejects.toBe(0)
   })
 })
 


### PR DESCRIPTION
## Problem

`rejectWithValue(0)`, `rejectWithValue('')`, `rejectWithValue(false)` and `rejectWithValue(null)` produce a rejected action that carries the payload but is flagged `rejectedWithValue: false`.

```ts
// createAsyncThunk.ts:593
rejectedWithValue: !!payload,
```

Three consumers then treat a deliberately handled rejection as an unhandled one: `unwrap()` throws the generic `{ message: 'Rejected' }` rather than the value (`createAsyncThunk.ts:784`), `isRejectedWithValue()` does not match (`matchers.ts:241`), and RTK Query's `queryFulfilled` rejects with `isUnhandledError: true` (`queryLifecycle.ts:497-500`).

RTK Query reaches it without anything unusual: `buildThunks.ts:839` passes whatever an endpoint's `transformErrorResponse` returns straight into `rejectWithValue`, so a transform that returns an empty string on an error response is enough.

The type already treats this as a presence discriminant rather than a truthiness one - `createAsyncThunk.ts:407-412` is a union on `{ rejectedWithValue: false }` vs `{ rejectedWithValue: true } & GetRejectedMeta` - and the docs say `rejectWithValue` passes "whatever value you give it".

## Fix

`rejectedWithValue: payload !== undefined`.

One residual gap I left alone deliberately: `rejectWithValue(undefined)` still flags `false`, because the `rejected` prepare callback cannot distinguish a fourth argument of `undefined` from an absent one without an arity check, and that would change behaviour for anyone calling `thunk.rejected(err, id, arg, undefined)` directly. Happy to switch to the arity version if you would rather cover it.

## Tests

Four cases across the falsy values plus an `unwrapResult` case, added next to the existing `rejectWithValue` tests. `packages/toolkit` goes 1067 to 1072 passing with no type errors; the suite has no pre-existing failures either way.

Related to #4725, though I cannot confirm which falsy value that reporter's `transformErrorResponse` produced, so I am not claiming it as closed.
