### PR TITLE
Keep duplicate listener cleanup from resetting setup state

### DIFF
--- a/packages/toolkit/src/query/core/setupListeners.ts
+++ b/packages/toolkit/src/query/core/setupListeners.ts
@@ -78,9 +78,7 @@ export function setupListeners(
       }
     }
 
-    let unsubscribe = () => {
-      initialized = false
-    }
+    let unsubscribe = () => {}
 
     if (!initialized) {
       if (typeof window !== 'undefined' && window.addEventListener) {

--- a/packages/toolkit/src/query/tests/setupListeners.test.ts
+++ b/packages/toolkit/src/query/tests/setupListeners.test.ts
@@ -1,0 +1,25 @@
+import { setupListeners } from '@reduxjs/toolkit/query'
+
+describe('setupListeners', () => {
+  test('a duplicate cleanup does not invalidate the active listener guard', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener')
+    const removeEventListener = vi.spyOn(window, 'removeEventListener')
+    const firstCleanup = setupListeners(vi.fn() as any)
+    const duplicateCleanup = setupListeners(vi.fn() as any)
+    let thirdCleanup = () => {}
+
+    try {
+      expect(addEventListener).toHaveBeenCalledTimes(4)
+
+      duplicateCleanup()
+      thirdCleanup = setupListeners(vi.fn() as any)
+
+      expect(addEventListener).toHaveBeenCalledTimes(4)
+      expect(removeEventListener).not.toHaveBeenCalled()
+    } finally {
+      firstCleanup()
+      duplicateCleanup()
+      thirdCleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Fix

Make the cleanup returned by a duplicate default setupListeners call a true no-op.

## Why

Only the first default setup installs window listeners. Today, a second call installs nothing but returns a cleanup that sets the module-level initialized guard to false. Calling that cleanup makes a later setup install a duplicate set while the original handlers are still active, causing duplicate dispatches and mismatched teardown.

The focused regression performs first, duplicate, and third setup calls. After duplicate cleanup, exact master records eight window-listener registrations; this change remains at the original four and removes nothing until the real owner cleans up.

## Verification

- Focused setupListeners regression passes with zero type errors.
- Full Toolkit suite: 89 files, 1,317 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.

No public API, type, event set, dispatch, custom-handler, or owner-cleanup semantics change.