### PR TITLE
Clear listener wait timers after early completion

### DIFF
--- a/packages/toolkit/src/listenerMiddleware/index.ts
+++ b/packages/toolkit/src/listenerMiddleware/index.ts
@@ -167,10 +167,13 @@ const createTakePattern = <S>(
     })
 
     const promises: (Promise<null> | Promise<[Action, S, S]>)[] = [tuplePromise]
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
 
     if (timeout != null) {
       promises.push(
-        new Promise<null>((resolve) => setTimeout(resolve, timeout, null)),
+        new Promise<null>((resolve) => {
+          timeoutId = setTimeout(resolve, timeout, null)
+        }),
       )
     }
 
@@ -182,6 +185,9 @@ const createTakePattern = <S>(
     } finally {
       // Always clean up the listener
       unsubscribe()
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId)
+      }
     }
   }
 

--- a/packages/toolkit/src/listenerMiddleware/task.ts
+++ b/packages/toolkit/src/listenerMiddleware/task.ts
@@ -93,8 +93,20 @@ export const createPause = <T>(signal: AbortSignal) => {
  * @returns
  */
 export const createDelay = (signal: AbortSignal) => {
-  const pause = createPause<void>(signal)
   return (timeoutMs: number): Promise<void> => {
-    return pause(new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)))
+    validateActive(signal)
+
+    return catchRejection(
+      new Promise<void>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          cleanup()
+          resolve()
+        }, timeoutMs)
+        const cleanup = addAbortSignalListener(signal, () => {
+          clearTimeout(timeoutId)
+          reject(new TaskAbortError(signal.reason))
+        })
+      }),
+    )
   }
 }

--- a/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
+++ b/packages/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test.ts
@@ -999,6 +999,29 @@ describe('createListenerMiddleware', () => {
       expect(await deferredCompletedEvt).toBeDefined()
       expect(await deferredCancelledEvt).toBeDefined()
     })
+
+    test('listenerApi.delay clears its timer when the listener is cancelled', async () => {
+      vi.useFakeTimers()
+      const listenerStarted = deferred()
+
+      startListening({
+        actionCreator: increment,
+        effect: async (_, listenerApi) => {
+          listenerStarted.resolve()
+          await listenerApi.delay(60_000)
+        },
+      })
+
+      store.dispatch(increment())
+      await listenerStarted
+
+      expect(vi.getTimerCount()).toBe(1)
+      clearListeners()
+      await Promise.resolve()
+      expect(vi.getTimerCount()).toBe(0)
+
+      vi.useRealTimers()
+    })
   })
 
   describe('Error handling', () => {
@@ -1175,6 +1198,29 @@ describe('createListenerMiddleware', () => {
 
       await delay(25)
       expect(takeResult).toEqual([increment(), stateCurrent, stateBefore])
+    })
+
+    test('take clears its timeout when the predicate succeeds', async () => {
+      vi.useFakeTimers()
+      const takeCompleted = deferred()
+
+      startListening({
+        predicate: incrementByAmount.match,
+        effect: async (_, listenerApi) => {
+          await listenerApi.take(increment.match, 60_000)
+          takeCompleted.resolve()
+        },
+      })
+
+      store.dispatch(incrementByAmount(1))
+      await Promise.resolve()
+      expect(vi.getTimerCount()).toBe(1)
+
+      store.dispatch(increment())
+      await takeCompleted
+      expect(vi.getTimerCount()).toBe(0)
+
+      vi.useRealTimers()
     })
 
     test('take resolves to `[A, CurrentState, PreviousState] | null` if a possibly undefined timeout parameter is provided', async () => {


### PR DESCRIPTION
## Fixes

- Clear listenerApi.delay timers immediately when the listener is cancelled.
- Clear take(predicate, timeout) timers when the predicate wins before the timeout.
- Remove the delay abort listener when its timer completes normally.

## Why

The existing races settle correctly, but the losing setTimeout remains registered until its full duration. Repeated cancelled delays or successful timed takes can therefore accumulate live timers and retained closures in long-running applications.

The new timer-count regressions fail on the exact master base: each path leaves one 60-second timer behind. Both report zero pending timers after this change.

## Verification

- Focused listener middleware suite: 51 tests pass, zero type errors.
- Full Toolkit suite: 88 files, 1,318 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.

No public API, type, action, or listener semantics change; this only releases resources when a wait is already settled.