### PR TITLE
Cancel pending subscription sync on API reset

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/batchActions.ts
@@ -134,6 +134,9 @@ export const buildBatchedActionsHandler: InternalHandlerBuilder<
     if (api.util.resetApiState.match(action)) {
       previousSubscriptions = {}
       internalState.currentSubscriptions.clear()
+      if (updateSyncTimer !== null) {
+        clearTimeout(updateSyncTimer)
+      }
       updateSyncTimer = null
       return [true, false]
     }

--- a/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
+++ b/packages/toolkit/src/query/tests/buildMiddleware.test.tsx
@@ -1,4 +1,5 @@
 import { createApi } from '@reduxjs/toolkit/query'
+import type { Middleware } from '@reduxjs/toolkit'
 import { delay } from 'msw'
 import { actionsReducer, setupApiStore } from '../../tests/utils/helpers'
 import { vi } from 'vitest'
@@ -213,6 +214,37 @@ it('correctly stringifies subscription state and dispatches subscriptionsUpdated
   expect(
     subscriptionState['getBananas(undefined)']?.[subscription3.requestId],
   ).toEqual({})
+})
+
+it('cancels a pending subscription sync when resetting API state', () => {
+  vi.useFakeTimers()
+
+  try {
+    let subscriptionUpdateCount = 0
+    const observeSubscriptionUpdates: Middleware = () => (next) => (action) => {
+      if (api.internalActions.subscriptionsUpdated.match(action)) {
+        subscriptionUpdateCount++
+      }
+      return next(action)
+    }
+    const testStoreRef = setupApiStore(
+      api,
+      { ...actionsReducer },
+      {
+        withoutListeners: true,
+        middleware: { concat: [observeSubscriptionUpdates] },
+      },
+    )
+
+    testStoreRef.store.dispatch(getBanana.initiate(3))
+    testStoreRef.store.dispatch(api.util.resetApiState())
+
+    expect(subscriptionUpdateCount).toBe(0)
+    vi.advanceTimersByTime(500)
+    expect(subscriptionUpdateCount).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 it('does not leak subscription state between multiple stores using the same API instance (SSR scenario)', async () => {


### PR DESCRIPTION
## Fixes

- Clear the pending 500ms subscription-state synchronization timeout when `resetApiState` runs.
- Prevent a stale `subscriptionsUpdated` action from being emitted after reset.
- Prevent an old callback from clearing the handle of a newer post-reset sync timer and allowing overlapping timers.

Closes #5407.

## Verification

- Added a downstream middleware observer with fake timers. On the exact base it records one `subscriptionsUpdated` action 500ms after reset; after the fix it records none.
- Focused build-middleware suite: 11 tests pass with zero type errors.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,317 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Prettier check over every changed file
- `git diff --check`

## Compatibility

No public type, API, action, or state-shape change. The only removed behavior is the obsolete deferred internal synchronization after an explicit API reset.