### PR TITLE
Use native Vite tsconfig path resolution

### DIFF
--- a/packages/rtk-query-codegen-openapi/package.json
+++ b/packages/rtk-query-codegen-openapi/package.json
@@ -74,7 +74,6 @@
     "rimraf": "^6.1.3",
     "ts-node": "^10.9.2",
     "tsup": "^8.4.0",
-    "vite-tsconfig-paths": "^5.0.1",
     "vitest": "^4",
     "yalc": "^1.0.0-pre.47"
   },

--- a/packages/rtk-query-codegen-openapi/vitest.config.mts
+++ b/packages/rtk-query-codegen-openapi/vitest.config.mts
@@ -1,16 +1,11 @@
 import * as path from 'node:path';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 import packageJson from './package.json' with { type: 'json' };
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      configNames: ['tsconfig.json'],
-      projects: ['./tsconfig.json'],
-      root: import.meta.dirname,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
 
   root: import.meta.dirname,
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -230,7 +230,6 @@
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "valibot": "^1.0.0",
-    "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^4"
   },
   "scripts": {

--- a/packages/toolkit/vitest.config.mts
+++ b/packages/toolkit/vitest.config.mts
@@ -1,14 +1,9 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
-// No __dirname under Node ESM
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
 export default defineConfig({
-  plugins: [tsconfigPaths({ root: __dirname })],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7811,7 +7811,6 @@ __metadata:
     tsx: "npm:^4.19.0"
     typescript: "npm:^5.9.3"
     valibot: "npm:^1.0.0"
-    vite-tsconfig-paths: "npm:^4.3.1"
     vitest: "npm:^4"
   peerDependencies:
     react: ^16.9.0 || ^17.0.0 || ^18 || ^19
@@ -8402,7 +8401,6 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.9.3"
-    vite-tsconfig-paths: "npm:^5.0.1"
     vitest: "npm:^4"
     yalc: "npm:^1.0.0-pre.47"
   bin:
@@ -31906,20 +31904,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.3":
-  version: 3.1.6
-  resolution: "tsconfck@npm:3.1.6"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10/8574595286850273bf83319b4e67ca760088df3c36f7ca1425aaf797416672e854271bd31e75c9b3e1836ed5b66410c6bc38cbbda9c638a5416c6a682ed94132
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -32875,38 +32859,6 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10/a5a85293c9eb8787aa42e180edaef00c13199a493d6ed82fecf13ab29a68526850788e22434d77808ea6b17a74e03ff899b9b4711df5b9eee75afcddd7c2e1fb
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^4.3.1":
-  version: 4.3.2
-  resolution: "vite-tsconfig-paths@npm:4.3.2"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  peerDependenciesMeta:
-    vite:
-      optional: true
-  checksum: 10/c12e2087fd01ac8a694850c649b79d5b9798cdba0ef9ab4116f669d8ffa1a9a3195c5a14410d3d9a12d2f08cd35ddd74f03d9c7b13a2d590d002055cdaab45c0
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^5.0.1":
-  version: 5.1.4
-  resolution: "vite-tsconfig-paths@npm:5.1.4"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  peerDependenciesMeta:
-    vite:
-      optional: true
-  checksum: 10/b409dbd17829f560021a71dba3e473b9c06dcf5fdc9d630b72c1f787145ec478b38caff1be04868971ac8bdcbf0f5af45eeece23dbc9c59c54b901f867740ae0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- replace `vite-tsconfig-paths` with Vite 8's native `resolve.tsconfigPaths` option
- update both Toolkit and OpenAPI codegen Vitest configs
- remove the two direct plugin dependencies and their now-unused lockfile graph

## Why

Vite 8 detects `vite-tsconfig-paths` and emits a migration warning on every test run because this behavior is now built in. Using the native option removes the extra plugin/configuration and drops `vite-tsconfig-paths` plus `tsconfck` from the dependency graph.

## Verification

- Toolkit test suite: 88 files, 1,316 passed, 2 todo, no type errors
- OpenAPI codegen test suite: 3 files, 100 passed, no type errors
- Toolkit build and declaration/type tests
- OpenAPI codegen build
- changed-file Prettier
- `git diff --check`

The prior Vite migration warning is absent from both test runs.