### PR TITLE
Read current query state when scheduled polls fire

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/polling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/polling.ts
@@ -102,8 +102,17 @@ export const buildPollingHandler: InternalHandlerBuilder = ({
       nextPollTimestamp,
       pollingInterval: lowestPollingInterval,
       timeout: setTimeout(() => {
-        if (state.config.focused || !skipPollingIfUnfocused) {
-          api.dispatch(refetchQuery(querySubState))
+        const currentState = api.getState()[reducerPath]
+        const currentQuerySubState = currentState.queries[queryCacheKey]
+        if (
+          !currentQuerySubState ||
+          currentQuerySubState.status === STATUS_UNINITIALIZED
+        ) {
+          cleanupPollForKey(queryCacheKey)
+          return
+        }
+        if (currentState.config.focused || !skipPollingIfUnfocused) {
+          api.dispatch(refetchQuery(currentQuerySubState))
         }
         startNextPoll({ queryCacheKey }, api)
       }, lowestPollingInterval),

--- a/packages/toolkit/src/query/tests/polling.test.tsx
+++ b/packages/toolkit/src/query/tests/polling.test.tsx
@@ -166,6 +166,48 @@ describe('polling tests', () => {
     storeRef.store.dispatch(api.util.resetApiState())
   })
 
+  it('uses current focus state when a scheduled poll fires', async () => {
+    mockBaseQuery.mockClear()
+    const subscription = storeRef.store.dispatch(
+      getPosts.initiate(4, {
+        subscriptionOptions: {
+          pollingInterval: 10,
+          skipPollingIfUnfocused: true,
+        },
+        subscribe: true,
+      }),
+    )
+
+    await subscription
+    storeRef.store.dispatch(api.internalActions.onFocusLost())
+    await delay(30)
+
+    expect(mockBaseQuery).toHaveBeenCalledOnce()
+  })
+
+  it('does not revive a cache entry removed after its poll is scheduled', async () => {
+    mockBaseQuery.mockClear()
+    const subscription = storeRef.store.dispatch(
+      getPosts.initiate(5, {
+        subscriptionOptions: { pollingInterval: 10 },
+        subscribe: true,
+      }),
+    )
+
+    await subscription
+    storeRef.store.dispatch(
+      api.internalActions.removeQueryResult({
+        queryCacheKey: subscription.queryCacheKey as any,
+      }),
+    )
+    await delay(30)
+
+    expect(getPosts.select(5)(storeRef.store.getState()).status).toBe(
+      'uninitialized',
+    )
+    expect(mockBaseQuery).toHaveBeenCalledOnce()
+  })
+
   it('respects skipPollingIfUnfocused if at least one subscription has it', async () => {
     storeRef.store.dispatch(
       getPosts.initiate(3, {


### PR DESCRIPTION
## Fixes

- Read the current RTK Query slice and cache entry inside each polling timeout instead of closing over the scheduling-time Redux snapshot.
- Honor focus loss that occurs after a poll was scheduled when `skipPollingIfUnfocused` is enabled.
- Stop and remove the poll when its cache entry was deleted, rather than refetching through a stale substate and reviving it.

Closes #5411. Related to the broader React Native background-polling request in #5034.

## Verification

- The focus regression waits for the initial request to fulfill (so the poll is already scheduled), then dispatches `onFocusLost`. On the exact base it makes a second request; after the fix it remains at one.
- Added a removed-cache regression that verifies the scheduled callback leaves the selector uninitialized and makes no second request.
- Focused polling suite: ten tests pass with zero type errors.
- `yarn workspace @reduxjs/toolkit test` — 88 files, 1,318 passing tests, two existing todos, zero type errors.
- `yarn workspace @reduxjs/toolkit build`
- `yarn workspace @reduxjs/toolkit type-tests`
- Prettier check over every changed file
- `git diff --check`

## Compatibility

No public type, API, option, action, or state-shape change. Poll cadence is unchanged while active/focused; callbacks now apply the documented focus option and current cache lifecycle at firing time.