### PR TITLE
Support empty-string fixed mutation cache keys

### DIFF
--- a/packages/toolkit/src/query/core/buildInitiate.ts
+++ b/packages/toolkit/src/query/core/buildInitiate.ts
@@ -580,7 +580,7 @@ You must add the middleware for RTK-Query to function correctly!`,
         ret.then(() => {
           runningMutations.delete(requestId)
         })
-        if (fixedCacheKey) {
+        if (fixedCacheKey != null) {
           runningMutations.set(fixedCacheKey, ret)
           ret.then(() => {
             if (runningMutations.get(fixedCacheKey) === ret) {

--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -2221,7 +2221,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       useEffect(
         () => () => {
-          if (!promise?.arg.fixedCacheKey) {
+          if (promise?.arg.fixedCacheKey == null) {
             promise?.reset()
           }
         },
@@ -2258,7 +2258,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           if (promise) {
             setPromise(undefined)
           }
-          if (fixedCacheKey) {
+          if (fixedCacheKey != null) {
             dispatch(
               api.internalActions.removeMutationResult({
                 requestId,

--- a/packages/toolkit/src/query/tests/buildInitiate.test.tsx
+++ b/packages/toolkit/src/query/tests/buildInitiate.test.tsx
@@ -303,3 +303,32 @@ describe('getRunningQueryThunk with multiple stores', () => {
     await Promise.all([query1Promise, query2Promise])
   })
 })
+
+test('getRunningMutationThunk supports an empty fixedCacheKey', async () => {
+  let resolveMutation!: (value: { data: string }) => void
+  const mutationResult = new Promise<{ data: string }>((resolve) => {
+    resolveMutation = resolve
+  })
+  const mutationApi = createApi({
+    baseQuery: fakeBaseQuery(),
+    endpoints: (build) => ({
+      mutation: build.mutation<string, void>({
+        queryFn: () => mutationResult,
+      }),
+    }),
+  })
+  const store = setupApiStore(mutationApi, undefined, {
+    withoutTestLifecycles: true,
+  }).store
+
+  const promise = store.dispatch(
+    mutationApi.endpoints.mutation.initiate(undefined, { fixedCacheKey: '' }),
+  )
+
+  expect(
+    store.dispatch(mutationApi.util.getRunningMutationThunk('mutation', '')),
+  ).toBe(promise)
+
+  resolveMutation({ data: 'done' })
+  await promise
+})

--- a/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
+++ b/packages/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx
@@ -111,6 +111,44 @@ describe('fixedCacheKey', () => {
     })
   })
 
+  test('an empty string is a shared, resettable, persistent fixedCacheKey', async () => {
+    const { rerender } = render(
+      <>
+        <Component name="C1" fixedCacheKey="" />
+        <Component name="C2" fixedCacheKey="" />
+      </>,
+      { wrapper: storeRef.wrapper },
+    )
+    const c1 = screen.getByTestId('C1')
+    const c2 = screen.getByTestId('C2')
+
+    act(() => {
+      getByTestId(c1, 'trigger').click()
+    })
+    await waitFor(() => {
+      expect(getByTestId(c1, 'data').textContent).toBe('C1')
+      expect(getByTestId(c2, 'data').textContent).toBe('C1')
+    })
+
+    act(() => {
+      getByTestId(c2, 'reset').click()
+    })
+    await waitFor(() => {
+      expect(getByTestId(c1, 'status').textContent).toBe('uninitialized')
+      expect(getByTestId(c2, 'status').textContent).toBe('uninitialized')
+    })
+
+    act(() => {
+      getByTestId(c1, 'trigger').click()
+    })
+    await waitFor(() => expect(getByTestId(c1, 'data').textContent).toBe('C1'))
+
+    rerender(<div />)
+    rerender(<Component name="C3" fixedCacheKey="" />)
+
+    expect(getByTestId(screen.getByTestId('C3'), 'data').textContent).toBe('C1')
+  })
+
   test('resetting from the component that triggered the mutation resets for each shared result', async () => {
     render(
       <>


### PR DESCRIPTION
## Fixes

- Treat an empty string as a present fixedCacheKey when tracking running mutations.
- Preserve empty-key mutation state across hook unmounts.
- Allow useMutation().reset() to remove shared state stored under an empty key.

## Why

fixedCacheKey is typed as string and mutation state/cache selection already uses nullish fallback semantics, but three runtime branches use truthiness. This makes the valid empty-string key behave inconsistently: shared data can be selected, yet reset does nothing, unmount removes it as if unkeyed, and getRunningMutationThunk cannot find it.

On exact master, the focused hook regression fails to reset the two shared empty-key results, and the running-mutation lookup returns undefined. Both pass with nullish presence checks; the hook case also verifies persistence across unmount/remount.

## Verification

- Focused hook/core suites: 20 tests pass, zero type errors.
- Full Toolkit suite: 88 files, 1,318 tests pass, two existing todos, zero type errors.
- Package build passes.
- Declaration/type tests pass.
- Changed-file Prettier and whitespace checks pass.

This is an observable bug fix for a previously inconsistent valid string value. No public type, API signature, action shape, or non-empty/undefined key behavior changes.