### PR TITLE
Cache unchanged dynamic middleware chains

### DIFF
--- a/packages/toolkit/src/dynamicMiddleware/index.ts
+++ b/packages/toolkit/src/dynamicMiddleware/index.ts
@@ -41,6 +41,7 @@ export const createDynamicMiddleware = <
     Middleware<any, State, DispatchType>,
     MiddlewareEntry<State, DispatchType>
   >()
+  let middlewareVersion = 0
 
   const withMiddleware = Object.assign(
     createAction(
@@ -59,9 +60,13 @@ export const createDynamicMiddleware = <
     function addMiddleware(
       ...middlewares: Middleware<any, State, DispatchType>[]
     ) {
+      const previousSize = middlewareMap.size
       middlewares.forEach((middleware) => {
         getOrInsertComputed(middlewareMap, middleware, createMiddlewareEntry)
       })
+      if (middlewareMap.size !== previousSize) {
+        middlewareVersion++
+      }
     },
     { withTypes: () => addMiddleware },
   ) as AddMiddleware<State, DispatchType>
@@ -76,12 +81,23 @@ export const createDynamicMiddleware = <
   const isWithMiddleware = isAllOf(withMiddleware, matchInstance(instanceId))
 
   const middleware: DynamicMiddleware<State, DispatchType> =
-    (api) => (next) => (action) => {
-      if (isWithMiddleware(action)) {
-        addMiddleware(...action.payload)
-        return api.dispatch
+    (api) => (next) => {
+      let appliedVersion = -1
+      let dispatch = next
+
+      return (action) => {
+        if (isWithMiddleware(action)) {
+          addMiddleware(...action.payload)
+          return api.dispatch
+        }
+
+        if (appliedVersion !== middlewareVersion) {
+          dispatch = getFinalMiddleware(api)(next)
+          appliedVersion = middlewareVersion
+        }
+
+        return dispatch(action)
       }
-      return getFinalMiddleware(api)(next)(action)
     }
 
   return {

--- a/packages/toolkit/src/dynamicMiddleware/tests/index.test.ts
+++ b/packages/toolkit/src/dynamicMiddleware/tests/index.test.ts
@@ -4,6 +4,7 @@ import {
   createAction,
   createDynamicMiddleware,
   isAllOf,
+  isAction,
 } from '@reduxjs/toolkit'
 import type { BaseActionCreator } from '../../createAction'
 
@@ -74,5 +75,56 @@ describe('createDynamicMiddleware', () => {
     expect(dispatch).toEqual(expect.any(Function))
 
     expect(dispatch(probeMiddleware(2))).toBe(2)
+  })
+
+  it('reuses the applied middleware chain until middleware changes', () => {
+    const dynamicInstance = createDynamicMiddleware()
+    const firstApplied = vi.fn()
+    const secondApplied = vi.fn()
+    const firstMiddleware: Middleware = () => (next) => {
+      firstApplied()
+      return (action) => next(action)
+    }
+    const secondMiddleware: Middleware = () => (next) => {
+      secondApplied()
+      return (action) => next(action)
+    }
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().prepend(dynamicInstance.middleware),
+    })
+
+    dynamicInstance.addMiddleware(firstMiddleware)
+    store.dispatch({ type: 'first' })
+    store.dispatch({ type: 'second' })
+
+    expect(firstApplied).toHaveBeenCalledTimes(1)
+
+    dynamicInstance.addMiddleware(secondMiddleware)
+    store.dispatch({ type: 'third' })
+    store.dispatch({ type: 'fourth' })
+
+    expect(firstApplied).toHaveBeenCalledTimes(2)
+    expect(secondApplied).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies newly added middleware to nested dispatches immediately', () => {
+    const dynamicInstance = createDynamicMiddleware()
+    const nestedMiddleware = makeProbeableMiddleware(2)
+    const addAndDispatch: Middleware = (api) => (next) => (action) => {
+      if (isAction(action) && action.type === 'add-and-dispatch') {
+        dynamicInstance.addMiddleware(nestedMiddleware)
+        return api.dispatch(probeMiddleware(2))
+      }
+      return next(action)
+    }
+    const store = configureStore({
+      reducer: () => 0,
+      middleware: (gDM) => gDM().prepend(dynamicInstance.middleware),
+    })
+
+    dynamicInstance.addMiddleware(addAndDispatch)
+
+    expect(store.dispatch({ type: 'add-and-dispatch' })).toBe(2)
   })
 })


### PR DESCRIPTION
## Improvement

- Compose and apply the dynamic middleware chain only when the registered middleware set changes.
- Reuse the resulting dispatch function for ordinary actions.
- Preserve immediate visibility of newly added middleware for nested dispatches.

## Why

The current hot path rebuilds an array, calls compose, and reapplies every middleware to next for every dispatched action, even though middleware additions are comparatively rare. This moves that work to the first dispatch after an actual addition.

The focused regression counts middleware-chain application. Exact master applies the first middleware twice for two unchanged dispatches; this change applies it once, then exactly once more after a second middleware is added. A nested-dispatch regression verifies that additions made during middleware execution are visible immediately.

## Verification

- Focused dynamic middleware suite: 4 tests pass, zero type errors.
- Full Toolkit suite: 88 files, 1,320 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.

No public API, type, dispatch result, middleware order, or addition semantics change.