### PR TITLE
fix(rtk-query): expose infinite query page error flags

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1286,6 +1286,8 @@ type UseInfiniteQueryStateBaseResult<
   hasPreviousPage: boolean
   isFetchingNextPage: boolean
   isFetchingPreviousPage: boolean
+  isFetchNextPageError: boolean
+  isFetchPreviousPageError: boolean
 }
 
 type UseInfiniteQueryStateDefaultResult<

--- a/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
@@ -139,10 +139,15 @@ describe('Infinite queries', () => {
         data,
         currentData,
         isFetching,
+        isFetchNextPageError,
+        isFetchPreviousPageError,
         isUninitialized,
         isSuccess,
         fetchNextPage,
       } = useGetInfinitePokemonQuery('a')
+
+      expectTypeOf(isFetchNextPageError).toBeBoolean()
+      expectTypeOf(isFetchPreviousPageError).toBeBoolean()
 
       expectTypeOf(data).toEqualTypeOf<
         InfiniteData<Pokemon[], number> | undefined


### PR DESCRIPTION
## Summary

Expose `isFetchNextPageError` and `isFetchPreviousPageError` on the generated React infinite query hook result type. The core selector already returns both flags at runtime and the public docs already list them, but `UseInfiniteQueryStateBaseResult` omitted them.

Adds a type regression test covering both properties.

Closes #5427.

## Testing

- `yarn workspace @reduxjs/toolkit test` (88 files, 1331 tests, no type errors)
- `yarn workspace @reduxjs/toolkit build`
- ESLint on the two changed files
- Prettier check on the two changed files