### PR TITLE
fix(toolkit): tag with a falsy id invalidation and cleanup

### DIFF
--- a/packages/toolkit/src/query/core/buildSlice.ts
+++ b/packages/toolkit/src/query/core/buildSlice.ts
@@ -512,7 +512,7 @@ export function buildSlice({
 
             for (const { type, id } of providedTags) {
               const subscribedQueries = ((draft.tags[type] ??= {})[
-                id || '__internal_without_id'
+                id ?? '__internal_without_id'
               ] ??= [])
               const alreadySubscribed =
                 subscribedQueries.includes(queryCacheKey)
@@ -549,7 +549,7 @@ export function buildSlice({
           )) {
             for (const [id, cacheKeys] of Object.entries(incomingTags)) {
               const subscribedQueries = ((draft.tags[type] ??= {})[
-                id || '__internal_without_id'
+                id ?? '__internal_without_id'
               ] ??= [])
               for (const queryCacheKey of cacheKeys) {
                 const alreadySubscribed =

--- a/packages/toolkit/src/query/tests/buildSlice.test.ts
+++ b/packages/toolkit/src/query/tests/buildSlice.test.ts
@@ -237,3 +237,33 @@ describe('`merge` callback', () => {
     expect(todoEntry2.data).toEqual([{ id: '1', text: 'B' }])
   })
 })
+
+describe('provided tag cleanup', () => {
+  it('removes the cache key from tags with a falsy id', async () => {
+    const api = createApi({
+      baseQuery,
+      tagTypes: ['Post'],
+      endpoints: (build) => ({
+        getPost: build.query<unknown, void>({
+          query: () => '/post',
+          providesTags: [{ type: 'Post', id: 0 }],
+          keepUnusedDataFor: 0,
+        }),
+      }),
+    })
+
+    const storeRef = setupApiStore(api, undefined, {
+      withoutTestLifecycles: true,
+    })
+
+    const promise = storeRef.store.dispatch(api.endpoints.getPost.initiate())
+    await promise
+    promise.unsubscribe()
+
+    await delay(10)
+
+    const state = storeRef.store.getState().api
+    expect(state.queries).toEqual({})
+    expect(Object.values(state.provided.tags.Post ?? {}).flat()).toEqual([])
+  })
+})

--- a/packages/toolkit/src/query/tests/invalidation.test.tsx
+++ b/packages/toolkit/src/query/tests/invalidation.test.tsx
@@ -39,6 +39,11 @@ const caseMatrix: [ProvidedTags, InvalidatesTags, boolean][] = [
   // type + id invalidates type + id
   [[{ type: 'apple', id: 1 }], [{ type: 'apple', id: 1 }], true],
   [[{ type: 'apple', id: 1 }], [{ type: 'apple', id: 2 }], false],
+  // falsy ids behave as normal ids
+  [[{ type: 'apple', id: 0 }], [{ type: 'apple', id: 0 }], true],
+  [[{ type: 'apple', id: '' }], [{ type: 'apple', id: '' }], true],
+  [[{ type: 'apple', id: 0 }], [{ type: 'apple' }], true],
+  [['apple'], [{ type: 'apple', id: 0 }], false],
   // null and undefined
   [['apple'], [null], false],
   [['apple'], [undefined], false],


### PR DESCRIPTION
A tag with a falsy id (number `0` or empty string `''`) was regarded as _without id_ (falling into `'__internal_without_id'`) on write, but regarded as a tag _with id_ on read and cleanup.

This change consistently uses `id ?? '__internal_without_id'` on the write path, so a tag with a falsy id is always regarded as _with id_.

Added tests for both invalidation and cleanup which catch exactly the previous behavior.

The previous behavior is described in detail in Issue #5397.

Closes #5397