### PR TITLE
Fix entity adapters for Object.prototype-named IDs

### DIFF
--- a/packages/toolkit/src/entities/sorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/sorted_state_adapter.ts
@@ -13,6 +13,8 @@ import {
   ensureEntitiesArray,
   splitAddedUpdatedEntities,
   getCurrent,
+  hasEntity,
+  setEntity,
 } from './utils'
 
 // Borrowed from Replay
@@ -93,7 +95,7 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     newEntities: readonly T[] | Record<Id, T>,
     state: R,
   ): void {
-    let deduplicatedEntities = {} as Record<Id, T>;
+    let deduplicatedEntities = Object.create(null) as Record<Id, T>;
     newEntities = ensureEntitiesArray(newEntities)
     if (newEntities.length !== 0) {
       for (const item of newEntities) {
@@ -134,11 +136,12 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     // the first rename moves the entity to a new key; a subsequent update that
     // still targets the original key finds nothing and is silently dropped,
     // producing results inconsistent with the unsorted adapter.
-    const updatesPerEntity: { [id: string]: Update<T, Id> } = {}
+    const updatesPerEntity: { [id: string]: Update<T, Id> } =
+      Object.create(null)
     for (const update of updates) {
       // Only collect updates for entities that currently exist (same guard
       // used by the unsorted adapter).
-      if (update.id in (state.entities as Record<Id, T>)) {
+      if (hasEntity(state.entities as Record<Id, T>, update.id)) {
         updatesPerEntity[update.id] = {
           id: update.id,
           changes: {
@@ -167,7 +170,7 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
         delete (state.entities as Record<Id, T>)[update.id]
         const oldIndex = (state.ids as Id[]).indexOf(update.id)
         state.ids[oldIndex] = newId
-        ;(state.entities as Record<Id, T>)[newId] = entity
+        setEntity(state, newId, entity)
       }
     }
 
@@ -228,8 +231,6 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     const currentEntities = getCurrent(state.entities)
     const currentIds = getCurrent(state.ids)
 
-    const stateEntities = state.entities as Record<Id, T>
-
     let ids: Iterable<Id> = currentIds
     if (replacedIds) {
       ids = new Set(currentIds)
@@ -238,7 +239,7 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
     let sortedEntities: T[] = []
     for (const id of ids) {
       const entity = currentEntities[id]
-      if (entity) {
+      if (entity !== undefined) {
         sortedEntities.push(entity)
       }
     }
@@ -246,7 +247,7 @@ export function createSortedStateAdapter<T, Id extends EntityId>(
 
     // Insert/overwrite all new/updated
     for (const item of addedItems) {
-      stateEntities[selectId(item)] = item
+      setEntity(state, selectId(item), item)
 
       if (!wasPreviouslyEmpty) {
         // Binary search insertion generally requires fewer comparisons

--- a/packages/toolkit/src/entities/state_selectors.ts
+++ b/packages/toolkit/src/entities/state_selectors.ts
@@ -1,6 +1,7 @@
 import type { CreateSelectorFunction, Selector } from 'reselect'
 import { createDraftSafeSelector } from '../createDraftSafeSelector'
 import type { EntityId, EntitySelectors, EntityState } from './models'
+import { hasEntity } from './utils'
 
 type AnyCreateSelectorFunction = CreateSelectorFunction<any, any, any>
 
@@ -37,7 +38,8 @@ export function createSelectorsFactory<T, Id extends EntityId>() {
 
     const selectId = (_: unknown, id: Id) => id
 
-    const selectById = (entities: Record<Id, T>, id: Id) => entities[id]
+    const selectById = (entities: Record<Id, T>, id: Id) =>
+      hasEntity(entities, id) ? entities[id] : (undefined as T)
 
     const selectTotal = createSelector(selectIds, (ids) => ids.length)
 

--- a/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/sorted_state_adapter.test.ts
@@ -96,6 +96,31 @@ describe('Sorted State Adapter', () => {
     })
   })
 
+  it('supports entity IDs that match Object.prototype properties', () => {
+    const entities = [
+      { id: 'toString', title: 'First' },
+      { id: '__proto__', title: 'Second' },
+      { id: 'constructor', title: 'Third' },
+    ]
+
+    const withEntities = adapter.addMany(state, entities)
+    const selectors = adapter.getSelectors()
+
+    expect(withEntities.ids).toEqual(entities.map(({ id }) => id))
+    expect(selectors.selectAll(withEntities)).toEqual(entities)
+    expect(selectors.selectById(withEntities, '__proto__')).toBe(entities[1])
+    expect(selectors.selectById(withEntities, 'valueOf')).toBeUndefined()
+
+    const updated = adapter.updateOne(withEntities, {
+      id: '__proto__',
+      changes: { title: 'Updated' },
+    })
+    const removed = adapter.removeOne(updated, 'constructor')
+
+    expect(selectors.selectById(updated, '__proto__')?.title).toBe('Updated')
+    expect(selectors.selectById(removed, 'constructor')).toBeUndefined()
+  })
+
   it('should let you add many entities to the state from a dictionary', () => {
     const withOneEntity = adapter.addOne(state, TheGreatGatsby)
 

--- a/packages/toolkit/src/entities/tests/unsorted_state_adapter.test.ts
+++ b/packages/toolkit/src/entities/tests/unsorted_state_adapter.test.ts
@@ -70,6 +70,31 @@ describe('Unsorted State Adapter', () => {
     })
   })
 
+  it('supports entity IDs that match Object.prototype properties', () => {
+    const entities = [
+      { id: 'toString', title: 'First' },
+      { id: '__proto__', title: 'Second' },
+      { id: 'constructor', title: 'Third' },
+    ]
+
+    const withEntities = adapter.addMany(state, entities)
+    const selectors = adapter.getSelectors()
+
+    expect(withEntities.ids).toEqual(entities.map(({ id }) => id))
+    expect(selectors.selectAll(withEntities)).toEqual(entities)
+    expect(selectors.selectById(withEntities, '__proto__')).toBe(entities[1])
+    expect(selectors.selectById(withEntities, 'valueOf')).toBeUndefined()
+
+    const updated = adapter.updateOne(withEntities, {
+      id: '__proto__',
+      changes: { title: 'Updated' },
+    })
+    const removed = adapter.removeOne(updated, 'constructor')
+
+    expect(selectors.selectById(updated, '__proto__')?.title).toBe('Updated')
+    expect(selectors.selectById(removed, 'constructor')).toBeUndefined()
+  })
+
   it('should let you add many entities to the state from a dictionary', () => {
     const withOneEntity = adapter.addOne(state, TheGreatGatsby)
 

--- a/packages/toolkit/src/entities/unsorted_state_adapter.ts
+++ b/packages/toolkit/src/entities/unsorted_state_adapter.ts
@@ -14,6 +14,8 @@ import {
   selectIdValue,
   ensureEntitiesArray,
   splitAddedUpdatedEntities,
+  hasEntity,
+  setEntity,
 } from './utils'
 
 export function createUnsortedStateAdapter<T, Id extends EntityId>(
@@ -24,12 +26,12 @@ export function createUnsortedStateAdapter<T, Id extends EntityId>(
   function addOneMutably(entity: T, state: R): void {
     const key = selectIdValue(entity, selectId)
 
-    if (key in state.entities) {
+    if (hasEntity(state.entities as Record<Id, T>, key)) {
       return
     }
 
     state.ids.push(key as Id & Draft<Id>)
-    ;(state.entities as Record<Id, T>)[key] = entity
+    setEntity(state, key, entity)
   }
 
   function addManyMutably(
@@ -45,10 +47,10 @@ export function createUnsortedStateAdapter<T, Id extends EntityId>(
 
   function setOneMutably(entity: T, state: R): void {
     const key = selectIdValue(entity, selectId)
-    if (!(key in state.entities)) {
+    if (!hasEntity(state.entities as Record<Id, T>, key)) {
       state.ids.push(key as Id & Draft<Id>)
     }
-    ;(state.entities as Record<Id, T>)[key] = entity
+    setEntity(state, key, entity)
   }
 
   function setManyMutably(
@@ -81,16 +83,16 @@ export function createUnsortedStateAdapter<T, Id extends EntityId>(
     let didMutate = false
 
     keys.forEach((key) => {
-      if (key in state.entities) {
+      if (hasEntity(state.entities as Record<Id, T>, key)) {
         delete (state.entities as Record<Id, T>)[key]
         didMutate = true
       }
     })
 
     if (didMutate) {
-      state.ids = (state.ids as Id[]).filter((id) => id in state.entities) as
-        | Id[]
-        | Draft<Id[]>
+      state.ids = (state.ids as Id[]).filter((id) =>
+        hasEntity(state.entities as Record<Id, T>, id),
+      ) as Id[] | Draft<Id[]>
     }
   }
 
@@ -119,7 +121,7 @@ export function createUnsortedStateAdapter<T, Id extends EntityId>(
       delete (state.entities as Record<Id, T>)[update.id]
     }
 
-    ;(state.entities as Record<Id, T>)[newKey] = updated
+    setEntity(state, newKey, updated)
 
     return hasNewKey
   }
@@ -132,13 +134,14 @@ export function createUnsortedStateAdapter<T, Id extends EntityId>(
     updates: ReadonlyArray<Update<T, Id>>,
     state: R,
   ): void {
-    const newKeys: { [id: string]: Id } = {}
+    const newKeys: { [id: string]: Id } = Object.create(null)
 
-    const updatesPerEntity: { [id: string]: Update<T, Id> } = {}
+    const updatesPerEntity: { [id: string]: Update<T, Id> } =
+      Object.create(null)
 
     updates.forEach((update) => {
       // Only apply updates to entities that currently exist
-      if (update.id in state.entities) {
+      if (hasEntity(state.entities as Record<Id, T>, update.id)) {
         // If there are multiple updates to one entity, merge them together
         updatesPerEntity[update.id] = {
           id: update.id,

--- a/packages/toolkit/src/entities/utils.ts
+++ b/packages/toolkit/src/entities/utils.ts
@@ -41,6 +41,29 @@ export function getCurrent<T>(value: T | Draft<T>): T {
   return (isDraft(value) ? current(value) : value) as T
 }
 
+export function hasEntity<T, Id extends EntityId>(
+  entities: Record<Id, T>,
+  id: Id,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(entities, id)
+}
+
+export function setEntity<T, Id extends EntityId>(
+  state: DraftableEntityState<T, Id>,
+  id: Id,
+  entity: T,
+): void {
+  if (id === '__proto__') {
+    state.entities = {
+      ...getCurrent(state.entities),
+      [id]: entity,
+    } as DraftableEntityState<T, Id>['entities']
+    return
+  }
+
+  ;(state.entities as Record<Id, T>)[id] = entity
+}
+
 export function splitAddedUpdatedEntities<T, Id extends EntityId>(
   newEntities: readonly T[] | Record<Id, T>,
   selectId: IdSelector<T, Id>,


### PR DESCRIPTION
## Fixes

- Store, update, remove, and select valid entity IDs such as `toString`, `constructor`, and `__proto__` in both sorted and unsorted adapters.
- Use own-property checks instead of inherited-property checks for entity membership.
- Keep temporary ID dictionaries prototype-safe without changing the public entity-state object prototype.
- Return `undefined` from `selectById` for missing prototype-named IDs instead of exposing inherited functions.

Closes #5399.

## Verification

- The untouched baseline drops all prototype-named entities and returns an inherited function for a missing `valueOf` ID.
- Added full add/select/update/remove regressions for both adapter variants.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,318 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Fixed standalone reproduction passes for sorted and unsorted adapters.
- `git diff --check`

## Compatibility

No public type or API-shape change. Ordinary entity dictionaries retain their existing prototype; only previously unusable valid string IDs change behavior.

The repository-wide formatter already reports the touched sorted-adapter source/test files on the exact base commit, before this patch; the new hunks follow the surrounding style. ESLint is currently blocked locally by the installed ESLint 7 dependency tree loading an ESM-only transitive module through CommonJS.