### PR TITLE
Release abort listeners after retry backoff

### DIFF
--- a/packages/toolkit/src/query/retry.ts
+++ b/packages/toolkit/src/query/retry.ts
@@ -33,12 +33,19 @@ async function defaultBackoff(
   const timeout = ~~((Math.random() + 0.4) * (300 << attempts)) // Force a positive int in the case we make this an option
 
   await new Promise<void>((resolve, reject) => {
-    const timeoutId = setTimeout(() => resolve(), timeout)
+    let abortHandler: (() => void) | undefined
+    const timeoutId = setTimeout(() => {
+      if (signal && abortHandler) {
+        signal.removeEventListener('abort', abortHandler)
+      }
+      resolve()
+    }, timeout)
 
     // If signal is provided and gets aborted, clear timeout and reject
     if (signal) {
-      const abortHandler = () => {
+      abortHandler = () => {
         clearTimeout(timeoutId)
+        signal.removeEventListener('abort', abortHandler!)
         reject(new Error('Aborted'))
       }
 

--- a/packages/toolkit/src/query/tests/retry.test.ts
+++ b/packages/toolkit/src/query/tests/retry.test.ts
@@ -830,6 +830,46 @@ describe('configuration', () => {
       expect(result.data).toEqual({ success: true })
     })
 
+    test('completed backoff removes its abort listener', async () => {
+      let addEventListenerSpy: ReturnType<typeof vi.spyOn> | undefined
+      let removeEventListenerSpy: ReturnType<typeof vi.spyOn> | undefined
+      let attempt = 0
+      const baseBaseQuery = vi.fn<BaseQueryFn>((_, api) => {
+        addEventListenerSpy ??= vi.spyOn(api.signal, 'addEventListener')
+        removeEventListenerSpy ??= vi.spyOn(api.signal, 'removeEventListener')
+
+        return Promise.resolve(
+          attempt++ === 0
+            ? { error: 'network error' }
+            : { data: { success: true } },
+        )
+      })
+
+      const baseQuery = retry(baseBaseQuery, { maxRetries: 1 })
+      const api = createApi({
+        baseQuery,
+        endpoints: (build) => ({
+          q1: build.query({ query: () => {} }),
+        }),
+      })
+      const storeRef = setupApiStore(api, undefined, {
+        withoutTestLifecycles: true,
+      })
+
+      const promise = storeRef.store.dispatch(api.endpoints.q1.initiate({}))
+      await loopTimers(2)
+      await promise
+
+      const backoffHandler = addEventListenerSpy!.mock.calls.find(
+        (call: any[]) => call[0] === 'abort',
+      )?.[1]
+      expect(backoffHandler).toEqual(expect.any(Function))
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'abort',
+        backoffHandler,
+      )
+    })
+
     test('multiple aborts are handled gracefully', async () => {
       const baseBaseQuery = vi.fn<BaseQueryFn>()
       baseBaseQuery.mockResolvedValue({ error: 'network error' })


### PR DESCRIPTION
## Fixes

- Remove a retry delay’s abort listener when its timer completes normally.
- Clear the timer and remove the same listener when abort wins.
- Avoid retaining one timeout/reject closure per completed backoff on long-lived request signals.

Closes #5409.

## Verification

- The regression spies on the real per-request signal before the first failed base-query attempt resolves, identifies the default-backoff listener, and requires the identical callback to be removed after the successful retry. It fails on the exact base and passes after the fix.
- Focused retry suite: 29 tests pass with zero type errors.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,317 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Prettier check over every changed file
- `git diff --check`

## Compatibility

No public type, API, retry-count, timing, or error-shape change. Abort still rejects immediately; normal timer completion now releases its obsolete listener.