### PR TITLE
Release external abort listeners after thunks settle

### DIFF
--- a/packages/toolkit/src/createAsyncThunk.ts
+++ b/packages/toolkit/src/createAsyncThunk.ts
@@ -609,6 +609,7 @@ export const createAsyncThunk = /* @__PURE__ */ (() => {
 
         const abortController = new AbortController()
         let abortHandler: (() => void) | undefined
+        let externalAbortHandler: (() => void) | undefined
         let abortReason: string | undefined
 
         function abort(reason?: string) {
@@ -620,11 +621,10 @@ export const createAsyncThunk = /* @__PURE__ */ (() => {
           if (signal.aborted) {
             abort(externalAbortMessage)
           } else {
-            signal.addEventListener(
-              'abort',
-              () => abort(externalAbortMessage),
-              { once: true },
-            )
+            externalAbortHandler = () => abort(externalAbortMessage)
+            signal.addEventListener('abort', externalAbortHandler, {
+              once: true,
+            })
           }
         }
 
@@ -715,6 +715,9 @@ export const createAsyncThunk = /* @__PURE__ */ (() => {
           } finally {
             if (abortHandler) {
               abortController.signal.removeEventListener('abort', abortHandler)
+            }
+            if (externalAbortHandler) {
+              signal?.removeEventListener('abort', externalAbortHandler)
             }
           }
           // We dispatch the result action _after_ the catch, to avoid having any errors

--- a/packages/toolkit/src/tests/createAsyncThunk.test.ts
+++ b/packages/toolkit/src/tests/createAsyncThunk.test.ts
@@ -1039,6 +1039,31 @@ describe('dispatch config', () => {
       'External signal was aborted',
     )
   })
+  test('removes the external abort listener after completion', async () => {
+    const asyncThunk = createAsyncThunk('test', async () => 42)
+    const abortController = new AbortController()
+    const addEventListener = vi.spyOn(
+      abortController.signal,
+      'addEventListener',
+    )
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      'removeEventListener',
+    )
+
+    await store.dispatch(
+      asyncThunk(undefined, { signal: abortController.signal }),
+    )
+
+    const externalAbortHandler = addEventListener.mock.calls.find(
+      ([type]) => type === 'abort',
+    )?.[1]
+    expect(externalAbortHandler).toEqual(expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      externalAbortHandler,
+    )
+  })
   test('an already-aborted external signal is not silently swallowed when options are provided', async () => {
     const dispatched: any[] = []
     const dispatch = vi.fn((action: any) => {


### PR DESCRIPTION
## Fix

Store the handler registered on a caller-provided AbortSignal and remove it when the async thunk settles.

## Why

The internal abort listener is already removed in finally, but the matching external listener is anonymous and remains attached until that external signal eventually aborts. Reusing a long-lived signal across completed thunks therefore accumulates retained listeners and thunk closures.

The focused regression spies on the actual external signal. Exact master registers its abort handler and performs zero removals after successful completion; this change removes the same handler. Already-aborted and in-flight abort behavior remain covered.

## Verification

- Focused createAsyncThunk suite: 44 tests pass, zero type errors.
- Full Toolkit suite: 88 files, 1,317 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.

No public API, type, action, result, abort reason, or timing semantics change.