### PR TITLE
Reset lazy queries with empty cache keys

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -2007,10 +2007,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       )
 
       const reset = useCallback(() => {
-        if (promiseRef.current?.queryCacheKey) {
+        if (promiseRef.current?.queryCacheKey !== undefined) {
           dispatch(
             api.internalActions.removeQueryResult({
-              queryCacheKey: promiseRef.current?.queryCacheKey as QueryCacheKey,
+              queryCacheKey: promiseRef.current.queryCacheKey as QueryCacheKey,
             }),
           )
         }

--- a/packages/toolkit/src/query/tests/buildHooks.test.tsx
+++ b/packages/toolkit/src/query/tests/buildHooks.test.tsx
@@ -1906,6 +1906,40 @@ describe('hooks tests', () => {
       await screen.findByText(/isUninitialized/i)
       expect(countObjectKeys(storeRef.store.getState().api.queries)).toBe(0)
     })
+
+    test('`reset` removes an empty-string query cache key', async () => {
+      const emptyKeyApi = createApi({
+        baseQuery: async () => ({ data: 'result' }),
+        endpoints: (build) => ({
+          query: build.query<string, void>({
+            query: () => '',
+            serializeQueryArgs: () => '',
+          }),
+        }),
+      })
+      const emptyKeyStoreRef = setupApiStore(emptyKeyApi, undefined, {
+        withoutTestLifecycles: true,
+      })
+      let reset!: () => void
+
+      function User() {
+        const [trigger, result] = emptyKeyApi.endpoints.query.useLazyQuery()
+        reset = result.reset
+
+        return <button onClick={() => trigger()}>trigger</button>
+      }
+
+      render(<User />, { wrapper: emptyKeyStoreRef.wrapper })
+
+      await userEvent.click(screen.getByRole('button', { name: 'trigger' }))
+      await waitFor(() =>
+        expect(emptyKeyStoreRef.store.getState().api.queries['']).toBeDefined(),
+      )
+
+      act(() => reset())
+
+      expect(emptyKeyStoreRef.store.getState().api.queries['']).toBeUndefined()
+    })
   })
 
   describe('useInfiniteQuery', () => {


### PR DESCRIPTION
## Summary

- treat an empty string as a present lazy-query cache key
- dispatch `removeQueryResult` when `serializeQueryArgs` intentionally returns `""`
- cover the public `reset` behavior with an empty custom cache key

## Why

`serializeQueryArgs` may return any string, including an empty string. The lazy-query `reset` callback currently tests `queryCacheKey` by truthiness, so the cache entry remains and the hook stays initialized for that valid key. Checking for `undefined` matches the actual optionality of the value.

## Verification

- `corepack yarn workspace @reduxjs/toolkit test buildHooks.test.tsx` (70 tests)
- `corepack yarn workspace @reduxjs/toolkit test` (88 files, 1,317 passed, 2 todo)
- `corepack yarn workspace @reduxjs/toolkit build`
- `corepack yarn workspace @reduxjs/toolkit type-tests`
- Prettier on changed files
- `git diff --check`