### PR TITLE
fix(rtk-query): expose infinite-query error flags on hook result type

### DIFF
--- a/packages/toolkit/src/query/react/buildHooks.ts
+++ b/packages/toolkit/src/query/react/buildHooks.ts
@@ -1286,6 +1286,8 @@ type UseInfiniteQueryStateBaseResult<
   hasPreviousPage: boolean
   isFetchingNextPage: boolean
   isFetchingPreviousPage: boolean
+  isFetchNextPageError: boolean
+  isFetchPreviousPageError: boolean
 }
 
 type UseInfiniteQueryStateDefaultResult<

--- a/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
+++ b/packages/toolkit/src/query/tests/infiniteQueries.test-d.ts
@@ -142,11 +142,26 @@ describe('Infinite queries', () => {
         isUninitialized,
         isSuccess,
         fetchNextPage,
+        hasNextPage,
+        hasPreviousPage,
+        isFetchingNextPage,
+        isFetchingPreviousPage,
+        isFetchNextPageError,
+        isFetchPreviousPageError,
       } = useGetInfinitePokemonQuery('a')
 
       expectTypeOf(data).toEqualTypeOf<
         InfiniteData<Pokemon[], number> | undefined
       >()
+
+      // The hook result should expose the same infinite-query flags the
+      // core selector computes at runtime, including the error flags.
+      expectTypeOf(hasNextPage).toBeBoolean()
+      expectTypeOf(hasPreviousPage).toBeBoolean()
+      expectTypeOf(isFetchingNextPage).toBeBoolean()
+      expectTypeOf(isFetchingPreviousPage).toBeBoolean()
+      expectTypeOf(isFetchNextPageError).toBeBoolean()
+      expectTypeOf(isFetchPreviousPageError).toBeBoolean()
 
       if (isSuccess) {
         expectTypeOf(data.pages).toEqualTypeOf<Pokemon[][]>()


### PR DESCRIPTION
Fixes #5427.

The RTK Query infinite-query hook returns `isFetchNextPageError` and `isFetchPreviousPageError` at runtime — the core selector (`InfiniteQueryResultFlags` in `buildSelectors.ts`) computes all six flags and the hook spreads the full selector result — but the hook's result type `UseInfiniteQueryStateBaseResult` in `buildHooks.ts` only declared four of them. So reading either error flag off the result is a type error even though the value is there (the docs advertise `isFetchNextPageError`, the type doesn't have it).

This adds the two missing flags to `UseInfiniteQueryStateBaseResult`, mirroring `InfiniteQueryResultFlags`. Type-only, no runtime change. Added a type test asserting all six flags exist on the hook result — it fails without the change (`Property 'isFetchNextPageError' does not exist`) and passes with it; the infinite-query unit tests (28) still pass.
