### PR TITLE
Preserve falsy rejectWithValue payload semantics

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -575,27 +575,29 @@ export const createAsyncThunk = /* @__PURE__ */ (() => {
     const rejected: AsyncThunkRejectedActionCreator<ThunkArg, ThunkApiConfig> =
       createAction(
         typePrefix + '/rejected',
-        (
+        function (
           error: Error | null,
           requestId: string,
           arg: ThunkArg,
           payload?: RejectedValue,
           meta?: RejectedMeta,
-        ) => ({
-          payload,
-          error: ((options && options.serializeError) || miniSerializeError)(
-            error || 'Rejected',
-          ) as GetSerializedErrorType<ThunkApiConfig>,
-          meta: {
-            ...((meta as any) || {}),
-            arg,
-            requestId,
-            rejectedWithValue: !!payload,
-            requestStatus: 'rejected' as const,
-            aborted: error?.name === 'AbortError',
-            condition: error?.name === 'ConditionError',
-          },
-        }),
+        ) {
+          return {
+            payload,
+            error: ((options && options.serializeError) || miniSerializeError)(
+              error || 'Rejected',
+            ) as GetSerializedErrorType<ThunkApiConfig>,
+            meta: {
+              ...((meta as any) || {}),
+              arg,
+              requestId,
+              rejectedWithValue: arguments.length >= 4,
+              requestStatus: 'rejected' as const,
+              aborted: error?.name === 'AbortError',
+              condition: error?.name === 'ConditionError',
+            },
+          }
+        },
       )
 
     function actionCreator(

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -778,6 +778,27 @@ describe('unwrapResult', () => {
     const unwrapPromise2 = asyncThunk()(dispatch, getState, extra)
     await expect(unwrapPromise2.unwrap()).rejects.toBe('rejectWithValue!')
   })
+
+  test.each([false, 0, '', null, undefined])(
+    'rejectWithValue case with falsy payload %p',
+    async (value) => {
+      const asyncThunk = createAsyncThunk<
+        never,
+        void,
+        { rejectValue: unknown }
+      >('test', (_, { rejectWithValue }) => rejectWithValue(value))
+
+      const promise = asyncThunk()(dispatch, getState, extra)
+      const action = await promise
+
+      expect(asyncThunk.rejected.match(action)).toBe(true)
+      if (!asyncThunk.rejected.match(action)) {
+        throw new Error('Expected a rejected action')
+      }
+      expect(action.meta.rejectedWithValue).toBe(true)
+      await expect(promise.unwrap()).rejects.toBe(value)
+    },
+  )
 })
 
 describe('idGenerator option', () => {


### PR DESCRIPTION
## Fixes

- Derive `meta.rejectedWithValue` from whether the rejected action creator received a payload argument, not from payload truthiness.
- Preserve `.unwrap()` / `unwrapResult()` behavior for `false`, `0`, `""`, `null`, and `undefined` rejection payloads.
- Keep ordinary thrown errors and manually created rejections without a payload unchanged.

Closes #5403.

## Verification

- Exact untouched-base reproduction returns `meta.rejectedWithValue: false` and unwraps as `{ message: "Rejected" }` for every falsy payload.
- Added runtime coverage for all five falsy JavaScript values, asserting the rejected-action discriminant and exact unwrapped rejection identity.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,321 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Prettier check over every changed file
- Fixed standalone controls for all five falsy values
- `git diff --check`

## Compatibility

No public type, function signature, or action shape change. This is an observable correction for values explicitly supplied through `rejectWithValue`; thrown errors and omitted payload arguments retain existing behavior.