### PR TITLE
fix(rtk-query): only treat a url as absolute when it starts with a scheme

### DIFF
--- a/packages/toolkit/src/query/tests/utils.test.ts
+++ b/packages/toolkit/src/query/tests/utils.test.ts
@@ -1,5 +1,10 @@
 import { vi } from 'vitest'
-import { isOnline, isDocumentVisible, joinUrls } from '@internal/query/utils'
+import {
+  isOnline,
+  isDocumentVisible,
+  joinUrls,
+  isAbsoluteUrl,
+} from '@internal/query/utils'
 
 afterAll(() => {
   vi.restoreAllMocks()
@@ -87,7 +92,39 @@ describe('joinUrls', () => {
     ['https://example.com/api/', '/banana', 'https://example.com/api/banana'],
     ['https://example.com/api/', 'https://example.org', 'https://example.org'],
     ['https://example.com/api/', '//example.org', '//example.org'],
+    // a relative url may carry an absolute one in its query string; the base still applies
+    [
+      'https://example.com/api/',
+      'redirect?target=https://example.org',
+      'https://example.com/api/redirect?target=https://example.org',
+    ],
+    [
+      '/api/',
+      'img?src=http://cdn.example/a.png',
+      '/api/img?src=http://cdn.example/a.png',
+    ],
   ])('%s and %s join to %s', (base, url, expected) => {
     expect(joinUrls(base, url)).toBe(expected)
+  })
+})
+
+describe('isAbsoluteUrl', () => {
+  test.each([
+    ['https://example.com', true],
+    ['http://example.com', true],
+    ['ftp://example.com', true],
+    ['web+custom://example.com', true],
+    ['//example.com', true],
+    ['banana', false],
+    ['/banana', false],
+    ['./banana', false],
+    ['banana/split', false],
+    ['?a=1', false],
+    // relative urls that merely contain an absolute one
+    ['redirect?target=https://example.org', false],
+    ['img?src=http://cdn.example/a.png', false],
+    ['search?q=a://b', false],
+  ])('%s is absolute: %s', (url, expected) => {
+    expect(isAbsoluteUrl(url)).toBe(expected)
   })
 })

--- a/packages/toolkit/src/query/utils/isAbsoluteUrl.ts
+++ b/packages/toolkit/src/query/utils/isAbsoluteUrl.ts
@@ -1,9 +1,14 @@
 /**
- * If either :// or // is present consider it to be an absolute url
+ * Determines whether a url is absolute: it either starts with a scheme
+ * (`https://example.com`) or is protocol-relative (`//example.com`).
+ *
+ * The test is anchored to the start of the string on purpose. A relative url can
+ * legitimately carry an absolute one inside its query string, as in
+ * `redirect?target=https://example.com`, and treating that as absolute would make
+ * `joinUrls` drop the `baseUrl`.
  *
  * @param url string
  */
-
 export function isAbsoluteUrl(url: string) {
-  return new RegExp(`(^|:)//`).test(url)
+  return /^([a-z][a-z\d+\-.]*:)?\/\//i.test(url)
 }


### PR DESCRIPTION
Found by probing RTK Query's url helpers rather than from a bug report, so there's no issue to link.

`isAbsoluteUrl` tests `(^|:)//` unanchored, so it answers "does this string contain `://` anywhere" rather than "does this url start with a scheme". A relative url that carries an absolute one in its query string matches, and `joinUrls` then returns it untouched — silently dropping `baseUrl`:

```js
joinUrls('https://api.example.com/', 'redirect?target=https://other.example')
// 'redirect?target=https://other.example'   <- baseUrl is gone
```

Same for anything else that embeds a url as a parameter, which isn't unusual: `img?src=http://cdn.example/a.png`, `login?next=https://...`, callback and return-to params. The request ends up resolved against the page instead of the API, and because nothing throws it just looks like a 404 from the wrong host.

The fix is to anchor the check and allow an optional scheme:

```js
/^([a-z][a-z\d+\-.]*:)?\/\//i
```

That keeps every case the existing `joinUrls` table already covers — `https://example.org` and the protocol-relative `//example.org` still count as absolute, `/banana` and `banana` still don't — and it also accepts custom schemes like `web+custom://`. Incidentally it's the same expression `msw` uses for its own `isAbsoluteUrl`, which is already in this repo's dev dependencies.

Worth noting the old behaviour isn't a deliberate loose check as far as I can tell: the comment above the function says "if either :// or // is present", which describes what the regex does rather than what an absolute url is, and there were no tests on `isAbsoluteUrl` itself — only the indirect coverage through `joinUrls`.

## Testing

Added a `describe('isAbsoluteUrl')` table covering schemes, protocol-relative, custom schemes, plain relative urls, and the embedded-url cases, plus two rows on the existing `joinUrls` table. Reverting only `isAbsoluteUrl.ts` fails exactly the five new assertions and leaves the 34 existing ones passing:

```
× https://example.com/api/ and redirect?target=https://example.org join to ...
× /api/ and img?src=http://cdn.example/a.png join to ...
× redirect?target=https://example.org is absolute: false
× img?src=http://cdn.example/a.png is absolute: false
× search?q=a://b is absolute: false
  Tests  5 failed | 34 passed (39)
```

With the fix, 39/39 pass, and the whole `src/query` suite is green at 31 files / 552 tests. Prettier clean.
