### PR TITLE
Fix stateful RegExp matching in ignored paths

### DIFF
--- a/packages/toolkit/src/immutableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/immutableStateInvariantMiddleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from 'redux'
 import type { IgnoredPaths } from './serializableStateInvariantMiddleware'
-import { getTimeMeasureUtils } from './utils'
+import { getTimeMeasureUtils, isIgnoredPath } from './utils'
 
 type EntryProcessor = (key: string, value: any) => any
 
@@ -50,13 +50,7 @@ function trackProperties(
       const nestedPath = path ? path + '.' + key : key
 
       if (hasIgnoredPaths) {
-        const hasMatches = ignoredPaths.some((ignored) => {
-          if (ignored instanceof RegExp) {
-            return ignored.test(nestedPath)
-          }
-          return nestedPath === ignored
-        })
-        if (hasMatches) {
+        if (isIgnoredPath(nestedPath, ignoredPaths)) {
           continue
         }
       }
@@ -107,13 +101,7 @@ function detectMutations(
     const nestedPath = path ? path + '.' + key : key
 
     if (hasIgnoredPaths) {
-      const hasMatches = ignoredPaths.some((ignored) => {
-        if (ignored instanceof RegExp) {
-          return ignored.test(nestedPath)
-        }
-        return nestedPath === ignored
-      })
-      if (hasMatches) {
+      if (isIgnoredPath(nestedPath, ignoredPaths)) {
         continue
       }
     }

--- a/packages/toolkit/src/serializableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/serializableStateInvariantMiddleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from 'redux'
 import { isAction, isPlainObject } from './reduxImports'
-import { getTimeMeasureUtils } from './utils'
+import { getTimeMeasureUtils, isIgnoredPath } from './utils'
 
 /**
  * Returns true if the passed value is "plain", i.e. a value that is either
@@ -64,13 +64,7 @@ export function findNonSerializableValue(
     const nestedPath = path ? path + '.' + key : key
 
     if (hasIgnoredPaths) {
-      const hasMatches = ignoredPaths.some((ignored) => {
-        if (ignored instanceof RegExp) {
-          return ignored.test(nestedPath)
-        }
-        return nestedPath === ignored
-      })
-      if (hasMatches) {
+      if (isIgnoredPath(nestedPath, ignoredPaths)) {
         continue
       }
     }

--- a/packages/toolkit/src/tests/immutableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/immutableStateInvariantMiddleware.test.ts
@@ -181,6 +181,28 @@ describe('createImmutableStateInvariantMiddleware', () => {
 })
 
 describe('trackForMutations', () => {
+  it.each([/^ignored/g, /^ignored/y])(
+    'matches stateful ignored-path expression %s independently',
+    (ignoredPath) => {
+      const state = {
+        ignoredA: { value: 1 },
+        ignoredB: { value: 1 },
+      }
+      ignoredPath.lastIndex = 2
+      const tracker = trackForMutations(
+        isImmutableDefault,
+        [ignoredPath],
+        state,
+      )
+
+      state.ignoredA.value = 2
+      state.ignoredB.value = 2
+
+      expect(tracker.detectMutations()).toEqual({ wasMutated: false })
+      expect(ignoredPath.lastIndex).toBe(2)
+    },
+  )
+
   function testCasesForMutation(spec: any) {
     it('returns true and the mutated path', () => {
       const state = spec.getState()

--- a/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
@@ -92,6 +92,27 @@ describe('findNonSerializableValue', () => {
 
     expect(result).toEqual(false)
   })
+
+  it.each([/^ignored/g, /^ignored/y])(
+    'matches stateful ignored-path expression %s independently',
+    (ignoredPath) => {
+      ignoredPath.lastIndex = 2
+
+      const result = findNonSerializableValue(
+        {
+          ignoredA: new Map(),
+          ignoredB: new Map(),
+        },
+        '',
+        undefined,
+        undefined,
+        [ignoredPath],
+      )
+
+      expect(result).toBe(false)
+      expect(ignoredPath.lastIndex).toBe(2)
+    },
+  )
 })
 
 describe('serializableStateInvariantMiddleware', () => {

--- a/packages/toolkit/src/utils.ts
+++ b/packages/toolkit/src/utils.ts
@@ -26,6 +26,29 @@ export function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+export function isIgnoredPath(
+  path: string,
+  ignoredPaths: readonly (string | RegExp)[],
+): boolean {
+  return ignoredPaths.some((ignored) => {
+    if (ignored instanceof RegExp) {
+      if (!ignored.global && !ignored.sticky) {
+        return ignored.test(path)
+      }
+
+      const lastIndex = ignored.lastIndex
+      try {
+        ignored.lastIndex = 0
+        return ignored.test(path)
+      } finally {
+        ignored.lastIndex = lastIndex
+      }
+    }
+
+    return path === ignored
+  })
+}
+
 export class Tuple<Items extends ReadonlyArray<unknown> = []> extends Array<
   Items[number]
 > {


### PR DESCRIPTION
## Fixes

- Match every invariant-middleware path independently when `ignoredPaths` contains a global or sticky RegExp.
- Preserve the caller’s original `RegExp.lastIndex` after each match.
- Share the matching behavior between serializability traversal and both mutation-tracking phases.

Closes #5401.

## Verification

- Exact untouched-base reproductions show `/^ignored/g` alternately ignoring sibling paths: serializability reports `ignoredB`, while mutation tracking reports a mutation inside an ignored subtree.
- Added global and sticky RegExp regressions for both invariant middleware implementations, including `lastIndex` preservation.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,320 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Prettier check over every changed file
- Fixed standalone serializability/mutation reproductions for both `/g` and `/y`
- `git diff --check`

## Compatibility

No public type or API-shape change. Non-stateful expressions and string paths retain their existing behavior; global/sticky expressions become deterministic and no longer leak matcher state.