### PR TITLE
Report circular serializable values without overflowing

### DIFF
--- a/packages/toolkit/src/serializableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/serializableStateInvariantMiddleware.ts
@@ -41,6 +41,26 @@ export function findNonSerializableValue(
   ignoredPaths: IgnoredPaths = [],
   cache?: WeakSet<object>,
 ): NonSerializableValue | false {
+  return findNonSerializableValueRecursive(
+    value,
+    path,
+    isSerializable,
+    getEntries,
+    ignoredPaths,
+    cache,
+    new Set(),
+  )
+}
+
+function findNonSerializableValueRecursive(
+  value: unknown,
+  path: string,
+  isSerializable: (value: unknown) => boolean,
+  getEntries: ((value: unknown) => [string, any][]) | undefined,
+  ignoredPaths: IgnoredPaths,
+  cache: WeakSet<object> | undefined,
+  ancestors: Set<object>,
+): NonSerializableValue | false {
   let foundNestedSerializable: NonSerializableValue | false
 
   if (!isSerializable(value)) {
@@ -55,6 +75,15 @@ export function findNonSerializableValue(
   }
 
   if (cache?.has(value)) return false
+
+  if (ancestors.has(value)) {
+    return {
+      keyPath: path || '<root>',
+      value,
+    }
+  }
+
+  ancestors.add(value)
 
   const entries = getEntries != null ? getEntries(value) : Object.entries(value)
 
@@ -83,13 +112,14 @@ export function findNonSerializableValue(
     }
 
     if (typeof nestedValue === 'object') {
-      foundNestedSerializable = findNonSerializableValue(
+      foundNestedSerializable = findNonSerializableValueRecursive(
         nestedValue,
         nestedPath,
         isSerializable,
         getEntries,
         ignoredPaths,
         cache,
+        ancestors,
       )
 
       if (foundNestedSerializable) {
@@ -98,18 +128,27 @@ export function findNonSerializableValue(
     }
   }
 
+  ancestors.delete(value)
+
   if (cache && isNestedFrozen(value)) cache.add(value)
 
   return false
 }
 
 export function isNestedFrozen(value: object) {
+  return isNestedFrozenRecursive(value, new Set())
+}
+
+function isNestedFrozenRecursive(value: object, visited: Set<object>) {
   if (!Object.isFrozen(value)) return false
+
+  if (visited.has(value)) return true
+  visited.add(value)
 
   for (const nestedValue of Object.values(value)) {
     if (typeof nestedValue !== 'object' || nestedValue === null) continue
 
-    if (!isNestedFrozen(nestedValue)) return false
+    if (!isNestedFrozenRecursive(nestedValue, visited)) return false
   }
 
   return true

--- a/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/serializableStateInvariantMiddleware.test.ts
@@ -92,6 +92,24 @@ describe('findNonSerializableValue', () => {
 
     expect(result).toEqual(false)
   })
+
+  it('Should report circular references instead of overflowing the stack', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    expect(findNonSerializableValue(circular)).toEqual({
+      keyPath: 'self',
+      value: circular,
+    })
+  })
+
+  it('Should accept repeated references that are not circular', () => {
+    const shared = { value: 42 }
+
+    expect(findNonSerializableValue({ first: shared, second: shared })).toBe(
+      false,
+    )
+  })
 })
 
 describe('serializableStateInvariantMiddleware', () => {
@@ -659,5 +677,13 @@ describe('serializableStateInvariantMiddleware', () => {
     numPlainChecks = 0
     store.dispatch({ type: 'NOOP' })
     expect(numPlainChecks).toBeLessThan(10)
+  })
+
+  it('Should identify deeply frozen circular values', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    Object.freeze(circular)
+
+    expect(isNestedFrozen(circular)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- detect circular references while traversing otherwise plain values
- report the repeated path/value instead of recursing until a `RangeError`
- make the nested-frozen cache check cycle-safe
- preserve support for shared references that are not circular

## Why

`findNonSerializableValue` currently treats each plain object as serializable and recursively visits its entries without tracking the active ancestor chain. A circular plain object therefore overflows the stack before the middleware can report it. `isNestedFrozen` has the same issue for frozen circular graphs.

Tracking only active ancestors avoids false positives for ordinary repeated references while allowing circular data to be reported through the existing `{ keyPath, value }` result.

## Verification

- `corepack yarn workspace @reduxjs/toolkit test serializableStateInvariantMiddleware.test.ts` (25 tests)
- `corepack yarn workspace @reduxjs/toolkit test` (88 files, 1,319 passed, 2 todo)
- `corepack yarn workspace @reduxjs/toolkit build`
- `corepack yarn workspace @reduxjs/toolkit type-tests`
- Prettier on changed files
- `git diff --check`