### PR TITLE
Clear cache-removal timers on resubscription

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts
@@ -176,28 +176,34 @@ export const buildCacheCollectionHandler: InternalHandlerBuilder = ({
       Math.min(keepUnusedDataFor, THIRTY_TWO_BIT_MAX_TIMER_SECONDS),
     )
 
-    if (!anySubscriptionsRemainingForKey(queryCacheKey)) {
-      const currentTimeout = currentRemovalTimeouts[queryCacheKey]
+    const currentTimeout = currentRemovalTimeouts[queryCacheKey]
+    if (anySubscriptionsRemainingForKey(queryCacheKey)) {
       if (currentTimeout) {
         clearTimeout(currentTimeout)
+        delete currentRemovalTimeouts[queryCacheKey]
       }
-
-      currentRemovalTimeouts[queryCacheKey] = setTimeout(() => {
-        if (!anySubscriptionsRemainingForKey(queryCacheKey)) {
-          // Try to abort any running query for this cache key
-          const entry = selectQueryEntry(api.getState(), queryCacheKey)
-
-          if (entry?.endpointName) {
-            const runningQuery = api.dispatch(
-              getRunningQueryThunk(entry.endpointName, entry.originalArgs),
-            )
-            runningQuery?.abort()
-          }
-          api.dispatch(removeQueryResult({ queryCacheKey }))
-        }
-        delete currentRemovalTimeouts![queryCacheKey]
-      }, finalKeepUnusedDataFor * 1000)
+      return
     }
+
+    if (currentTimeout) {
+      clearTimeout(currentTimeout)
+    }
+
+    currentRemovalTimeouts[queryCacheKey] = setTimeout(() => {
+      if (!anySubscriptionsRemainingForKey(queryCacheKey)) {
+        // Try to abort any running query for this cache key
+        const entry = selectQueryEntry(api.getState(), queryCacheKey)
+
+        if (entry?.endpointName) {
+          const runningQuery = api.dispatch(
+            getRunningQueryThunk(entry.endpointName, entry.originalArgs),
+          )
+          runningQuery?.abort()
+        }
+        api.dispatch(removeQueryResult({ queryCacheKey }))
+      }
+      delete currentRemovalTimeouts![queryCacheKey]
+    }, finalKeepUnusedDataFor * 1000)
   }
 
   return handler

--- a/packages/toolkit/src/query/tests/cacheCollection.test.ts
+++ b/packages/toolkit/src/query/tests/cacheCollection.test.ts
@@ -60,6 +60,40 @@ test(`query: await cleanup, keepUnusedDataFor set`, async () => {
   expect(onCleanup).toHaveBeenCalled()
 })
 
+test('query: resubscription clears the pending cleanup timer', async () => {
+  const { store, api } = storeForApi(
+    createApi({
+      baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
+      endpoints: (build) => ({
+        query: build.query<unknown, string>({
+          query: () => '/success',
+        }),
+      }),
+    }),
+  )
+  const initialTimerCount = vi.getTimerCount()
+  let secondPromise: { unsubscribe(): void } | undefined
+
+  try {
+    const firstPromise = store.dispatch(api.endpoints.query.initiate('arg'))
+    await firstPromise
+    vi.advanceTimersByTime(500)
+
+    firstPromise.unsubscribe()
+    vi.advanceTimersByTime(500)
+    expect(vi.getTimerCount()).toBe(initialTimerCount + 1)
+
+    secondPromise = store.dispatch(api.endpoints.query.initiate('arg'))
+    await secondPromise
+    vi.advanceTimersByTime(500)
+    expect(vi.getTimerCount()).toBe(initialTimerCount)
+  } finally {
+    secondPromise?.unsubscribe()
+    store.dispatch(api.util.resetApiState())
+    vi.clearAllTimers()
+  }
+})
+
 test(`query: handles large keepUnusedDataFor values over 32-bit ms`, async () => {
   const { store, api } = storeForApi(
     createApi({


### PR DESCRIPTION
## Fix

Cancel and remove a pending cache-removal timeout as soon as a subscription for that cache key becomes active again.

## Why

The timeout callback already rechecks subscriptions, so data is not removed incorrectly. However, the timer and its captured cache/API state remain alive for the entire keepUnusedDataFor duration after resubscription. With long retention periods and repeated subscribe/unsubscribe cycles, obsolete timers can accumulate unnecessarily.

The focused regression settles a query, unsubscribes, drains the subscription-sync timer, and observes one cache-removal timer. After resubscribing and draining the next sync timer, exact master still retains that timer; this change retains none.

## Verification

- Focused cache-collection suite: 9 tests pass, zero type errors.
- Full Toolkit suite: 88 files, 1,317 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.

No public API, type, cache retention duration, subscription, query, or eviction behavior changes.