### PR TITLE
Preserve delayed invalidations after duplicate query rejection

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts
@@ -53,7 +53,10 @@ export const buildInvalidationByTagsHandler: InternalHandlerBuilder = ({
       pendingRequestCount++
     }
 
-    if (isQueryEnd(action)) {
+    if (
+      isQueryEnd(action) &&
+      !(queryThunk.rejected.match(action) && action.meta.condition)
+    ) {
       pendingRequestCount = Math.max(0, pendingRequestCount - 1)
     }
 

--- a/packages/toolkit/src/query/tests/raceConditions.test.ts
+++ b/packages/toolkit/src/query/tests/raceConditions.test.ts
@@ -107,3 +107,36 @@ it('invalidates a query whose corresponding mutation finished while the query wa
   expect(getQueryState()?.status).toBe(QueryStatus.fulfilled)
   expect(getQueryState()?.data).toBe(1)
 })
+
+it('keeps invalidations delayed after a duplicate query is condition-rejected', async () => {
+  eatenBananas = 0
+
+  const initialQuery = storeRef.store.dispatch(getEatenBananas.initiate())
+  getEatenBananaPromises.resolveOldest()
+  await initialQuery
+
+  const inFlightQuery = storeRef.store.dispatch(
+    getEatenBananas.initiate(undefined, { forceRefetch: true }),
+  )
+  storeRef.store.dispatch(
+    getEatenBananas.initiate(undefined, { forceRefetch: true }),
+  )
+
+  const mutation = storeRef.store.dispatch(eatBanana.initiate())
+  eatBananaPromises.resolveOldest()
+  await mutation
+
+  getEatenBananaPromises.resolveOldest()
+  await inFlightQuery
+
+  const getQueryState = () =>
+    storeRef.store.getState().api.queries[inFlightQuery.queryCacheKey]
+
+  expect(getQueryState()?.status).toBe(QueryStatus.pending)
+
+  getEatenBananaPromises.resolveOldest()
+  await delay(2)
+
+  expect(getQueryState()?.status).toBe(QueryStatus.fulfilled)
+  expect(getQueryState()?.data).toBe(1)
+})


### PR DESCRIPTION
## Fixes

- Do not decrement RTK Query’s pending-request counter for a query rejected by the thunk condition.
- Keep tag invalidations queued while the original deduplicated request is still running.
- Prevent a premature invalidation attempt from being condition-rejected and then lost, leaving stale data cached.

Closes #5405.

## Reproduced race

The integration regression caches a tag-providing query, holds a forced refetch open, dispatches a duplicate initiation, completes an invalidating mutation, and finally completes the original refetch. On the exact base, the duplicate condition rejection drops the pending count to zero; invalidation runs too early, its refetch is rejected as a duplicate, and the stale response remains fulfilled. After the fix, invalidation waits, a fresh refetch starts after the held request completes, and the updated value is cached.

## Verification

- Focused race-condition suite: three tests pass; the new test fails on the untouched base with `fulfilled` instead of the expected invalidation refetch `pending`.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,317 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Prettier check over every changed file
- `git diff --check`

## Compatibility

No public type, API, action, or cache shape change. This only corrects pending-request accounting for condition rejections that never emitted a corresponding pending action.