### PR TITLE
Release fetch timeout resources after completion

### DIFF
--- a/packages/toolkit/src/query/fetchBaseQuery.ts
+++ b/packages/toolkit/src/query/fetchBaseQuery.ts
@@ -234,133 +234,140 @@ export function fetchBaseQuery({
       ...rest
     } = typeof arg == 'string' ? { url: arg } : arg
 
+    const timeoutSignalResult = timeout ? timeoutSignal(timeout) : undefined
+    const combinedSignal = timeoutSignalResult
+      ? anySignal(api.signal, timeoutSignalResult.signal)
+      : undefined
     let config: RequestInit = {
       ...baseFetchOptions,
-      signal: timeout
-        ? anySignal(api.signal, timeoutSignal(timeout))
-        : api.signal,
+      signal: combinedSignal?.signal ?? api.signal,
       ...rest,
     }
 
-    headers = new Headers(stripUndefined(headers))
-    config.headers =
-      (await prepareHeaders(headers, {
-        getState,
-        arg,
-        extra,
-        endpoint,
-        forced,
-        type,
-        extraOptions,
-      })) || headers
-
-    const bodyIsJsonifiable = isJsonifiable(config.body)
-
-    // Remove content-type for non-jsonifiable bodies to let the browser set it automatically
-    // Exception: keep content-type for string bodies as they might be intentional (text/plain, text/html, etc.)
-    if (
-      config.body != null &&
-      !bodyIsJsonifiable &&
-      typeof config.body !== 'string'
-    ) {
-      config.headers.delete('content-type')
-    }
-
-    if (!config.headers.has('content-type') && bodyIsJsonifiable) {
-      config.headers.set('content-type', jsonContentType)
-    }
-
-    if (bodyIsJsonifiable && isJsonContentType(config.headers)) {
-      config.body = JSON.stringify(config.body, jsonReplacer)
-    }
-
-    // Set Accept header based on responseHandler if not already set
-    if (!config.headers.has('accept')) {
-      if (responseHandler === 'json') {
-        config.headers.set('accept', 'application/json')
-      } else if (responseHandler === 'text') {
-        config.headers.set('accept', 'text/plain, text/html, */*')
-      }
-      // For 'content-type' responseHandler, don't set Accept (let server decide)
-    }
-
-    if (params) {
-      const divider = ~url.indexOf('?') ? '&' : '?'
-      const query = paramsSerializer
-        ? paramsSerializer(params)
-        : new URLSearchParams(stripUndefined(params))
-      url += divider + query
-    }
-
-    url = joinUrls(baseUrl, url)
-
-    const request = new Request(url, config)
-    const requestClone = new Request(url, config)
-    meta = { request: requestClone }
-
-    let response
     try {
-      response = await fetchFn(request)
-    } catch (e) {
-      return {
-        error: {
-          status:
-            (e instanceof Error ||
-              (typeof DOMException !== 'undefined' &&
-                e instanceof DOMException)) &&
-            e.name === 'TimeoutError'
-              ? 'TIMEOUT_ERROR'
-              : 'FETCH_ERROR',
-          error: String(e),
-        },
-        meta,
+      headers = new Headers(stripUndefined(headers))
+      config.headers =
+        (await prepareHeaders(headers, {
+          getState,
+          arg,
+          extra,
+          endpoint,
+          forced,
+          type,
+          extraOptions,
+        })) || headers
+
+      const bodyIsJsonifiable = isJsonifiable(config.body)
+
+      // Remove content-type for non-jsonifiable bodies to let the browser set it automatically
+      // Exception: keep content-type for string bodies as they might be intentional (text/plain, text/html, etc.)
+      if (
+        config.body != null &&
+        !bodyIsJsonifiable &&
+        typeof config.body !== 'string'
+      ) {
+        config.headers.delete('content-type')
       }
-    }
-    const responseClone = response.clone()
 
-    meta.response = responseClone
-
-    let resultData: any
-    let responseText: string = ''
-    try {
-      let handleResponseError
-      await Promise.all([
-        handleResponse(response, responseHandler).then(
-          (r) => (resultData = r),
-          (e) => (handleResponseError = e),
-        ),
-        // see https://github.com/node-fetch/node-fetch/issues/665#issuecomment-538995182
-        // we *have* to "use up" both streams at the same time or they will stop running in node-fetch scenarios
-        responseClone.text().then(
-          (r) => (responseText = r),
-          () => {},
-        ),
-      ])
-      if (handleResponseError) throw handleResponseError
-    } catch (e) {
-      return {
-        error: {
-          status: 'PARSING_ERROR',
-          originalStatus: response.status,
-          data: responseText,
-          error: String(e),
-        },
-        meta,
+      if (!config.headers.has('content-type') && bodyIsJsonifiable) {
+        config.headers.set('content-type', jsonContentType)
       }
-    }
 
-    return validateStatus(response, resultData)
-      ? {
-          data: resultData,
-          meta,
+      if (bodyIsJsonifiable && isJsonContentType(config.headers)) {
+        config.body = JSON.stringify(config.body, jsonReplacer)
+      }
+
+      // Set Accept header based on responseHandler if not already set
+      if (!config.headers.has('accept')) {
+        if (responseHandler === 'json') {
+          config.headers.set('accept', 'application/json')
+        } else if (responseHandler === 'text') {
+          config.headers.set('accept', 'text/plain, text/html, */*')
         }
-      : {
+        // For 'content-type' responseHandler, don't set Accept (let server decide)
+      }
+
+      if (params) {
+        const divider = ~url.indexOf('?') ? '&' : '?'
+        const query = paramsSerializer
+          ? paramsSerializer(params)
+          : new URLSearchParams(stripUndefined(params))
+        url += divider + query
+      }
+
+      url = joinUrls(baseUrl, url)
+
+      const request = new Request(url, config)
+      const requestClone = new Request(url, config)
+      meta = { request: requestClone }
+
+      let response
+      try {
+        response = await fetchFn(request)
+      } catch (e) {
+        return {
           error: {
-            status: response.status,
-            data: resultData,
+            status:
+              (e instanceof Error ||
+                (typeof DOMException !== 'undefined' &&
+                  e instanceof DOMException)) &&
+              e.name === 'TimeoutError'
+                ? 'TIMEOUT_ERROR'
+                : 'FETCH_ERROR',
+            error: String(e),
           },
           meta,
         }
+      }
+      const responseClone = response.clone()
+
+      meta.response = responseClone
+
+      let resultData: any
+      let responseText: string = ''
+      try {
+        let handleResponseError
+        await Promise.all([
+          handleResponse(response, responseHandler).then(
+            (r) => (resultData = r),
+            (e) => (handleResponseError = e),
+          ),
+          // see https://github.com/node-fetch/node-fetch/issues/665#issuecomment-538995182
+          // we *have* to "use up" both streams at the same time or they will stop running in node-fetch scenarios
+          responseClone.text().then(
+            (r) => (responseText = r),
+            () => {},
+          ),
+        ])
+        if (handleResponseError) throw handleResponseError
+      } catch (e) {
+        return {
+          error: {
+            status: 'PARSING_ERROR',
+            originalStatus: response.status,
+            data: responseText,
+            error: String(e),
+          },
+          meta,
+        }
+      }
+
+      return validateStatus(response, resultData)
+        ? {
+            data: resultData,
+            meta,
+          }
+        : {
+            error: {
+              status: response.status,
+              data: resultData,
+            },
+            meta,
+          }
+    } finally {
+      combinedSignal?.cleanup()
+      timeoutSignalResult?.cleanup()
+    }
   }
 
   async function handleResponse(

--- a/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
+++ b/packages/toolkit/src/query/tests/fetchBaseQuery.test.tsx
@@ -1509,6 +1509,45 @@ describe('still throws on completely unexpected errors', () => {
 })
 
 describe('timeout', () => {
+  test('clears timeout resources after a request completes', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchFn = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ value: 'success' }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      const addEventListener = vi.spyOn(
+        commonBaseQueryApi.signal,
+        'addEventListener',
+      )
+      const removeEventListener = vi.spyOn(
+        commonBaseQueryApi.signal,
+        'removeEventListener',
+      )
+
+      const result = await fetchBaseQuery({
+        baseUrl,
+        fetchFn,
+        timeout: 60_000,
+      })('/success', commonBaseQueryApi, {})
+
+      expect(result.data).toEqual({ value: 'success' })
+      expect(vi.getTimerCount()).toBe(0)
+      expect(addEventListener).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+        { once: true },
+      )
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('throws a timeout error when a request takes longer than specified timeout duration', async () => {
     server.use(
       http.get(

--- a/packages/toolkit/src/query/utils/signals.ts
+++ b/packages/toolkit/src/query/utils/signals.ts
@@ -1,7 +1,7 @@
 // AbortSignal.timeout() is currently baseline 2024
 export const timeoutSignal = (milliseconds: number) => {
   const abortController = new AbortController()
-  setTimeout(() => {
+  const timeoutId = setTimeout(() => {
     const message = 'signal timed out'
     const name = 'TimeoutError'
     abortController.abort(
@@ -11,23 +11,36 @@ export const timeoutSignal = (milliseconds: number) => {
         : Object.assign(new Error(message), { name }),
     )
   }, milliseconds)
-  return abortController.signal
+  return {
+    signal: abortController.signal,
+    cleanup: () => clearTimeout(timeoutId),
+  }
 }
 
 // AbortSignal.any() is currently baseline 2024
 export const anySignal = (...signals: AbortSignal[]) => {
   // if any are already aborted, return an already aborted signal
   for (const signal of signals)
-    if (signal.aborted) return AbortSignal.abort(signal.reason)
+    if (signal.aborted) {
+      return { signal: AbortSignal.abort(signal.reason), cleanup: () => {} }
+    }
 
   // otherwise, create a new signal that aborts when any of the given signals abort
   const abortController = new AbortController()
-  for (const signal of signals) {
-    signal.addEventListener(
-      'abort',
-      () => abortController.abort(signal.reason),
-      { signal: abortController.signal, once: true },
-    )
+  const listeners = new Map<AbortSignal, () => void>()
+  const cleanup = () => {
+    for (const [signal, listener] of listeners) {
+      signal.removeEventListener('abort', listener)
+    }
+    listeners.clear()
   }
-  return abortController.signal
+  for (const signal of signals) {
+    const listener = () => {
+      cleanup()
+      abortController.abort(signal.reason)
+    }
+    listeners.set(signal, listener)
+    signal.addEventListener('abort', listener, { once: true })
+  }
+  return { signal: abortController.signal, cleanup }
 }


### PR DESCRIPTION
## Fixes

- Clear fetchBaseQuery timeout timers as soon as the request and response handling settle.
- Remove listeners from every source signal when the combined signal settles or is disposed.
- Apply cleanup through finally so success, handled errors, parsing failures, and unexpected throws all release resources.

## Why

A successful request with a configured timeout currently retains its timer, timeout controller, combined controller, and source-signal listeners until the entire timeout duration elapses. Repeated fast requests with long timeouts can accumulate those resources in long-running apps.

The exact built master baseline completes an immediate JSON request with a 60-second timeout while retaining one pending timer. The fixed build retains zero. The permanent test also verifies the API abort listener is removed.

## Verification

- Focused fetchBaseQuery suite: 65 tests pass, zero type errors.
- Full Toolkit suite: 88 files, 1,317 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.
- Existing global and per-request timeout-error coverage remains green.

No public API, type, timeout duration, error shape, response handling, or abort semantics change.