### PR TITLE
fix(toolkit): handle circular references in immutableStateInvariantMiddleware

### DIFF
--- a/packages/toolkit/src/immutableStateInvariantMiddleware.ts
+++ b/packages/toolkit/src/immutableStateInvariantMiddleware.ts
@@ -36,13 +36,20 @@ function trackProperties(
   ignoredPaths: IgnoredPaths = [],
   obj: Record<string, any>,
   path: string = '',
-  checkedObjects: Set<Record<string, any>> = new Set(),
+  inProgress: Map<Record<string, any>, TrackedProperty> = new Map(),
 ) {
   const tracked: Partial<TrackedProperty> = { value: obj }
 
-  if (!isImmutable(obj) && !checkedObjects.has(obj)) {
-    checkedObjects.add(obj)
+  if (!isImmutable(obj)) {
+    // An object already being tracked further up the stack contains itself
+    const alreadyInProgress = inProgress.get(obj)
+    if (alreadyInProgress) {
+      return alreadyInProgress
+    }
+
     tracked.children = {}
+    // Registered before walking children, so a circular reference finds it
+    inProgress.set(obj, tracked as TrackedProperty)
 
     const hasIgnoredPaths = ignoredPaths.length > 0
 
@@ -66,8 +73,11 @@ function trackProperties(
         ignoredPaths,
         obj[key],
         nestedPath,
+        inProgress,
       )
     }
+
+    inProgress.delete(obj)
   }
   return tracked as TrackedProperty
 }
@@ -79,6 +89,7 @@ function detectMutations(
   obj: any,
   sameParentRef: boolean = false,
   path: string = '',
+  seen: Map<TrackedProperty, Set<unknown>> = new Map(),
 ): { wasMutated: boolean; path?: string } {
   const prevObj = trackedProperty ? trackedProperty.value : undefined
 
@@ -91,6 +102,18 @@ function detectMutations(
   if (isImmutable(prevObj) || isImmutable(obj)) {
     return { wasMutated: false }
   }
+
+  // Compare each (tracked node, value) pair once, so cycles terminate
+  let seenValues = seen.get(trackedProperty)
+
+  if (!seenValues) {
+    seenValues = new Set()
+    seen.set(trackedProperty, seenValues)
+  } else if (seenValues.has(obj)) {
+    return { wasMutated: false }
+  }
+
+  seenValues.add(obj)
 
   // Gather all keys from prev (tracked) and after objs
   const keysToDetect: Record<string, boolean> = {}
@@ -125,6 +148,7 @@ function detectMutations(
       obj[key],
       sameRef,
       nestedPath,
+      seen,
     )
 
     if (result.wasMutated) {

--- a/packages/toolkit/src/tests/immutableStateInvariantMiddleware.test.ts
+++ b/packages/toolkit/src/tests/immutableStateInvariantMiddleware.test.ts
@@ -13,6 +13,12 @@ import {
 
 type MWNext = Parameters<ReturnType<Middleware>>[0]
 
+interface CircularNode {
+  name: string
+  self?: CircularNode
+  parent?: unknown
+}
+
 describe('createImmutableStateInvariantMiddleware', () => {
   let state: { foo: { bar: number[]; baz: string } }
   const getState: Store['getState'] = () => state
@@ -87,7 +93,7 @@ describe('createImmutableStateInvariantMiddleware', () => {
     }).not.toThrow()
   })
 
-  it('works correctly with circular references', () => {
+  it('works correctly with circular references in an action', () => {
     const next: MWNext = (action) => action
 
     const dispatch = middleware()(next)
@@ -100,6 +106,95 @@ describe('createImmutableStateInvariantMiddleware', () => {
     expect(() => {
       dispatch({ type: 'SOME_ACTION', x })
     }).not.toThrow()
+  })
+
+  it('works correctly with circular references in the state', () => {
+    const next: MWNext = (action) => action
+
+    const circular: CircularNode = { name: 'circular' }
+    circular.self = circular
+    circular.parent = state.foo
+    Object.assign(state.foo, { circular })
+
+    const dispatch = middleware()(next)
+
+    expect(() => {
+      dispatch({ type: 'SOME_ACTION' })
+    }).not.toThrow()
+
+    expect(() => {
+      dispatch({ type: 'SOME_OTHER_ACTION' })
+    }).not.toThrow()
+  })
+
+  it('detects a mutation inside a circular reference', () => {
+    const circular: CircularNode = { name: 'circular' }
+    circular.self = circular
+    Object.assign(state.foo, { circular })
+
+    const next: MWNext = (action) => {
+      circular.name = 'mutated'
+      return action
+    }
+
+    const dispatch = middleware()(next)
+
+    expect(() => {
+      dispatch({ type: 'SOME_ACTION' })
+    }).toThrow(new RegExp('foo\\.circular\\.name'))
+  })
+
+  it('does not report shared references as mutations', () => {
+    const next: MWNext = (action) => action
+
+    const shared = { value: 'shared' }
+    Object.assign(state.foo, {
+      a: shared,
+      b: shared,
+      list: new Array(10).fill(shared),
+    })
+
+    const dispatch = middleware()(next)
+
+    expect(() => {
+      dispatch({ type: 'SOME_ACTION' })
+    }).not.toThrow()
+
+    expect(() => {
+      dispatch({ type: 'SOME_OTHER_ACTION' })
+    }).not.toThrow()
+  })
+
+  it('detects a mutation of a shared reference', () => {
+    const shared = { value: 'shared' }
+    Object.assign(state.foo, { a: shared, b: shared })
+
+    const next: MWNext = (action) => {
+      shared.value = 'mutated'
+      return action
+    }
+
+    const dispatch = middleware()(next)
+
+    expect(() => {
+      dispatch({ type: 'SOME_ACTION' })
+    }).toThrow(new RegExp('foo\\.a\\.value'))
+  })
+
+  it('respects "ignoredPaths" per path for shared references', () => {
+    const shared = { nested: { value: 'shared' } }
+    Object.assign(state.foo, { first: shared, second: shared })
+
+    const next: MWNext = (action) => {
+      shared.nested.value = 'mutated'
+      return action
+    }
+
+    const dispatch = middleware({ ignoredPaths: ['foo.first.nested'] })(next)
+
+    expect(() => {
+      dispatch({ type: 'SOME_ACTION' })
+    }).toThrow(new RegExp('foo\\.second\\.nested\\.value'))
   })
 
   it('respects "isImmutable" option', function () {


### PR DESCRIPTION
Fixes #4843.

## The bug

`trackProperties` takes a `checkedObjects` set to guard against cycles, but never passes it to its recursive call. Every level starts with a fresh empty set, so `checkedObjects.has(obj)` is never true and the guard is dead code. Circular state throws `RangeError: Maximum call stack size exceeded` on the first dispatch. The parameter has been inert since #3428 added it.

The existing test named "works correctly with circular references" does not catch this, because it puts the cycle on the dispatched action. The middleware only tracks `getState()`, so that cycle never reaches `trackProperties`.

## Why not just forward the set

That was #4844, and it trades one crash for another. The set catches two different situations: a real cycle, and an object reachable from more than one path. The second is ordinary in Redux state. On a repeat visit the function returns `{ value }` with no `children`, so `detectMutations` evaluates `trackedProperty.children[key]` on `undefined` and throws.

Applying that one-line change to current master fails an existing test:

```
× Should print a warning if execution takes too long
TypeError: Cannot read properties of undefined (reading 'value')
```

That test builds `new Array(10000).fill({ value: 'more' })`, which is 10000 references to one object, so the `value` in the message is the fixture's key name rather than `TrackedProperty.value`. This is the failure reported in #4844.

## This change

Track the objects currently on the recursion stack instead of every object seen. A node is registered before its children are walked, so a self-reference finds it. It is removed on the way out, so an object at two sibling paths is still tracked once per path, exactly as today.

`detectMutations` needs its own guard, because a cyclic node contains itself. It now compares each (tracked node, value) pair at most once. The reference check above it still runs on every path, so a changed reference is still reported.

## Tests

Added to the existing file:

- circular state, two dispatches, no throw
- a mutation inside a cycle reports the right path
- shared references are not reported as mutations
- a mutation of a shared reference is reported
- `ignoredPaths` still applies per path when one object sits at two paths

The two circular tests fail on master with `RangeError`. The three shared reference tests pass on master and fail under #4844's approach, so they pin the regression that closed it.

I also ran the current and new algorithms side by side over 20000 randomly generated state trees, covering shared references, frozen objects, arrays, `NaN`, and both string and RegExp `ignoredPaths`, applying a random mutation to each. 13005 of them produced a mutation. The two agree on every case, so behavior only changes for circular state.

## Checks

- `yarn test` in `packages/toolkit`: 88 files, 1336 tests, no type errors
- eslint and prettier clean on both changed files
- production bundle is byte identical (25015 raw, 9547 gzip); the dev build grows by 415 bytes
